### PR TITLE
Use a closure in the auth macro for compatibility

### DIFF
--- a/scrypto-derive/src/auth.rs
+++ b/scrypto-derive/src/auth.rs
@@ -107,9 +107,10 @@ mod tests {
                     if !(auth.contains(self.foo.clone()) || auth.contains(self.bar.clone())) {
                         panic!("Auth check failure")
                     }
-                    let output = {
+                    let func = || {
                         self.a
                     };
+                    let output = func();
                     auth.drop();
                     output
                 }
@@ -130,10 +131,11 @@ mod tests {
                     if !(auth.contains(self.foo.clone())) {
                         panic!("Auth check failure")
                     }
-                    let output = {
+                    let func = || {
                         auth.drop();
                         self.a
                     };
+                    let output = func();
                     output
                 }
             },

--- a/scrypto-derive/src/auth.rs
+++ b/scrypto-derive/src/auth.rs
@@ -68,7 +68,8 @@ pub fn handle_auth(attr: TokenStream, item: TokenStream) -> Result<TokenStream> 
                 panic!("Auth check failure")
             }
 
-            let output = #f_body;
+            let func = || #f_body ;
+            let output = func();
             #drop
             output
         }


### PR DESCRIPTION
Instead of generating a block, generate a closure with the
same body.  This way, the body can include a return statement.

Fixes #76