### PR TITLE
Change resim output to use **writeln!** instead of **println!**

### DIFF
--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -1,3 +1,5 @@
+#![allow(unused_must_use)]
+
 use clap::Parser;
 use radix_engine::transaction::*;
 use scrypto::engine::types::*;

--- a/simulator/src/resim/cmd_export_abi.rs
+++ b/simulator/src/resim/cmd_export_abi.rs
@@ -1,3 +1,5 @@
+#![allow(unused_must_use)]
+
 use clap::Parser;
 use radix_engine::transaction::*;
 use scrypto::engine::types::*;
@@ -19,12 +21,13 @@ pub struct ExportAbi {
 }
 
 impl ExportAbi {
-    pub fn run(&self) -> Result<(), Error> {
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let executor = TransactionExecutor::new(&mut ledger, self.trace);
         match executor.export_abi(self.package_address, &self.blueprint_name) {
             Ok(a) => {
-                println!(
+                writeln!(out,
                     "{}",
                     serde_json::to_string_pretty(&a).map_err(Error::JSONError)?
                 );

--- a/simulator/src/resim/cmd_export_abi.rs
+++ b/simulator/src/resim/cmd_export_abi.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 
 use clap::Parser;
 use radix_engine::transaction::*;
@@ -30,7 +29,7 @@ impl ExportAbi {
                 writeln!(out,
                     "{}",
                     serde_json::to_string_pretty(&a).map_err(Error::JSONError)?
-                );
+                ).map_err(Error::IOError)?;
                 Ok(())
             }
             Err(e) => Err(Error::AbiExportError(e)),

--- a/simulator/src/resim/cmd_generate_key_pair.rs
+++ b/simulator/src/resim/cmd_generate_key_pair.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 use rand::Rng;
@@ -10,12 +11,13 @@ use crate::resim::*;
 pub struct GenerateKeyPair {}
 
 impl GenerateKeyPair {
-    pub fn run(&self) -> Result<(), Error> {
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let secret = rand::thread_rng().gen::<[u8; 32]>();
         let private_key = EcdsaPrivateKey::from_bytes(&secret).unwrap();
         let public_key = private_key.public_key();
-        println!("Public key: {}", public_key.to_string().green());
-        println!(
+        writeln!(out, "Public key: {}", public_key.to_string().green());
+        writeln!(out,
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
         );

--- a/simulator/src/resim/cmd_generate_key_pair.rs
+++ b/simulator/src/resim/cmd_generate_key_pair.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 use rand::Rng;
@@ -16,11 +15,11 @@ impl GenerateKeyPair {
         let secret = rand::thread_rng().gen::<[u8; 32]>();
         let private_key = EcdsaPrivateKey::from_bytes(&secret).unwrap();
         let public_key = private_key.public_key();
-        writeln!(out, "Public key: {}", public_key.to_string().green());
+        writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
         writeln!(out,
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
-        );
+        ).map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 
 use clap::Parser;
 use colored::*;
@@ -41,25 +40,25 @@ impl NewAccount {
                 })
                 .build_with_no_nonce();
             let manifest = decompile(&transaction).map_err(Error::DecompileError)?;
-            writeln!(out, "A manifest has been produced for the following key pair. To complete account creation, you will need to run the manifest!");
-            writeln!(out, "Public key: {}", public_key.to_string().green());
+            writeln!(out, "A manifest has been produced for the following key pair. To complete account creation, you will need to run the manifest!").map_err(Error::IOError)?;
+            writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
             writeln!(out, 
                 "Private key: {}",
                 hex::encode(private_key.to_bytes()).green()
-            );
+            ).map_err(Error::IOError)?;
             return fs::write(path, manifest).map_err(Error::IOError);
         }
 
         let (public_key, private_key, account) = executor.new_account();
-        writeln!(out, "A new account has been created!");
-        writeln!(out, "Account component address: {}", account.to_string().green());
-        writeln!(out, "Public key: {}", public_key.to_string().green());
+        writeln!(out, "A new account has been created!").map_err(Error::IOError)?;
+        writeln!(out, "Account component address: {}", account.to_string().green()).map_err(Error::IOError)?;
+        writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
         writeln!(out, 
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
-        );
+        ).map_err(Error::IOError)?;
         if get_configs()?.is_none() {
-            writeln!(out, "No configuration found on system. will use the above account as default.");
+            writeln!(out, "No configuration found on system. will use the above account as default.").map_err(Error::IOError)?;
             set_configs(&Configs {
                 default_account: account,
                 default_public_key: public_key,

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -1,3 +1,5 @@
+#![allow(unused_must_use)]
+
 use clap::Parser;
 use colored::*;
 use rand::Rng;
@@ -18,7 +20,8 @@ pub struct NewAccount {
 }
 
 impl NewAccount {
-    pub fn run(&self) -> Result<(), Error> {
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
 
@@ -38,9 +41,9 @@ impl NewAccount {
                 })
                 .build_with_no_nonce();
             let manifest = decompile(&transaction).map_err(Error::DecompileError)?;
-            println!("A manifest has been produced for the following key pair. To complete account creation, you will need to run the manifest!");
-            println!("Public key: {}", public_key.to_string().green());
-            println!(
+            writeln!(out, "A manifest has been produced for the following key pair. To complete account creation, you will need to run the manifest!");
+            writeln!(out, "Public key: {}", public_key.to_string().green());
+            writeln!(out, 
                 "Private key: {}",
                 hex::encode(private_key.to_bytes()).green()
             );
@@ -48,15 +51,15 @@ impl NewAccount {
         }
 
         let (public_key, private_key, account) = executor.new_account();
-        println!("A new account has been created!");
-        println!("Account component address: {}", account.to_string().green());
-        println!("Public key: {}", public_key.to_string().green());
-        println!(
+        writeln!(out, "A new account has been created!");
+        writeln!(out, "Account component address: {}", account.to_string().green());
+        writeln!(out, "Public key: {}", public_key.to_string().green());
+        writeln!(out, 
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
         );
         if get_configs()?.is_none() {
-            println!("No configuration found on system. will use the above account as default.");
+            writeln!(out, "No configuration found on system. will use the above account as default.");
             set_configs(&Configs {
                 default_account: account,
                 default_public_key: public_key,

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 use radix_engine::transaction::*;
@@ -56,7 +55,7 @@ impl Publish {
             executor
                 .overwrite_package(package_address, code)
                 .map_err(|e| Error::PackageValidationError(e))?;
-            writeln!(out, "Package updated!");
+            writeln!(out, "Package updated!").map_err(Error::IOError)?;
             Ok(())
         } else {
             match executor.publish_package(&code) {
@@ -64,7 +63,7 @@ impl Publish {
                     writeln!(out,
                         "Success! New Package: {}",
                         package_address.to_string().green()
-                    );
+                    ).map_err(Error::IOError)?;
                     Ok(())
                 }
                 Err(error) => Err(Error::TransactionExecutionError(error)),

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 use radix_engine::transaction::*;
@@ -30,7 +31,7 @@ pub struct Publish {
 }
 
 impl Publish {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         // Load wasm code
         let code = fs::read(if self.path.extension() != Some(OsStr::new("wasm")) {
             build_package(&self.path, false).map_err(Error::CargoError)?
@@ -55,12 +56,12 @@ impl Publish {
             executor
                 .overwrite_package(package_address, code)
                 .map_err(|e| Error::PackageValidationError(e))?;
-            println!("Package updated!");
+            writeln!(out, "Package updated!");
             Ok(())
         } else {
             match executor.publish_package(&code) {
                 Ok(package_address) => {
-                    println!(
+                    writeln!(out,
                         "Success! New Package: {}",
                         package_address.to_string().green()
                     );

--- a/simulator/src/resim/cmd_reset.rs
+++ b/simulator/src/resim/cmd_reset.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use std::fs::remove_dir_all;
 
@@ -12,7 +11,7 @@ impl Reset {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let dir = get_data_dir()?;
         remove_dir_all(dir).map_err(Error::IOError)?;
-        writeln!(out, "Data directory cleared.");
+        writeln!(out, "Data directory cleared.").map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_reset.rs
+++ b/simulator/src/resim/cmd_reset.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use std::fs::remove_dir_all;
 
@@ -8,10 +9,10 @@ use crate::resim::*;
 pub struct Reset {}
 
 impl Reset {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let dir = get_data_dir()?;
         remove_dir_all(dir).map_err(Error::IOError)?;
-        println!("Data directory cleared.");
+        writeln!(out, "Data directory cleared.");
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_set_current_epoch.rs
+++ b/simulator/src/resim/cmd_set_current_epoch.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use radix_engine::ledger::SubstateStore;
 
@@ -11,11 +12,11 @@ pub struct SetCurrentEpoch {
 }
 
 impl SetCurrentEpoch {
-    pub fn run(&self) -> Result<(), Error> {
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         ledger.set_epoch(self.epoch);
 
-        println!("Current epoch set!");
+        writeln!(out, "Current epoch set!");
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_set_current_epoch.rs
+++ b/simulator/src/resim/cmd_set_current_epoch.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use radix_engine::ledger::SubstateStore;
 
@@ -16,7 +15,7 @@ impl SetCurrentEpoch {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         ledger.set_epoch(self.epoch);
 
-        writeln!(out, "Current epoch set!");
+        writeln!(out, "Current epoch set!").map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_set_default_account.rs
+++ b/simulator/src/resim/cmd_set_default_account.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use scrypto::engine::types::*;
 
@@ -17,14 +18,15 @@ pub struct SetDefaultAccount {
 }
 
 impl SetDefaultAccount {
-    pub fn run(&self) -> Result<(), Error> {
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         set_configs(&Configs {
             default_account: self.component_address,
             default_public_key: self.public_key,
             default_private_key: hex::decode(&self.private_key).unwrap(),
         })?;
 
-        println!("Default account updated!");
+        writeln!(out, "Default account updated!");
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_set_default_account.rs
+++ b/simulator/src/resim/cmd_set_default_account.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use scrypto::engine::types::*;
 
@@ -26,7 +25,7 @@ impl SetDefaultAccount {
             default_private_key: hex::decode(&self.private_key).unwrap(),
         })?;
 
-        writeln!(out, "Default account updated!");
+        writeln!(out, "Default account updated!").map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use scrypto::engine::types::*;
 use std::str::FromStr;
@@ -13,15 +14,17 @@ pub struct Show {
 }
 
 impl Show {
-    pub fn run(&self) -> Result<(), Error> {
+
+   pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
+
         let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
 
         if let Ok(package_address) = PackageAddress::from_str(&self.address) {
-            dump_package(package_address, &ledger).map_err(Error::LedgerDumpError)
+            dump_package(package_address, &ledger, out).map_err(Error::LedgerDumpError)
         } else if let Ok(component_address) = ComponentAddress::from_str(&self.address) {
-            dump_component(component_address, &ledger).map_err(Error::LedgerDumpError)
+            dump_component(component_address, &ledger, out).map_err(Error::LedgerDumpError)
         } else if let Ok(resource_address) = ResourceAddress::from_str(&self.address) {
-            dump_resource_manager(resource_address, &ledger).map_err(Error::LedgerDumpError)
+            dump_resource_manager(resource_address, &ledger, out).map_err(Error::LedgerDumpError)
         } else {
             Err(Error::InvalidId(self.address.clone()))
         }

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use scrypto::engine::types::*;
 use std::str::FromStr;

--- a/simulator/src/resim/cmd_show_configs.rs
+++ b/simulator/src/resim/cmd_show_configs.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 
@@ -16,19 +15,19 @@ impl ShowConfigs {
                 "{}: {}",
                 "Default Account".green().bold(),
                 configs.default_account
-            );
+            ).map_err(Error::IOError)?;
             writeln!(out,
                 "{}: {}",
                 "Default Public Key".green().bold(),
                 configs.default_public_key
-            );
+            ).map_err(Error::IOError)?;
             writeln!(out,
                 "{}: {}",
                 "Default Private Key".green().bold(),
                 hex::encode(configs.default_private_key)
-            );
+            ).map_err(Error::IOError)?;
         } else {
-            writeln!(out,"No configuration found");
+            writeln!(out,"No configuration found").map_err(Error::IOError)?;
         }
         Ok(())
     }

--- a/simulator/src/resim/cmd_show_configs.rs
+++ b/simulator/src/resim/cmd_show_configs.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 
@@ -8,25 +9,26 @@ use crate::resim::*;
 pub struct ShowConfigs {}
 
 impl ShowConfigs {
-    pub fn run(&self) -> Result<(), Error> {
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         if let Some(configs) = get_configs()? {
-            println!(
+            writeln!(out,
                 "{}: {}",
                 "Default Account".green().bold(),
                 configs.default_account
             );
-            println!(
+            writeln!(out,
                 "{}: {}",
                 "Default Public Key".green().bold(),
                 configs.default_public_key
             );
-            println!(
+            writeln!(out,
                 "{}: {}",
                 "Default Private Key".green().bold(),
                 hex::encode(configs.default_private_key)
             );
         } else {
-            println!("No configuration found");
+            writeln!(out,"No configuration found");
         }
         Ok(())
     }

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 
@@ -16,22 +15,22 @@ impl ShowLedger {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
 
-        writeln!(out, "{}:", "Packages".green().bold());
+        writeln!(out, "{}:", "Packages".green().bold()).map_err(Error::IOError)?;
         for (last, package_address) in ledger.list_packages().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), package_address);
+            writeln!(out, "{} {}", list_item_prefix(last), package_address).map_err(Error::IOError)?;
         }
 
-        writeln!(out, "{}:", "Components".green().bold());
+        writeln!(out, "{}:", "Components".green().bold()).map_err(Error::IOError)?;
         for (last, component_address) in ledger.list_components().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), component_address);
+            writeln!(out, "{} {}", list_item_prefix(last), component_address).map_err(Error::IOError)?;
         }
 
-        writeln!(out, "{}:", "Resource Managers".green().bold());
+        writeln!(out, "{}:", "Resource Managers".green().bold()).map_err(Error::IOError)?;
         for (last, resource_address) in ledger.list_resource_managers().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), resource_address);
+            writeln!(out, "{} {}", list_item_prefix(last), resource_address).map_err(Error::IOError)?;
         }
 
-        writeln!(out, "{}: {}", "Nonce".green().bold(), ledger.get_nonce());
+        writeln!(out, "{}: {}", "Nonce".green().bold(), ledger.get_nonce()).map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -1,3 +1,4 @@
+#![allow(unused_must_use)]
 use clap::Parser;
 use colored::*;
 
@@ -10,25 +11,27 @@ use crate::utils::*;
 pub struct ShowLedger {}
 
 impl ShowLedger {
-    pub fn run(&self) -> Result<(), Error> {
+
+
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
 
-        println!("{}:", "Packages".green().bold());
+        writeln!(out, "{}:", "Packages".green().bold());
         for (last, package_address) in ledger.list_packages().iter().identify_last() {
-            println!("{} {}", list_item_prefix(last), package_address);
+            writeln!(out, "{} {}", list_item_prefix(last), package_address);
         }
 
-        println!("{}:", "Components".green().bold());
+        writeln!(out, "{}:", "Components".green().bold());
         for (last, component_address) in ledger.list_components().iter().identify_last() {
-            println!("{} {}", list_item_prefix(last), component_address);
+            writeln!(out, "{} {}", list_item_prefix(last), component_address);
         }
 
-        println!("{}:", "Resource Managers".green().bold());
+        writeln!(out, "{}:", "Resource Managers".green().bold());
         for (last, resource_address) in ledger.list_resource_managers().iter().identify_last() {
-            println!("{} {}", list_item_prefix(last), resource_address);
+            writeln!(out, "{} {}", list_item_prefix(last), resource_address);
         }
 
-        println!("{}: {}", "Nonce".green().bold(), ledger.get_nonce());
+        writeln!(out, "{}: {}", "Nonce".green().bold(), ledger.get_nonce());
         Ok(())
     }
 }

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -86,25 +86,27 @@ pub enum Command {
 pub fn run() -> Result<(), Error> {
     let cli = ResimCli::parse();
 
+    let mut out = std::io::stdout() ;
+
     match cli.command {
         Command::CallFunction(cmd) => cmd.run(),
         Command::CallMethod(cmd) => cmd.run(),
-        Command::ExportAbi(cmd) => cmd.run(),
-        Command::GenerateKeyPair(cmd) => cmd.run(),
+        Command::ExportAbi(cmd) => cmd.run(&mut out),
+        Command::GenerateKeyPair(cmd) => cmd.run(&mut out),
         Command::Mint(cmd) => cmd.run(),
-        Command::NewAccount(cmd) => cmd.run(),
+        Command::NewAccount(cmd) => cmd.run(&mut out),
         Command::NewBadgeFixed(cmd) => cmd.run(),
         Command::NewBadgeMutable(cmd) => cmd.run(),
         Command::NewTokenFixed(cmd) => cmd.run(),
         Command::NewTokenMutable(cmd) => cmd.run(),
-        Command::Publish(cmd) => cmd.run(),
-        Command::Reset(cmd) => cmd.run(),
+        Command::Publish(cmd) => cmd.run(&mut out),
+        Command::Reset(cmd) => cmd.run(&mut out),
         Command::Run(cmd) => cmd.run(),
-        Command::SetCurrentEpoch(cmd) => cmd.run(),
-        Command::SetDefaultAccount(cmd) => cmd.run(),
-        Command::ShowConfigs(cmd) => cmd.run(),
-        Command::ShowLedger(cmd) => cmd.run(),
-        Command::Show(cmd) => cmd.run(),
+        Command::SetCurrentEpoch(cmd) => cmd.run(&mut out),
+        Command::SetDefaultAccount(cmd) => cmd.run(&mut out),
+        Command::ShowConfigs(cmd) => cmd.run(&mut out),
+        Command::ShowLedger(cmd) => cmd.run(&mut out),
+        Command::Show(cmd) => cmd.run(&mut out),
         Command::Transfer(cmd) => cmd.run(),
     }
 }


### PR DESCRIPTION
Currently, resim functions which emit output to the console use println! to do so. This means they can only send output to the console. Other applications might wish to redirect the output to other IO objects such as files, network streams, or anything else that implements the std::io:Write trait.

Changes made here replaced the uses of println! with writeln! to use an output object such that what was previously:
println!("This is some text") ;
becomes
writeln!(out, "This is some text") ;

The "out" in this case can be a stdout, a file; or a TcpStream

Doing this allows the TCP server to use the same functions used by local resim without resorting to copying files for this purpose and then having them be out of sync.