### PR TITLE
Check new resources for dynamic auth

### DIFF
--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -42,7 +42,7 @@ pub enum ResourceManagerError {
     MethodNotFound(String),
     CouldNotCreateBucket,
     CouldNotCreateVault,
-    DynamicAccessRulesNotSupported
+    DynamicAccessRulesNotSupported,
 }
 
 enum MethodAccessRuleMethod {
@@ -163,7 +163,8 @@ impl ResourceManager {
         }
 
         // Checking that resource has no dynamic auth.
-        let contains_dynamic_rules: bool = auth.values()
+        let contains_dynamic_rules: bool = auth
+            .values()
             .flat_map(|rule_mutability_tuple| {
                 let mut vec = Vec::new();
                 vec.push(rule_mutability_tuple.0.clone());

--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -165,7 +165,8 @@ impl ResourceManager {
         // Checking that resource has no dynamic auth.
         let contains_dynamic_rules: bool = auth.values()
             .flat_map(|rule_mutability_tuple| {
-                let mut vec = vec![rule_mutability_tuple.0.clone()];
+                let mut vec = Vec::new();
+                vec.push(rule_mutability_tuple.0.clone());
                 match rule_mutability_tuple.1.clone() {
                     MUTABLE(rule) => vec.push(rule),
                     _ => {}

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -5,6 +5,41 @@ use radix_engine::transaction::*;
 use scrypto::call_data;
 use scrypto::prelude::*;
 
+pub fn test_resource_creation(
+    resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)>,
+    expect_err: bool,
+) {
+    // Arrange
+    let mut substate_store = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut substate_store, false);
+    let (pk, sk, account) = executor.new_account();
+
+    // Act
+    let metadata: HashMap<String, String> = HashMap::new();
+    let new_token_tx = TransactionBuilder::new()
+        .call_function(
+            SYSTEM_PACKAGE,
+            "System",
+            call_data![new_resource(
+                ResourceType::Fungible { divisibility: 18 },
+                metadata,
+                resource_auth,
+                Some(MintParams::Fungible { amount: dec!("1") })
+            )]
+        )
+        .call_method_with_all_resources(account, "deposit_batch")
+        .build(executor.get_nonce([pk]))
+        .sign([&sk]);
+    let receipt = executor.validate_and_execute(&new_token_tx).unwrap();
+
+    // Assert
+    if expect_err {
+        receipt.result.expect_err("Should be a runtime error");
+    } else {
+        receipt.result.expect("Should be okay.");
+    }
+}
+
 #[test]
 fn test_resource_manager() {
     // Arrange
@@ -96,4 +131,51 @@ fn mint_too_much_should_fail() {
         runtime_error,
         RuntimeError::ResourceManagerError(ResourceManagerError::MaxMintAmountExceeded)
     );
+}
+
+#[test]
+fn resource_creation_with_static_rules_should_succeed() {
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    resource_auth.insert(ResourceMethodAuthKey::Mint, (rule!(require(RADIX_TOKEN)), LOCKED));
+
+    test_resource_creation(resource_auth, false);
+}
+
+#[test]
+fn resource_creation_with_dynamic_behavior_rule_should_fail() {
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    resource_auth.insert(
+        ResourceMethodAuthKey::Mint,
+        (rule!(require("some_dynamic_badge")), LOCKED),
+    );
+
+    test_resource_creation(resource_auth, true);
+}
+
+#[test]
+fn resource_creation_with_dynamic_mutable_rule_should_fail() {
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    resource_auth.insert(
+        ResourceMethodAuthKey::Mint,
+        (
+            rule!(require(RADIX_TOKEN)),
+            MUTABLE(rule!(require("some_dynamic_badge"))),
+        ),
+    );
+
+    test_resource_creation(resource_auth, true);
+}
+
+#[test]
+fn resource_creation_with_dynamic_behavior_and_mutable_rule_should_fail() {
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    resource_auth.insert(
+        ResourceMethodAuthKey::Mint,
+        (
+            rule!(require("some_dynamic_badge")),
+            MUTABLE(rule!(require("some_dynamic_badge"))),
+        ),
+    );
+
+    test_resource_creation(resource_auth, true);
 }

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -25,7 +25,7 @@ pub fn test_resource_creation(
                 metadata,
                 resource_auth,
                 Some(MintParams::Fungible { amount: dec!("1") })
-            )]
+            )],
         )
         .call_method_with_all_resources(account, "deposit_batch")
         .build(executor.get_nonce([pk]))
@@ -135,15 +135,20 @@ fn mint_too_much_should_fail() {
 
 #[test]
 fn resource_creation_with_static_rules_should_succeed() {
-    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
-    resource_auth.insert(ResourceMethodAuthKey::Mint, (rule!(require(RADIX_TOKEN)), LOCKED));
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> =
+        HashMap::new();
+    resource_auth.insert(
+        ResourceMethodAuthKey::Mint,
+        (rule!(require(RADIX_TOKEN)), LOCKED),
+    );
 
     test_resource_creation(resource_auth, false);
 }
 
 #[test]
 fn resource_creation_with_dynamic_behavior_rule_should_fail() {
-    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> =
+        HashMap::new();
     resource_auth.insert(
         ResourceMethodAuthKey::Mint,
         (rule!(require("some_dynamic_badge")), LOCKED),
@@ -154,7 +159,8 @@ fn resource_creation_with_dynamic_behavior_rule_should_fail() {
 
 #[test]
 fn resource_creation_with_dynamic_mutable_rule_should_fail() {
-    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> =
+        HashMap::new();
     resource_auth.insert(
         ResourceMethodAuthKey::Mint,
         (
@@ -168,7 +174,8 @@ fn resource_creation_with_dynamic_mutable_rule_should_fail() {
 
 #[test]
 fn resource_creation_with_dynamic_behavior_and_mutable_rule_should_fail() {
-    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> = HashMap::new();
+    let mut resource_auth: HashMap<ResourceMethodAuthKey, (AccessRule, Mutability)> =
+        HashMap::new();
     resource_auth.insert(
         ResourceMethodAuthKey::Mint,
         (

--- a/scrypto/src/resource/access_rules.rs
+++ b/scrypto/src/resource/access_rules.rs
@@ -6,7 +6,6 @@ use sbor::rust::string::ToString;
 use sbor::*;
 
 use crate::resource::*;
-use std::iter::*;
 
 /// Method authorization rules for a component
 #[derive(Debug, Clone, PartialEq, Describe, TypeId, Encode, Decode)]
@@ -50,9 +49,9 @@ impl AccessRules {
     }
 
     pub fn contains_dynamic_rules(&self) -> bool {
-        self.iter()
-            .map(|(_, access_rule)| access_rule)
-            .chain(std::iter::once(self.get_default()))
-            .any(|access_rule| access_rule.contains_dynamic_rules())
+            self.get_default().contains_dynamic_rules() || 
+            self.iter()
+                .map(|(_, access_rule)| access_rule)
+                .any(|access_rule| access_rule.contains_dynamic_rules())
     }
 }

--- a/scrypto/src/resource/access_rules.rs
+++ b/scrypto/src/resource/access_rules.rs
@@ -6,6 +6,7 @@ use sbor::rust::string::ToString;
 use sbor::*;
 
 use crate::resource::*;
+use std::iter::*;
 
 /// Method authorization rules for a component
 #[derive(Debug, Clone, PartialEq, Describe, TypeId, Encode, Decode)]
@@ -46,5 +47,12 @@ impl AccessRules {
     pub fn iter(&self) -> Iter<'_, String, AccessRule> {
         let l = self.method_auth.iter();
         l
+    }
+
+    pub fn contains_dynamic_rules(&self) -> bool {
+        self.iter()
+            .map(|(_, access_rule)| access_rule)
+            .chain(std::iter::once(self.get_default()))
+            .any(|access_rule| access_rule.contains_dynamic_rules())
     }
 }

--- a/scrypto/src/resource/access_rules.rs
+++ b/scrypto/src/resource/access_rules.rs
@@ -49,8 +49,9 @@ impl AccessRules {
     }
 
     pub fn contains_dynamic_rules(&self) -> bool {
-            self.get_default().contains_dynamic_rules() || 
-            self.iter()
+        self.get_default().contains_dynamic_rules()
+            || self
+                .iter()
                 .map(|(_, access_rule)| access_rule)
                 .any(|access_rule| access_rule.contains_dynamic_rules())
     }

--- a/scrypto/src/resource/proof_rule.rs
+++ b/scrypto/src/resource/proof_rule.rs
@@ -432,7 +432,7 @@ impl AccessRule {
     pub fn contains_dynamic_rules(&self) -> bool {
         match self {
             Self::AllowAll | Self::DenyAll => false,
-            Self::Protected(access_rule_node) => access_rule_node.contains_dynamic_rules()
+            Self::Protected(access_rule_node) => access_rule_node.contains_dynamic_rules(),
         }
     }
 }


### PR DESCRIPTION
This PR adds checks to the radix-engine when building a new resource. Now, the radix-engine ensures that the resource does not have any dynamic rules for either the behavior or the mutability. 