### PR TITLE
Added the ability to check an access rule from Scrypto

### DIFF
--- a/radix-engine/src/engine/process.rs
+++ b/radix-engine/src/engine/process.rs
@@ -1252,7 +1252,7 @@ impl<'r, 'l, L: SubstateStore> Process<'r, 'l, L> {
     fn handle_check_access_rule(&mut self, input: CheckAccessRuleInput) -> Result<CheckAccessRuleOutput, RuntimeError> {
         let proofs = input.proof_ids
             .iter()
-            .map(|proof_id| self.proofs.remove(&proof_id).ok_or(RuntimeError::ProofNotFound(proof_id.clone())).unwrap())
+            .map(|proof_id| self.proofs.get(&proof_id).ok_or(RuntimeError::ProofNotFound(proof_id.clone())).unwrap().clone())
             .collect::<Vec<Proof>>();
         let simulated_auth_zone = AuthZone::new_with_proofs(proofs);
         let method_authorization = convert(&Type::Unit, &Value::Unit, &input.access_rule);

--- a/scrypto/src/engine/api.rs
+++ b/scrypto/src/engine/api.rs
@@ -216,5 +216,5 @@ pub struct CheckAccessRuleInput {
 
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct CheckAccessRuleOutput {
-    pub authorized: bool
+    pub is_authorized: bool
 }

--- a/scrypto/src/engine/api.rs
+++ b/scrypto/src/engine/api.rs
@@ -1,6 +1,6 @@
 use crate::core::SNodeRef;
 use sbor::*;
-use scrypto::prelude::AccessRules;
+use scrypto::prelude::{AccessRule, AccessRules};
 
 use crate::engine::types::*;
 use crate::rust::string::String;
@@ -45,6 +45,9 @@ pub const GET_CURRENT_EPOCH: u32 = 0xf3;
 pub const GET_TRANSACTION_HASH: u32 = 0xf4;
 /// Retrieve the running entity
 pub const GET_ACTOR: u32 = 0xf5;
+
+/// Check that an access rule is satisfied
+pub const CHECK_ACCESS_RULE: u32 = 0xf6;
 
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct InvokeSNodeInput {
@@ -203,4 +206,15 @@ pub struct GetActorInput {}
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct GetActorOutput {
     pub actor: ScryptoActorInfo,
+}
+
+#[derive(Debug, TypeId, Encode, Decode)]
+pub struct CheckAccessRuleInput {
+    pub access_rule: AccessRule,
+    pub proof_ids: Vec<ProofId>
+}
+
+#[derive(Debug, TypeId, Encode, Decode)]
+pub struct CheckAccessRuleOutput {
+    pub authorized: bool
 }

--- a/scrypto/src/resource/proof_rule.rs
+++ b/scrypto/src/resource/proof_rule.rs
@@ -361,7 +361,7 @@ impl AccessRule {
         };
         let output: CheckAccessRuleOutput = call_engine(CHECK_ACCESS_RULE, input);
 
-        output.authorized
+        output.is_authorized
     }
 }
 

--- a/scrypto/src/resource/proof_rule.rs
+++ b/scrypto/src/resource/proof_rule.rs
@@ -354,7 +354,7 @@ pub enum AccessRule {
 }
 
 impl AccessRule {
-    pub fn check(&self, proofs: Vec<Proof>) -> bool {
+    pub fn check(&self, proofs: &[Proof]) -> bool {
         let input = CheckAccessRuleInput {
             access_rule: self.clone(),
             proof_ids: proofs.iter().map(|proof| proof.0).collect()

--- a/scrypto/src/resource/proof_rule.rs
+++ b/scrypto/src/resource/proof_rule.rs
@@ -1,3 +1,5 @@
+use crate::engine::api::{CheckAccessRuleInput, CheckAccessRuleOutput, CHECK_ACCESS_RULE};
+use crate::engine::call_engine;
 use crate::resource::AccessRuleNode::{AllOf, AnyOf};
 use crate::resource::*;
 use crate::rust::borrow::ToOwned;
@@ -349,6 +351,18 @@ pub enum AccessRule {
     AllowAll,
     DenyAll,
     Protected(AccessRuleNode),
+}
+
+impl AccessRule {
+    pub fn check(&self, proofs: Vec<Proof>) -> bool {
+        let input = CheckAccessRuleInput {
+            access_rule: self.clone(),
+            proof_ids: proofs.iter().map(|proof| proof.0).collect()
+        };
+        let output: CheckAccessRuleOutput = call_engine(CHECK_ACCESS_RULE, input);
+
+        output.authorized
+    }
 }
 
 #[macro_export]


### PR DESCRIPTION
This pull request adds the ability to check whether a given vector of `Proof`s satisfies an `AccessRule` or not, inside of Scrypto. Example usage looks as follows:

```rust
pub fn is_allowed(proofs: Vec<Proof>)  {
    let rule: AccessRule = rule!(
        require_amount(dec!("20"), RADIX_TOKEN)
    );
    info!("Proofs satisfy AuthRule: {:?}", rule.check(&proofs[..])); 
}
```