### PR TITLE
Feature/add non fungible method

### DIFF
--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -952,7 +952,10 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
         if !method_auths.is_empty() {
             let proofs_vector = match &snode {
                 // Same process auth check
-                SNodeState::ResourceRef(_, _) | SNodeState::VaultRef(_) | SNodeState::BucketRef(_, _) | SNodeState::Bucket(_) => {
+                SNodeState::ResourceRef(_, _)
+                | SNodeState::VaultRef(_)
+                | SNodeState::BucketRef(_, _)
+                | SNodeState::Bucket(_) => {
                     vec![self.caller_auth_zone, &self.auth_zone]
                 }
                 // Extern call auth check

--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -140,7 +140,10 @@ impl ResourceManager {
         }
 
         if let ResourceType::NonFungible = resource_type {
-            method_table.insert("update_non_fungible_mutable_data".to_string(), Some(UpdateNonFungibleData));
+            method_table.insert(
+                "update_non_fungible_mutable_data".to_string(),
+                Some(UpdateNonFungibleData),
+            );
             for pub_method in [
                 "take_non_fungibles_from_bucket",
                 "non_fungible_exists",

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -122,3 +122,22 @@ fn test_non_fungible() {
     println!("{:?}", receipt);
     assert!(receipt.result.is_ok());
 }
+
+#[test]
+fn test_singleton_non_fungible() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, true);
+    let (pk, sk, account) = executor.new_account();
+    let package = executor
+        .publish_package(&compile_package!(format!("./tests/{}", "non_fungible")))
+        .unwrap();
+
+    let transaction = TransactionBuilder::new()
+        .call_function(package, "NonFungibleTest", "singleton_non_fungible", vec![])
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt = executor.validate_and_execute(&transaction).unwrap();
+    println!("{:?}", receipt);
+    assert!(receipt.result.is_ok());
+}

--- a/radix-engine/tests/non_fungible/src/lib.rs
+++ b/radix-engine/tests/non_fungible/src/lib.rs
@@ -187,5 +187,26 @@ blueprint! {
 
             non_fungible_bucket
         }
+
+        pub fn singleton_non_fungible() {
+            let mut bucket = Self::create_non_fungible_fixed();
+            assert_eq!(bucket.amount(), 3.into());
+
+            // read singleton bucket
+            let singleton = bucket.take(1);
+            let _: Sandwich = singleton.non_fungible().data();
+
+            // read singleton vault
+            let mut vault = Vault::with_bucket(singleton);
+            let _: Sandwich = vault.non_fungible().data();
+
+            // read singleton proof
+            let proof = vault.create_proof();
+            let _: Sandwich = proof.non_fungible().data();
+
+            // clean up
+            vault.put(bucket);
+            NonFungibleTest { vault }.instantiate().globalize();
+        }
     }
 }

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -157,12 +157,11 @@ impl Bucket {
     /// # Panics
     /// Panics if this is not a singleton bucket
     pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
-        let resource_address = self.resource_address();
         let non_fungibles = self.non_fungibles();
         if non_fungibles.len() != 1 {
             panic!("Expecting singleton NFT bucket");
         }
-        non_fungibles[0]
+        non_fungibles.into_iter().next().unwrap()
     }
 }
 

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -151,6 +151,19 @@ impl Bucket {
             .map(|id| NonFungible::from(NonFungibleAddress::new(resource_address, id.clone())))
             .collect()
     }
+
+    /// Returns a singleton non-fungible.
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton bucket
+    pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
+        let resource_address = self.resource_address();
+        let non_fungibles = self.non_fungibles();
+        if non_fungibles.len() != 1 {
+            panic!("Expecting singleton NFT bucket");
+        }
+        non_fungibles[0]
+    }
 }
 
 //========

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -73,6 +73,31 @@ impl Proof {
         output.non_fungible_ids
     }
 
+    /// Returns all the non-fungible units contained.
+    ///
+    /// # Panics
+    /// Panics if this is not a non-fungible proof.
+    pub fn non_fungibles<T: NonFungibleData>(&self) -> Vec<NonFungible<T>> {
+        let resource_address = self.resource_address();
+        self.non_fungible_ids()
+            .iter()
+            .map(|id| NonFungible::from(NonFungibleAddress::new(resource_address, id.clone())))
+            .collect()
+    }
+
+    /// Returns a singleton non-fungible.
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton proof
+    pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
+        let resource_address = self.resource_address();
+        let non_fungibles = self.non_fungibles();
+        if non_fungibles.len() != 1 {
+            panic!("Expecting singleton NFT proof");
+        }
+        non_fungibles[0]
+    }
+
     /// Destroys this proof.
     pub fn drop(self) {
         let input = DropProofInput { proof_id: self.0 };

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -90,12 +90,11 @@ impl Proof {
     /// # Panics
     /// Panics if this is not a singleton proof
     pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
-        let resource_address = self.resource_address();
         let non_fungibles = self.non_fungibles();
         if non_fungibles.len() != 1 {
             panic!("Expecting singleton NFT proof");
         }
-        non_fungibles[0]
+        non_fungibles.into_iter().next().unwrap()
     }
 
     /// Destroys this proof.

--- a/scrypto/src/resource/vault.rs
+++ b/scrypto/src/resource/vault.rs
@@ -178,12 +178,11 @@ impl Vault {
     /// # Panics
     /// Panics if this is not a singleton bucket
     pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
-        let resource_address = self.resource_address();
         let non_fungibles = self.non_fungibles();
         if non_fungibles.len() != 1 {
             panic!("Expecting singleton NFT vault");
         }
-        non_fungibles[0]
+        non_fungibles.into_iter().next().unwrap()
     }
 }
 

--- a/scrypto/src/resource/vault.rs
+++ b/scrypto/src/resource/vault.rs
@@ -166,15 +166,24 @@ impl Vault {
     /// # Panics
     /// Panics if this is not a non-fungible vault.
     pub fn non_fungibles<T: NonFungibleData>(&self) -> Vec<NonFungible<T>> {
-        let input = GetNonFungibleIdsInVaultInput { vault_id: self.0 };
-        let output: GetNonFungibleIdsInVaultOutput =
-            call_engine(GET_NON_FUNGIBLE_IDS_IN_VAULT, input);
         let resource_address = self.resource_address();
-        output
-            .non_fungible_ids
+        self.non_fungible_ids()
             .iter()
             .map(|id| NonFungible::from(NonFungibleAddress::new(resource_address, id.clone())))
             .collect()
+    }
+
+    /// Returns a singleton non-fungible.
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton bucket
+    pub fn non_fungible<T: NonFungibleData>(&self) -> NonFungible<T> {
+        let resource_address = self.resource_address();
+        let non_fungibles = self.non_fungibles();
+        if non_fungibles.len() != 1 {
+            panic!("Expecting singleton NFT vault");
+        }
+        non_fungibles[0]
     }
 }
 

--- a/scrypto/src/values.rs
+++ b/scrypto/src/values.rs
@@ -9,11 +9,11 @@ use crate::math::*;
 use crate::resource::*;
 use crate::rust::borrow::Borrow;
 use crate::rust::collections::HashMap;
+use crate::rust::collections::HashSet;
 use crate::rust::fmt;
 use crate::rust::format;
 use crate::rust::string::String;
 use crate::rust::string::ToString;
-use crate::rust::collections::HashSet;
 use crate::rust::vec::Vec;
 use crate::types::*;
 
@@ -138,9 +138,10 @@ impl CustomValueVisitor for ScryptoCustomValueChecker {
                     .map_err(ScryptoCustomValueCheckError::InvalidComponentAddress)?;
             }
             ScryptoType::LazyMap => {
-                let map = LazyMap::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidLazyMap)?;
+                let map = LazyMap::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidLazyMap)?;
                 if !self.lazy_maps.insert(map) {
-                    return Err(ScryptoCustomValueCheckError::DuplicateIds)
+                    return Err(ScryptoCustomValueCheckError::DuplicateIds);
                 }
             }
             ScryptoType::Hash => {
@@ -158,21 +159,24 @@ impl CustomValueVisitor for ScryptoCustomValueChecker {
                 Decimal::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidDecimal)?;
             }
             ScryptoType::Bucket => {
-                let bucket = Bucket::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidBucket)?;
+                let bucket =
+                    Bucket::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidBucket)?;
                 if !self.buckets.insert(bucket) {
-                    return Err(ScryptoCustomValueCheckError::DuplicateIds)
+                    return Err(ScryptoCustomValueCheckError::DuplicateIds);
                 }
             }
             ScryptoType::Proof => {
-                let proof = Proof::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidProof)?;
+                let proof =
+                    Proof::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidProof)?;
                 if !self.proofs.insert(proof) {
-                    return Err(ScryptoCustomValueCheckError::DuplicateIds)
+                    return Err(ScryptoCustomValueCheckError::DuplicateIds);
                 }
             }
             ScryptoType::Vault => {
-                let vault = Vault::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidVault)?;
+                let vault =
+                    Vault::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidVault)?;
                 if !self.vaults.insert(vault) {
-                    return Err(ScryptoCustomValueCheckError::DuplicateIds)
+                    return Err(ScryptoCustomValueCheckError::DuplicateIds);
                 }
             }
             ScryptoType::NonFungibleId => {
@@ -440,17 +444,24 @@ impl ScryptoValueFormatter {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
     use super::rust::vec;
+    use super::*;
 
     #[test]
     fn should_reject_duplicate_ids() {
-        let buckets = scrypto_encode(&vec![scrypto::resource::Bucket(0), scrypto::resource::Bucket(0)]);
+        let buckets = scrypto_encode(&vec![
+            scrypto::resource::Bucket(0),
+            scrypto::resource::Bucket(0),
+        ]);
         let error = ScryptoValue::from_slice(&buckets).expect_err("Should be an error");
-        assert_eq!(error, ParseScryptoValueError::CustomValueCheckError(ScryptoCustomValueCheckError::DuplicateIds));
+        assert_eq!(
+            error,
+            ParseScryptoValueError::CustomValueCheckError(
+                ScryptoCustomValueCheckError::DuplicateIds
+            )
+        );
     }
 }


### PR DESCRIPTION
Added method `non_fungible()` to `Bucket`, `Vault` and `Proof`.

It will **panic** if the resource container or proof is not a singleton NFT.