### PR TITLE
Refactor read of return value

### DIFF
--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -12,6 +12,9 @@ lru = { version = "0.7" }
 bencher = { version = "0.1.5" }
 hex = { version = "0.4", default-features = false }
 
+[dev-dependencies]
+wabt = { version = "0.10.0" }
+
 [[bench]]
 name = "bench"
 harness = false

--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -1235,8 +1235,7 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
             return Err(RuntimeError::MemoryAccessError);
         }
 
-        ValidatedData::from_slice(&buffer[range])
-            .map_err(RuntimeError::DataValidationError)
+        ValidatedData::from_slice(&buffer[range]).map_err(RuntimeError::DataValidationError)
     }
 
     /// Handles a system call.

--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -1229,8 +1229,13 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
             .ok_or(RuntimeError::MemoryAccessError)?;
         let range = start as usize..end as usize;
         let direct = wasm_process.vm.memory.direct_access();
+        let buffer = direct.as_ref();
 
-        ValidatedData::from_slice(&direct.as_ref()[range])
+        if end > buffer.len().try_into().unwrap() {
+            return Err(RuntimeError::MemoryAccessError);
+        }
+
+        ValidatedData::from_slice(&buffer[range])
             .map_err(RuntimeError::DataValidationError)
     }
 

--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -775,8 +775,7 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
         // move resource based on return data
         let output = match rtn {
             RuntimeValue::I32(ptr) => {
-                let data = ValidatedData::from_slice(&self.read_bytes(ptr)?)
-                    .map_err(RuntimeError::DataValidationError)?;
+                let data = self.read_return_value(ptr as u32)?;
                 self.process_return_data(&data)?;
                 data
             }
@@ -1215,36 +1214,24 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
         Err(RuntimeError::MemoryAllocError)
     }
 
-    /// Read a byte array from wasm instance.
-    fn read_bytes(&mut self, ptr: i32) -> Result<Vec<u8>, RuntimeError> {
+    fn read_return_value(&mut self, ptr: u32) -> Result<ValidatedData, RuntimeError> {
         let wasm_process = self.wasm_process_state.as_ref().unwrap();
         // read length
         let len: u32 = wasm_process
             .vm
             .memory
-            .get_value(ptr as u32)
+            .get_value(ptr)
             .map_err(|_| RuntimeError::MemoryAccessError)?;
 
-        // SECURITY: meter before allocating memory
-        let mut data = vec![0u8; len as usize];
-        wasm_process
-            .vm
-            .memory
-            .get_into((ptr + 4) as u32, &mut data)
-            .map_err(|_| RuntimeError::MemoryAccessError)?;
+        let start = ptr.checked_add(4).ok_or(RuntimeError::MemoryAccessError)?;
+        let end = start
+            .checked_add(len)
+            .ok_or(RuntimeError::MemoryAccessError)?;
+        let range = start as usize..end as usize;
+        let direct = wasm_process.vm.memory.direct_access();
 
-        // free the buffer
-        wasm_process
-            .vm
-            .module
-            .invoke_export(
-                "scrypto_free",
-                &[RuntimeValue::I32(ptr as i32)],
-                &mut NopExternals,
-            )
-            .map_err(|_| RuntimeError::MemoryAccessError)?;
-
-        Ok(data.to_vec())
+        ValidatedData::from_slice(&direct.as_ref()[range])
+            .map_err(RuntimeError::DataValidationError)
     }
 
     /// Handles a system call.

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -3,9 +3,7 @@ pub mod test_runner;
 
 use crate::test_runner::TestRunner;
 use radix_engine::errors::RuntimeError;
-use radix_engine::ledger::{InMemorySubstateStore, SubstateStore};
-use radix_engine::model::{Component, HardProofRule, MethodAuthorization};
-use radix_engine::transaction::*;
+use radix_engine::ledger::InMemorySubstateStore;
 use scrypto::prelude::*;
 
 #[test]

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -1,0 +1,60 @@
+#[rustfmt::skip]
+pub mod test_runner;
+
+use crate::test_runner::TestRunner;
+use radix_engine::errors::WasmValidationError::NoValidMemoryExport;
+use radix_engine::errors::RuntimeError;
+use radix_engine::ledger::InMemorySubstateStore;
+use scrypto::prelude::*;
+
+#[test]
+fn missing_memory_should_cause_error() {
+    // Arrange
+    let mut substate_store = InMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(&mut substate_store);
+
+    // Act
+    let code: Vec<u8> = wabt::wat2wasm(
+        r#"
+            (module
+                (func (export "test") (result i32)
+                    i32.const 1337
+                )
+            )
+            "#,
+    )
+    .expect("failed to parse wat");
+    let transaction = test_runner
+        .new_transaction_builder()
+        .publish_package(&code)
+        .build(vec![])
+        .unwrap();
+    let receipt = test_runner.run(transaction);
+
+    // Assert
+    let error = receipt.result.expect_err("Should be error.");
+    assert_eq!(
+        error,
+        RuntimeError::WasmValidationError(NoValidMemoryExport)
+    );
+}
+
+#[test]
+fn large_len_return_should_cause_memory_access_error() {
+    // Arrange
+    let mut substate_store = InMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(&mut substate_store);
+    let package = test_runner.publish_package("package");
+
+    // Act
+    let transaction = test_runner
+        .new_transaction_builder()
+        .call_function(package, "Package", "something", vec![])
+        .build(vec![])
+        .unwrap();
+    let receipt = test_runner.run(transaction);
+
+    // Assert
+    let error = receipt.result.expect_err("Should be an error.");
+    assert_eq!(error, RuntimeError::MemoryAccessError);
+}

--- a/radix-engine/tests/package/Cargo.toml
+++ b/radix-engine/tests/package/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "package"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sbor = { path = "../../../sbor" }
+scrypto = { path = "../../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../../radix-engine" }
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/radix-engine/tests/package/src/lib.rs
+++ b/radix-engine/tests/package/src/lib.rs
@@ -1,0 +1,8 @@
+static mut MAX: [u8; 4] = (u32::MAX / 2).to_le_bytes();
+
+#[no_mangle]
+pub extern "C" fn Package_main() -> *mut u8 {
+    unsafe {
+        MAX.as_mut_ptr()
+    }
+}

--- a/radix-engine/tests/package/src/lib.rs
+++ b/radix-engine/tests/package/src/lib.rs
@@ -1,8 +1,18 @@
-static mut MAX: [u8; 4] = (u32::MAX / 2).to_le_bytes();
+static mut LARGE: [u8; 4] = (u32::MAX / 2).to_le_bytes();
+static mut MAX: [u8; 4] = u32::MAX.to_le_bytes();
+static mut ZERO: [u8; 4] = [0, 0, 0, 0];
 
 #[no_mangle]
-pub extern "C" fn Package_main() -> *mut u8 {
-    unsafe {
-        MAX.as_mut_ptr()
-    }
+pub extern "C" fn LargeReturnSize_main() -> *mut u8 {
+    unsafe { LARGE.as_mut_ptr() }
+}
+
+#[no_mangle]
+pub extern "C" fn MaxReturnSize_main() -> *mut u8 {
+    unsafe { MAX.as_mut_ptr() }
+}
+
+#[no_mangle]
+pub extern "C" fn ZeroReturnSize_main() -> *mut u8 {
+    unsafe { ZERO.as_mut_ptr() }
 }


### PR DESCRIPTION
Cleaned up processing of return value:
* Removed call to `scrypto_free` which is unnecessary since process will get garbage collected.
* Removed memcopy of returned value and instead process the value directly from the buffer.