### PR TITLE
Add deposit_all_buckets... to new-package template

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -14,6 +14,8 @@ fn test_hello() {
     // Test the `new` function.
     let transaction1 = TransactionBuilder::new(&executor)
         .call_function(package, "Hello", "new", vec![], None)
+        .drop_all_bucket_refs()
+        .deposit_all_buckets(account)
         .build(vec![key])
         .unwrap();
     let receipt1 = executor.run(transaction1, false).unwrap();


### PR DESCRIPTION
Fixes the `TransactionBuilder` to use both `drop_all_bucket_refs` and
`deposit_all_buckets(account)` in the `Hello::new` function call of
`test_hello` unit test.  This is now consistent for both transactions
in the unit test and matches how `resim call-function` works.

Fixes #71