### PR TITLE
Add support for taking non-fungibles from worktop

### DIFF
--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -16,6 +16,7 @@ use wasmi::*;
 use crate::engine::*;
 use crate::ledger::*;
 use crate::model::*;
+use crate::transaction::*;
 
 macro_rules! re_trace {
     ($proc:expr, $($args: expr),+) => {
@@ -126,33 +127,31 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
     }
 
     // (Transaction ONLY) Takes resource from worktop and returns a bucket.
-    pub fn take_from_worktop(
-        &mut self,
-        amount: Option<Decimal>,
-        resource_address: Address,
-    ) -> Result<ValidatedData, RuntimeError> {
+    pub fn take_from_worktop(&mut self, resource: Resource) -> Result<ValidatedData, RuntimeError> {
         re_debug!(
             self,
-            "(Transaction) Taking from worktop: amount = {:?}, resource_address = {:?}",
-            amount,
-            resource_address
+            "(Transaction) Taking from worktop: resource = {:?}",
+            resource
         );
 
+        let resource_address = resource.resource_address();
         let new_bid = self
             .id_allocator
             .new_bid()
             .map_err(RuntimeError::IdAllocatorError)?;
         let bucket = match self.worktop.remove(&resource_address) {
             Some(mut bucket) => {
-                if let Some(amount) = amount {
-                    let to_return = bucket.take(amount).map_err(RuntimeError::BucketError)?;
-                    if !bucket.amount().is_zero() {
-                        self.worktop.insert(resource_address, bucket);
-                    }
-                    Ok(to_return)
-                } else {
-                    Ok(bucket)
+                let to_return = match resource {
+                    Resource::Fungible { amount, .. } => bucket.take(amount),
+                    Resource::NonFungible { keys, .. } => bucket.take_non_fungibles(&keys),
+                    Resource::All { .. } => bucket.take(bucket.amount()),
                 }
+                .map_err(RuntimeError::BucketError)?;
+
+                if !bucket.amount().is_zero() {
+                    self.worktop.insert(resource_address, bucket);
+                }
+                Ok(to_return)
             }
             None => Err(RuntimeError::BucketError(BucketError::InsufficientBalance)),
         }?;

--- a/radix-engine/src/model/transaction.rs
+++ b/radix-engine/src/model/transaction.rs
@@ -1,4 +1,5 @@
 use sbor::*;
+use scrypto::rust::collections::BTreeSet;
 use scrypto::rust::string::String;
 use scrypto::rust::vec::Vec;
 use scrypto::types::*;
@@ -20,6 +21,12 @@ pub enum Instruction {
 
     /// Takes all of a given resource from worktop.
     TakeAllFromWorktop { resource_address: Address },
+
+    /// Takes non-fungibles from worktop.
+    TakeNonFungiblesFromWorktop {
+        keys: BTreeSet<NonFungibleKey>,
+        resource_address: Address,
+    },
 
     /// Returns resource to worktop.
     ReturnToWorktop { bid: Bid },

--- a/radix-engine/src/model/validated_transaction.rs
+++ b/radix-engine/src/model/validated_transaction.rs
@@ -1,3 +1,4 @@
+use scrypto::rust::collections::BTreeSet;
 use scrypto::rust::string::String;
 use scrypto::rust::vec::Vec;
 use scrypto::types::*;
@@ -17,6 +18,10 @@ pub enum ValidatedInstruction {
         resource_address: Address,
     },
     TakeAllFromWorktop {
+        resource_address: Address,
+    },
+    TakeNonFungiblesFromWorktop {
+        keys: BTreeSet<NonFungibleKey>,
         resource_address: Address,
     },
     ReturnToWorktop {

--- a/radix-engine/src/transaction/executor.rs
+++ b/radix-engine/src/transaction/executor.rs
@@ -150,10 +150,20 @@ impl<'l, L: SubstateStore> TransactionExecutor<'l, L> {
                 ValidatedInstruction::TakeFromWorktop {
                     amount,
                     resource_address,
-                } => proc.take_from_worktop(Some(amount), resource_address),
+                } => proc.take_from_worktop(Resource::Fungible {
+                    amount,
+                    resource_address,
+                }),
                 ValidatedInstruction::TakeAllFromWorktop { resource_address } => {
-                    proc.take_from_worktop(None, resource_address)
+                    proc.take_from_worktop(Resource::All { resource_address })
                 }
+                ValidatedInstruction::TakeNonFungiblesFromWorktop {
+                    keys,
+                    resource_address,
+                } => proc.take_from_worktop(Resource::NonFungible {
+                    keys,
+                    resource_address,
+                }),
                 ValidatedInstruction::ReturnToWorktop { bid } => proc.return_to_worktop(bid),
                 ValidatedInstruction::AssertWorktopContains {
                     amount,

--- a/radix-engine/src/transaction/validator.rs
+++ b/radix-engine/src/transaction/validator.rs
@@ -32,6 +32,18 @@ pub fn validate_transaction(
                     .map_err(TransactionValidationError::IdValidatorError)?;
                 instructions.push(ValidatedInstruction::TakeAllFromWorktop { resource_address });
             }
+            Instruction::TakeNonFungiblesFromWorktop {
+                keys,
+                resource_address,
+            } => {
+                id_validator
+                    .new_bucket()
+                    .map_err(TransactionValidationError::IdValidatorError)?;
+                instructions.push(ValidatedInstruction::TakeNonFungiblesFromWorktop {
+                    keys,
+                    resource_address,
+                });
+            }
             Instruction::ReturnToWorktop { bid } => {
                 id_validator
                     .drop_bucket(bid)

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -121,7 +121,7 @@ fn account_to_bucket_to_account() {
     let amount = fungible_amount();
     let transaction = TransactionBuilder::new(&executor)
         .withdraw_from_account(&amount, account)
-        .take_from_worktop(amount.amount(), RADIX_TOKEN, |builder, bid| {
+        .take_from_worktop(&amount, |builder, bid| {
             builder
                 .add_instruction(Instruction::CallMethod {
                     component_address: account,

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -138,27 +138,30 @@ impl Bucket {
             .collect()
     }
 
-    /// Get all non-fungible IDs in this bucket.
+    /// Returns the key of a singleton non-fungible.
+    ///
+    /// # Panic
+    /// If this bucket is empty or contains more than one non-fungibles.
+    pub fn get_non_fungible_key(&self) -> NonFungibleKey {
+        let keys = self.get_non_fungible_keys();
+        assert!(
+            keys.len() == 1,
+            "1 non-fungible expected, but {} found",
+            keys.len()
+        );
+        keys[0].clone()
+    }
+
+    /// Returns the keys of all non-fungibles in this bucket.
     ///
     /// # Panics
-    /// Panics if this is not a non-fungible bucket.
+    /// If this bucket is not a non-fungible bucket.
     pub fn get_non_fungible_keys(&self) -> Vec<NonFungibleKey> {
         let input = GetNonFungibleKeysInBucketInput { bid: self.bid };
         let output: GetNonFungibleKeysInBucketOutput =
             call_engine(GET_NON_FUNGIBLE_KEYS_IN_BUCKET, input);
 
         output.keys
-    }
-
-    /// Get the non-fungible id and panic if not singleton.
-    pub fn get_non_fungible_key(&self) -> NonFungibleKey {
-        let keys = self.get_non_fungible_keys();
-        assert!(
-            keys.len() == 1,
-            "Expect 1 non-fungible, but found {}",
-            keys.len()
-        );
-        keys[0].clone()
     }
 
     /// Returns the data of a non-fungible unit, both the immutable and mutable parts.

--- a/scrypto/src/resource/bucket_ref.rs
+++ b/scrypto/src/resource/bucket_ref.rs
@@ -81,24 +81,30 @@ impl BucketRef {
         self.resource_def().address()
     }
 
-    /// Get the non-fungible ids in the referenced bucket.
+    /// Returns the key of a singleton non-fungible.
+    ///
+    /// # Panic
+    /// If the bucket is empty or contains more than one non-fungibles.
+    pub fn get_non_fungible_key(&self) -> NonFungibleKey {
+        let keys = self.get_non_fungible_keys();
+        assert!(
+            keys.len() == 1,
+            "1 non-fungible expected, but {} found",
+            keys.len()
+        );
+        keys[0].clone()
+    }
+
+    /// Returns the keys of all non-fungibles in this bucket.
+    ///
+    /// # Panics
+    /// If the bucket is not a non-fungible bucket.
     pub fn get_non_fungible_keys(&self) -> Vec<NonFungibleKey> {
         let input = GetNonFungibleKeysInBucketRefInput { rid: self.rid };
         let output: GetNonFungibleKeysInBucketRefOutput =
             call_engine(GET_NON_FUNGIBLE_KEYS_IN_BUCKET_REF, input);
 
         output.keys
-    }
-
-    /// Get the non-fungible id and panic if not singleton.
-    pub fn get_non_fungible_key(&self) -> NonFungibleKey {
-        let keys = self.get_non_fungible_keys();
-        assert!(
-            keys.len() == 1,
-            "Expect 1 non-fungible, but found {}",
-            keys.len()
-        );
-        keys[0].clone()
     }
 
     /// Destroys this reference.

--- a/scrypto/src/resource/vault.rs
+++ b/scrypto/src/resource/vault.rs
@@ -219,7 +219,10 @@ impl Vault {
         output.keys
     }
 
-    /// Get the non-fungible id and panic if not singleton.
+    /// Returns the key of a singleton non-fungible.
+    ///
+    /// # Panic
+    /// If this vault is empty or contains more than one non-fungibles.
     pub fn get_non_fungible_key(&self) -> NonFungibleKey {
         let keys = self.get_non_fungible_keys();
         assert!(

--- a/scrypto/src/types/non_fungible_key.rs
+++ b/scrypto/src/types/non_fungible_key.rs
@@ -49,7 +49,7 @@ impl TypeId for NonFungibleKey {
 
 impl Display for NonFungibleKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x?}", self.0)
+        write!(f, "{}", hex::encode(&self.0))
     }
 }
 

--- a/transaction-manifest/examples/call.rtm
+++ b/transaction-manifest/examples/call.rtm
@@ -12,4 +12,6 @@ DROP_BUCKET_REF  BucketRef("badge2");
 DROP_BUCKET_REF  BucketRef("badge1");
 RETURN_TO_WORKTOP  Bucket("remaining_xrd");
 
+TAKE_NON_FUNGIBLES_FROM_WORKTOP TreeSet<NonFungibleKey>(NonFungibleKey("11"), NonFungibleKey("22")) Address("030000000000000000000000000000000000000000000000000004")  Bucket("nfts");
+
 CALL_METHOD_WITH_ALL_RESOURCES  Address("02d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de")  "deposit_batch";

--- a/transaction-manifest/src/ast.rs
+++ b/transaction-manifest/src/ast.rs
@@ -16,6 +16,12 @@ pub enum Instruction {
         new_bucket: Value,
     },
 
+    TakeNonFungiblesFromWorktop {
+        keys: Value,
+        resource_address: Value,
+        new_bucket: Value,
+    },
+
     ReturnToWorktop {
         bucket: Value,
     },

--- a/transaction-manifest/src/lexer.rs
+++ b/transaction-manifest/src/lexer.rs
@@ -79,6 +79,7 @@ pub enum TokenKind {
     /* Instructions */
     TakeFromWorktop,
     TakeAllFromWorktop,
+    TakeNonFungiblesFromWorktop,
     ReturnToWorktop,
     AssertWorktopContains,
     CreateBucketRef,
@@ -386,6 +387,7 @@ impl Lexer {
 
             "TAKE_FROM_WORKTOP" => Ok(TokenKind::TakeFromWorktop),
             "TAKE_ALL_FROM_WORKTOP" => Ok(TokenKind::TakeAllFromWorktop),
+            "TAKE_NON_FUNGIBLES_FROM_WORKTOP" => Ok(TokenKind::TakeNonFungiblesFromWorktop),
             "RETURN_TO_WORKTOP" => Ok(TokenKind::ReturnToWorktop),
             "ASSERT_WORKTOP_CONTAINS" => Ok(TokenKind::AssertWorktopContains),
             "CREATE_BUCKET_REF" => Ok(TokenKind::CreateBucketRef),

--- a/transaction-manifest/src/parser.rs
+++ b/transaction-manifest/src/parser.rs
@@ -76,6 +76,11 @@ impl Parser {
                 resource_address: self.parse_value()?,
                 new_bucket: self.parse_value()?,
             },
+            TokenKind::TakeNonFungiblesFromWorktop => Instruction::TakeNonFungiblesFromWorktop {
+                keys: self.parse_value()?,
+                resource_address: self.parse_value()?,
+                new_bucket: self.parse_value()?,
+            },
             TokenKind::ReturnToWorktop => Instruction::ReturnToWorktop {
                 bucket: self.parse_value()?,
             },


### PR DESCRIPTION
This PR introduces a  new instruction `TAKE_NON_FUNGIBLES_FROM_WORKTOP` to support taking non-fungibles from worktop.