### PR TITLE
Feature: Limited caller AuthZone access and AuthZone stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ flamegraph.svg
 
 # Emacs
 *~
+
+# Rusty Tags
+rusty-tags.vi
+rusty-tags.emacs

--- a/radix-engine/src/engine/component_objects.rs
+++ b/radix-engine/src/engine/component_objects.rs
@@ -145,7 +145,11 @@ impl ComponentObjects {
             lazy_maps.insert(lazy_map_id, lazy_map);
         }
 
-        Ok(ComponentObjects { vaults, lazy_maps, borrowed_vault: None })
+        Ok(ComponentObjects {
+            vaults,
+            lazy_maps,
+            borrowed_vault: None,
+        })
     }
 
     pub fn insert_objects_into_map(
@@ -229,7 +233,11 @@ impl ComponentObjects {
     pub fn return_borrowed_vault_mut(&mut self, vault: Vault) {
         if let Some((vault_id, maybe_ancestor)) = self.borrowed_vault.take() {
             if let Some(ancestor_id) = maybe_ancestor {
-                self.lazy_maps.get_mut(&ancestor_id).unwrap().descendent_vaults.insert(vault_id, vault);
+                self.lazy_maps
+                    .get_mut(&ancestor_id)
+                    .unwrap()
+                    .descendent_vaults
+                    .insert(vault_id, vault);
             } else {
                 self.vaults.insert(vault_id, vault);
             }

--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -611,11 +611,16 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
                 _ => {}
             };
 
-            // new shadow_auth_zone for each call (when there are some method_auths)
+            // new shadow_auth_zone for each call
+            // but code here so it only exists when there are some method_auths
+            // and, only shadow zones after the first default auth zone
             process_shadow_auth_zone = match snode {
                 SNodeState::Proof(_) => None,
                 SNodeState::Bucket(_) => None,
-                _ => Some(AuthZone::new()),
+                _ => match self.auth_zone_stack.len() {
+                    0 => None,
+                    _ => Some(AuthZone::new()),
+                },
             };
 
             for method_auth in method_auths {

--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -508,7 +508,11 @@ impl<'s, S: SubstateStore> Track<'s, S> {
         resource_address
     }
 
-    pub fn borrow_vault_mut(&mut self, component_address: &ComponentAddress, vid: &VaultId) -> Vault {
+    pub fn borrow_vault_mut(
+        &mut self,
+        component_address: &ComponentAddress,
+        vid: &VaultId,
+    ) -> Vault {
         let canonical_id = (component_address.clone(), vid.clone());
         if self.borrowed_vaults.contains_key(&canonical_id) {
             panic!("Invalid vault reentrancy");
@@ -519,9 +523,11 @@ impl<'s, S: SubstateStore> Track<'s, S> {
             return value;
         }
 
-        if let Some((vault, phys_id)) = self.substate_store.get_decoded_child_substate(component_address, vid) {
-            self.borrowed_vaults
-                .insert(canonical_id, Some(phys_id));
+        if let Some((vault, phys_id)) = self
+            .substate_store
+            .get_decoded_child_substate(component_address, vid)
+        {
+            self.borrowed_vaults.insert(canonical_id, Some(phys_id));
             return vault;
         }
 

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -232,7 +232,6 @@ pub enum RuntimeError {
 
     /// Can't move restricted proof.
     CantMoveRestrictedProof(ProofId),
-
 }
 
 impl fmt::Display for RuntimeError {

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -1,11 +1,11 @@
 use sbor::*;
-use scrypto::rule;
 use scrypto::buffer::*;
 use scrypto::constants::*;
 use scrypto::crypto::*;
 use scrypto::engine::types::*;
 use scrypto::prelude::LOCKED;
 use scrypto::resource::ResourceMethod::Withdraw;
+use scrypto::rule;
 use scrypto::rust::borrow::ToOwned;
 use scrypto::rust::collections::*;
 use scrypto::rust::vec;

--- a/radix-engine/src/model/auth_converter.rs
+++ b/radix-engine/src/model/auth_converter.rs
@@ -6,7 +6,7 @@ use crate::model::MethodAuthorization;
 use sbor::any::Value;
 use sbor::*;
 use scrypto::engine::types::*;
-use scrypto::prelude::{AccessRuleNode, AccessRule, SoftResource};
+use scrypto::prelude::{AccessRule, AccessRuleNode, SoftResource};
 use scrypto::resource::{
     NonFungibleAddress, ProofRule, SoftCount, SoftDecimal, SoftResourceOrNonFungible,
     SoftResourceOrNonFungibleList,

--- a/radix-engine/src/model/auth_zone.rs
+++ b/radix-engine/src/model/auth_zone.rs
@@ -48,7 +48,7 @@ impl AuthZone {
         self.proofs.push(proof);
     }
 
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         loop {
             if let Some(proof) = self.proofs.pop() {
                 proof.drop();

--- a/radix-engine/src/model/auth_zone.rs
+++ b/radix-engine/src/model/auth_zone.rs
@@ -1,12 +1,12 @@
+use crate::engine::SystemApi;
 use sbor::DecodeError;
 use scrypto::engine::types::*;
 use scrypto::prelude::scrypto_decode;
 use scrypto::rust::collections::BTreeSet;
-use scrypto::rust::vec::Vec;
 use scrypto::rust::string::String;
 use scrypto::rust::string::ToString;
+use scrypto::rust::vec::Vec;
 use scrypto::values::ScryptoValue;
-use crate::engine::SystemApi;
 
 use crate::model::{Proof, ProofError, ResourceManager};
 
@@ -29,15 +29,11 @@ pub struct AuthZone {
 
 impl AuthZone {
     pub fn new_with_proofs(proofs: Vec<Proof>) -> Self {
-        Self {
-            proofs
-        }
+        Self { proofs }
     }
 
     pub fn new() -> Self {
-        Self {
-            proofs: Vec::new()
-        }
+        Self { proofs: Vec::new() }
     }
 
     pub fn pop(&mut self) -> Result<Proof, AuthZoneError> {
@@ -62,18 +58,31 @@ impl AuthZone {
         }
     }
 
-    fn create_proof(&self, resource_address: ResourceAddress, resource_type: ResourceType) -> Result<Proof, AuthZoneError> {
+    fn create_proof(
+        &self,
+        resource_address: ResourceAddress,
+        resource_type: ResourceType,
+    ) -> Result<Proof, AuthZoneError> {
         Proof::compose(&self.proofs, resource_address, resource_type)
             .map_err(AuthZoneError::ProofError)
     }
 
-    fn create_proof_by_amount(&self, amount:Decimal, resource_address: ResourceAddress, resource_type: ResourceType) -> Result<Proof, AuthZoneError> {
+    fn create_proof_by_amount(
+        &self,
+        amount: Decimal,
+        resource_address: ResourceAddress,
+        resource_type: ResourceType,
+    ) -> Result<Proof, AuthZoneError> {
         Proof::compose_by_amount(&self.proofs, amount, resource_address, resource_type)
             .map_err(AuthZoneError::ProofError)
     }
 
-
-    fn create_proof_by_ids(&self, ids: &BTreeSet<NonFungibleId>, resource_address: ResourceAddress, resource_type: ResourceType) -> Result<Proof, AuthZoneError> {
+    fn create_proof_by_ids(
+        &self,
+        ids: &BTreeSet<NonFungibleId>,
+        resource_address: ResourceAddress,
+        resource_type: ResourceType,
+    ) -> Result<Proof, AuthZoneError> {
         Proof::compose_by_ids(&self.proofs, ids, resource_address, resource_type)
             .map_err(AuthZoneError::ProofError)
     }
@@ -91,13 +100,19 @@ impl AuthZone {
             }
             "pop" => {
                 let proof = self.pop()?;
-                let proof_id = system_api.create_proof(proof).map_err(|_| AuthZoneError::CouldNotCreateProof)?;
-                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(proof_id)))
+                let proof_id = system_api
+                    .create_proof(proof)
+                    .map_err(|_| AuthZoneError::CouldNotCreateProof)?;
+                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(
+                    proof_id,
+                )))
             }
             "push" => {
-                let proof_id: scrypto::resource::Proof =
-                    scrypto_decode(&args[0].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let mut proof = system_api.take_proof(proof_id.0).map_err(|_| AuthZoneError::CouldNotGetProof)?;
+                let proof_id: scrypto::resource::Proof = scrypto_decode(&args[0].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let mut proof = system_api
+                    .take_proof(proof_id.0)
+                    .map_err(|_| AuthZoneError::CouldNotGetProof)?;
                 // FIXME: this is a hack for now until we can get snode_state into process
                 // FIXME: and be able to determine which snode the proof is going into
                 proof.change_to_unrestricted();
@@ -106,33 +121,59 @@ impl AuthZone {
                 Ok(ScryptoValue::from_value(&()))
             }
             "create_proof" => {
-                let resource_address = scrypto_decode(&args[0].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let resource_manager: ResourceManager = system_api.borrow_global_mut_resource_manager(resource_address).map_err(|_| AuthZoneError::CouldNotGetResource)?;
+                let resource_address = scrypto_decode(&args[0].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let resource_manager: ResourceManager = system_api
+                    .borrow_global_mut_resource_manager(resource_address)
+                    .map_err(|_| AuthZoneError::CouldNotGetResource)?;
                 let resource_type = resource_manager.resource_type();
-                system_api.return_borrowed_global_resource_manager(resource_address, resource_manager);
+                system_api
+                    .return_borrowed_global_resource_manager(resource_address, resource_manager);
                 let proof = self.create_proof(resource_address, resource_type)?;
-                let proof_id = system_api.create_proof(proof).map_err(|_| AuthZoneError::CouldNotCreateProof)?;
-                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(proof_id)))
+                let proof_id = system_api
+                    .create_proof(proof)
+                    .map_err(|_| AuthZoneError::CouldNotCreateProof)?;
+                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(
+                    proof_id,
+                )))
             }
             "create_proof_by_amount" => {
-                let amount = scrypto_decode(&args[0].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let resource_address = scrypto_decode(&args[1].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let resource_manager: ResourceManager = system_api.borrow_global_mut_resource_manager(resource_address).map_err(|_| AuthZoneError::CouldNotGetResource)?;
+                let amount = scrypto_decode(&args[0].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let resource_address = scrypto_decode(&args[1].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let resource_manager: ResourceManager = system_api
+                    .borrow_global_mut_resource_manager(resource_address)
+                    .map_err(|_| AuthZoneError::CouldNotGetResource)?;
                 let resource_type = resource_manager.resource_type();
-                system_api.return_borrowed_global_resource_manager(resource_address, resource_manager);
+                system_api
+                    .return_borrowed_global_resource_manager(resource_address, resource_manager);
                 let proof = self.create_proof_by_amount(amount, resource_address, resource_type)?;
-                let proof_id = system_api.create_proof(proof).map_err(|_| AuthZoneError::CouldNotCreateProof)?;
-                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(proof_id)))
+                let proof_id = system_api
+                    .create_proof(proof)
+                    .map_err(|_| AuthZoneError::CouldNotCreateProof)?;
+                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(
+                    proof_id,
+                )))
             }
             "create_proof_by_ids" => {
-                let ids = scrypto_decode(&args[0].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let resource_address = scrypto_decode(&args[1].raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
-                let resource_manager: ResourceManager = system_api.borrow_global_mut_resource_manager(resource_address).map_err(|_| AuthZoneError::CouldNotGetResource)?;
+                let ids = scrypto_decode(&args[0].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let resource_address = scrypto_decode(&args[1].raw)
+                    .map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let resource_manager: ResourceManager = system_api
+                    .borrow_global_mut_resource_manager(resource_address)
+                    .map_err(|_| AuthZoneError::CouldNotGetResource)?;
                 let resource_type = resource_manager.resource_type();
-                system_api.return_borrowed_global_resource_manager(resource_address, resource_manager);
+                system_api
+                    .return_borrowed_global_resource_manager(resource_address, resource_manager);
                 let proof = self.create_proof_by_ids(&ids, resource_address, resource_type)?;
-                let proof_id = system_api.create_proof(proof).map_err(|_| AuthZoneError::CouldNotCreateProof)?;
-                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(proof_id)))
+                let proof_id = system_api
+                    .create_proof(proof)
+                    .map_err(|_| AuthZoneError::CouldNotCreateProof)?;
+                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(
+                    proof_id,
+                )))
             }
             _ => Err(AuthZoneError::MethodNotFound(function.to_string())),
         }

--- a/radix-engine/src/model/method_authorization.rs
+++ b/radix-engine/src/model/method_authorization.rs
@@ -52,7 +52,8 @@ impl HardResourceOrNonFungible {
     pub fn check_has_amount(&self, amount: Decimal, auth_zones: &[&AuthZone]) -> bool {
         for auth_zone in auth_zones {
             // FIXME: Need to check the composite max amount rather than just each proof individually
-            if auth_zone.proofs
+            if auth_zone
+                .proofs
                 .iter()
                 .any(|p| self.proof_matches(p) && p.total_amount() >= amount)
             {

--- a/radix-engine/src/model/mod.rs
+++ b/radix-engine/src/model/mod.rs
@@ -15,8 +15,8 @@ mod validated_transaction;
 mod vault;
 mod worktop;
 
-pub use auth_zone::{AuthZone, AuthZoneError};
 pub use auth_converter::convert;
+pub use auth_zone::{AuthZone, AuthZoneError};
 pub use bucket::{Bucket, BucketError};
 pub use component::Component;
 pub use method_authorization::{
@@ -28,10 +28,8 @@ pub use proof::*;
 pub use receipt::Receipt;
 pub use resource::*;
 pub use resource_manager::{ResourceManager, ResourceManagerError};
-pub use transaction_process::{TransactionProcess};
-pub use transaction::{
-    Instruction, SignedTransaction, Transaction,
-};
-pub use validated_transaction::{ValidatedTransaction, ValidatedInstruction};
+pub use transaction::{Instruction, SignedTransaction, Transaction};
+pub use transaction_process::TransactionProcess;
+pub use validated_transaction::{ValidatedInstruction, ValidatedTransaction};
 pub use vault::{Vault, VaultError};
 pub use worktop::{Worktop, WorktopError};

--- a/radix-engine/src/model/proof.rs
+++ b/radix-engine/src/model/proof.rs
@@ -1,3 +1,4 @@
+use crate::engine::SystemApi;
 use scrypto::engine::types::*;
 use scrypto::rust::cell::RefCell;
 use scrypto::rust::collections::BTreeSet;
@@ -7,7 +8,6 @@ use scrypto::rust::string::String;
 use scrypto::rust::string::ToString;
 use scrypto::rust::vec::Vec;
 use scrypto::values::ScryptoValue;
-use crate::engine::SystemApi;
 
 use crate::model::{
     LockedAmountOrIds, ResourceContainer, ResourceContainerError, ResourceContainerId,
@@ -335,13 +335,17 @@ impl Proof {
             "get_non_fungible_ids" => {
                 let ids = self.total_ids()?;
                 Ok(ScryptoValue::from_value(&ids))
-            },
+            }
             "get_resource_address" => Ok(ScryptoValue::from_value(&self.resource_address())),
             "clone" => {
                 let cloned_proof = self.clone();
-                let proof_id = system_api.create_proof(cloned_proof).map_err(|_| ProofError::CouldNotCreateProof)?;
-                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(proof_id)))
-            },
+                let proof_id = system_api
+                    .create_proof(cloned_proof)
+                    .map_err(|_| ProofError::CouldNotCreateProof)?;
+                Ok(ScryptoValue::from_value(&scrypto::resource::Proof(
+                    proof_id,
+                )))
+            }
             _ => Err(ProofError::MethodNotFound(function.to_string())),
         }
     }
@@ -351,7 +355,7 @@ impl Proof {
             "drop" => {
                 self.drop();
                 Ok(ScryptoValue::from_value(&()))
-            },
+            }
             _ => Err(ProofError::MethodNotFound(function.to_string())),
         }
     }

--- a/radix-engine/src/model/transaction.rs
+++ b/radix-engine/src/model/transaction.rs
@@ -26,7 +26,6 @@ pub struct SignedTransaction {
     pub signatures: Vec<(EcdsaPublicKey, EcdsaSignature)>,
 }
 
-
 /// Represents an instruction
 #[derive(Debug, Clone, TypeId, Encode, Decode, PartialEq, Eq)]
 pub enum Instruction {

--- a/radix-engine/src/model/transaction.rs
+++ b/radix-engine/src/model/transaction.rs
@@ -62,6 +62,11 @@ pub enum Instruction {
         resource_address: ResourceAddress,
     },
 
+    /// Creates a new AuthZone making the old one the previous AuthZone
+    StartAuthZone,
+    /// Removes the current AuthZone and replaces it with the previous AuthZone
+    EndAuthZone,
+
     /// Takes the last proof from the auth zone.
     PopFromAuthZone,
 
@@ -234,6 +239,12 @@ impl SignedTransaction {
                         ids,
                         resource_address,
                     });
+                }
+                Instruction::StartAuthZone => {
+                    instructions.push(ValidatedInstruction::StartAuthZone);
+                }
+                Instruction::EndAuthZone => {
+                    instructions.push(ValidatedInstruction::EndAuthZone);
                 }
                 Instruction::PopFromAuthZone => {
                     id_validator

--- a/radix-engine/src/model/transaction_process.rs
+++ b/radix-engine/src/model/transaction_process.rs
@@ -160,6 +160,14 @@ impl TransactionProcess {
                         ScryptoValue::from_value(resource_address),
                     ],
                 ),
+                ValidatedInstruction::StartAuthZone => {
+                    //self.proof_id_mapping.clear(); // FIXME handle proof_id_mapping (stack?)
+                    system_api.invoke_snode(SNodeRef::AuthZoneManager, "start".to_string(), vec![])
+                }
+                ValidatedInstruction::EndAuthZone => {
+                    //self.proof_id_mapping.clear(); // FIXME handle proof_id_mapping (stack?)
+                    system_api.invoke_snode(SNodeRef::AuthZoneManager, "end".to_string(), vec![])
+                }
                 ValidatedInstruction::PopFromAuthZone {} => self
                     .id_allocator
                     .new_proof_id()

--- a/radix-engine/src/model/transaction_process.rs
+++ b/radix-engine/src/model/transaction_process.rs
@@ -1,15 +1,15 @@
+use crate::engine::{IdAllocator, IdSpace, SystemApi};
+use crate::errors::RuntimeError;
+use crate::errors::RuntimeError::ProofNotFound;
+use crate::model::{ValidatedInstruction, ValidatedTransaction};
 use scrypto::core::SNodeRef;
 use scrypto::engine::types::*;
 use scrypto::prelude::ScryptoActor;
-use scrypto::rust::collections::{HashMap};
+use scrypto::rust::collections::HashMap;
 use scrypto::rust::string::ToString;
 use scrypto::rust::vec;
 use scrypto::rust::vec::Vec;
 use scrypto::values::*;
-use crate::engine::{IdAllocator, IdSpace, SystemApi};
-use crate::errors::RuntimeError::{ProofNotFound};
-use crate::errors::RuntimeError;
-use crate::model::{ValidatedInstruction, ValidatedTransaction};
 
 pub struct TransactionProcess {
     transaction: ValidatedTransaction,
@@ -35,10 +35,15 @@ impl TransactionProcess {
         mut values: Vec<ScryptoValue>,
     ) -> Result<Vec<ScryptoValue>, RuntimeError> {
         for value in values.iter_mut() {
-            value.replace_ids(&mut self.proof_id_mapping, &mut self.bucket_id_mapping)
+            value
+                .replace_ids(&mut self.proof_id_mapping, &mut self.bucket_id_mapping)
                 .map_err(|e| match e {
-                    ScryptoValueReplaceError::BucketIdNotFound(bucket_id) => RuntimeError::BucketNotFound(bucket_id),
-                    ScryptoValueReplaceError::ProofIdNotFound(proof_id) => RuntimeError::ProofNotFound(proof_id),
+                    ScryptoValueReplaceError::BucketIdNotFound(bucket_id) => {
+                        RuntimeError::BucketNotFound(bucket_id)
+                    }
+                    ScryptoValueReplaceError::ProofIdNotFound(proof_id) => {
+                        RuntimeError::ProofNotFound(proof_id)
+                    }
                 })?;
         }
         Ok(values)
@@ -51,248 +56,259 @@ impl TransactionProcess {
     pub fn main<S: SystemApi>(&mut self, system_api: &mut S) -> Result<ScryptoValue, RuntimeError> {
         for inst in &self.transaction.instructions.clone() {
             let result = match inst {
-                ValidatedInstruction::TakeFromWorktop { resource_address } => {
-                    self.id_allocator.new_bucket_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                ValidatedInstruction::TakeFromWorktop { resource_address } => self
+                    .id_allocator
+                    .new_bucket_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::WorktopRef,
                                 "take_all".to_string(),
-                                vec![
-                                    ScryptoValue::from_value(resource_address),
-                                ]
-                            ).map(|rtn| {
+                                vec![ScryptoValue::from_value(resource_address)],
+                            )
+                            .map(|rtn| {
                                 let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                 self.bucket_id_mapping.insert(new_id, bucket_id);
                                 ScryptoValue::from_value(&scrypto::resource::Bucket(new_id))
                             })
-                        })
-                },
+                    }),
                 ValidatedInstruction::TakeFromWorktopByAmount {
                     amount,
                     resource_address,
-                } =>
-                    self.id_allocator
-                        .new_bucket_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                } => self
+                    .id_allocator
+                    .new_bucket_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::WorktopRef,
                                 "take_amount".to_string(),
                                 vec![
                                     ScryptoValue::from_value(amount),
                                     ScryptoValue::from_value(resource_address),
-                                ]
-                            ).map(|rtn| {
+                                ],
+                            )
+                            .map(|rtn| {
                                 let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                 self.bucket_id_mapping.insert(new_id, bucket_id);
                                 ScryptoValue::from_value(&scrypto::resource::Bucket(new_id))
                             })
-                        }),
+                    }),
                 ValidatedInstruction::TakeFromWorktopByIds {
                     ids,
                     resource_address,
-                } =>
-                    self.id_allocator
-                        .new_bucket_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                } => self
+                    .id_allocator
+                    .new_bucket_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::WorktopRef,
                                 "take_non_fungibles".to_string(),
                                 vec![
                                     ScryptoValue::from_value(ids),
                                     ScryptoValue::from_value(resource_address),
-                                ]
-                            ).map(|rtn| {
+                                ],
+                            )
+                            .map(|rtn| {
                                 let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                 self.bucket_id_mapping.insert(new_id, bucket_id);
                                 ScryptoValue::from_value(&scrypto::resource::Bucket(new_id))
                             })
-                        }),
-                ValidatedInstruction::ReturnToWorktop { bucket_id } => {
-                    self.bucket_id_mapping.remove(bucket_id)
-                        .map(|real_id| {
-                            system_api.invoke_snode(
-                                SNodeRef::WorktopRef,
-                                "put".to_string(),
-                                vec![
-                                    ScryptoValue::from_value(&scrypto::resource::Bucket(real_id)),
-                                ]
-                            )
-                        })
-                        .unwrap_or(Err(RuntimeError::BucketNotFound(*bucket_id)))
-                }
-                ValidatedInstruction::AssertWorktopContains { resource_address } => {
-                    system_api.invoke_snode(
+                    }),
+                ValidatedInstruction::ReturnToWorktop { bucket_id } => self
+                    .bucket_id_mapping
+                    .remove(bucket_id)
+                    .map(|real_id| {
+                        system_api.invoke_snode(
+                            SNodeRef::WorktopRef,
+                            "put".to_string(),
+                            vec![ScryptoValue::from_value(&scrypto::resource::Bucket(
+                                real_id,
+                            ))],
+                        )
+                    })
+                    .unwrap_or(Err(RuntimeError::BucketNotFound(*bucket_id))),
+                ValidatedInstruction::AssertWorktopContains { resource_address } => system_api
+                    .invoke_snode(
                         SNodeRef::WorktopRef,
                         "assert_contains".to_string(),
-                        vec![
-                            ScryptoValue::from_value(resource_address),
-                        ]
-                    )
-                }
+                        vec![ScryptoValue::from_value(resource_address)],
+                    ),
                 ValidatedInstruction::AssertWorktopContainsByAmount {
                     amount,
                     resource_address,
-                } => {
-                    system_api.invoke_snode(
-                        SNodeRef::WorktopRef,
-                        "assert_contains_amount".to_string(),
-                        vec![
-                            ScryptoValue::from_value(amount),
-                            ScryptoValue::from_value(resource_address),
-                        ]
-                    )
-                },
+                } => system_api.invoke_snode(
+                    SNodeRef::WorktopRef,
+                    "assert_contains_amount".to_string(),
+                    vec![
+                        ScryptoValue::from_value(amount),
+                        ScryptoValue::from_value(resource_address),
+                    ],
+                ),
                 ValidatedInstruction::AssertWorktopContainsByIds {
                     ids,
                     resource_address,
-                } => {
-                    system_api.invoke_snode(
-                        SNodeRef::WorktopRef,
-                        "assert_contains_amount".to_string(),
-                        vec![
-                            ScryptoValue::from_value(ids),
-                            ScryptoValue::from_value(resource_address),
-                        ]
-                    )
-                },
-                ValidatedInstruction::PopFromAuthZone {} => {
-                    self.id_allocator.new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
-                                SNodeRef::AuthZoneRef,
-                                "pop".to_string(),
-                                vec![]
-                            ).map(|rtn| {
+                } => system_api.invoke_snode(
+                    SNodeRef::WorktopRef,
+                    "assert_contains_amount".to_string(),
+                    vec![
+                        ScryptoValue::from_value(ids),
+                        ScryptoValue::from_value(resource_address),
+                    ],
+                ),
+                ValidatedInstruction::PopFromAuthZone {} => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(SNodeRef::AuthZoneRef, "pop".to_string(), vec![])
+                            .map(|rtn| {
                                 let proof_id = *rtn.proof_ids.iter().next().unwrap().0;
                                 self.proof_id_mapping.insert(new_id, proof_id);
                                 ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                             })
-                        })
-                },
+                    }),
                 ValidatedInstruction::ClearAuthZone => {
                     self.proof_id_mapping.clear();
                     system_api.invoke_snode(SNodeRef::AuthZoneRef, "clear".to_string(), vec![])
-                },
-                ValidatedInstruction::PushToAuthZone { proof_id } => {
-                    self.proof_id_mapping.remove(proof_id)
-                        .ok_or(RuntimeError::ProofNotFound(*proof_id))
-                        .and_then(|real_id|
-                            system_api.invoke_snode(
-                                SNodeRef::AuthZoneRef,
-                                "push".to_string(),
-                                vec![ScryptoValue::from_value(&scrypto::resource::Proof(real_id))]
-                            )
+                }
+                ValidatedInstruction::PushToAuthZone { proof_id } => self
+                    .proof_id_mapping
+                    .remove(proof_id)
+                    .ok_or(RuntimeError::ProofNotFound(*proof_id))
+                    .and_then(|real_id| {
+                        system_api.invoke_snode(
+                            SNodeRef::AuthZoneRef,
+                            "push".to_string(),
+                            vec![ScryptoValue::from_value(&scrypto::resource::Proof(real_id))],
                         )
-                },
-                ValidatedInstruction::CreateProofFromAuthZone { resource_address } =>
-                    self.id_allocator.new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                    }),
+                ValidatedInstruction::CreateProofFromAuthZone { resource_address } => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::AuthZoneRef,
                                 "create_proof".to_string(),
-                                vec![ScryptoValue::from_value(resource_address)]
-                            ).map(|rtn| {
+                                vec![ScryptoValue::from_value(resource_address)],
+                            )
+                            .map(|rtn| {
                                 let proof_id = *rtn.proof_ids.iter().next().unwrap().0;
                                 self.proof_id_mapping.insert(new_id, proof_id);
                                 ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                             })
-                        }),
+                    }),
                 ValidatedInstruction::CreateProofFromAuthZoneByAmount {
                     amount,
                     resource_address,
-                } =>
-                    self.id_allocator.new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                } => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::AuthZoneRef,
                                 "create_proof_by_amount".to_string(),
                                 vec![
                                     ScryptoValue::from_value(amount),
-                                    ScryptoValue::from_value(resource_address)
-                                ]
-                            ).map(|rtn| {
+                                    ScryptoValue::from_value(resource_address),
+                                ],
+                            )
+                            .map(|rtn| {
                                 let proof_id = *rtn.proof_ids.iter().next().unwrap().0;
                                 self.proof_id_mapping.insert(new_id, proof_id);
                                 ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                             })
-                        }),
+                    }),
                 ValidatedInstruction::CreateProofFromAuthZoneByIds {
                     ids,
                     resource_address,
-                } =>
-                    self.id_allocator.new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            system_api.invoke_snode(
+                } => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::AuthZoneRef,
                                 "create_proof_by_ids".to_string(),
                                 vec![
                                     ScryptoValue::from_value(ids),
-                                    ScryptoValue::from_value(resource_address)
-                                ]
-                            ).map(|rtn| {
+                                    ScryptoValue::from_value(resource_address),
+                                ],
+                            )
+                            .map(|rtn| {
                                 let proof_id = *rtn.proof_ids.iter().next().unwrap().0;
                                 self.proof_id_mapping.insert(new_id, proof_id);
                                 ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                             })
-                        }),
-                ValidatedInstruction::CreateProofFromBucket { bucket_id } => {
-                    self.id_allocator.new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            self.bucket_id_mapping.get(bucket_id).cloned()
-                                .map(|real_bucket_id| (new_id, real_bucket_id))
-                                .ok_or(RuntimeError::BucketNotFound(new_id))
-                        })
-                        .and_then(|(new_id, real_bucket_id)| {
-                            system_api.invoke_snode(
+                    }),
+                ValidatedInstruction::CreateProofFromBucket { bucket_id } => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        self.bucket_id_mapping
+                            .get(bucket_id)
+                            .cloned()
+                            .map(|real_bucket_id| (new_id, real_bucket_id))
+                            .ok_or(RuntimeError::BucketNotFound(new_id))
+                    })
+                    .and_then(|(new_id, real_bucket_id)| {
+                        system_api
+                            .invoke_snode(
                                 SNodeRef::BucketRef(real_bucket_id),
                                 "create_bucket_proof".to_string(),
                                 vec![],
-                            ).map(|rtn| {
+                            )
+                            .map(|rtn| {
                                 let proof_id = *rtn.proof_ids.iter().next().unwrap().0;
                                 self.proof_id_mapping.insert(new_id, proof_id);
                                 ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                             })
-                        })
-                },
-                ValidatedInstruction::CloneProof { proof_id } =>
-                    self.id_allocator
-                        .new_proof_id()
-                        .map_err(RuntimeError::IdAllocatorError)
-                        .and_then(|new_id| {
-                            self.proof_id_mapping
-                                .get(proof_id)
-                                .cloned()
-                                .map(|real_id| {
-                                    system_api.invoke_snode(SNodeRef::ProofRef(real_id),
-                                                            "clone".to_string(),
-                                                            vec![]
-                                    ).map(|v| {
+                    }),
+                ValidatedInstruction::CloneProof { proof_id } => self
+                    .id_allocator
+                    .new_proof_id()
+                    .map_err(RuntimeError::IdAllocatorError)
+                    .and_then(|new_id| {
+                        self.proof_id_mapping
+                            .get(proof_id)
+                            .cloned()
+                            .map(|real_id| {
+                                system_api
+                                    .invoke_snode(
+                                        SNodeRef::ProofRef(real_id),
+                                        "clone".to_string(),
+                                        vec![],
+                                    )
+                                    .map(|v| {
                                         let cloned_proof_id = v.proof_ids.iter().next().unwrap().0;
                                         self.proof_id_mapping.insert(new_id, *cloned_proof_id);
                                         ScryptoValue::from_value(&scrypto::resource::Proof(new_id))
                                     })
-                                })
-                                .unwrap_or(Err(RuntimeError::ProofNotFound(*proof_id)))
-                        }),
-                ValidatedInstruction::DropProof { proof_id } => {
-                    self.proof_id_mapping.remove(proof_id)
-                        .map(|real_id| {
-                            system_api.invoke_snode(
-                                SNodeRef::Proof(real_id),
-                                "drop".to_string(),
-                                vec![]
-                            )
-                        })
-                        .unwrap_or(Err(ProofNotFound(*proof_id)))
-                },
+                            })
+                            .unwrap_or(Err(RuntimeError::ProofNotFound(*proof_id)))
+                    }),
+                ValidatedInstruction::DropProof { proof_id } => self
+                    .proof_id_mapping
+                    .remove(proof_id)
+                    .map(|real_id| {
+                        system_api.invoke_snode(
+                            SNodeRef::Proof(real_id),
+                            "drop".to_string(),
+                            vec![],
+                        )
+                    })
+                    .unwrap_or(Err(ProofNotFound(*proof_id))),
                 ValidatedInstruction::CallFunction {
                     package_address,
                     blueprint_name,
@@ -300,103 +316,117 @@ impl TransactionProcess {
                     args,
                 } => {
                     self.replace_ids(args.clone())
-                        .and_then(|args|
+                        .and_then(|args| {
                             system_api.invoke_snode(
-                                SNodeRef::Scrypto(ScryptoActor::Blueprint(*package_address, blueprint_name.to_string())),
+                                SNodeRef::Scrypto(ScryptoActor::Blueprint(
+                                    *package_address,
+                                    blueprint_name.to_string(),
+                                )),
                                 function.to_string(),
-                                args
+                                args,
                             )
-                        )
+                        })
                         .and_then(|result| {
                             // Auto move into auth_zone
                             for (proof_id, _) in &result.proof_ids {
-                                system_api.invoke_snode(
-                                    SNodeRef::AuthZoneRef,
-                                    "push".to_string(),
-                                    vec![ScryptoValue::from_value(&scrypto::resource::Proof(*proof_id))]
-                                ).unwrap(); // TODO: Remove unwrap
+                                system_api
+                                    .invoke_snode(
+                                        SNodeRef::AuthZoneRef,
+                                        "push".to_string(),
+                                        vec![ScryptoValue::from_value(&scrypto::resource::Proof(
+                                            *proof_id,
+                                        ))],
+                                    )
+                                    .unwrap(); // TODO: Remove unwrap
                             }
                             // Auto move into worktop
                             for (bucket_id, _) in &result.bucket_ids {
-                                system_api.invoke_snode(
-                                    SNodeRef::WorktopRef,
-                                    "put".to_string(),
-                                    vec![ScryptoValue::from_value(&scrypto::resource::Bucket(*bucket_id))]
-                                ).unwrap(); // TODO: Remove unwrap
+                                system_api
+                                    .invoke_snode(
+                                        SNodeRef::WorktopRef,
+                                        "put".to_string(),
+                                        vec![ScryptoValue::from_value(&scrypto::resource::Bucket(
+                                            *bucket_id,
+                                        ))],
+                                    )
+                                    .unwrap(); // TODO: Remove unwrap
                             }
                             Ok(result)
                         })
-                },
+                }
                 ValidatedInstruction::CallMethod {
                     component_address,
                     method,
                     args,
                 } => {
                     self.replace_ids(args.clone())
-                        .and_then(|args|
+                        .and_then(|args| {
                             system_api.invoke_snode(
                                 SNodeRef::Scrypto(ScryptoActor::Component(*component_address)),
                                 method.to_string(),
-                                args
+                                args,
                             )
-                        )
+                        })
                         .and_then(|result| {
                             // Auto move into auth_zone
                             for (proof_id, _) in &result.proof_ids {
-                                system_api.invoke_snode(
-                                    SNodeRef::AuthZoneRef,
-                                    "push".to_string(),
-                                    vec![ScryptoValue::from_value(&scrypto::resource::Proof(*proof_id))]
-                                ).unwrap();
+                                system_api
+                                    .invoke_snode(
+                                        SNodeRef::AuthZoneRef,
+                                        "push".to_string(),
+                                        vec![ScryptoValue::from_value(&scrypto::resource::Proof(
+                                            *proof_id,
+                                        ))],
+                                    )
+                                    .unwrap();
                             }
                             // Auto move into worktop
                             for (bucket_id, _) in &result.bucket_ids {
-                                system_api.invoke_snode(
-                                    SNodeRef::WorktopRef,
-                                    "put".to_string(),
-                                    vec![ScryptoValue::from_value(&scrypto::resource::Bucket(*bucket_id))]
-                                ).unwrap(); // TODO: Remove unwrap
+                                system_api
+                                    .invoke_snode(
+                                        SNodeRef::WorktopRef,
+                                        "put".to_string(),
+                                        vec![ScryptoValue::from_value(&scrypto::resource::Bucket(
+                                            *bucket_id,
+                                        ))],
+                                    )
+                                    .unwrap(); // TODO: Remove unwrap
                             }
                             Ok(result)
                         })
-                },
+                }
                 ValidatedInstruction::CallMethodWithAllResources {
                     component_address,
                     method,
-                } => {
-                    system_api.invoke_snode(SNodeRef::AuthZoneRef, "clear".to_string(), vec![])
-                        .and_then(|_| {
-                            for (_, real_id) in self.proof_id_mapping.drain() {
-                                system_api.invoke_snode(
-                                    SNodeRef::Proof(real_id),
-                                    "drop".to_string(),
-                                    vec![]
-                                ).unwrap();
-                            }
-                            system_api.invoke_snode(SNodeRef::WorktopRef, "drain".to_string(), vec![])
-                        })
-                        .and_then(|result| {
-                            let mut buckets = Vec::new();
-                            for (bucket_id, _) in result.bucket_ids {
-                                buckets.push(scrypto::resource::Bucket(bucket_id));
-                            }
-                            for (_, real_id) in self.bucket_id_mapping.drain() {
-                                buckets.push(scrypto::resource::Bucket(real_id));
-                            }
-                            system_api.invoke_snode(
-                                SNodeRef::Scrypto(ScryptoActor::Component(*component_address)),
-                                method.to_string(),
-                                vec![ScryptoValue::from_value(&buckets)],
-                            )
-                        })
-                },
-                ValidatedInstruction::PublishPackage { code } => {
-                    system_api.invoke_snode(
-                        SNodeRef::PackageStatic,
-                        "publish".to_string(),
-                        vec![ScryptoValue::from_value(code)],
-                    )
-                },
+                } => system_api
+                    .invoke_snode(SNodeRef::AuthZoneRef, "clear".to_string(), vec![])
+                    .and_then(|_| {
+                        for (_, real_id) in self.proof_id_mapping.drain() {
+                            system_api
+                                .invoke_snode(SNodeRef::Proof(real_id), "drop".to_string(), vec![])
+                                .unwrap();
+                        }
+                        system_api.invoke_snode(SNodeRef::WorktopRef, "drain".to_string(), vec![])
+                    })
+                    .and_then(|result| {
+                        let mut buckets = Vec::new();
+                        for (bucket_id, _) in result.bucket_ids {
+                            buckets.push(scrypto::resource::Bucket(bucket_id));
+                        }
+                        for (_, real_id) in self.bucket_id_mapping.drain() {
+                            buckets.push(scrypto::resource::Bucket(real_id));
+                        }
+                        system_api.invoke_snode(
+                            SNodeRef::Scrypto(ScryptoActor::Component(*component_address)),
+                            method.to_string(),
+                            vec![ScryptoValue::from_value(&buckets)],
+                        )
+                    }),
+                ValidatedInstruction::PublishPackage { code } => system_api.invoke_snode(
+                    SNodeRef::PackageStatic,
+                    "publish".to_string(),
+                    vec![ScryptoValue::from_value(code)],
+                ),
             }?;
             self.outputs.push(result);
         }

--- a/radix-engine/src/model/validated_transaction.rs
+++ b/radix-engine/src/model/validated_transaction.rs
@@ -40,6 +40,8 @@ pub enum ValidatedInstruction {
         ids: BTreeSet<NonFungibleId>,
         resource_address: ResourceAddress,
     },
+    StartAuthZone,
+    EndAuthZone,
     PopFromAuthZone,
     PushToAuthZone {
         proof_id: ProofId,

--- a/radix-engine/src/model/validated_transaction.rs
+++ b/radix-engine/src/model/validated_transaction.rs
@@ -1,6 +1,6 @@
 use scrypto::crypto::*;
 use scrypto::engine::types::*;
-use scrypto::rust::collections::{BTreeSet};
+use scrypto::rust::collections::BTreeSet;
 use scrypto::rust::string::String;
 use scrypto::rust::vec::Vec;
 use scrypto::values::*;

--- a/radix-engine/src/transaction/builder.rs
+++ b/radix-engine/src/transaction/builder.rs
@@ -59,6 +59,8 @@ impl TransactionBuilder {
             Instruction::AssertWorktopContains { .. }
             | Instruction::AssertWorktopContainsByAmount { .. }
             | Instruction::AssertWorktopContainsByIds { .. } => {}
+            Instruction::StartAuthZone => {}
+            Instruction::EndAuthZone => {}
             Instruction::PopFromAuthZone { .. } => {
                 new_proof_id = Some(
                     self.id_validator
@@ -189,6 +191,16 @@ impl TransactionBuilder {
             resource_address,
         })
         .0
+    }
+
+    pub fn start_auth_zone(&mut self) -> &mut Self {
+        self.add_instruction(Instruction::StartAuthZone);
+        self
+    }
+
+    pub fn end_auth_zone(&mut self) -> &mut Self {
+        self.add_instruction(Instruction::EndAuthZone);
+        self
     }
 
     /// Pops the most recent proof from auth zone.

--- a/radix-engine/src/transaction/builder.rs
+++ b/radix-engine/src/transaction/builder.rs
@@ -3,7 +3,7 @@ use sbor::*;
 use scrypto::buffer::*;
 use scrypto::crypto::*;
 use scrypto::engine::types::*;
-use scrypto::prelude::{AccessRuleNode, Burn, AccessRule, Mint, Withdraw};
+use scrypto::prelude::{AccessRule, AccessRuleNode, Burn, Mint, Withdraw};
 use scrypto::resource::{require, LOCKED};
 use scrypto::rust::borrow::ToOwned;
 use scrypto::rust::collections::BTreeSet;

--- a/radix-engine/src/transaction/executor.rs
+++ b/radix-engine/src/transaction/executor.rs
@@ -1,10 +1,10 @@
 use scrypto::crypto::hash;
 use scrypto::engine::types::*;
 use scrypto::resource::*;
+use scrypto::rust::string::ToString;
 use scrypto::rust::vec;
 use scrypto::rust::vec::Vec;
-use scrypto::rust::string::ToString;
-use scrypto::{abi, rule, access_rule_node};
+use scrypto::{abi, access_rule_node, rule};
 
 use crate::engine::*;
 use crate::errors::*;
@@ -199,8 +199,6 @@ impl<'l, L: SubstateStore> TransactionExecutor<'l, L> {
         } else {
             None
         };
-
-
 
         #[cfg(feature = "alloc")]
         let execution_time = None;

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -71,15 +71,17 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
         Action::Deposit => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
-            .take_from_worktop(token_address, |builder, bucket_id|
-                builder.call_method(account, "deposit", args![scrypto::resource::Bucket(bucket_id)])
-            )
+            .take_from_worktop(token_address, |builder, bucket_id| {
+                builder.call_method(
+                    account,
+                    "deposit",
+                    args![scrypto::resource::Bucket(bucket_id)],
+                )
+            })
             .call_method_with_all_resources(account, "deposit_batch"),
     };
 
-    let transaction = builder
-        .build(test_runner.get_nonce([pk]))
-        .sign([&sk]);
+    let transaction = builder.build(test_runner.get_nonce([pk])).sign([&sk]);
     let receipt = test_runner.validate_and_execute(&transaction);
 
     // Assert

--- a/radix-engine/tests/caller_auth_zone.rs
+++ b/radix-engine/tests/caller_auth_zone.rs
@@ -1,0 +1,134 @@
+use radix_engine::ledger::*;
+use radix_engine::transaction::*;
+use scrypto::prelude::*;
+
+#[test]
+fn test_tx() {
+    // Set up environment.
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let (pk, sk, account) = executor.new_account();
+    let package = executor
+        .publish_package(&compile_package!(format!("./tests/{}", "caller_auth_zone")))
+        .unwrap();
+
+    // Test the `instantiate_hello` function.
+    let transaction1 = TransactionBuilder::new()
+        .call_function(package, "Hello", "instantiate_hello", args![])
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt1 = executor.validate_and_execute(&transaction1).unwrap();
+    println!("{:?}\n", receipt1);
+    assert!(receipt1.result.is_ok());
+
+    let component = receipt1.new_component_addresses[0];
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![])
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+
+    let component = receipt1.new_component_addresses[0];
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![])
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+
+    let component = receipt1.new_component_addresses[0];
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "badge_for_both", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![])
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(!receipt2.result.is_ok()); // fails because free_token does not like getting proof with both
+
+    // test AuthZone::start
+    let component = receipt1.new_component_addresses[0];
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .start_auth_zone() // this pushes the authzone
+        .call_method(component, "free_token", args![]) // fails since no badges
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(!receipt2.result.is_ok());
+
+    // test AuthZone::start and AuthZone::end
+    let component = receipt1.new_component_addresses[0];
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .start_auth_zone() // this pushes the authzone
+        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![]) // get tokens for bob
+        .end_auth_zone() // end authzone which drops the bob token proof
+        .call_method(component, "free_token", args![]) // gets token with alice
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+}
+
+#[test]
+fn test_component() {
+    // Set up environment.
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let (pk, sk, _account) = executor.new_account();
+    let package = executor
+        .publish_package(&compile_package!(format!("./tests/{}", "caller_auth_zone")))
+        .unwrap();
+
+    // Test the `instantiate_hello` function.
+    let transaction1 = TransactionBuilder::new()
+        .call_function(package, "Hello", "instantiate_hello", args![])
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt1 = executor.validate_and_execute(&transaction1).unwrap();
+    println!("{:?}\n", receipt1);
+    assert!(receipt1.result.is_ok());
+    let hello_component = receipt1.new_component_addresses[0];
+
+    // Test the `instantiate_hello` function.
+    let transaction1 = TransactionBuilder::new()
+        .call_function(package, "Caller", "instantiate_caller", args![])
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction1).unwrap();
+    println!("{:?}\n", receipt1);
+    assert!(receipt2.result.is_ok());
+    let component = receipt2.new_component_addresses[0];
+
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "run_as_alice", args![hello_component]) // returned Proof just goes to auth zone automatically (without using "push")
+        //.call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "run_as_both", args![hello_component]) // returned Proof just goes to auth zone automatically (without using "push")
+        //.call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+}

--- a/radix-engine/tests/caller_auth_zone.rs
+++ b/radix-engine/tests/caller_auth_zone.rs
@@ -1,81 +1,84 @@
+#[rustfmt::skip]
+pub mod test_runner;
+
+//use crate::test_runner::TestRunner;
 use radix_engine::ledger::*;
 use radix_engine::transaction::*;
 use scrypto::prelude::*;
 
+macro_rules! setup {
+    ($executor:expr) => {{
+        // Set up environment.
+        let executor = &mut $executor;
+        let (pk, sk, account) = executor.new_account();
+        let package = executor
+            .publish_package(&compile_package!(format!("./tests/{}", "caller_auth_zone")))
+            .unwrap();
+
+        // Test the `instantiate_hello` function.
+        let transaction1 = TransactionBuilder::new()
+            .call_function(package, "Hello", "instantiate_hello", args![])
+            .build(executor.get_nonce([pk]))
+            .sign([&sk]);
+        let receipt1 = executor.validate_and_execute(&transaction1).unwrap();
+        println!("{:?}\n", receipt1);
+        assert!(receipt1.result.is_ok());
+
+        let component = receipt1.new_component_addresses[0];
+
+        ((pk, sk, account), package, component)
+    }};
+}
+
+macro_rules! setup2 {
+    ($executor:expr) => {{
+        let ((pk, sk, account), package, hello_component) = setup!($executor);
+
+        let executor = &mut $executor;
+
+        // Test the `instantiate_hello` function.
+        let transaction1 = TransactionBuilder::new()
+            .call_function(package, "Caller", "instantiate_caller", args![])
+            .build(executor.get_nonce([pk]))
+            .sign([&sk]);
+        let receipt2 = executor.validate_and_execute(&transaction1).unwrap();
+        println!("{:?}\n", receipt2);
+        assert!(receipt2.result.is_ok());
+        let component = receipt2.new_component_addresses[0];
+
+        ((pk, sk, account), hello_component, component)
+    }};
+}
+
 #[test]
-fn test_tx() {
-    // Set up environment.
+fn test_xfail_alice() {
     let mut ledger = InMemorySubstateStore::with_bootstrap();
     let mut executor = TransactionExecutor::new(&mut ledger, false);
-    let (pk, sk, account) = executor.new_account();
-    let package = executor
-        .publish_package(&compile_package!(format!("./tests/{}", "caller_auth_zone")))
-        .unwrap();
+    let ((pk, sk, account), _package, component) = setup!(executor);
 
-    // Test the `instantiate_hello` function.
-    let transaction1 = TransactionBuilder::new()
-        .call_function(package, "Hello", "instantiate_hello", args![])
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt1 = executor.validate_and_execute(&transaction1).unwrap();
-    println!("{:?}\n", receipt1);
-    assert!(receipt1.result.is_ok());
-
-    let component = receipt1.new_component_addresses[0];
     let transaction2 = TransactionBuilder::new()
+        // fails in the default auth zone
+        // .start_auth_zone()
         .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .call_method(component, "free_token", args![])
+        .call_method(component, "free_token", args![]) // use the badge in the auth zone without knowing exactly what it is
         .call_method_with_all_resources(account, "deposit_batch")
         .build(executor.get_nonce([pk]))
         .sign([&sk]);
     let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
     println!("{:?}\n", receipt2);
-    assert!(receipt2.result.is_ok());
+    assert!(receipt2.result.is_err());
+}
 
-    let component = receipt1.new_component_addresses[0];
-    let transaction2 = TransactionBuilder::new()
-        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .call_method(component, "free_token", args![])
-        .call_method_with_all_resources(account, "deposit_batch")
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
-    println!("{:?}\n", receipt2);
-    assert!(receipt2.result.is_ok());
+#[test]
+fn test_alice() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, account), _package, component) = setup!(executor);
 
-    let component = receipt1.new_component_addresses[0];
     let transaction2 = TransactionBuilder::new()
-        .call_method(component, "badge_for_both", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .call_method(component, "free_token", args![])
-        .call_method_with_all_resources(account, "deposit_batch")
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
-    println!("{:?}\n", receipt2);
-    assert!(!receipt2.result.is_ok()); // fails because free_token does not like getting proof with both
-
-    // test AuthZone::start
-    let component = receipt1.new_component_addresses[0];
-    let transaction2 = TransactionBuilder::new()
+        .start_auth_zone() // enable caller auth zone by using the non-default auth zone (note this also segregates the tx signer badges)
         .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .start_auth_zone() // this pushes the authzone
-        .call_method(component, "free_token", args![]) // fails since no badges
-        .call_method_with_all_resources(account, "deposit_batch")
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
-    println!("{:?}\n", receipt2);
-    assert!(!receipt2.result.is_ok());
-
-    // test AuthZone::start and AuthZone::end
-    let component = receipt1.new_component_addresses[0];
-    let transaction2 = TransactionBuilder::new()
-        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .start_auth_zone() // this pushes the authzone
-        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
-        .call_method(component, "free_token", args![]) // get tokens for bob
-        .end_auth_zone() // end authzone which drops the bob token proof
-        .call_method(component, "free_token", args![]) // gets token with alice
+        .call_method(component, "free_token", args![]) // use the badge in the auth zone without knowing exactly what it is
         .call_method_with_all_resources(account, "deposit_batch")
         .build(executor.get_nonce([pk]))
         .sign([&sk]);
@@ -85,34 +88,89 @@ fn test_tx() {
 }
 
 #[test]
-fn test_component() {
+fn test_bob() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, account), _package, component) = setup!(executor);
+
+    let transaction2 = TransactionBuilder::new()
+        .start_auth_zone() // enable caller auth zone by using the non-default auth zone (note this also segregates the tx signer badges)
+        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![]) // use the badge in the auth zone without knowing exactly what it is
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+}
+
+#[test]
+fn test_xfail_both() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, account), _package, component) = setup!(executor);
+
+    let transaction2 = TransactionBuilder::new()
+        .start_auth_zone() // enable caller auth zone by using the non-default auth zone (note this also segregates the tx signer badges)
+        .call_method(component, "badge_for_both", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![]) // uses both badges, and the callee can decide if that's a problem or not (in this case free_token doesn't like it)
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_err()); // fails because free_token does not like getting proof with both
+}
+
+#[test]
+fn test_xfail_start_auth_zone_is_empty() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, account), _package, component) = setup!(executor);
+
+    let transaction2 = TransactionBuilder::new()
+        .start_auth_zone() // enable caller auth zone by using the non-default auth zone (note this also segregates the tx signer badges)
+        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .start_auth_zone() // this pushes the authzone and get's a new one
+        .call_method(component, "free_token", args![]) // fails since no badges
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_err());
+}
+
+#[test]
+fn test_alice_then_bob() {
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, account), _package, component) = setup!(executor);
+
+    let transaction2 = TransactionBuilder::new()
+        .start_auth_zone() // enable caller auth zone by using the non-default auth zone (note this also segregates the tx signer badges)
+        .call_method(component, "badge_for_alice", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .start_auth_zone() // this pushes the authzone, getting a new one and leaving alice's badge in the pushed zone
+        .call_method(component, "badge_for_bob", args![]) // returned Proof just goes to auth zone automatically (without using "push")
+        .call_method(component, "free_token", args![]) // get tokens for bob (no conflict with alice's badge)
+        .end_auth_zone() // end authzone which drops the bob token proof, alice's badge is now available
+        .call_method(component, "free_token", args![]) // free tokens ok authorized with alice's badge
+        // elided the end_auth-zone() calls as they are optional
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_ok());
+}
+
+#[test]
+fn test_component_as_alice() {
     // Set up environment.
     let mut ledger = InMemorySubstateStore::with_bootstrap();
     let mut executor = TransactionExecutor::new(&mut ledger, false);
-    let (pk, sk, _account) = executor.new_account();
-    let package = executor
-        .publish_package(&compile_package!(format!("./tests/{}", "caller_auth_zone")))
-        .unwrap();
-
-    // Test the `instantiate_hello` function.
-    let transaction1 = TransactionBuilder::new()
-        .call_function(package, "Hello", "instantiate_hello", args![])
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt1 = executor.validate_and_execute(&transaction1).unwrap();
-    println!("{:?}\n", receipt1);
-    assert!(receipt1.result.is_ok());
-    let hello_component = receipt1.new_component_addresses[0];
-
-    // Test the `instantiate_hello` function.
-    let transaction1 = TransactionBuilder::new()
-        .call_function(package, "Caller", "instantiate_caller", args![])
-        .build(executor.get_nonce([pk]))
-        .sign([&sk]);
-    let receipt2 = executor.validate_and_execute(&transaction1).unwrap();
-    println!("{:?}\n", receipt1);
-    assert!(receipt2.result.is_ok());
-    let component = receipt2.new_component_addresses[0];
+    let ((pk, sk, _account), hello_component, component) = setup2!(executor);
 
     let transaction2 = TransactionBuilder::new()
         .call_method(component, "run_as_alice", args![hello_component]) // returned Proof just goes to auth zone automatically (without using "push")
@@ -122,6 +180,31 @@ fn test_component() {
     let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
     println!("{:?}\n", receipt2);
     assert!(receipt2.result.is_ok());
+}
+
+#[test]
+fn test_component_xfail_as_alice() {
+    // Set up environment.
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, _account), hello_component, component) = setup2!(executor);
+
+    let transaction2 = TransactionBuilder::new()
+        .call_method(component, "xfail_run_as_alice", args![hello_component]) // returned Proof just goes to auth zone automatically (without using "push")
+        //.call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt2 = executor.validate_and_execute(&transaction2).unwrap();
+    println!("{:?}\n", receipt2);
+    assert!(receipt2.result.is_err())
+}
+
+#[test]
+fn test_component_as_both() {
+    // Set up environment.
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, false);
+    let ((pk, sk, _account), hello_component, component) = setup2!(executor);
 
     let transaction2 = TransactionBuilder::new()
         .call_method(component, "run_as_both", args![hello_component]) // returned Proof just goes to auth zone automatically (without using "push")

--- a/radix-engine/tests/caller_auth_zone/Cargo.toml
+++ b/radix-engine/tests/caller_auth_zone/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "caller_auth_zone"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sbor = { path = "../../../sbor" }
+scrypto = { path = "../../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../../radix-engine" }
+
+[profile.release]
+opt-level = 's'     # Optimize for size.
+lto = true          # Enable Link Time Optimization.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations.
+panic = 'abort'     # Abort on panic.
+strip = "debuginfo" # Strip debug info.
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/radix-engine/tests/caller_auth_zone/src/lib.rs
+++ b/radix-engine/tests/caller_auth_zone/src/lib.rs
@@ -1,0 +1,153 @@
+use scrypto::prelude::*;
+
+#[derive(NonFungibleData)]
+pub struct User {
+    pub name: String,
+}
+
+blueprint! {
+    struct Hello {
+        // Define what resources and data will be managed by Hello components
+        sample_vault: Vault,
+        nf_badge_vault: Vault,
+        access_rules: AccessRules,
+    }
+
+    impl Hello {
+        pub fn badge_for_both(&self) -> Proof {
+            let p = self.nf_badge_vault.create_proof(); // by returning it someone pushes it, not sure who
+            info!("nf_badge_for returning: {} {:?}", p.resource_address(), p.non_fungible_ids());
+            p
+        }
+        pub fn badge_for_alice(&self) -> Proof {
+            let mut ids = BTreeSet::new();
+            ids.insert(NonFungibleId::from_u64(1));
+            let p = self.nf_badge_vault.create_proof_by_ids(&ids); // by returning it someone pushes it, not sure who
+            info!("badge_for_alice returning: {} {:?}", p.resource_address(), p.non_fungible_ids());
+            p
+        }
+        pub fn badge_for_bob(&self) -> Proof {
+            let mut ids = BTreeSet::new();
+            ids.insert(NonFungibleId::from_u64(2));
+            let p = self.nf_badge_vault.create_proof_by_ids(&ids); // by returning it someone pushes it, not sure who
+            info!("badge_for_bob returning: {} {:?}", p.resource_address(), p.non_fungible_ids());
+            p
+        }
+        pub fn instantiate_hello() -> ComponentAddress {
+            // Create a new token called "HelloToken," with a fixed supply of 1000, and put that supply into a bucket
+            let my_bucket: Bucket = ResourceBuilder::new_fungible()
+                .metadata("name", "HelloToken")
+                .metadata("symbol", "HT")
+                .initial_supply(dec!(1000u32));
+
+            let nf_admin_badge: Bucket = ResourceBuilder::new_non_fungible()
+                .initial_supply([
+                    (NonFungibleId::from_u64(1), User{ name: "Alice".to_owned() }),
+                    (NonFungibleId::from_u64(2), User{ name: "Bob".to_owned() }),
+                ]);
+
+            let access_rules = AccessRules::new()
+                .method("free_token", rule!(require(nf_admin_badge.resource_address()))) // limit to only those with badge (and record them in CallerAuthZone)
+                .default(rule!(allow_all));
+
+
+            // Instantiate a Hello component, populating its vault with our supply of 1000 HelloToken
+            let my_component = Self {
+                sample_vault: Vault::with_bucket(my_bucket),
+                nf_badge_vault: Vault::with_bucket(nf_admin_badge),
+                access_rules: access_rules.clone() // keeping a local copy for internal checks
+            }
+            .instantiate();
+            // Apply my rules, and add my component to global address space so it can be called by others
+            let component_address = my_component.add_access_check(access_rules).globalize();
+
+            component_address
+        }
+
+        pub fn free_token(&mut self) -> Bucket {
+            // get the NF proof that is required even though it was passed via AuthZone
+            info!("free_token called");
+            let ra = self.nf_badge_vault.resource_address();
+            let proof = CallerAuthZone::create_proof(ra);
+            let count = proof.non_fungible_ids().len();
+            info!("nf_free_token got some nf_badge_vault proof with count: {}", count);
+            assert_eq!(count, 1, "CallerAuthZone had too many NFTs in proof");
+            let user: User = proof.non_fungibles()[0].data(); // only care about the first one (this could cause problems if the create_proof order is not consistent and deterministic)
+            let take_amount = if user.name == "Alice" {
+                dec!(10)
+            } else {
+                dec!(1)
+            };
+            info!("My balance is: {} HelloToken. Now giving away {} tokens to {}", self.sample_vault.amount(), take_amount, user.name);
+            self.sample_vault.take(take_amount)
+        }
+
+    }
+}
+
+mod caller {
+use scrypto::prelude::*;
+
+blueprint! {
+    struct Caller {
+        tokens: Option<Vault>
+    }
+    impl Caller {
+        pub fn instantiate_caller() -> ComponentAddress {
+            // Create a new token called "HelloToken," with a fixed supply of 1000, and put that supply into a bucket
+            Self {
+                tokens: None
+            }
+            .instantiate().globalize()
+        }
+
+        pub fn run_as_alice(&mut self, callee: ComponentAddress) {
+            info!("running");
+            let hello: super::super::Hello = callee.into();
+            let alice_badge: Proof = hello.badge_for_alice();
+            ComponentAuthZone::push(alice_badge);
+            let free_tokens = hello.free_token();
+            if let Some(vault) = &mut self.tokens {
+                vault.put(free_tokens);
+            } else {
+                self.tokens = Some(Vault::with_bucket(free_tokens));
+            }
+        }
+
+        pub fn run_as_both(&mut self, callee: ComponentAddress) {
+            info!("running");
+            let hello: super::super::Hello = callee.into();
+            let alice_badge: Proof = hello.badge_for_alice();
+            let bob_badge: Proof = hello.badge_for_bob();
+
+            ComponentAuthZone::push(alice_badge);
+            let alice_tokens = hello.free_token();
+
+            ComponentAuthZone::start(); // fresh auth zone
+            ComponentAuthZone::push(bob_badge);
+            let bob_tokens = hello.free_token();
+            ComponentAuthZone::end(); // end auth zone
+
+            // more for alice
+            let more_alice_tokens = hello.free_token();
+
+            assert_eq!(alice_tokens.amount(), dec!(10));
+            assert_eq!(bob_tokens.amount(), dec!(1));
+            assert_eq!(more_alice_tokens.amount(), dec!(10));
+
+            if let Some(vault) = &mut self.tokens {
+                vault.put(alice_tokens);
+                vault.put(bob_tokens);
+                vault.put(more_alice_tokens);
+            } else {
+                let mut vault = Vault::new(alice_tokens.resource_address());
+                vault.put(alice_tokens);
+                vault.put(bob_tokens);
+                vault.put(more_alice_tokens);
+                self.tokens = Some(vault);
+            }
+        }
+
+    }
+}
+}

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -5,8 +5,8 @@ use crate::test_runner::TestRunner;
 use radix_engine::errors::RuntimeError;
 use radix_engine::errors::WasmValidationError::NoValidMemoryExport;
 use radix_engine::ledger::InMemorySubstateStore;
-use scrypto::prelude::*;
 use radix_engine::model::PackageError;
+use scrypto::prelude::*;
 
 #[test]
 fn missing_memory_should_cause_error() {

--- a/scrypto/src/core/invocation.rs
+++ b/scrypto/src/core/invocation.rs
@@ -8,6 +8,7 @@ use sbor::*;
 pub enum SNodeRef {
     PackageStatic,
     AuthZoneRef,
+    CallerAuthZoneRef,
     WorktopRef,
     Scrypto(ScryptoActor),
     ResourceStatic,

--- a/scrypto/src/core/invocation.rs
+++ b/scrypto/src/core/invocation.rs
@@ -9,6 +9,7 @@ pub enum SNodeRef {
     PackageStatic,
     AuthZoneRef,
     CallerAuthZoneRef,
+    AuthZoneManager,
     WorktopRef,
     Scrypto(ScryptoActor),
     ResourceStatic,

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -7,9 +7,9 @@ pub use crate::math::*;
 pub use crate::misc::*;
 pub use crate::resource::*;
 pub use crate::{
-    args, rule, access_and_or, access_rule_node, blueprint, borrow_component, borrow_package,
+    access_and_or, access_rule_node, args, blueprint, borrow_component, borrow_package,
     borrow_resource_manager, compile_package, debug, dec, error, import, include_package, info,
-    resource_list, trace, warn, Decode, Describe, Encode, NonFungibleData, TypeId,
+    resource_list, rule, trace, warn, Decode, Describe, Encode, NonFungibleData, TypeId,
 };
 
 pub use crate::rust::borrow::ToOwned;

--- a/scrypto/src/resource/auth_zone.rs
+++ b/scrypto/src/resource/auth_zone.rs
@@ -70,3 +70,41 @@ impl ComponentAuthZone {
         scrypto_decode(&output.rtn).unwrap()
     }
 }
+
+// just like above for create_proof* but targeting CallAuthZoneRef instead of AuthZoneRef
+pub struct CallerAuthZone {}
+
+impl CallerAuthZone {
+    pub fn create_proof(resource_address: ResourceAddress) -> Proof {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::CallerAuthZoneRef,
+            function: "create_proof".to_string(),
+            args: args![resource_address],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
+    pub fn create_proof_by_amount(amount: Decimal, resource_address: ResourceAddress) -> Proof {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::CallerAuthZoneRef,
+            function: "create_proof_by_amount".to_string(),
+            args: args![amount, resource_address],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
+    pub fn create_proof_by_ids(
+        ids: &BTreeSet<NonFungibleId>,
+        resource_address: ResourceAddress,
+    ) -> Proof {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::CallerAuthZoneRef,
+            function: "create_proof_by_ids".to_string(),
+            args: args![ids.clone(), resource_address],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+}

--- a/scrypto/src/resource/auth_zone.rs
+++ b/scrypto/src/resource/auth_zone.rs
@@ -15,6 +15,26 @@ use crate::rust::string::ToString;
 pub struct ComponentAuthZone {}
 
 impl ComponentAuthZone {
+    pub fn start() {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::AuthZoneManager,
+            function: "start".to_string(),
+            args: args![],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
+    pub fn end() {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::AuthZoneManager,
+            function: "end".to_string(),
+            args: args![],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
     /// Pushes a proof to the auth zone.
     pub fn push(proof: Proof) {
         let input = InvokeSNodeInput {

--- a/scrypto/src/resource/mod.rs
+++ b/scrypto/src/resource/mod.rs
@@ -16,7 +16,7 @@ mod system;
 mod vault;
 
 pub use access_rules::AccessRules;
-pub use auth_zone::ComponentAuthZone;
+pub use auth_zone::{CallerAuthZone, ComponentAuthZone};
 pub use bucket::{Bucket, ParseBucketError};
 pub use mint_params::MintParams;
 pub use non_fungible::NonFungible;

--- a/scrypto/src/resource/mod.rs
+++ b/scrypto/src/resource/mod.rs
@@ -25,8 +25,8 @@ pub use non_fungible_data::NonFungibleData;
 pub use non_fungible_id::{NonFungibleId, ParseNonFungibleIdError};
 pub use proof::{ParseProofError, Proof};
 pub use proof_rule::{
-    require, require_all_of, require_amount, require_any_of, require_n_of, AccessRuleNode,
-    AccessRule, ProofRule, SoftCount, SoftDecimal, SoftResource, SoftResourceOrNonFungible,
+    require, require_all_of, require_amount, require_any_of, require_n_of, AccessRule,
+    AccessRuleNode, ProofRule, SoftCount, SoftDecimal, SoftResource, SoftResourceOrNonFungible,
     SoftResourceOrNonFungibleList,
 };
 pub use resource_builder::{ResourceBuilder, DIVISIBILITY_MAXIMUM, DIVISIBILITY_NONE};

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -1,7 +1,7 @@
-use sbor::*;
 use crate::args;
 use crate::buffer::scrypto_decode;
 use crate::core::SNodeRef;
+use sbor::*;
 
 use crate::engine::{api::*, call_engine, types::ProofId};
 use crate::math::*;
@@ -10,8 +10,8 @@ use crate::resource::*;
 use crate::rust::collections::BTreeSet;
 #[cfg(not(feature = "alloc"))]
 use crate::rust::fmt;
-use crate::rust::vec::Vec;
 use crate::rust::string::ToString;
+use crate::rust::vec::Vec;
 use crate::types::*;
 
 /// Represents a proof of owning some resource.

--- a/scrypto/src/resource/proof_rule.rs
+++ b/scrypto/src/resource/proof_rule.rs
@@ -1,9 +1,9 @@
 use crate::resource::AccessRuleNode::{AllOf, AnyOf};
 use crate::resource::*;
 use crate::rust::borrow::ToOwned;
+use crate::rust::string::ToString;
 use crate::rust::vec;
 use crate::rust::vec::Vec;
-use crate::rust::string::ToString;
 use sbor::*;
 use scrypto::math::Decimal;
 

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -1,6 +1,6 @@
-use crate::rule;
 use crate::math::*;
 use crate::resource::*;
+use crate::rule;
 use crate::rust::borrow::ToOwned;
 use crate::rust::collections::HashMap;
 use crate::rust::string::String;


### PR DESCRIPTION
This is an implementation of the ideas I put forward in #285.

The high level summary:  Caller's can optionally use an AuthZone which will be visible to Callee's.  The callee's can optionally indicate the caller proofs they want access to by simply using the AccessRules as they already do.  When both sides agree, authorization and follow-on business logic (ie. based on a Proof of NonFungableData) works seamlessly.  The caller can specify their "pass by intent" by using an AuthZone to group their Proofs instead of seperate args.  This is kind of like varargs for Proofs.

There are 2 complementary features that work together.
1. AuthZones now live in a stack so actors can push the current one back putting a new empty AuthZone in it's place, or undo that.  (instructions `StartAuthZone`, `EndAuthZone` and API `ComponentAuthZone::start()` and `ComponentAuthZone::end()`)
2. Components can access the caller's AuthZone proofs with the same AuthZone API (not push/pop) using `CallerAuthZone::create_proof*` as they would have used `ComponentAuthZone`

These features are joined up forming a nice usable enhancement but with safety restrictions:

1. The `CallerAuthZone` is *at most* a "shadow" of only the top AuthZone in the stack, so it's fully controlled by the caller.
2. Which proofs are allowed in to the shadow must be explicitly defined by the *callee*.  This is done by using the same `AccessRules` they already use to protect method calls.  When those `HardAuthRule`s are checked, the shadow AuthZone is built up based on the matches which were already being visited.  The only overhead is cloning the Proofs.  So nothing happens on "allow_all", only explicit rule matches.
3.  And finally, if the caller is only using the default AuthZone, ie they've never done a single `StartAuthZone` instruction or `AuthZone::start()` to push a new AuthZone on the stack, then the shadow calculation does not happen at all, leaving the CallerAuthZone empty.  So everything is completely opt-in by the caller and protects their tx signing virtual badges.  Even the performance hit for the clones only happens when needed.

Would love feedback on the idea now that you can see it more concretely @russellharvey .  I think the implementation is pretty straight forward, though there are a few places I still had questions. Also I'm not sure I love the vocabulary I used everywhere, start/end, caller, shadow, etc.  A second opinion on if that all makes sense would be nice.  Maybe @iamyulong or @talekhinezh can take a look at this PR when they have time (I realize there are other priorities).  (See the "FIXMEs for some specific questions").  I also think adding `try_create_proofs*` APIs to return Option<Proof> instead of panic would be really helpful to enable more use cases.  I'd be willing to add those.

I don't expect this to be merged as is, but it is feature complete with tests and in decent shape. This is mostly meant to move that discussion forward and was a good way for me to dig into some of the Scrypto internals.  If it's never accepted that's fine but I think there's room to iterate on this idea for sure at leaset.  It was a good learning experience for me either way.  I realize some of the SNode and wasm stuff is changing, and at minimum this PR should probably be rebased and fixed up for the develop branch so it certainly needs a little care before it's ready too. 

My use case for wanting this is honestly not fully flushed out.  But the friction for me came when I was trying to build up a more complex authorization model and interacting with multiple components.  In this case I wanted some components to return badges to the caller and then have the caller use them against other components without having to specify them (because they might not know the resource address or ids if another component is in charge of authentication/authorization for a group of components).  And of course they would be NFT badges.  So this type of thing isn't possible without this PR because NFT badges have to be passed by intent right now so the callee can access the data.