### PR TITLE
Macro to simplify Decimal creation

### DIFF
--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -133,11 +133,11 @@ impl From<bool> for Decimal {
 #[macro_export]
 macro_rules! dec {
     
-    ($x:expr) => {
+    ($x:literal) => {
        Decimal::from($x) 
     };
     
-    ($int:expr, $exponent:expr) => {
+    ($int:literal, $exponent:literal) => {
         if ($exponent) < 0 {
             Decimal(($int) * PRECISION)
                 .div(10i128.pow((-1i128 * ($exponent)) as u32))
@@ -537,12 +537,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dec_string_decimal_exp() {
-        assert_eq!(dec!("1.12345678901234567".to_string() + "8").to_string(), "1.123456789012345678");
-        assert_eq!(dec!("-".to_string() + "5.6").to_string(), "-5.6");
-    }
-
-    #[test]
     fn test_dec_string() {
         assert_eq!(dec!("1").to_string(), "1");
         assert_eq!(dec!("0").to_string(), "0");
@@ -555,21 +549,9 @@ mod tests {
     }
 
     #[test]
-    fn test_dec_int_expr() {
-        assert_eq!(dec!(1 + 2 - 2).to_string(), "1");
-        assert_eq!(dec!(5 * 3 / 3).to_string(), "5");
-    }
-
-    #[test]
     fn test_dec_bool() {
         assert_eq!((dec!(true)).to_string(), "1");
         assert_eq!((dec!(false)).to_string(), "0");
-    }
-
-    #[test]
-    fn test_dec_bool_expr() {
-        assert_eq!((dec!(if 4 < 5 {true} else {false})).to_string(), "1");
-        assert_eq!((dec!(if -2 > 3 {true} else {false})).to_string(), "0");
     }
 
     #[test]
@@ -585,12 +567,5 @@ mod tests {
             "112.000000000000000001");
     }
 
-    #[test]
-    fn test_dec_rational_expr() {
-        let a = 3;
-        assert_eq!((dec!(a + 2, 5)).to_string(), "500000");
-        assert_eq!((dec!(3 + 2, 5)).to_string(), "500000");
-        assert_eq!((dec!(100 + 12, 0 - 2)).to_string(), "1.12");
-        assert_eq!((dec!(a, a - 5)).to_string(), "0.03");
-    }
+
 }

--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -138,10 +138,12 @@ macro_rules! dec {
     };
     
     ($int:expr, $exponent:expr) => {
-        if (($exponent) / 1i128) < 0 {
-            Decimal(($int) * PRECISION).div(10f64.powf(-($exponent) as f64) as i128)
+        if ($exponent) < 0 {
+            Decimal(($int) * PRECISION)
+                .div(10i128.pow((-1i128 * ($exponent)) as u32))
         } else {
-            Decimal(($int) * PRECISION).mul(10f64.powf(($exponent) as f64) as i128)
+            Decimal(($int) * PRECISION)
+                .mul(10i128.pow((1i128 * ($exponent)) as u32))
         }
     };
 }

--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -138,12 +138,16 @@ macro_rules! dec {
     };
     
     ($int:literal, $exponent:literal) => {
-        if ($exponent) < 0 {
-            Decimal(($int) * PRECISION)
-                .div(10i128.pow((-1i128 * ($exponent)) as u32))
+        if u32::try_from((($exponent) as i128).abs()).is_err() {
+            panic!("Overflow of arg2.");
         } else {
-            Decimal(($int) * PRECISION)
-                .mul(10i128.pow((1i128 * ($exponent)) as u32))
+            if (($exponent) as i128) < 0 {
+                Decimal(($int) * PRECISION)
+                    .div(10i128.pow((-1i128 * ($exponent)) as u32))
+            } else {
+                Decimal(($int) * PRECISION)
+                    .mul(10i128.pow((1i128 * ($exponent)) as u32))
+            }
         }
     };
 }
@@ -566,6 +570,11 @@ mod tests {
         assert_eq!((dec!(112000000000000000001, -18)).to_string(),
             "112.000000000000000001");
     }
-
-
+    
+    #[test]
+    #[should_panic(expected = "Overflow of arg2.")]
+    fn test_arg1_overflow_arg1() {
+        //u32::MAX + 1
+        dec!(1, 4_294_967_296);
+    }
 }

--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -142,10 +142,10 @@ macro_rules! dec {
             panic!("Overflow of arg2.");
         } else {
             if (($exponent) as i128) < 0 {
-                Decimal(($int) * PRECISION)
+                Decimal::from(1i128 * ($int))
                     .div(10i128.pow((-1i128 * ($exponent)) as u32))
             } else {
-                Decimal(($int) * PRECISION)
+                Decimal::from(1i128 * ($int))
                     .mul(10i128.pow((1i128 * ($exponent)) as u32))
             }
         }


### PR DESCRIPTION
Created the dec! macro to simplify Decimal creation.
```rust
dec!(5).to_string() = "5"
dec!(1.23).to_string() = won't compile
dec!("1.23").to_string() = "1.23"
dec!(123, -2).to_string() = "1.23"
dec!(123, 2).to_string() = "12300"
dec!(170_141_183_460_469_231_732, 0) = won't compile
dec!(1, 4_294_967_296) = panic!("Overflow of arg2.")
```