### PR TITLE
Overflow

### DIFF
--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -28,3 +28,8 @@ trace = ["scrypto-derive/trace"]
 
 # Enable serde derives
 serde = ["sbor/serde", "scrypto-abi/serde"]
+
+[profile.release]
+# Enable checking of overflow in Scrypto
+# Do not remove this as all scrypto code depends on overflow safe operations.
+overflow-checks = true

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -15,6 +15,7 @@ cargo_toml = { version = "0.10", optional = true }
 sbor = { path = "../sbor", default-features = false }
 scrypto-abi = { path = "../scrypto-abi", default-features = false }
 scrypto-derive = { path = "../scrypto-derive", default-features = false }
+paste = { version = "1.0.7" }
 
 [features]
 # You should enable either `std` or `alloc`

--- a/scrypto/src/math/mod.rs
+++ b/scrypto/src/math/mod.rs
@@ -1,3 +1,4 @@
 mod decimal;
+mod test_overflow;
 
 pub use decimal::*;

--- a/scrypto/src/math/test_overflow.rs
+++ b/scrypto/src/math/test_overflow.rs
@@ -17,7 +17,7 @@ mod tests {
                     fn [<overflow_test_add_$t>]() {
                         let a: $t = 1;
                         let b = <$t>::MAX;
-                        let _c = a + b;         
+                        let _c = a + b;
                     }
 
 
@@ -26,7 +26,7 @@ mod tests {
                     fn [<overflow_test_mul_$t>]() {
                         let a: $t = 2;
                         let b = <$t>::MAX;
-                        let _c = a * b;         
+                        let _c = a * b;
                     }
 
                     #[test]
@@ -34,7 +34,7 @@ mod tests {
                     fn [<overflow_test_pow_$t>]() {
                         let a: $t = 2;
                         let b = <$t>::MAX;
-                        let _c = b.pow(a.try_into().unwrap());         
+                        let _c = b.pow(a.try_into().unwrap());
                     }
 
                     #[test]
@@ -42,7 +42,7 @@ mod tests {
                     fn [<overflow_test_shl_$t>]() {
                         let a: $t = $b + 1;
                         let b: $t = <$t>::MAX;
-                        let _c = b << a;         
+                        let _c = b << a;
                     }
 
                     #[test]
@@ -50,7 +50,7 @@ mod tests {
                     fn [<overflow_test_shr_$t>]() {
                         let a: $t = $b + 1;
                         let b: $t = <$t>::MAX;
-                        let _c = b >> a;         
+                        let _c = b >> a;
                     }
                 }
             )*
@@ -65,13 +65,13 @@ mod tests {
                     fn [<overflow_test_sub_$t>]() {
                         let a: $t = -1;
                         let b = <$t>::MAX;
-                        let _c = b - a;         
+                        let _c = b - a;
                     }
                 }
             )*
         };
     }
 
-    overflow!{ i8, 8, i16, 16, i32, 32, i64, 64, i128, 128, u8, 8, u16, 16, u32, 32, u64, 64, u128, 128 }
-    overflow_signed!{i8, i16, i32, i64, i128}
+    overflow! { i8, 8, i16, 16, i32, 32, i64, 64, i128, 128, u8, 8, u16, 16, u32, 32, u64, 64, u128, 128 }
+    overflow_signed! { i8, i16, i32, i64, i128 }
 }

--- a/scrypto/src/math/test_overflow.rs
+++ b/scrypto/src/math/test_overflow.rs
@@ -72,6 +72,23 @@ mod tests {
         };
     }
 
+    macro_rules! underflow_unsigned {
+        ($( $t:ty ),*) => {
+            $(
+                paste::paste! {
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_unsigned_sub_$t>]() {
+                        let a: $t = 1;
+                        let b: $t = 0;
+                        let _c = b - a;
+                    }
+                }
+            )*
+        };
+    }
+
     overflow! { i8, 8, i16, 16, i32, 32, i64, 64, i128, 128, u8, 8, u16, 16, u32, 32, u64, 64, u128, 128 }
     overflow_signed! { i8, i16, i32, i64, i128 }
+    underflow_unsigned!{ u8, u16, u32, u64, u128 }
 }

--- a/scrypto/src/math/test_overflow.rs
+++ b/scrypto/src/math/test_overflow.rs
@@ -90,5 +90,5 @@ mod tests {
 
     overflow! { i8, 8, i16, 16, i32, 32, i64, 64, i128, 128, u8, 8, u16, 16, u32, 32, u64, 64, u128, 128 }
     overflow_signed! { i8, i16, i32, i64, i128 }
-    underflow_unsigned!{ u8, u16, u32, u64, u128 }
+    underflow_unsigned! { u8, u16, u32, u64, u128 }
 }

--- a/scrypto/src/math/test_overflow.rs
+++ b/scrypto/src/math/test_overflow.rs
@@ -1,77 +1,77 @@
 // We are testing if builtin types panic on overflow. They should as this creates a safe math
 // environment for Scrypto
+// Whenever these tests fail, Cargo.toml file shold be doulblechecked for following lines:
+// [profile.release]
+// overflow-checks = true
+
+#![allow(arithmetic_overflow)]
+
 #[cfg(test)]
 mod tests {
     macro_rules! overflow {
-        ($t:ty, $b:literal) => (
-            paste::paste! {
+        ( $( $t:ty, $b:literal ),* ) => {
+            $(
+                paste::paste! {
                     #[test]
                     #[should_panic]
                     fn [<overflow_test_add_$t>]() {
-                        let a = 1$t;
+                        let a: $t = 1;
                         let b = <$t>::MAX;
-                        let c = a + b;         
+                        let _c = a + b;         
                     }
 
 
                     #[test]
                     #[should_panic]
                     fn [<overflow_test_mul_$t>]() {
-                        let a = 2$t;
+                        let a: $t = 2;
                         let b = <$t>::MAX;
-                        let c = a * b;         
+                        let _c = a * b;         
                     }
 
                     #[test]
                     #[should_panic]
-                    fn [<overflow_test_div_$t>]() {
-                        let a = 0$t;
+                    fn [<overflow_test_pow_$t>]() {
+                        let a: $t = 2;
                         let b = <$t>::MAX;
-                        let c = b / a;         
-                    }
-
-                    #[test]
-                    #[should_panic]
-                    fn [<overflow_test_powi_$t>]() {
-                        let a = 2$t;
-                        let b = <$t>::MAX;
-                        let c = b.powi(a);         
+                        let _c = b.pow(a.try_into().unwrap());         
                     }
 
                     #[test]
                     #[should_panic]
                     fn [<overflow_test_shl_$t>]() {
-                        let a = $b$t + 1;
-                        let b = <$t>::MAX;
-                        let c = b.shl(a);         
+                        let a: $t = $b + 1;
+                        let b: $t = <$t>::MAX;
+                        let _c = b << a;         
                     }
 
                     #[test]
                     #[should_panic]
-                    fn [<overflow_test_shl_$t>]() {
-                        let a = $b$t + 1;
-                        let b = <$t>::MAX;
-                        let c = b.shr(a);         
+                    fn [<overflow_test_shr_$t>]() {
+                        let a: $t = $b + 1;
+                        let b: $t = <$t>::MAX;
+                        let _c = b >> a;         
                     }
-            }
-        )
+                }
+            )*
+        };
     }
     macro_rules! overflow_signed {
-        ($($t:ty)*) => (
+        ($( $t:ty ),*) => {
             $(
                 paste::paste! {
                     #[test]
                     #[should_panic]
                     fn [<overflow_test_sub_$t>]() {
-                        let a = -1$t;
+                        let a: $t = -1;
                         let b = <$t>::MAX;
-                        let c = a - b;         
+                        let _c = b - a;         
                     }
                 }
             )*
-        )
+        };
     }
 
-    overflow!{ i8, 8 }
-    overflow_signed! { i8 i16 i32 i64 i128 }
+    overflow!{ i8, 8, i16, 16, i32, 32, i64, 64, i128, 128, u8, 8, u16, 16, u32, 32, u64, 64, u128, 128 }
+    overflow_signed!{i8, i16, i32, i64, i128}
 }

--- a/scrypto/src/math/test_overflow.rs
+++ b/scrypto/src/math/test_overflow.rs
@@ -1,0 +1,77 @@
+// We are testing if builtin types panic on overflow. They should as this creates a safe math
+// environment for Scrypto
+#[cfg(test)]
+mod tests {
+    macro_rules! overflow {
+        ($t:ty, $b:literal) => (
+            paste::paste! {
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_add_$t>]() {
+                        let a = 1$t;
+                        let b = <$t>::MAX;
+                        let c = a + b;         
+                    }
+
+
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_mul_$t>]() {
+                        let a = 2$t;
+                        let b = <$t>::MAX;
+                        let c = a * b;         
+                    }
+
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_div_$t>]() {
+                        let a = 0$t;
+                        let b = <$t>::MAX;
+                        let c = b / a;         
+                    }
+
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_powi_$t>]() {
+                        let a = 2$t;
+                        let b = <$t>::MAX;
+                        let c = b.powi(a);         
+                    }
+
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_shl_$t>]() {
+                        let a = $b$t + 1;
+                        let b = <$t>::MAX;
+                        let c = b.shl(a);         
+                    }
+
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_shl_$t>]() {
+                        let a = $b$t + 1;
+                        let b = <$t>::MAX;
+                        let c = b.shr(a);         
+                    }
+            }
+        )
+    }
+    macro_rules! overflow_signed {
+        ($($t:ty)*) => (
+            $(
+                paste::paste! {
+                    #[test]
+                    #[should_panic]
+                    fn [<overflow_test_sub_$t>]() {
+                        let a = -1$t;
+                        let b = <$t>::MAX;
+                        let c = a - b;         
+                    }
+                }
+            )*
+        )
+    }
+
+    overflow!{ i8, 8 }
+    overflow_signed! { i8 i16 i32 i64 i128 }
+}

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,7 @@ echo "Testing with std..."
 (cd sbor-derive; cargo test)
 (cd sbor-tests; cargo test)
 (cd scrypto; cargo test)
+(cd scrypto; cargo test --release overflow_test)
 (cd scrypto-derive; cargo test)
 (cd scrypto-tests; cargo test)
 (cd radix-engine; cargo test)
@@ -19,6 +20,7 @@ echo "Testing with no_std..."
 (cd sbor; cargo test --no-default-features --features alloc)
 (cd sbor-tests; cargo test --no-default-features --features alloc)
 (cd scrypto; cargo test --no-default-features --features alloc)
+(cd scrypto; cargo test --no-default-features --features alloc --release overflow_test)
 (cd scrypto-abi; cargo test --no-default-features --features alloc)
 (cd scrypto-tests; cargo test --no-default-features --features alloc)
 


### PR DESCRIPTION
As Dave has pointed out, we can rust do checked math with setting `overflow-checks = true` in `Cargo.toml`.
In this PR this was done, along with all tests to make sure that we always have overflow-checks on Scrypto code.
