### PR TITLE
Rust analyzer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Visual studio code
-.vscode
-
 # macOS folder attributes
 .DS_Store
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "radix-engine/Cargo.toml",
+        "sbor/Cargo.toml",
+        "sbor-derive/Cargo.toml",
+        "sbor-tests/Cargo.toml",
+        "scrypto/Cargo.toml",
+        "scrypto-abi/Cargo.toml",
+        "scrypto-derive/Cargo.toml",
+        "scrypto-tests/Cargo.toml",
+        "simulator/Cargo.toml",
+        "transaction-manifest/Cargo.toml",
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation: https://docs.radixdlt.com/main/scrypto/introduction.html
 
 ## Installation
 
-1. Install Rust
+1. Install Rust - this requires Rust 1.60+ (if rust is already installed, upgrade with `rustup update`)
    * Windows:
        * Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)
        * Install "Desktop development with C++" with [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 sbor-derive = { path = "../sbor-derive" }
 hashbrown = { version = "0.12", optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, optional = true, features=["derive"] }
 hex = { version = "0.4.3", default-features = false, optional = true }
 
 [features]
@@ -16,7 +16,7 @@ std = ["serde?/std", "hex?/std"]
 alloc = ["hashbrown", "serde?/alloc", "hex?/alloc"]
 
 # Enable serde derives for SBOR value and type models
-serde = ["serde/derive", "hex/serde"]
+serde = ["dep:serde", "hex/serde"]
 
 # Enable tracing
 trace = ["sbor-derive/trace"]


### PR DESCRIPTION
## Context

Rust Analyzer is the recommended VSCode extension for Rust, but had some issues running with this repo, notably:
* It didn't like that `serde` was both a dependency and a feature - see https://doc.rust-lang.org/cargo/reference/features.html
* It didn't pick up the Cargo.toml files

## Change overview

* The .vscode folder is intended to be team-shared, workspace settings - so I've removed this from the .gitignore
* I've added a "rust-analyzer.linkedProjects" section to the .vscode settings so that it picks up the Cargo.toml files
* I've fixed the serde feature to now use `dep:serde`, so rust-analyzer is happy (see also https://doc.rust-lang.org/cargo/reference/features.html )