### PR TITLE
Resolve bucket name in call args

### DIFF
--- a/radix-engine/src/model/mod.rs
+++ b/radix-engine/src/model/mod.rs
@@ -24,6 +24,6 @@ pub use package::Package;
 pub use receipt::Receipt;
 pub use resource_def::{ResourceDef, ResourceDefError};
 pub use transaction::{Instruction, Transaction};
-pub use validated_data::ValidatedData;
+pub use validated_data::*;
 pub use validated_transaction::{ValidatedInstruction, ValidatedTransaction};
 pub use vault::{Vault, VaultError};

--- a/transaction-manifest/src/decompiler.rs
+++ b/transaction-manifest/src/decompiler.rs
@@ -120,7 +120,8 @@ pub fn decompile(tx: &Transaction) -> Result<String, DecompileError> {
                     id_validator
                         .move_resources(&validated_arg)
                         .map_err(DecompileError::IdValidatorError)?;
-                    buf.push_str(&format!(" {}", validated_arg,));
+                    buf.push(' ');
+                    buf.push_str(&format_value(&validated_arg.dom, &buckets, &bucket_refs));
                 }
                 buf.push_str(";\n");
             }
@@ -139,7 +140,8 @@ pub fn decompile(tx: &Transaction) -> Result<String, DecompileError> {
                     id_validator
                         .move_resources(&validated_arg)
                         .map_err(DecompileError::IdValidatorError)?;
-                    buf.push_str(&format!(" {}", validated_arg,));
+                    buf.push(' ');
+                    buf.push_str(&format_value(&validated_arg.dom, &buckets, &bucket_refs));
                 }
                 buf.push_str(";\n");
             }


### PR DESCRIPTION
Command:
```shell
resim call-method 02045ae9a11a80df853143b94868672b2ad7e26753e5bdc0b9a9b9 buy_gumball 1,030000000000000000000000000000000000000000000000000004 --manifest out.rtm
```

Before:
```rust
CLONE_BUCKET_REF BucketRef(1u32) BucketRef("badge1");
CALL_METHOD Address("0293c502780e23621475989d707cd8128e4506362e5fed6ac0c00a") "withdraw" Decimal("1") Address("030000000000000000000000000000000000000000000000000004") BucketRef(512u32);
TAKE_FROM_WORKTOP Decimal("1") Address("030000000000000000000000000000000000000000000000000004") Bucket("bucket1");
CALL_METHOD Address("02045ae9a11a80df853143b94868672b2ad7e26753e5bdc0b9a9b9") "buy_gumball" Bucket(513u32);
CALL_METHOD_WITH_ALL_RESOURCES Address("0293c502780e23621475989d707cd8128e4506362e5fed6ac0c00a") "deposit_batch";
```

After:
```rust
CLONE_BUCKET_REF BucketRef(1u32) BucketRef("badge1");
CALL_METHOD Address("0293c502780e23621475989d707cd8128e4506362e5fed6ac0c00a") "withdraw" Decimal("1") Address("030000000000000000000000000000000000000000000000000004") BucketRef("badge1");
TAKE_FROM_WORKTOP Decimal("1") Address("030000000000000000000000000000000000000000000000000004") Bucket("bucket1");
CALL_METHOD Address("02045ae9a11a80df853143b94868672b2ad7e26753e5bdc0b9a9b9") "buy_gumball" Bucket("bucket1");
CALL_METHOD_WITH_ALL_RESOURCES Address("0293c502780e23621475989d707cd8128e4506362e5fed6ac0c00a") "deposit_batch";
```