### PR TITLE
Fixed a bug with creating empty buckets

### DIFF
--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -129,6 +129,7 @@ impl ResourceManager {
         for pub_method in [
             "create_bucket",
             "create_bucket_proof",
+            "create_empty_bucket",
             "get_metadata",
             "get_resource_type",
             "get_total_supply",

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -25,6 +25,7 @@ fn test_bucket() {
         .call_function(package, "BucketTest", "test_restricted_transfer", args![])
         .call_function(package, "BucketTest", "test_burn", args![])
         .call_function(package, "BucketTest", "test_burn_freely", args![])
+        .call_function(package, "BucketTest", "create_empty_bucket", args![])
         .call_method_with_all_resources(account, "deposit_batch")
         .build(executor.get_nonce([]))
         .sign([]);

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -25,7 +25,8 @@ fn test_bucket() {
         .call_function(package, "BucketTest", "test_restricted_transfer", args![])
         .call_function(package, "BucketTest", "test_burn", args![])
         .call_function(package, "BucketTest", "test_burn_freely", args![])
-        .call_function(package, "BucketTest", "create_empty_bucket", args![])
+        .call_function(package, "BucketTest", "create_empty_bucket_fungible", args![])
+        .call_function(package, "BucketTest", "create_empty_bucket_non_fungible", args![])
         .call_method_with_all_resources(account, "deposit_batch")
         .build(executor.get_nonce([]))
         .sign([]);

--- a/radix-engine/tests/bucket/src/bucket.rs
+++ b/radix-engine/tests/bucket/src/bucket.rs
@@ -90,5 +90,9 @@ blueprint! {
             let x = bucket.take(amount);
             (bucket, x)
         }
+
+        pub fn create_empty_bucket() -> Bucket {
+            Bucket::new(RADIX_TOKEN)
+        }
     }
 }

--- a/radix-engine/tests/bucket/src/bucket.rs
+++ b/radix-engine/tests/bucket/src/bucket.rs
@@ -91,8 +91,13 @@ blueprint! {
             (bucket, x)
         }
 
-        pub fn create_empty_bucket() -> Bucket {
+        pub fn create_empty_bucket_fungible() -> Bucket {
             Bucket::new(RADIX_TOKEN)
+        }
+        
+        pub fn create_empty_bucket_non_fungible() -> Bucket {
+            let resource_address = ResourceBuilder::new_non_fungible().no_initial_supply();
+            Bucket::new(resource_address)
         }
     }
 }


### PR DESCRIPTION
The `Bucket::new()` function calls the `create_empty_bucket` function on the resource manager for the creation of empty buckets. However, this function was not in the list of allowed functions which meant that any call to `Bucket::new()` would result in a `MethodAuthorization::Unsupported` error.

This PR adds the `create_empty_bucket` function to the allowed functions on the resource manager and adds tests for the empty bucket creation. 