### PR TITLE
Support --singing-keys for all transaction-based commands

### DIFF
--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -9,7 +9,6 @@ use std::collections::VecDeque;
 
 use crate::utils::*;
 
-
 /// Represents an error when displaying an entity.
 #[derive(Debug, Clone)]
 pub enum DisplayError {
@@ -22,19 +21,25 @@ pub enum DisplayError {
 pub fn dump_package<T: SubstateStore, O: std::io::Write>(
     package_address: PackageAddress,
     substate_store: &T,
-    output: &mut O
+    output: &mut O,
 ) -> Result<(), DisplayError> {
     let package: Option<Package> = substate_store
         .get_decoded_substate(&package_address)
         .map(|(package, _)| package);
     match package {
         Some(b) => {
-            writeln!(output,
+            writeln!(
+                output,
                 "{}: {}",
                 "Package".green().bold(),
                 package_address.to_string()
             );
-            writeln!(output,"{}: {} bytes", "Code size".green().bold(), b.code().len());
+            writeln!(
+                output,
+                "{}: {} bytes",
+                "Code size".green().bold(),
+                b.code().len()
+            );
             Ok(())
         }
         None => Err(DisplayError::PackageNotFound),
@@ -45,36 +50,38 @@ pub fn dump_package<T: SubstateStore, O: std::io::Write>(
 pub fn dump_component<T: SubstateStore + QueryableSubstateStore, O: std::io::Write>(
     component_address: ComponentAddress,
     substate_store: &T,
-    output: &mut O
+    output: &mut O,
 ) -> Result<(), DisplayError> {
     let component: Option<Component> = substate_store
         .get_decoded_substate(&component_address)
         .map(|(component, _)| component);
     match component {
         Some(c) => {
-            writeln!(output,
+            writeln!(
+                output,
                 "{}: {}",
                 "Component".green().bold(),
                 component_address.to_string()
             );
 
-            writeln!(output,
+            writeln!(
+                output,
                 "{}: {{ package_address: {}, blueprint_name: \"{}\" }}",
                 "Blueprint".green().bold(),
                 c.package_address(),
                 c.blueprint_name()
             );
 
-            writeln!(output,"{}", "Authorization".green().bold());
+            writeln!(output, "{}", "Authorization".green().bold());
             for (_, auth) in c.authorization().iter().identify_last() {
                 for (last, (k, v)) in auth.iter().identify_last() {
-                    writeln!(output,"{} {:?} => {:?}", list_item_prefix(last), k, v);
+                    writeln!(output, "{} {:?} => {:?}", list_item_prefix(last), k, v);
                 }
             }
 
             let state = c.state();
             let state_data = ScryptoValue::from_slice(state).unwrap();
-            writeln!(output,"{}: {}", "State".green().bold(), state_data);
+            writeln!(output, "{}: {}", "State".green().bold(), state_data);
 
             // Find all vaults owned by the component, assuming a tree structure.
             let mut vaults_found: HashSet<VaultId> = state_data.vault_ids.iter().cloned().collect();
@@ -98,12 +105,13 @@ fn dump_lazy_map<T: SubstateStore + QueryableSubstateStore, O: std::io::Write>(
     component_address: ComponentAddress,
     lazy_map_id: &LazyMapId,
     substate_store: &T,
-    output: &mut O
+    output: &mut O,
 ) -> Result<(Vec<LazyMapId>, Vec<VaultId>), DisplayError> {
     let mut referenced_maps = Vec::new();
     let mut referenced_vaults = Vec::new();
     let map = substate_store.get_lazy_map_entries(component_address, lazy_map_id);
-    writeln!(output,
+    writeln!(
+        output,
         "{}: {:?}{:?}",
         "Lazy Map".green().bold(),
         component_address,
@@ -112,7 +120,8 @@ fn dump_lazy_map<T: SubstateStore + QueryableSubstateStore, O: std::io::Write>(
     for (last, (k, v)) in map.iter().identify_last() {
         let k_validated = ScryptoValue::from_slice(k).unwrap();
         let v_validated = ScryptoValue::from_slice(v).unwrap();
-        writeln!(output,
+        writeln!(
+            output,
             "{} {} => {}",
             list_item_prefix(last),
             k_validated,
@@ -128,9 +137,9 @@ fn dump_resources<T: SubstateStore, O: std::io::Write>(
     component_address: ComponentAddress,
     vaults: &HashSet<VaultId>,
     substate_store: &T,
-    output: &mut O
+    output: &mut O,
 ) -> Result<(), DisplayError> {
-    writeln!(output,"{}:", "Resources".green().bold());
+    writeln!(output, "{}:", "Resources".green().bold());
     for (last, vault_id) in vaults.iter().identify_last() {
         let vault: Vault = substate_store
             .get_decoded_child_substate(&component_address, vault_id)
@@ -143,7 +152,8 @@ fn dump_resources<T: SubstateStore, O: std::io::Write>(
             .get_decoded_substate(&resource_address)
             .map(|(resource, _)| resource)
             .unwrap();
-        writeln!(output,
+        writeln!(
+            output,
             "{} {{ amount: {}, resource address: {}{}{} }}",
             list_item_prefix(last),
             amount,
@@ -170,8 +180,10 @@ fn dump_resources<T: SubstateStore, O: std::io::Write>(
                 if let Some(non_fungible) = non_fungible {
                     let immutable_data =
                         ScryptoValue::from_slice(&non_fungible.immutable_data()).unwrap();
-                    let mutable_data = ScryptoValue::from_slice(&non_fungible.mutable_data()).unwrap();
-                    writeln!(output,
+                    let mutable_data =
+                        ScryptoValue::from_slice(&non_fungible.mutable_data()).unwrap();
+                    writeln!(
+                        output,
                         "{}  {} NON_FUNGIBLE {{ id: {}, immutable_data: {}, mutable_data: {} }}",
                         if last { " " } else { "│" },
                         list_item_prefix(inner_last),
@@ -190,23 +202,40 @@ fn dump_resources<T: SubstateStore, O: std::io::Write>(
 pub fn dump_resource_manager<T: SubstateStore, O: std::io::Write>(
     resource_address: ResourceAddress,
     substate_store: &T,
-    output: &mut O
+    output: &mut O,
 ) -> Result<(), DisplayError> {
     let resource_manager: Option<ResourceManager> = substate_store
         .get_decoded_substate(&resource_address)
         .map(|(resource, _)| resource);
     match resource_manager {
         Some(r) => {
-            writeln!(output,
+            writeln!(
+                output,
                 "{}: {:?}",
                 "Resource Type".green().bold(),
                 r.resource_type()
             );
-            writeln!(output,"{}: {}", "Metadata".green().bold(), r.metadata().len());
+            writeln!(
+                output,
+                "{}: {}",
+                "Metadata".green().bold(),
+                r.metadata().len()
+            );
             for (last, e) in r.metadata().iter().identify_last() {
-                writeln!(output,"{} {}: {}", list_item_prefix(last), e.0.green().bold(), e.1);
+                writeln!(
+                    output,
+                    "{} {}: {}",
+                    list_item_prefix(last),
+                    e.0.green().bold(),
+                    e.1
+                );
             }
-            writeln!(output,"{}: {}", "Total Supply".green().bold(), r.total_supply());
+            writeln!(
+                output,
+                "{}: {}",
+                "Total Supply".green().bold(),
+                r.total_supply()
+            );
             Ok(())
         }
         None => Err(DisplayError::ResourceManagerNotFound),

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -23,6 +23,10 @@ pub struct CallFunction {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -33,7 +37,6 @@ impl CallFunction {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         let default_account = get_default_account()?;
-        let (default_pk, default_sk) = get_default_signers()?;
 
         let transaction = TransactionBuilder::new()
             .call_function_with_abi(
@@ -48,8 +51,13 @@ impl CallFunction {
             )
             .map_err(Error::TransactionConstructionError)?
             .call_method_with_all_resources(default_account, "deposit_batch")
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -22,6 +22,10 @@ pub struct CallMethod {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -32,7 +36,6 @@ impl CallMethod {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         let default_account = get_default_account()?;
-        let (default_pk, default_sk) = get_default_signers()?;
 
         let transaction = TransactionBuilder::new()
             .call_method_with_abi(
@@ -46,8 +49,13 @@ impl CallMethod {
             )
             .map_err(Error::TransactionConstructionError)?
             .call_method_with_all_resources(default_account, "deposit_batch")
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_export_abi.rs
+++ b/simulator/src/resim/cmd_export_abi.rs
@@ -1,4 +1,3 @@
-
 use clap::Parser;
 use radix_engine::transaction::*;
 use scrypto::engine::types::*;
@@ -20,16 +19,17 @@ pub struct ExportAbi {
 }
 
 impl ExportAbi {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let executor = TransactionExecutor::new(&mut ledger, self.trace);
         match executor.export_abi(self.package_address, &self.blueprint_name) {
             Ok(a) => {
-                writeln!(out,
+                writeln!(
+                    out,
                     "{}",
                     serde_json::to_string_pretty(&a).map_err(Error::JSONError)?
-                ).map_err(Error::IOError)?;
+                )
+                .map_err(Error::IOError)?;
                 Ok(())
             }
             Err(e) => Err(Error::AbiExportError(e)),

--- a/simulator/src/resim/cmd_generate_key_pair.rs
+++ b/simulator/src/resim/cmd_generate_key_pair.rs
@@ -10,16 +10,17 @@ use crate::resim::*;
 pub struct GenerateKeyPair {}
 
 impl GenerateKeyPair {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let secret = rand::thread_rng().gen::<[u8; 32]>();
         let private_key = EcdsaPrivateKey::from_bytes(&secret).unwrap();
         let public_key = private_key.public_key();
         writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
-        writeln!(out,
+        writeln!(
+            out,
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
-        ).map_err(Error::IOError)?;
+        )
+        .map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -1,4 +1,3 @@
-
 use clap::Parser;
 use colored::*;
 use rand::Rng;
@@ -19,7 +18,6 @@ pub struct NewAccount {
 }
 
 impl NewAccount {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
@@ -39,29 +37,41 @@ impl NewAccount {
                     builder.new_account_with_resource(&withdraw_auth, bucket_id)
                 })
                 .build_with_no_nonce();
-            let manifest = decompile(&transaction).map_err(Error::DecompileError)?;
+            process_transaction(&mut executor, transaction, &None, &Some(path.clone()), out)?;
             writeln!(out, "A manifest has been produced for the following key pair. To complete account creation, you will need to run the manifest!").map_err(Error::IOError)?;
-            writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
-            writeln!(out, 
+            writeln!(out, "Public key: {}", public_key.to_string().green())
+                .map_err(Error::IOError)?;
+            writeln!(
+                out,
                 "Private key: {}",
                 hex::encode(private_key.to_bytes()).green()
-            ).map_err(Error::IOError)?;
-            return fs::write(path, manifest).map_err(Error::IOError);
+            )
+            .map_err(Error::IOError)?;
         }
 
         let (public_key, private_key, account) = executor.new_account();
         writeln!(out, "A new account has been created!").map_err(Error::IOError)?;
-        writeln!(out, "Account component address: {}", account.to_string().green()).map_err(Error::IOError)?;
+        writeln!(
+            out,
+            "Account component address: {}",
+            account.to_string().green()
+        )
+        .map_err(Error::IOError)?;
         writeln!(out, "Public key: {}", public_key.to_string().green()).map_err(Error::IOError)?;
-        writeln!(out, 
+        writeln!(
+            out,
             "Private key: {}",
             hex::encode(private_key.to_bytes()).green()
-        ).map_err(Error::IOError)?;
+        )
+        .map_err(Error::IOError)?;
         if get_configs()?.is_none() {
-            writeln!(out, "No configuration found on system. will use the above account as default.").map_err(Error::IOError)?;
+            writeln!(
+                out,
+                "No configuration found on system. will use the above account as default."
+            )
+            .map_err(Error::IOError)?;
             set_configs(&Configs {
                 default_account: account,
-                default_public_key: public_key,
                 default_private_key: private_key.to_bytes(),
             })?;
         }

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -35,6 +35,10 @@ pub struct NewBadgeFixed {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -45,7 +49,6 @@ impl NewBadgeFixed {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         let default_account = get_default_account()?;
-        let (default_pk, default_sk) = get_default_signers()?;
         let mut metadata = HashMap::new();
         if let Some(symbol) = self.symbol.clone() {
             metadata.insert("symbol".to_string(), symbol);
@@ -66,8 +69,13 @@ impl NewBadgeFixed {
         let transaction = TransactionBuilder::new()
             .new_badge_fixed(metadata, self.total_supply)
             .call_method_with_all_resources(default_account, "deposit_batch")
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_new_badge_mutable.rs
+++ b/simulator/src/resim/cmd_new_badge_mutable.rs
@@ -35,6 +35,10 @@ pub struct NewBadgeMutable {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -44,7 +48,6 @@ impl NewBadgeMutable {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
-        let (default_pk, default_sk) = get_default_signers()?;
         let mut metadata = HashMap::new();
         if let Some(symbol) = self.symbol.clone() {
             metadata.insert("symbol".to_string(), symbol);
@@ -64,8 +67,13 @@ impl NewBadgeMutable {
 
         let transaction = TransactionBuilder::new()
             .new_badge_mutable(metadata, self.minter_resource_address)
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -35,6 +35,10 @@ pub struct NewTokenFixed {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -45,7 +49,6 @@ impl NewTokenFixed {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         let default_account = get_default_account()?;
-        let (default_pk, default_sk) = get_default_signers()?;
         let mut metadata = HashMap::new();
         if let Some(symbol) = self.symbol.clone() {
             metadata.insert("symbol".to_string(), symbol);
@@ -66,8 +69,13 @@ impl NewTokenFixed {
         let transaction = TransactionBuilder::new()
             .new_token_fixed(metadata, self.total_supply)
             .call_method_with_all_resources(default_account, "deposit_batch")
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_new_token_mutable.rs
+++ b/simulator/src/resim/cmd_new_token_mutable.rs
@@ -35,6 +35,10 @@ pub struct NewTokenMutable {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -44,7 +48,6 @@ impl NewTokenMutable {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
-        let (default_pk, default_sk) = get_default_signers()?;
         let mut metadata = HashMap::new();
         if let Some(symbol) = self.symbol.clone() {
             metadata.insert("symbol".to_string(), symbol);
@@ -64,8 +67,13 @@ impl NewTokenMutable {
 
         let transaction = TransactionBuilder::new()
             .new_token_mutable(metadata, self.minter_resource_address)
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -30,7 +30,6 @@ pub struct Publish {
 }
 
 impl Publish {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         // Load wasm code
         let code = fs::read(if self.path.extension() != Some(OsStr::new("wasm")) {
@@ -38,20 +37,24 @@ impl Publish {
         } else {
             self.path.clone()
         })
-            .map_err(Error::IOError)?;
+        .map_err(Error::IOError)?;
 
         if let Some(path) = &self.manifest {
+            let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
+            let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
             let transaction = TransactionBuilder::new()
                 .publish_package(code.as_ref())
                 .build_with_no_nonce();
-
-            let manifest = decompile(&transaction).map_err(Error::DecompileError)?;
-            return fs::write(path, manifest).map_err(Error::IOError);
+            process_transaction(&mut executor, transaction, &None, &Some(path.clone()), out)?;
         }
         self.store_package(out, &code)
     }
 
-    pub fn publish_wasm<O: std::io::Write>(&self, out: &mut O, wasm_file_path: &str) -> Result<(), Error> {
+    pub fn publish_wasm<O: std::io::Write>(
+        &self,
+        out: &mut O,
+        wasm_file_path: &str,
+    ) -> Result<(), Error> {
         // Load wasm code
         println!("Publishing ..");
         let code = fs::read(wasm_file_path).map_err(Error::IOError)?;
@@ -60,7 +63,6 @@ impl Publish {
     }
 
     pub fn store_package<O: std::io::Write>(&self, out: &mut O, code: &[u8]) -> Result<(), Error> {
-
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         if let Some(package_address) = self.package_address.clone() {
@@ -73,24 +75,21 @@ impl Publish {
         } else {
             match executor.publish_package(code) {
                 Ok(package_address) => {
-                    writeln!(out,
-                             "Success! New Package: {}",
-                             package_address.to_string().green()
-                    ).map_err(Error::IOError)?;
+                    writeln!(
+                        out,
+                        "Success! New Package: {}",
+                        package_address.to_string().green()
+                    )
+                    .map_err(Error::IOError)?;
                     Ok(())
                 }
 
                 Err(error) => {
-                    writeln!(out,
-                             "Error creating new package: {:?}", error
-                    ).map_err(Error::IOError)?;
+                    writeln!(out, "Error creating new package: {:?}", error)
+                        .map_err(Error::IOError)?;
                     Err(Error::TransactionExecutionError(error))
-                },
+                }
             }
         }
-
     }
-
-
-
 }

--- a/simulator/src/resim/cmd_run.rs
+++ b/simulator/src/resim/cmd_run.rs
@@ -1,6 +1,4 @@
 use clap::Parser;
-use radix_engine::model::*;
-use scrypto::crypto::*;
 use std::path::PathBuf;
 
 use crate::resim::*;
@@ -22,30 +20,10 @@ pub struct Run {
 
 impl Run {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-        let private_keys = if let Some(keys) = &self.signing_keys {
-            keys.split(",")
-                .map(str::trim)
-                .map(|key| {
-                    hex::decode(key)
-                        .map_err(|_| Error::InvalidPrivateKey)
-                        .and_then(|bytes| {
-                            EcdsaPrivateKey::from_bytes(&bytes)
-                                .map_err(|_| Error::InvalidPrivateKey)
-                        })
-                })
-                .collect::<Result<Vec<EcdsaPrivateKey>, Error>>()?
-        } else {
-            vec![get_default_signers()?.1]
-        };
-
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
         let manifest = std::fs::read_to_string(&self.path).map_err(Error::IOError)?;
-        let mut unsigned = transaction_manifest::compile(&manifest).map_err(Error::CompileError)?;
-        unsigned.instructions.push(Instruction::Nonce {
-            nonce: executor.substate_store().get_nonce(),
-        });
-        let signed = unsigned.sign(private_keys.iter().collect::<Vec<&EcdsaPrivateKey>>());
-        process_transaction(signed, &mut executor, &None, out)
+        let transaction = transaction_manifest::compile(&manifest).map_err(Error::CompileError)?;
+        process_transaction(&mut executor, transaction, &self.signing_keys, &None, out)
     }
 }

--- a/simulator/src/resim/cmd_set_default_account.rs
+++ b/simulator/src/resim/cmd_set_default_account.rs
@@ -9,19 +9,14 @@ pub struct SetDefaultAccount {
     /// The account component address
     component_address: ComponentAddress,
 
-    /// The public key for accessing the account
-    public_key: EcdsaPublicKey,
-
     /// The private key for accessing the account
     private_key: String,
 }
 
 impl SetDefaultAccount {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         set_configs(&Configs {
             default_account: self.component_address,
-            default_public_key: self.public_key,
             default_private_key: hex::decode(&self.private_key).unwrap(),
         })?;
 

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -13,9 +13,7 @@ pub struct Show {
 }
 
 impl Show {
-
-   pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-
+    pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
 
         if let Ok(package_address) = PackageAddress::from_str(&self.address) {

--- a/simulator/src/resim/cmd_show_configs.rs
+++ b/simulator/src/resim/cmd_show_configs.rs
@@ -8,26 +8,33 @@ use crate::resim::*;
 pub struct ShowConfigs {}
 
 impl ShowConfigs {
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         if let Some(configs) = get_configs()? {
-            writeln!(out,
+            writeln!(
+                out,
                 "{}: {}",
                 "Default Account".green().bold(),
                 configs.default_account
-            ).map_err(Error::IOError)?;
-            writeln!(out,
+            )
+            .map_err(Error::IOError)?;
+            writeln!(
+                out,
                 "{}: {}",
                 "Default Public Key".green().bold(),
-                configs.default_public_key
-            ).map_err(Error::IOError)?;
-            writeln!(out,
+                EcdsaPrivateKey::from_bytes(&configs.default_private_key)
+                    .unwrap()
+                    .public_key()
+            )
+            .map_err(Error::IOError)?;
+            writeln!(
+                out,
                 "{}: {}",
                 "Default Private Key".green().bold(),
                 hex::encode(configs.default_private_key)
-            ).map_err(Error::IOError)?;
+            )
+            .map_err(Error::IOError)?;
         } else {
-            writeln!(out,"No configuration found").map_err(Error::IOError)?;
+            writeln!(out, "No configuration found").map_err(Error::IOError)?;
         }
         Ok(())
     }

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -10,27 +10,29 @@ use crate::utils::*;
 pub struct ShowLedger {}
 
 impl ShowLedger {
-
-
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
 
         writeln!(out, "{}:", "Packages".green().bold()).map_err(Error::IOError)?;
         for (last, package_address) in ledger.list_packages().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), package_address).map_err(Error::IOError)?;
+            writeln!(out, "{} {}", list_item_prefix(last), package_address)
+                .map_err(Error::IOError)?;
         }
 
         writeln!(out, "{}:", "Components".green().bold()).map_err(Error::IOError)?;
         for (last, component_address) in ledger.list_components().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), component_address).map_err(Error::IOError)?;
+            writeln!(out, "{} {}", list_item_prefix(last), component_address)
+                .map_err(Error::IOError)?;
         }
 
         writeln!(out, "{}:", "Resource Managers".green().bold()).map_err(Error::IOError)?;
         for (last, resource_address) in ledger.list_resource_managers().iter().identify_last() {
-            writeln!(out, "{} {}", list_item_prefix(last), resource_address).map_err(Error::IOError)?;
+            writeln!(out, "{} {}", list_item_prefix(last), resource_address)
+                .map_err(Error::IOError)?;
         }
 
-        writeln!(out, "{}: {}", "Nonce".green().bold(), ledger.get_nonce()).map_err(Error::IOError)?;
+        writeln!(out, "{}: {}", "Nonce".green().bold(), ledger.get_nonce())
+            .map_err(Error::IOError)?;
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -20,6 +20,10 @@ pub struct Transfer {
     #[clap(short, long)]
     manifest: Option<PathBuf>,
 
+    /// The private keys used for signing, separated by comma
+    #[clap(short, long)]
+    signing_keys: Option<String>,
+
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
@@ -29,13 +33,20 @@ impl Transfer {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
         let mut executor = TransactionExecutor::new(&mut ledger, self.trace);
-        let default_account = get_default_account()?;
-        let (default_pk, default_sk) = get_default_signers()?;
         let transaction = TransactionBuilder::new()
-            .withdraw_from_account_by_amount(self.amount, self.resource_address, default_account)
+            .withdraw_from_account_by_amount(
+                self.amount,
+                self.resource_address,
+                get_default_account()?,
+            )
             .call_method_with_all_resources(self.recipient, "deposit_batch")
-            .build(executor.get_nonce([default_pk]))
-            .sign([&default_sk]);
-        process_transaction(transaction, &mut executor, &self.manifest, out)
+            .build_with_no_nonce();
+        process_transaction(
+            &mut executor,
+            transaction,
+            &self.signing_keys,
+            &self.manifest,
+            out,
+        )
     }
 }

--- a/simulator/src/resim/config.rs
+++ b/simulator/src/resim/config.rs
@@ -17,11 +17,11 @@ pub struct Configs {
 
 /// Returns the data directory.
 pub fn get_data_dir() -> Result<PathBuf, Error> {
-    let path = match env::var("DATA_DIR") {
+    let path = match env::var(ENV_DATA_DIR) {
         Ok(value) => std::path::PathBuf::from(value),
         Err(..) => {
             let mut path = dirs::home_dir().ok_or(Error::HomeDirUnknown)?;
-            path.push("scrypto-simulator");
+            path.push(DEFAULT_SCRYPTO_DIR_UNDER_HOME);
             path
         }
     };

--- a/simulator/src/resim/config.rs
+++ b/simulator/src/resim/config.rs
@@ -6,22 +6,19 @@ use scrypto::buffer::*;
 use scrypto::engine::types::*;
 
 use crate::resim::*;
-use std::env ;
+use std::env;
 
 /// Simulator configurations.
 #[derive(Debug, Clone, TypeId, Encode, Decode)]
 pub struct Configs {
     pub default_account: ComponentAddress,
-    pub default_public_key: EcdsaPublicKey,
     pub default_private_key: Vec<u8>,
 }
 
 /// Returns the data directory.
 pub fn get_data_dir() -> Result<PathBuf, Error> {
     let path = match env::var("DATA_DIR") {
-        Ok(value) => {
-            std::path::PathBuf::from(value)
-        },
+        Ok(value) => std::path::PathBuf::from(value),
         Err(..) => {
             let mut path = dirs::home_dir().ok_or(Error::HomeDirUnknown)?;
             path.push("scrypto-simulator");
@@ -64,11 +61,8 @@ pub fn get_default_account() -> Result<ComponentAddress, Error> {
         .map(|config| config.default_account)
 }
 
-pub fn get_default_signers() -> Result<(EcdsaPublicKey, EcdsaPrivateKey), Error> {
-    get_configs()?.ok_or(Error::NoDefaultAccount).map(|config| {
-        (
-            config.default_public_key,
-            EcdsaPrivateKey::from_bytes(&config.default_private_key).unwrap(),
-        )
-    })
+pub fn get_default_private_key() -> Result<EcdsaPrivateKey, Error> {
+    get_configs()?
+        .ok_or(Error::NoDefaultAccount)
+        .map(|config| EcdsaPrivateKey::from_bytes(&config.default_private_key).unwrap())
 }

--- a/simulator/src/rtmc/mod.rs
+++ b/simulator/src/rtmc/mod.rs
@@ -1,7 +1,5 @@
 use clap::Parser;
 use scrypto::buffer::scrypto_encode;
-use std::fs::read_to_string;
-use std::fs::write;
 use std::path::PathBuf;
 use transaction_manifest::compile;
 
@@ -27,9 +25,9 @@ pub enum Error {
 pub fn run() -> Result<(), Error> {
     let args = Args::parse();
 
-    let content = read_to_string(args.input).map_err(Error::IoError)?;
+    let content = std::fs::read_to_string(args.input).map_err(Error::IoError)?;
     let transaction = compile(&content).map_err(Error::CompileError)?;
-    write(args.output, scrypto_encode(&transaction)).map_err(Error::IoError)?;
+    std::fs::write(args.output, scrypto_encode(&transaction)).map_err(Error::IoError)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR enables `--signing-keys` for all transaction-based commands, as PTE terminal won't allow account switch. This gives users an alternative approach to simulate different accounts.