### PR TITLE
Fix an issue with scrypto new-package

### DIFF
--- a/simulator/src/scrypto/cmd_new_package.rs
+++ b/simulator/src/scrypto/cmd_new_package.rs
@@ -50,7 +50,7 @@ impl NewPackage {
             Err(Error::PackageAlreadyExists)
         } else {
             fs::create_dir_all(child_of(&path, "src")).map_err(Error::IOError)?;
-            fs::create_dir_all(child_of(&path, "test")).map_err(Error::IOError)?;
+            fs::create_dir_all(child_of(&path, "tests")).map_err(Error::IOError)?;
 
             fs::write(
                 child_of(&path, "Cargo.toml"),
@@ -69,7 +69,7 @@ impl NewPackage {
             .map_err(Error::IOError)?;
 
             fs::write(
-                child_of(&child_of(&path, "test"), "lib.rs"),
+                child_of(&child_of(&path, "tests"), "lib.rs"),
                 include_str!("../../../assets/template/tests/lib.rs")
                     .replace("${lib_name}", &lib_name),
             )


### PR DESCRIPTION
The tests folder was incorrectly named after recent refactoring. This caused `scrypto test` not running any test.