### PR TITLE
Rename borrow macros

### DIFF
--- a/assets/system/src/lib.rs
+++ b/assets/system/src/lib.rs
@@ -24,7 +24,7 @@ blueprint! {
 
         /// Mints fungible resource. TODO: Remove
         pub fn mint(amount: Decimal, resource_address: ResourceAddress) -> Bucket {
-            resource_manager!(resource_address).mint(amount)
+            borrow_resource_manager!(resource_address).mint(amount)
         }
 
         /// Burns bucket. TODO: Remove

--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -1,9 +1,9 @@
+use indexmap::IndexMap;
 use scrypto::constants::*;
 use scrypto::engine::types::*;
 use scrypto::rust::collections::*;
 use scrypto::rust::string::String;
 use scrypto::rust::vec::Vec;
-use indexmap::IndexMap;
 
 use crate::engine::*;
 use crate::errors::RuntimeError;

--- a/radix-engine/src/model/package.rs
+++ b/radix-engine/src/model/package.rs
@@ -156,7 +156,8 @@ impl Package {
     ) -> Result<ScryptoValue, PackageError> {
         match function {
             "publish" => {
-                let bytes = scrypto_decode(&args[0].raw).map_err(PackageError::InvalidRequestData)?;
+                let bytes =
+                    scrypto_decode(&args[0].raw).map_err(PackageError::InvalidRequestData)?;
                 let package = Package::new(bytes).map_err(PackageError::WasmValidationError)?;
                 let package_address = system_api.create_package(package);
                 Ok(ScryptoValue::from_value(&package_address))

--- a/radix-engine/tests/component/src/component.rs
+++ b/radix-engine/tests/component/src/component.rs
@@ -25,8 +25,8 @@ blueprint! {
 
         pub fn get_component_info(component_address: ComponentAddress) -> (PackageAddress, String) {
             (
-                component!(component_address).package_address(),
-                component!(component_address).blueprint_name(),
+                borrow_component!(component_address).package_address(),
+                borrow_component!(component_address).blueprint_name(),
             )
         }
 

--- a/radix-engine/tests/component/src/cross_component.rs
+++ b/radix-engine/tests/component/src/cross_component.rs
@@ -31,7 +31,7 @@ blueprint! {
         }
 
         pub fn cross_component_call(&mut self, component_address: ComponentAddress) -> String {
-            let other_component = component!(component_address);
+            let other_component = borrow_component!(component_address);
             match &mut self.auth_vault {
                 Some(vault) => {
                     let auth_bucket = vault.take_all();

--- a/radix-engine/tests/component/src/reentrant_component.rs
+++ b/radix-engine/tests/component/src/reentrant_component.rs
@@ -12,7 +12,7 @@ blueprint! {
 
         pub fn call_self(&mut self) {
             if let ScryptoActor::Component(addr) = Runtime::actor().actor() {
-                let self_component = component!(addr);
+                let self_component = borrow_component!(addr);
                 self_component.call("func", vec![])
             }
         }

--- a/radix-engine/tests/non_fungible/src/lib.rs
+++ b/radix-engine/tests/non_fungible/src/lib.rs
@@ -29,7 +29,7 @@ blueprint! {
 
             // Mint a non-fungible
             let non_fungible = mint_badge.authorize(|| {
-                resource_manager!(resource_address).mint_non_fungible(
+                borrow_resource_manager!(resource_address).mint_non_fungible(
                     &NonFungibleId::from_u32(0),
                     Sandwich {
                         name: "Test".to_owned(),
@@ -93,7 +93,7 @@ blueprint! {
 
         pub fn verify_does_not_exist(address: NonFungibleAddress) {
             assert_eq!(
-                resource_manager!(address.resource_address())
+                borrow_resource_manager!(address.resource_address())
                     .non_fungible_exists(&address.non_fungible_id()),
                 false
             );
@@ -101,17 +101,17 @@ blueprint! {
 
         pub fn update_and_get_non_fungible() -> (Bucket, Bucket) {
             let (mint_badge, resource_address, bucket) = Self::create_non_fungible_mutable();
-            let mut data: Sandwich = resource_manager!(resource_address)
+            let mut data: Sandwich = borrow_resource_manager!(resource_address)
                 .get_non_fungible_data(&NonFungibleId::from_u32(0));
             assert_eq!(data.available, false);
 
             data.available = true;
             mint_badge.authorize(|| {
-                resource_manager!(resource_address)
+                borrow_resource_manager!(resource_address)
                     .update_non_fungible_data(&NonFungibleId::from_u32(0), data);
             });
 
-            let data: Sandwich = resource_manager!(resource_address)
+            let data: Sandwich = borrow_resource_manager!(resource_address)
                 .get_non_fungible_data(&NonFungibleId::from_u32(0));
             assert_eq!(data.available, true);
             (mint_badge, bucket)
@@ -120,12 +120,12 @@ blueprint! {
         pub fn non_fungible_exists() -> (Bucket, Bucket) {
             let (mint_badge, resource_address, bucket) = Self::create_non_fungible_mutable();
             assert_eq!(
-                resource_manager!(resource_address)
+                borrow_resource_manager!(resource_address)
                     .non_fungible_exists(&NonFungibleId::from_u32(0)),
                 true
             );
             assert_eq!(
-                resource_manager!(resource_address)
+                borrow_resource_manager!(resource_address)
                     .non_fungible_exists(&NonFungibleId::from_u32(1)),
                 false
             );

--- a/radix-engine/tests/resource/src/lib.rs
+++ b/radix-engine/tests/resource/src/lib.rs
@@ -30,7 +30,7 @@ blueprint! {
                 .mintable(auth!(require(badge.resource_address())), LOCKED)
                 .burnable(auth!(require(badge.resource_address())), LOCKED)
                 .no_initial_supply();
-            let tokens = badge.authorize(|| resource_manager!(token_address).mint(amount));
+            let tokens = badge.authorize(|| borrow_resource_manager!(token_address).mint(amount));
             (badge, tokens, token_address)
         }
 
@@ -66,7 +66,7 @@ blueprint! {
 
         pub fn query() -> (Bucket, HashMap<String, String>, Decimal) {
             let (badge, resource_address) = Self::create_fungible();
-            let resource_manager = resource_manager!(resource_address);
+            let resource_manager = borrow_resource_manager!(resource_address);
             (
                 badge,
                 resource_manager.metadata(),
@@ -76,7 +76,7 @@ blueprint! {
 
         pub fn burn() -> Bucket {
             let (badge, resource_address) = Self::create_fungible();
-            let resource_manager = resource_manager!(resource_address);
+            let resource_manager = borrow_resource_manager!(resource_address);
             badge.authorize(|| {
                 let bucket: Bucket = resource_manager.mint(1);
                 resource_manager.burn(bucket)
@@ -88,7 +88,7 @@ blueprint! {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
                 .initial_supply(1);
-            let token_resource_manager = resource_manager!(ResourceBuilder::new_fungible()
+            let token_resource_manager = borrow_resource_manager!(ResourceBuilder::new_fungible()
                 .updateable_metadata(auth!(require(badge.resource_address())), LOCKED)
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")

--- a/radix-engine/tests/resource_creator/src/resource_creator.rs
+++ b/radix-engine/tests/resource_creator/src/resource_creator.rs
@@ -49,19 +49,20 @@ blueprint! {
         }
 
         pub fn set_mintable(resource_address: ResourceAddress, auth_address: ResourceAddress) {
-            resource_manager!(resource_address).set_mintable(auth!(require(auth_address)));
+            borrow_resource_manager!(resource_address).set_mintable(auth!(require(auth_address)));
         }
 
         pub fn set_burnable(resource_address: ResourceAddress, auth_address: ResourceAddress) {
-            resource_manager!(resource_address).set_burnable(auth!(require(auth_address)));
+            borrow_resource_manager!(resource_address).set_burnable(auth!(require(auth_address)));
         }
 
         pub fn set_withdrawable(resource_address: ResourceAddress, auth_address: ResourceAddress) {
-            resource_manager!(resource_address).set_withdrawable(auth!(require(auth_address)));
+            borrow_resource_manager!(resource_address)
+                .set_withdrawable(auth!(require(auth_address)));
         }
 
         pub fn lock_mintable(resource_address: ResourceAddress) {
-            resource_manager!(resource_address).lock_mintable();
+            borrow_resource_manager!(resource_address).lock_mintable();
         }
 
         pub fn create_non_fungible_fixed() -> Bucket {

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -185,13 +185,13 @@ fn generate_dispatcher(bp_ident: &Ident, items: &[ImplItem]) -> Result<(Vec<Expr
                             // Generate a `Stmt` for loading the component state
                             assert!(get_state.is_none(), "Can have at most 1 self reference");
                             get_state = Some(parse_quote! {
-                                let #mutability state: blueprint::#bp_ident = component!(#arg).get_state();
+                                let #mutability state: blueprint::#bp_ident = borrow_component!(#arg).get_state();
                             });
 
                             // Generate a `Stmt` for writing back component state
                             if mutability.is_some() {
                                 put_state = Some(parse_quote! {
-                                    ::scrypto::component!(#arg).put_state(state);
+                                    ::scrypto::borrow_component!(#arg).put_state(state);
                                 });
                             }
                         }
@@ -526,7 +526,7 @@ mod tests {
                                 ::scrypto::buffer::scrypto_decode::<::scrypto::component::ComponentAddress>(
                                     &calldata.args[0usize]
                                 ).unwrap();
-                            let state: blueprint::Test = component!(arg0).get_state();
+                            let state: blueprint::Test = borrow_component!(arg0).get_state();
                             rtn = ::scrypto::buffer::scrypto_encode_for_radix_engine(&blueprint::Test::x(&state));
                         }
                         _ => {

--- a/scrypto/src/component/system.rs
+++ b/scrypto/src/component/system.rs
@@ -98,7 +98,7 @@ pub fn component_system() -> &'static mut ComponentSystem {
 /// This macro creates a `&Package` from a `PackageAddress` via the
 /// Radix Engine component subsystem.
 #[macro_export]
-macro_rules! package {
+macro_rules! borrow_package {
     ($id:expr) => {
         component_system().get_package($id)
     };
@@ -107,7 +107,7 @@ macro_rules! package {
 /// This macro converts a `ComponentAddress` into a `&Component` via the
 /// Radix Engine component subsystem.
 #[macro_export]
-macro_rules! component {
+macro_rules! borrow_component {
     ($id:expr) => {
         component_system().get_component($id)
     };
@@ -121,9 +121,9 @@ mod tests {
     fn test_component_macro() {
         init_component_system(ComponentSystem::new());
 
-        let component = component!(ComponentAddress([0u8; 26]));
-        let component_same_id = component!(ComponentAddress([0u8; 26]));
-        let component_different_id = component!(ComponentAddress([1u8; 26]));
+        let component = borrow_component!(ComponentAddress([0u8; 26]));
+        let component_same_id = borrow_component!(ComponentAddress([0u8; 26]));
+        let component_different_id = borrow_component!(ComponentAddress([1u8; 26]));
 
         assert_eq!(ComponentAddress([0u8; 26]), component.0);
         assert_eq!(ComponentAddress([0u8; 26]), component_same_id.0);
@@ -134,9 +134,9 @@ mod tests {
     fn test_package_macro() {
         init_component_system(ComponentSystem::new());
 
-        let package = package!(PackageAddress([0u8; 26]));
-        let package_same_id = package!(PackageAddress([0u8; 26]));
-        let package_different_id = package!(PackageAddress([1u8; 26]));
+        let package = borrow_package!(PackageAddress([0u8; 26]));
+        let package_same_id = borrow_package!(PackageAddress([0u8; 26]));
+        let package_different_id = borrow_package!(PackageAddress([1u8; 26]));
 
         assert_eq!(PackageAddress([0u8; 26]), package.0);
         assert_eq!(PackageAddress([0u8; 26]), package_same_id.0);

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -7,9 +7,9 @@ pub use crate::math::*;
 pub use crate::misc::*;
 pub use crate::resource::*;
 pub use crate::{
-    args, auth, auth_and_or, auth_rule_node, blueprint, compile_package, component, debug, dec,
-    error, import, include_package, info, package, resource_list, resource_manager, trace, warn,
-    Decode, Describe, Encode, NonFungibleData, TypeId,
+    args, auth, auth_and_or, auth_rule_node, blueprint, borrow_component, borrow_package,
+    borrow_resource_manager, compile_package, debug, dec, error, import, include_package, info,
+    resource_list, trace, warn, Decode, Describe, Encode, NonFungibleData, TypeId,
 };
 
 pub use crate::rust::borrow::ToOwned;

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -12,7 +12,7 @@ use crate::rust::fmt;
 use crate::rust::string::ToString;
 use crate::rust::vec::Vec;
 use crate::types::*;
-use crate::{args, resource_manager};
+use crate::{args, borrow_resource_manager};
 
 /// Represents a transient resource container.
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -77,7 +77,7 @@ impl Bucket {
 
     /// Burns resource within this bucket.
     pub fn burn(self) {
-        resource_manager!(self.resource_address()).burn(self);
+        borrow_resource_manager!(self.resource_address()).burn(self);
     }
 
     /// Creates an ownership proof of this bucket.

--- a/scrypto/src/resource/non_fungible.rs
+++ b/scrypto/src/resource/non_fungible.rs
@@ -1,5 +1,5 @@
+use crate::borrow_resource_manager;
 use crate::resource::*;
-use crate::resource_manager;
 use crate::rust::marker::PhantomData;
 
 /// Represents a non-fungible unit.
@@ -36,11 +36,12 @@ impl<T: NonFungibleData> NonFungible<T> {
 
     /// Returns the associated data of this unit.
     pub fn data(&self) -> T {
-        resource_manager!(self.resource_address()).get_non_fungible_data(&self.id())
+        borrow_resource_manager!(self.resource_address()).get_non_fungible_data(&self.id())
     }
 
     /// Updates the associated data of this unit.
     pub fn update_data(&self, new_data: T) {
-        resource_manager!(self.resource_address()).update_non_fungible_data(&self.id(), new_data);
+        borrow_resource_manager!(self.resource_address())
+            .update_non_fungible_data(&self.id(), new_data);
     }
 }

--- a/scrypto/src/resource/system.rs
+++ b/scrypto/src/resource/system.rs
@@ -70,7 +70,7 @@ pub fn resource_system() -> &'static mut ResourceSystem {
 /// This macro creates a `&ResourceManager` from a `ResourceAddress` via the
 /// Radix Engine resource subsystem.
 #[macro_export]
-macro_rules! resource_manager {
+macro_rules! borrow_resource_manager {
     ($id:expr) => {
         resource_system().get_resource_manager($id)
     };
@@ -83,9 +83,9 @@ mod tests {
     fn test_resource_manager_macro() {
         init_resource_system(ResourceSystem::new());
 
-        let resource_manager = resource_manager!(ResourceAddress([0u8; 26]));
-        let resource_manager_same_id = resource_manager!(ResourceAddress([0u8; 26]));
-        let resource_manager_different_id = resource_manager!(ResourceAddress([1u8; 26]));
+        let resource_manager = borrow_resource_manager!(ResourceAddress([0u8; 26]));
+        let resource_manager_same_id = borrow_resource_manager!(ResourceAddress([0u8; 26]));
+        let resource_manager_different_id = borrow_resource_manager!(ResourceAddress([1u8; 26]));
 
         assert_eq!(ResourceAddress([0u8; 26]), resource_manager.0);
         assert_eq!(ResourceAddress([0u8; 26]), resource_manager_same_id.0);


### PR DESCRIPTION
New names:
- `borrow_package`, 
- `borrow_component`, 
- `borrow_resource_manager`