### PR TITLE
Update burn APIs

### DIFF
--- a/examples/core/flat-admin/src/lib.rs
+++ b/examples/core/flat-admin/src/lib.rs
@@ -47,7 +47,7 @@ blueprint! {
                 "Can not destroy the contents of this bucket!"
             );
             self.admin_mint_badge
-                .authorize(|auth| self.admin_badge.burn(to_destroy, Some(auth)))
+                .authorize(|auth| self.admin_badge.burn_with_auth(to_destroy, auth))
         }
 
         pub fn get_admin_badge_address(&self) -> Address {

--- a/examples/defi/radiswap/src/lib.rs
+++ b/examples/defi/radiswap/src/lib.rs
@@ -130,7 +130,7 @@ blueprint! {
 
             // Burn the LP tokens received
             self.lp_mint_badge.authorize(|auth| {
-                lp_tokens.burn(Some(auth));
+                lp_tokens.burn_with_auth(auth);
             });
 
             // Return the withdrawn tokens

--- a/examples/defi/regulated-token/src/lib.rs
+++ b/examples/defi/regulated-token/src/lib.rs
@@ -129,7 +129,7 @@ blueprint! {
                 // With the resource flags all forever disabled and locked, our admin badges no longer have any use
                 // We will burn our internal badge, and the holders of the other badges may burn them at will
                 // It has the FREELY_BURNABLE flag, so there's no need to provide a burning authority           
-                self.internal_authority.take_all().burn(None);
+                self.internal_authority.take_all().burn();
                 info!("Advanced to stage 3");
             }
 

--- a/examples/defi/synthetics/src/lib.rs
+++ b/examples/defi/synthetics/src/lib.rs
@@ -258,10 +258,10 @@ blueprint! {
             );
 
             self.synthetics_mint_badge.authorize(|auth| {
-                shares_to_burn.burn(Some(auth));
+                shares_to_burn.burn_with_auth(auth);
             });
             self.synthetics_mint_badge
-                .authorize(|auth| bucket.burn(Some(auth)));
+                .authorize(|auth| bucket.burn_with_auth(auth));
         }
 
         /// Returns the total global debt.

--- a/examples/nft/magic-card/src/lib.rs
+++ b/examples/nft/magic-card/src/lib.rs
@@ -177,7 +177,7 @@ blueprint! {
 
             // Burn the original cards
             self.random_card_mint_badge.authorize(|auth| {
-                nft_bucket.burn(Some(auth));
+                nft_bucket.burn_with_auth(auth);
             });
 
             // Mint a new one.

--- a/radix-engine/tests/bucket/src/bucket.rs
+++ b/radix-engine/tests/bucket/src/bucket.rs
@@ -58,7 +58,7 @@ blueprint! {
                 .flags(BURNABLE)
                 .badge(badge.resource_address(), MAY_BURN)
                 .initial_supply_fungible(5);
-            bucket.burn(Some(badge.present()));
+            bucket.burn_with_auth(badge.present());
             vec![badge]
         }
 
@@ -68,8 +68,8 @@ blueprint! {
                 .flags(FREELY_BURNABLE)
                 .initial_supply_fungible(5);
             let bucket2 = bucket1.take(2);
-            bucket1.burn(Some(badge.present()));
-            bucket2.burn(None);
+            bucket1.burn_with_auth(badge.present());
+            bucket2.burn();
             vec![badge]
         }
     }

--- a/radix-engine/tests/resource_def/src/resource_def.rs
+++ b/radix-engine/tests/resource_def/src/resource_def.rs
@@ -33,7 +33,7 @@ blueprint! {
         pub fn burn() -> Bucket {
             let (badge, resource_def) = Self::create_fungible();
             let bucket = resource_def.mint(1, badge.present());
-            resource_def.burn(bucket, Some(badge.present()));
+            resource_def.burn_with_auth(bucket, badge.present());
             badge
         }
 

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -88,8 +88,13 @@ impl Bucket {
     }
 
     /// Burns resource within this bucket.
-    pub fn burn(self, auth: Option<BucketRef>) {
-        self.resource_def().burn(self, auth);
+    pub fn burn(self) {
+        self.resource_def().burn(self);
+    }
+
+    /// Burns resource within this bucket.
+    pub fn burn_with_auth(self, auth: BucketRef) {
+        self.resource_def().burn_with_auth(self, auth);
     }
 
     /// Checks if this bucket is empty.

--- a/scrypto/src/resource/resource_def.rs
+++ b/scrypto/src/resource/resource_def.rs
@@ -90,10 +90,19 @@ impl ResourceDef {
     }
 
     /// Burns a bucket of resources.
-    pub fn burn(&self, bucket: Bucket, auth: Option<BucketRef>) {
+    pub fn burn(&self, bucket: Bucket) {
         let input = BurnResourceInput {
             bid: bucket.into(),
-            auth: auth.map(Into::into),
+            auth: None,
+        };
+        let _output: BurnResourceOutput = call_kernel(BURN_RESOURCE, input);
+    }
+
+    /// Burns a bucket of resources.
+    pub fn burn_with_auth(&self, bucket: Bucket, auth: BucketRef) {
+        let input = BurnResourceInput {
+            bid: bucket.into(),
+            auth: Some(auth.into()),
         };
         let _output: BurnResourceOutput = call_kernel(BURN_RESOURCE, input);
     }


### PR DESCRIPTION
Following https://github.com/radixdlt/radixdlt-scrypto/issues/65, we're replacing `ResourceDef::burn(bucket: Bucket, auth: Option<BucketRef>)` with two APIs:
* `ResourceDef::burn(bucket: Bucket)` - For resource with flag `FREELY_BURNABLE`
* `ResourceDef::burn_with_resource(bucket: Bucket, auth: BucketRef)` - For all resources