### PR TITLE
Resim new entities sorting

### DIFF
--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -11,6 +11,7 @@ colored = { version = "2.0", default-features = false }
 lru = { version = "0.7" }
 bencher = { version = "0.1.5" }
 hex = { version = "0.4", default-features = false }
+indexmap = { git = "https://github.com/bluss/indexmap", tag = "1.8.1" }
 
 [dev-dependencies]
 wabt = { version = "0.10.0" }

--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -3,6 +3,7 @@ use scrypto::engine::types::*;
 use scrypto::rust::collections::*;
 use scrypto::rust::string::String;
 use scrypto::rust::vec::Vec;
+use indexmap::IndexMap;
 
 use crate::engine::*;
 use crate::errors::RuntimeError;
@@ -50,12 +51,12 @@ pub struct Track<'s, S: SubstateStore> {
     id_allocator: IdAllocator,
     logs: Vec<(Level, String)>,
 
-    packages: HashMap<PackageAddress, SubstateUpdate<Package>>,
+    packages: IndexMap<PackageAddress, SubstateUpdate<Package>>,
 
-    components: HashMap<ComponentAddress, SubstateUpdate<Component>>,
+    components: IndexMap<ComponentAddress, SubstateUpdate<Component>>,
     borrowed_components: HashMap<ComponentAddress, Option<(Hash, u32)>>,
 
-    resource_managers: HashMap<ResourceAddress, SubstateUpdate<ResourceManager>>,
+    resource_managers: IndexMap<ResourceAddress, SubstateUpdate<ResourceManager>>,
     borrowed_resource_managers: HashMap<ResourceAddress, Option<(Hash, u32)>>,
 
     vaults: HashMap<(ComponentAddress, VaultId), SubstateUpdate<Vault>>,
@@ -76,10 +77,10 @@ impl<'s, S: SubstateStore> Track<'s, S> {
             transaction_signers,
             id_allocator: IdAllocator::new(IdSpace::Application),
             logs: Vec::new(),
-            packages: HashMap::new(),
-            components: HashMap::new(),
+            packages: IndexMap::new(),
+            components: IndexMap::new(),
             borrowed_components: HashMap::new(),
-            resource_managers: HashMap::new(),
+            resource_managers: IndexMap::new(),
             borrowed_resource_managers: HashMap::new(),
             lazy_map_entries: HashMap::new(),
             vaults: HashMap::new(),


### PR DESCRIPTION
# Summary

Resim is no longer sorting resource addresses in the order in which they were created which makes it harder for users to later reuse these addresses.

# Description

In v0.3.0, when viewing a receipt of a transaction, the resource addresses shown there would be sorted according to which resource was created first. However, this is not the case as of commit [8117d9fffc753f8af9c10ec0b3335610080827ba](https://github.com/radixdlt/radixdlt-scrypto/tree/8117d9fffc753f8af9c10ec0b3335610080827ba) in the develop branch. 

As an example, let's say that we would like to create 6 tokens named Token A though F. The following is a portion of the receipt we get after creating these 6 tokens:
```
Logs: 6
├─ [INFO ] Resource Address of Token A is 0399da10517093bdd534b3d5a46df314cb0f561ba6b590884006ad
├─ [INFO ] Resource Address of Token B is 0312b0210a5609ab4bab7f58b77272430fb1e76cd734f03014e392
├─ [INFO ] Resource Address of Token C is 035cf967aad6d6530267086be30c304fdf7030551d9fff0d13d4bd
├─ [INFO ] Resource Address of Token D is 0301a1e5e16df6b555405b11d79862ab659a525b386ed814bfad33
├─ [INFO ] Resource Address of Token E is 032590fb11a9ef802a0d1fffc068e658f904254cddc77b75ed06bc
└─ [INFO ] Resource Address of Token F is 030c490151ecac5a32ef57534d2c134dee2011d342135a990922f7
New Entities: 7
└─ Component: 022088636b2436269fbb180ab7f37b3e28982a69738d78b948f840
├─ Resource: 030c490151ecac5a32ef57534d2c134dee2011d342135a990922f7
├─ Resource: 035cf967aad6d6530267086be30c304fdf7030551d9fff0d13d4bd
├─ Resource: 0399da10517093bdd534b3d5a46df314cb0f561ba6b590884006ad
├─ Resource: 0301a1e5e16df6b555405b11d79862ab659a525b386ed814bfad33
├─ Resource: 032590fb11a9ef802a0d1fffc068e658f904254cddc77b75ed06bc
└─ Resource: 0312b0210a5609ab4bab7f58b77272430fb1e76cd734f03014e392
```

As can be seen from the logs above, despite `Token A` being created first its resource address is the third in the list of new resource addresses, with the second created token (`Token B`) being the very last one on the list. The order in which the resource addresses are printed to the console varies from one run to another.

This behavior is different from that in v0.3.0. This makes it more difficult for users to know which resource address to save to which environment variables as most people are used to the v0.3.0 way of doing things where the first resource address shown would correspond to the first created resource.

# Source of the Issue

This issue is caused by using a `HashMap` in the `Track` struct to keep track of the resource managers as `HashMap`s are unordered which leads to the issue you see here. The specific line causing the issue is [here](https://github.com/radixdlt/radixdlt-scrypto/blob/8117d9fffc753f8af9c10ec0b3335610080827ba/radix-engine/src/engine/track.rs#L58).

I should note that this issue could potentially be present for `ComponentAddress`es as well and not just for `ResourceAddress`es as the `Track` struct stores the component addresses in a `HashMap` as well.

# Solution

A quick fix that I have tested and have verified to be working is to replace the use of `HashMap`s with `IndexMap`s from the crate [IndexMap](https://crates.io/crates/indexmap) for the `components` and `resource_managers` state variables of the `Track` struct.
