### PR TITLE
Externalise dec and bdec macros

### DIFF
--- a/scrypto-tests/tests/math.rs
+++ b/scrypto-tests/tests/math.rs
@@ -1,0 +1,19 @@
+use scrypto::prelude::*;
+
+blueprint! {
+    struct TestDecimal {
+    }
+
+    impl TestDecimal {
+        pub fn test_dec_macro() -> Decimal {
+            dec!(1) + dec!("2") - dec!("3.5") * dec!(5, 6) / dec!("7", -8)
+        }
+
+        pub fn test_bdec_macro() -> BigDecimal {
+            bdec!(1) + bdec!("2") - bdec!("3.5") * bdec!(5, 6) / bdec!("7", -8)
+        }
+    }
+}
+
+#[test]
+fn it_compiles() {}

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -164,3 +164,7 @@ macro_rules! include_code {
         ))
     };
 }
+
+// This is to make derives work within this crate.
+// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+extern crate self as scrypto;

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -5,7 +5,8 @@ pub use crate::resource::*;
 pub use crate::types::*;
 pub use crate::utils::*;
 pub use crate::{
-    args, auth, blueprint, debug, error, import, include_code, info, trace, warn, NonFungibleData,
+    args, auth, bdec, blueprint, debug, dec, error, import, include_code, info, trace, warn,
+    NonFungibleData,
 };
 
 pub use crate::rust::borrow::ToOwned;

--- a/scrypto/src/types/big_decimal.rs
+++ b/scrypto/src/types/big_decimal.rs
@@ -140,9 +140,9 @@ macro_rules! bdec {
         {
             let base = ::scrypto::types::BigDecimal::from($base);
             if $shift >= 0 {
-                base * 10i128.pow(u32::try_from($shift).unwrap())
+                base * 10i128.pow(u32::try_from($shift).expect("Shift overflow"))
             } else {
-                base / 10i128.pow(u32::try_from(-$shift).unwrap())
+                base / 10i128.pow(u32::try_from(-$shift).expect("Shift overflow"))
             }
         }
     };
@@ -677,5 +677,12 @@ mod tests {
             (bdec!(112000000000000000001i128, -18)).to_string(),
             "112.000000000000000001"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "Shift overflow")]
+    fn test_overflow() {
+        // u32::MAX + 1
+        bdec!(1, 4_294_967_296i128); // use explicit type to defer error to runtime
     }
 }

--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -133,17 +133,18 @@ impl From<bool> for Decimal {
 #[macro_export]
 macro_rules! dec {
     ($x:literal) => {
-        Decimal::from($x)
+        ::scrypto::types::Decimal::from($x)
     };
 
-    ($int:literal, $exponent:literal) => {
-        if u32::try_from((($exponent) as i128).abs()).is_err() {
-            panic!("Overflow of arg2.");
-        } else {
-            if (($exponent) as i128) < 0 {
-                Decimal::from(1i128 * ($int)).div(10i128.pow((-1i128 * ($exponent)) as u32))
+    ($base:literal, $shift:literal) => {
+        // Base can be any type that converts into a Decimal, and shift must support
+        // comparison and `-` unary operation, enforced by rustc.
+        {
+            let base = ::scrypto::types::Decimal::from($base);
+            if $shift >= 0 {
+                base * 10i128.pow(u32::try_from($shift).unwrap())
             } else {
-                Decimal::from(1i128 * ($int)).mul(10i128.pow((1i128 * ($exponent)) as u32))
+                base / 10i128.pow(u32::try_from(-$shift).unwrap())
             }
         }
     };
@@ -565,20 +566,13 @@ mod tests {
         assert_eq!((dec!(11235, 2)).to_string(), "1123500");
 
         assert_eq!(
-            (dec!(112000000000000000001, -18)).to_string(),
+            (dec!(112000000000000000001i128, -18)).to_string(),
             "112.000000000000000001"
         );
 
         assert_eq!(
-            (dec!(112000000000000000001, -18)).to_string(),
+            (dec!(112000000000000000001i128, -18)).to_string(),
             "112.000000000000000001"
         );
-    }
-
-    #[test]
-    #[should_panic(expected = "Overflow of arg2.")]
-    fn test_arg1_overflow_arg1() {
-        //u32::MAX + 1
-        dec!(1, 4_294_967_296);
     }
 }

--- a/scrypto/src/types/decimal.rs
+++ b/scrypto/src/types/decimal.rs
@@ -142,9 +142,9 @@ macro_rules! dec {
         {
             let base = ::scrypto::types::Decimal::from($base);
             if $shift >= 0 {
-                base * 10i128.pow(u32::try_from($shift).unwrap())
+                base * 10i128.pow(u32::try_from($shift).expect("Shift overflow"))
             } else {
-                base / 10i128.pow(u32::try_from(-$shift).unwrap())
+                base / 10i128.pow(u32::try_from(-$shift).expect("Shift overflow"))
             }
         }
     };
@@ -574,5 +574,12 @@ mod tests {
             (dec!(112000000000000000001i128, -18)).to_string(),
             "112.000000000000000001"
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "Shift overflow")]
+    fn test_overflow() {
+        // u32::MAX + 1
+        dec!(1, 4_294_967_296i128); // use explicit type to defer error to runtime
     }
 }


### PR DESCRIPTION
This is to make `dec!` and `bdec!` work both inside the crate and outside.