### PR TITLE
Fix auth macro failure when capturing &mut self

### DIFF
--- a/scrypto-derive/src/auth.rs
+++ b/scrypto-derive/src/auth.rs
@@ -68,8 +68,7 @@ pub fn handle_auth(attr: TokenStream, item: TokenStream) -> Result<TokenStream> 
                 panic!("Auth check failure")
             }
 
-            let func = || #f_body ;
-            let output = func();
+            let output = (|| #f_body )();
             #drop
             output
         }
@@ -107,10 +106,9 @@ mod tests {
                     if !(auth.contains(self.foo.clone()) || auth.contains(self.bar.clone())) {
                         panic!("Auth check failure")
                     }
-                    let func = || {
+                    let output = (|| {
                         self.a
-                    };
-                    let output = func();
+                    })();
                     auth.drop();
                     output
                 }
@@ -131,11 +129,10 @@ mod tests {
                     if !(auth.contains(self.foo.clone())) {
                         panic!("Auth check failure")
                     }
-                    let func = || {
+                    let output = (|| {
                         auth.drop();
                         self.a
-                    };
-                    let output = func();
+                    })();
                     output
                 }
             },

--- a/scrypto-tests/tests/auth.rs
+++ b/scrypto-tests/tests/auth.rs
@@ -32,6 +32,15 @@ blueprint! {
         pub fn airdrop(&self) -> Bucket {
             self.reserves.take(1)
         }
+
+        #[auth(admin, user)]
+        pub fn airdrop_mut(&mut self) -> Bucket {
+            return self.mut_take(); // tests both return and &mut self with auth
+        }
+
+        fn mut_take(&mut self) -> Bucket {
+            self.reserves.take(1)
+        }
     }
 }
 
@@ -93,6 +102,22 @@ fn test_simple_auth() {
                 {
                     "name": "airdrop",
                     "mutability": "Immutable",
+                    "inputs": [
+                        {
+                            "type": "Custom",
+                            "name": "scrypto::resource::BucketRef",
+                            "generics": []
+                        }
+                    ],
+                    "output": {
+                        "type": "Custom",
+                        "name": "scrypto::resource::Bucket",
+                        "generics": []
+                    }
+                },
+                {
+                    "name": "airdrop_mut",
+                    "mutability": "Mutable",
                     "inputs": [
                         {
                             "type": "Custom",


### PR DESCRIPTION
Don't use a let binding at all so the closure can be called regardless
of Fn or FnMut type.  Also drops the closure as soon as possible which
leads to better inlining and less chance of lifetime/borrow issues later

Fixes #84