### PR TITLE
Allow to specify XRD instead of 030000..004 address in resim

### DIFF
--- a/radix-engine/src/transaction/builder.rs
+++ b/radix-engine/src/transaction/builder.rs
@@ -451,7 +451,14 @@ impl<'a, A: AbiProvider> TransactionBuilder<'a, A> {
             SCRYPTO_NAME_BID | SCRYPTO_NAME_BUCKET => {
                 let mut split = arg.split(',');
                 let amount = split.next().and_then(|v| v.trim().parse::<Decimal>().ok());
-                let resource_def = split.next().and_then(|v| v.trim().parse::<Address>().ok());
+                let resource_def = split.next().and_then(|v| {
+                    let address = v.trim();
+                    if address == "XRD" {
+                        return Some(RADIX_TOKEN);
+                    }
+                    address.parse::<Address>().ok()
+                });
+
                 match (amount, resource_def) {
                     (Some(a), Some(r)) => {
                         if let Some(account) = account {


### PR DESCRIPTION
This might not be the best way to do it but I think it is useful to only have to specify "XRD" when sending buckets to functions and methods instead of the full address.