### PR TITLE
Use snake case for JSON property names

### DIFF
--- a/assets/account/src/lib.rs
+++ b/assets/account/src/lib.rs
@@ -17,10 +17,7 @@ blueprint! {
                 .method("deposit_batch", auth!(allow_all))
                 .default(withdraw_rule);
 
-            Self { vaults }
-                .instantiate()
-                .auth(auth)
-                .globalize()
+            Self { vaults }.instantiate().auth(auth).globalize()
         }
 
         pub fn new(withdraw_rule: MethodAuth) -> ComponentAddress {

--- a/assets/system/src/lib.rs
+++ b/assets/system/src/lib.rs
@@ -23,10 +23,7 @@ blueprint! {
         }
 
         /// Mints fungible resource. TODO: Remove
-        pub fn mint(
-            amount: Decimal,
-            resource_address: ResourceAddress
-        ) -> Bucket {
+        pub fn mint(amount: Decimal, resource_address: ResourceAddress) -> Bucket {
             resource_manager!(resource_address).mint(amount)
         }
 

--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -936,9 +936,7 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
                     }
                 }
             }
-            SNodeRef::ResourceStatic => {
-                Ok((SNodeState::ResourceStatic, vec![]))
-            }
+            SNodeRef::ResourceStatic => Ok((SNodeState::ResourceStatic, vec![])),
             SNodeRef::Resource(resource_address) => {
                 let resource_manager: ResourceManager = self
                     .track
@@ -969,7 +967,10 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
                     .get_resource_manager(&resource_address)
                     .unwrap()
                     .get_auth(&function);
-                Ok((SNodeState::Vault(vault_id.clone()), vec![method_auth.clone()]))
+                Ok((
+                    SNodeState::Vault(vault_id.clone()),
+                    vec![method_auth.clone()],
+                ))
             }
         }?;
 
@@ -977,7 +978,7 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
         if !method_auths.is_empty() {
             let proofs_vector = match &snode {
                 // Same process auth check
-                SNodeState::Resource(_,_) | SNodeState::Vault(_) | SNodeState::Bucket(_) => {
+                SNodeState::Resource(_, _) | SNodeState::Vault(_) | SNodeState::Bucket(_) => {
                     vec![self.caller_auth_zone, &self.auth_zone]
                 }
                 // Extern call auth check

--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -317,10 +317,11 @@ impl<'s, S: SubstateStore> Track<'s, S> {
         non_fungible_address: NonFungibleAddress,
         non_fungible: Option<NonFungible>,
     ) {
-        let cur: Option<(Option<NonFungible>, (Hash, u32))> = self.substate_store.get_decoded_child_substate(
-            &non_fungible_address.resource_address(),
-            &non_fungible_address.non_fungible_id(),
-        );
+        let cur: Option<(Option<NonFungible>, (Hash, u32))> =
+            self.substate_store.get_decoded_child_substate(
+                &non_fungible_address.resource_address(),
+                &non_fungible_address.non_fungible_id(),
+            );
         let prev_id = cur.map(|(_, cur_id)| cur_id);
 
         self.non_fungibles.insert(

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -7,8 +7,8 @@ use scrypto::engine::types::*;
 use scrypto::resource::ResourceMethod::TakeFromVault;
 use scrypto::rust::borrow::ToOwned;
 use scrypto::rust::collections::*;
-use scrypto::rust::vec::Vec;
 use scrypto::rust::vec;
+use scrypto::rust::vec::Vec;
 
 use crate::model::*;
 

--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -107,7 +107,10 @@ impl ResourceManager {
                 "non_fungible_exists".to_string(),
                 MethodAuthorization::AllowAll,
             );
-            authorization.insert("get_non_fungible".to_string(), MethodAuthorization::AllowAll);
+            authorization.insert(
+                "get_non_fungible".to_string(),
+                MethodAuthorization::AllowAll,
+            );
         }
 
         let resource_manager = Self {
@@ -235,10 +238,7 @@ impl ResourceManager {
             let mutable_data = Self::process_non_fungible_data(&data.1)?;
             let non_fungible = NonFungible::new(immutable_data.raw, mutable_data.raw);
 
-            system_api.set_non_fungible(
-                non_fungible_address,
-                Some(non_fungible),
-            );
+            system_api.set_non_fungible(non_fungible_address, Some(non_fungible));
             ids.insert(id);
         }
 

--- a/radix-engine/src/transaction/builder.rs
+++ b/radix-engine/src/transaction/builder.rs
@@ -531,61 +531,47 @@ impl TransactionBuilder {
     }
 
     /// Mints resource.
-    pub fn mint(
-        &mut self,
-        amount: Decimal,
-        resource_address: ResourceAddress,
-    ) -> &mut Self {
+    pub fn mint(&mut self, amount: Decimal, resource_address: ResourceAddress) -> &mut Self {
         self.add_instruction(Instruction::CallFunction {
             package_address: SYSTEM_PACKAGE,
             blueprint_name: "System".to_owned(),
             function: "mint".to_owned(),
-            args: vec![
-                scrypto_encode(&amount),
-                scrypto_encode(&resource_address),
-            ],
+            args: vec![scrypto_encode(&amount), scrypto_encode(&resource_address)],
         });
         self
     }
 
     /// Burns a resource.
-    pub fn burn(
-        &mut self,
-        amount: Decimal,
-        resource_address: ResourceAddress,
-    ) -> &mut Self {
+    pub fn burn(&mut self, amount: Decimal, resource_address: ResourceAddress) -> &mut Self {
         self.take_from_worktop_by_amount(amount, resource_address, |builder, bucket_id| {
             builder
                 .add_instruction(Instruction::CallFunction {
                     package_address: SYSTEM_PACKAGE,
                     blueprint_name: "System".to_owned(),
                     function: "burn".to_owned(),
-                    args: vec![
-                        scrypto_encode(&scrypto::resource::Bucket(bucket_id)),
-                    ],
+                    args: vec![scrypto_encode(&scrypto::resource::Bucket(bucket_id))],
                 })
                 .0
         })
     }
 
-    pub fn burn_non_fungible(
-        &mut self,
-        non_fungible_address: NonFungibleAddress,
-    ) -> &mut Self {
+    pub fn burn_non_fungible(&mut self, non_fungible_address: NonFungibleAddress) -> &mut Self {
         let mut ids = BTreeSet::new();
         ids.insert(non_fungible_address.non_fungible_id());
-        self.take_from_worktop_by_ids(&ids, non_fungible_address.resource_address(), |builder, bucket_id| {
-            builder
-                .add_instruction(Instruction::CallFunction {
-                    package_address: SYSTEM_PACKAGE,
-                    blueprint_name: "System".to_owned(),
-                    function: "burn".to_owned(),
-                    args: vec![
-                        scrypto_encode(&scrypto::resource::Bucket(bucket_id)),
-                    ],
-                })
-                .0
-        })
+        self.take_from_worktop_by_ids(
+            &ids,
+            non_fungible_address.resource_address(),
+            |builder, bucket_id| {
+                builder
+                    .add_instruction(Instruction::CallFunction {
+                        package_address: SYSTEM_PACKAGE,
+                        blueprint_name: "System".to_owned(),
+                        function: "burn".to_owned(),
+                        args: vec![scrypto_encode(&scrypto::resource::Bucket(bucket_id))],
+                    })
+                    .0
+            },
+        )
     }
 
     /// Creates an account.

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -15,8 +15,8 @@ fn cannot_make_cross_component_call_without_authorization() {
     let auth = test_runner.create_non_fungible_resource(account.clone());
     let auth_id = NonFungibleId::from_u32(1);
     let auth_address = NonFungibleAddress::new(auth, auth_id);
-    let authorization = Authorization::new()
-        .method("get_component_state", auth!(require(auth_address.clone())));
+    let authorization =
+        Authorization::new().method("get_component_state", auth!(require(auth_address.clone())));
 
     let package_address = test_runner.publish_package("component");
     let transaction = test_runner
@@ -73,8 +73,8 @@ fn can_make_cross_component_call_with_authorization() {
     let auth = test_runner.create_non_fungible_resource(account.clone());
     let auth_id = NonFungibleId::from_u32(1);
     let auth_address = NonFungibleAddress::new(auth, auth_id.clone());
-    let authorization = Authorization::new()
-        .method("get_component_state", auth!(require(auth_address.clone())));
+    let authorization =
+        Authorization::new().method("get_component_state", auth!(require(auth_address.clone())));
 
     let package_address = test_runner.publish_package("component");
     let transaction = test_runner

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -19,10 +19,7 @@ fn cannot_mint_with_wrong_auth() {
     let transaction = test_runner
         .new_transaction_builder()
         .create_proof_from_account_by_amount(Decimal::one(), random_resource_address, account)
-        .mint(
-            Decimal::from("1.0"),
-            token_resource_address,
-        )
+        .mint(Decimal::from("1.0"), token_resource_address)
         .call_method_with_all_resources(account, "deposit_batch")
         .build(test_runner.get_nonce([pk]))
         .sign([&sk]);
@@ -46,10 +43,7 @@ fn can_mint_with_right_auth() {
     let transaction = test_runner
         .new_transaction_builder()
         .create_proof_from_account_by_amount(Decimal::one(), auth_token_resource_address, account)
-        .mint(
-            Decimal::from("1.0"),
-            token_resource_address,
-        )
+        .mint(Decimal::from("1.0"), token_resource_address)
         .call_method_with_all_resources(account, "deposit_batch")
         .build(test_runner.get_nonce([pk]))
         .sign([&sk]);
@@ -72,10 +66,7 @@ fn cannot_burn_with_wrong_auth() {
         .new_transaction_builder()
         .withdraw_from_account_by_amount(Decimal::from(1), token_resource_address, account)
         .create_proof_from_account_by_amount(Decimal::from(1), token_resource_address, account)
-        .burn(
-            Decimal::one(),
-            token_resource_address,
-        )
+        .burn(Decimal::one(), token_resource_address)
         .call_method_with_all_resources(account, "deposit_batch")
         .build(test_runner.get_nonce([pk]))
         .sign([&sk]);
@@ -100,10 +91,7 @@ fn can_burn_with_auth() {
         .new_transaction_builder()
         .create_proof_from_account_by_amount(Decimal::one(), auth_token_resource_address, account)
         .withdraw_from_account_by_amount(Decimal::one(), token_resource_address, account)
-        .burn(
-            Decimal::one(),
-            token_resource_address,
-        )
+        .burn(Decimal::one(), token_resource_address)
         .call_method_with_all_resources(account, "deposit_batch")
         .build(test_runner.get_nonce([pk]))
         .sign([&sk]);

--- a/radix-engine/tests/component/src/auth_component.rs
+++ b/radix-engine/tests/component/src/auth_component.rs
@@ -12,7 +12,7 @@ blueprint! {
                 .auth(
                     Authorization::new()
                         .method("get_secret", auth!(require("some_non_fungible")))
-                        .default(auth!(allow_all))
+                        .default(auth!(allow_all)),
                 )
                 .globalize()
         }

--- a/radix-engine/tests/component/src/chess.rs
+++ b/radix-engine/tests/component/src/chess.rs
@@ -7,13 +7,9 @@ blueprint! {
 
     impl Chess {
         pub fn create_game(players: [NonFungibleAddress; 2]) -> ComponentAddress {
-            let auth = Authorization::new()
-                .method("make_move", auth!(require("players/0")));
+            let auth = Authorization::new().method("make_move", auth!(require("players/0")));
 
-            Self { players }
-                .instantiate()
-                .auth(auth)
-                .globalize()
+            Self { players }.instantiate().auth(auth).globalize()
         }
 
         pub fn make_move(&mut self) {

--- a/radix-engine/tests/component/src/cross_component.rs
+++ b/radix-engine/tests/component/src/cross_component.rs
@@ -7,9 +7,7 @@ blueprint! {
     }
 
     impl CrossComponent {
-        pub fn create_component_with_auth(
-            auth: Authorization,
-        ) -> ComponentAddress {
+        pub fn create_component_with_auth(auth: Authorization) -> ComponentAddress {
             Self {
                 secret: "Secret".to_owned(),
                 auth_vault: None,

--- a/radix-engine/tests/component/src/reentrant_component.rs
+++ b/radix-engine/tests/component/src/reentrant_component.rs
@@ -5,9 +5,7 @@ blueprint! {
 
     impl ReentrantComponent {
         pub fn new() -> ComponentAddress {
-            Self {}
-                .instantiate()
-                .globalize()
+            Self {}.instantiate().globalize()
         }
 
         pub fn func(&mut self) {}

--- a/radix-engine/tests/core/src/call.rs
+++ b/radix-engine/tests/core/src/call.rs
@@ -23,18 +23,14 @@ blueprint! {
 
         pub fn move_bucket() {
             let bucket = Self::create_test_token(1000);
-            let component_address = MoveTest { vaults: Vec::new() }
-                .instantiate()
-                .globalize();
+            let component_address = MoveTest { vaults: Vec::new() }.instantiate().globalize();
 
             Runtime::call_method(component_address, "receive_bucket", args!(bucket));
         }
 
         pub fn move_proof() -> Bucket {
             let bucket = Self::create_test_token(1000);
-            let component_address = MoveTest { vaults: Vec::new() }
-                .instantiate()
-                .globalize();
+            let component_address = MoveTest { vaults: Vec::new() }.instantiate().globalize();
 
             Runtime::call_method(
                 component_address,

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -53,7 +53,8 @@ fn can_burn_non_fungible() {
     let receipt = test_runner.validate_and_execute(&transaction);
     receipt.result.expect("Should be okay.");
     let resource_address = receipt.new_resource_addresses[0];
-    let non_fungible_address = NonFungibleAddress::new(resource_address, NonFungibleId::from_u32(0));
+    let non_fungible_address =
+        NonFungibleAddress::new(resource_address, NonFungibleId::from_u32(0));
     let mut ids = BTreeSet::new();
     ids.insert(NonFungibleId::from_u32(0));
 
@@ -62,7 +63,12 @@ fn can_burn_non_fungible() {
         .new_transaction_builder()
         .withdraw_from_account(resource_address, account)
         .burn_non_fungible(non_fungible_address.clone())
-        .call_function(package, "NonFungibleTest", "verify_does_not_exist", args![non_fungible_address])
+        .call_function(
+            package,
+            "NonFungibleTest",
+            "verify_does_not_exist",
+            args![non_fungible_address],
+        )
         .call_method_with_all_resources(account, "deposit_batch")
         .build(test_runner.get_nonce([pk]))
         .sign([&sk]);

--- a/sbor-tests/Cargo.toml
+++ b/sbor-tests/Cargo.toml
@@ -18,5 +18,5 @@ harness = false
 
 [features]
 default = ["std"]
-std = ["serde/std", "serde_json/std", "bincode_core/std", "sbor/std", "sbor/serde_std"]
-alloc = ["serde/alloc", "serde_json/alloc", "bincode_core/alloc", "sbor/alloc", "sbor/serde_alloc"]
+std = ["serde/std", "serde_json/std", "bincode_core/std", "sbor/std", "sbor/std", "sbor/serde"]
+alloc = ["serde/alloc", "serde_json/alloc", "bincode_core/alloc", "sbor/alloc", "sbor/alloc", "sbor/serde"]

--- a/sbor-tests/tests/any.rs
+++ b/sbor-tests/tests/any.rs
@@ -48,7 +48,7 @@ fn test_encode_as_json() {
                             "value": 2
                         },
                         {
-                            "elementTypeId": 7,
+                            "element_type_id": 7,
                             "elements": [
                                 {
                                     "type": "U8",

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -5,19 +5,18 @@ edition = "2021"
 
 [dependencies]
 sbor-derive = { path = "../sbor-derive" }
-hashbrown = { version = "0.11", optional = true } 
+hashbrown = { version = "0.12", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+hex = { version = "0.4.3", default-features = false, optional = true }
 
 [features]
 # You should enable either `std` or `alloc`
 default = ["std"]
-std = []
-alloc = ["hashbrown"]
+std = ["serde?/std", "hex?/std"]
+alloc = ["hashbrown", "serde?/alloc", "hex?/alloc"]
+
+# Enable serde derives for SBOR value and type models
+serde = ["serde/derive", "hex/serde"]
 
 # Enable tracing
 trace = ["sbor-derive/trace"]
-
-# Enable serde annotations by either `serde_std` or `serde_alloc`.
-# TODO: use weak depedency feature once it's stablized, https://github.com/rust-lang/cargo/issues/8832 
-serde_std = ["serde", "serde/std", "serde/derive"]
-serde_alloc = ["serde", "serde/alloc", "serde/derive"]

--- a/sbor/src/any.rs
+++ b/sbor/src/any.rs
@@ -8,7 +8,7 @@ use crate::type_id::*;
 
 /// Represents a SBOR value.
 #[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type") // For JSON readability, see https://serde.rs/enum-representations.html
 )]
@@ -64,10 +64,6 @@ pub enum Value {
         value: Box<Option<Value>>,
     },
     Array {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "elementTypeId")
-        )]
         element_type_id: u8,
         elements: Vec<Value>,
     },
@@ -79,61 +75,30 @@ pub enum Value {
     },
 
     Vec {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "elementTypeId")
-        )]
         element_type_id: u8,
         elements: Vec<Value>,
     },
     TreeSet {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "elementTypeId")
-        )]
         element_type_id: u8,
         elements: Vec<Value>,
     },
     TreeMap {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "keyTypeId")
-        )]
         key_type_id: u8,
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "valueTypeId")
-        )]
         value_type_id: u8,
         elements: Vec<Value>,
     },
     HashSet {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "elementTypeId")
-        )]
         element_type_id: u8,
         elements: Vec<Value>,
     },
     HashMap {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "keyTypeId")
-        )]
         key_type_id: u8,
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "valueTypeId")
-        )]
         value_type_id: u8,
         elements: Vec<Value>,
     },
     Custom {
-        #[cfg_attr(
-            any(feature = "serde_std", feature = "serde_alloc"),
-            serde(rename = "typeId")
-        )]
         type_id: u8,
+        #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
         bytes: Vec<u8>,
     },
 }

--- a/sbor/src/describe.rs
+++ b/sbor/src/describe.rs
@@ -1,6 +1,3 @@
-#[cfg(any(feature = "serde_std", feature = "serde_alloc"))]
-use serde::{Deserialize, Serialize};
-
 use crate::sbor::{Decode, Encode, TypeId};
 
 use crate::rust::boxed::Box;
@@ -11,8 +8,8 @@ use crate::rust::vec::Vec;
 
 /// Represents a SBOR type.
 #[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize),
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")  // For JSON readability, see https://serde.rs/enum-representations.html
 )]
 #[derive(Debug, Clone, PartialEq, Eq, TypeId, Decode, Encode)]
@@ -88,10 +85,7 @@ pub enum Type {
 }
 
 /// Represents the type info of an enum variant.
-#[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, TypeId, Decode, Encode)]
 pub struct Variant {
     pub name: String,
@@ -100,8 +94,8 @@ pub struct Variant {
 
 /// Represents the type info of struct fields.
 #[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize),
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")
 )]
 #[derive(Debug, Clone, PartialEq, Eq, TypeId, Decode, Encode)]

--- a/scrypto-abi/Cargo.toml
+++ b/scrypto-abi/Cargo.toml
@@ -10,10 +10,8 @@ serde = { version = "1.0", default-features = false, optional = true }
 [features]
 # You should enable either `std` or `alloc`
 default = ["std"]
-std = ["sbor/std"]
-alloc = ["sbor/alloc"]
+std = ["sbor/std", "serde?/std"]
+alloc = ["sbor/alloc", "serde?/alloc"]
 
-# Enable serde annotations by either `serde_std` or `serde_alloc`.
-# TODO: use weak depedency feature once it's stablized, https://github.com/rust-lang/cargo/issues/8832 
-serde_std = ["serde", "serde/std", "serde/derive", "sbor/serde_std"]
-serde_alloc = ["serde", "serde/alloc", "serde/derive", "sbor/serde_alloc"]
+# Enable serde derives
+serde = ["serde/derive", "sbor/serde"]

--- a/scrypto-abi/src/abi.rs
+++ b/scrypto-abi/src/abi.rs
@@ -5,17 +5,11 @@ pub use alloc::string::String;
 #[cfg(feature = "alloc")]
 pub use alloc::vec::Vec;
 
-#[cfg(any(feature = "serde_std", feature = "serde_alloc"))]
-use serde::{Deserialize, Serialize};
-
 use sbor::describe::*;
 use sbor::{Decode, Encode, TypeId};
 
 /// Represents a blueprint.
-#[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, TypeId, Encode, Decode)]
 pub struct Blueprint {
     pub package_address: String,
@@ -25,10 +19,7 @@ pub struct Blueprint {
 }
 
 /// Represents a function.
-#[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, TypeId, Encode, Decode)]
 pub struct Function {
     pub name: String,
@@ -37,10 +28,7 @@ pub struct Function {
 }
 
 /// Represents a method.
-#[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, TypeId, Encode, Decode)]
 pub struct Method {
     pub name: String,
@@ -50,10 +38,7 @@ pub struct Method {
 }
 
 /// Whether a method is going to change the component state.
-#[cfg_attr(
-    any(feature = "serde_std", feature = "serde_alloc"),
-    derive(Serialize, Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, TypeId, Encode, Decode)]
 pub enum Mutability {
     /// An immutable method requires an immutable reference to component state.

--- a/scrypto-derive/Cargo.toml
+++ b/scrypto-derive/Cargo.toml
@@ -30,13 +30,13 @@ scrypto-abi = { path = "../scrypto-abi", default-features = false }
 default = ["std"]
 std = [
     "serde/std", "serde_json/std", 
-    "sbor/std", "sbor/serde_std", 
-    "scrypto-abi/std", "scrypto-abi/serde_std"
+    "sbor/std", "sbor/serde", 
+    "scrypto-abi/std", "scrypto-abi/serde"
 ]
 alloc = [
     "serde/alloc", "serde_json/alloc", 
-    "sbor/alloc", "sbor/serde_alloc", 
-    "scrypto-abi/alloc", "scrypto-abi/serde_alloc"
+    "sbor/alloc", "sbor/serde", 
+    "scrypto-abi/alloc", "scrypto-abi/serde"
 ]
 
 trace = []

--- a/scrypto-tests/Cargo.toml
+++ b/scrypto-tests/Cargo.toml
@@ -11,5 +11,5 @@ serde_json = { version = "1.0", default-features = false }
 
 [features]
 default = ["std"]
-std = ["serde/std", "serde_json/std", "scrypto/std", "scrypto/serde_std", "sbor/std"]
-alloc = ["serde/alloc", "serde_json/alloc", "scrypto/alloc", "scrypto/serde_alloc", "sbor/alloc"]
+std = ["serde/std", "serde_json/std", "scrypto/std", "scrypto/serde", "sbor/std"]
+alloc = ["serde/alloc", "serde_json/alloc", "scrypto/alloc", "scrypto/serde", "sbor/alloc"]

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -10,8 +10,8 @@ p256 = { git = "https://github.com/radix-scrypto/elliptic-curves", branch = "fea
 hex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
-hashbrown = { version = "0.11", optional = true } 
-cargo_toml = { version = "0.10", optional = true }
+hashbrown = { version = "0.12", optional = true } 
+cargo_toml = { version = "0.11.5", optional = true }
 sbor = { path = "../sbor", default-features = false }
 scrypto-abi = { path = "../scrypto-abi", default-features = false }
 scrypto-derive = { path = "../scrypto-derive", default-features = false }
@@ -25,7 +25,5 @@ alloc = ["hashbrown", "hex/alloc", "sbor/alloc", "scrypto-abi/alloc", "scrypto-d
 # Turn on this feature to enable tracing.
 trace = ["scrypto-derive/trace"]
 
-# Enable serde annotations by either `serde_std` or `serde_alloc`.
-# TODO: use weak depedency feature once it's stablized, https://github.com/rust-lang/cargo/issues/8832 
-serde_std = ["sbor/serde_std", "scrypto-abi/serde_std"]
-serde_alloc = ["sbor/serde_alloc", "scrypto-abi/serde_alloc"]
+# Enable serde derives
+serde = ["sbor/serde", "scrypto-abi/serde"]

--- a/scrypto/src/component/system.rs
+++ b/scrypto/src/component/system.rs
@@ -3,8 +3,8 @@ use crate::component::*;
 use crate::engine::{api::*, call_engine};
 use crate::prelude::Authorization;
 use crate::rust::borrow::ToOwned;
-use crate::rust::vec::Vec;
 use crate::rust::collections::*;
+use crate::rust::vec::Vec;
 
 /// Represents the Radix Engine component subsystem.
 ///

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -7,10 +7,9 @@ pub use crate::math::*;
 pub use crate::misc::*;
 pub use crate::resource::*;
 pub use crate::{
-    args, auth, auth_and_or, auth_rule_node, blueprint, compile_package, component,
-    debug, dec, error, import, include_package, info, package,
-    resource_list, resource_manager, trace, warn, Decode, Describe, Encode, NonFungibleData,
-    TypeId,
+    args, auth, auth_and_or, auth_rule_node, blueprint, compile_package, component, debug, dec,
+    error, import, include_package, info, package, resource_list, resource_manager, trace, warn,
+    Decode, Describe, Encode, NonFungibleData, TypeId,
 };
 
 pub use crate::rust::borrow::ToOwned;

--- a/scrypto/src/resource/authorization.rs
+++ b/scrypto/src/resource/authorization.rs
@@ -10,7 +10,7 @@ use sbor::*;
 #[derive(Debug, Clone, PartialEq, Describe, TypeId, Encode, Decode)]
 pub struct Authorization {
     method_auth: HashMap<String, MethodAuth>,
-    default_auth: MethodAuth
+    default_auth: MethodAuth,
 }
 
 impl Authorization {
@@ -22,11 +22,14 @@ impl Authorization {
     }
 
     pub fn get(&self, method_name: &str) -> &MethodAuth {
-        self.method_auth.get(method_name).unwrap_or(&self.default_auth)
+        self.method_auth
+            .get(method_name)
+            .unwrap_or(&self.default_auth)
     }
 
     pub fn method(mut self, method_name: &str, method_auth: MethodAuth) -> Self {
-        self.method_auth.insert(method_name.to_string(), method_auth);
+        self.method_auth
+            .insert(method_name.to_string(), method_auth);
         self
     }
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 radix-engine = { path = "../radix-engine" }
-scrypto = { path = "../scrypto", features = ["serde_std"] }
+scrypto = { path = "../scrypto", features = ["serde"] }
 sbor = { path = "../sbor" }
 transaction-manifest = { path = "../transaction-manifest" }
 serde = { version = "1.0", features = ["derive"] }
@@ -15,7 +15,7 @@ dirs = { version = "4.0" }
 colored = { version = "2.0" }
 uuid = { version = "0.8", features = ["v4"] }
 hex = { version = "0.4" }
-cargo_toml = { version = "0.10" }
+cargo_toml = { version = "0.11.5" }
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", tag = "v0.17.0" }
 rand = "*"
 

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -34,10 +34,7 @@ impl Mint {
 
         let transaction = TransactionBuilder::new()
             .create_proof_from_account(self.minter_resource_address, default_account)
-            .mint(
-                self.amount,
-                self.resource_address,
-            )
+            .mint(self.amount, self.resource_address)
             .call_method_with_all_resources(default_account, "deposit_batch")
             .build(executor.get_nonce([default_pk]))
             .sign([&default_sk]);


### PR DESCRIPTION
Changes:
- Remove unnecessary serde annotation and use snake case for field names
- Use week feature dependency (YEAH!)

On the down side,  you now need rust `v1.60` or above. 

Run `rustup update` to update your toolchain.