### PR TITLE
Remove error cloning and partialEq

### DIFF
--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -11,7 +11,7 @@ use crate::model::*;
 use crate::wasm::InvokeError;
 
 /// Represents an error when executing a transaction.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub enum RuntimeError {
     /// Error when invoking a blueprint or component (recursive).
     InvokeError(Box<InvokeError>),
@@ -126,7 +126,7 @@ pub enum RuntimeError {
     CostingError(CostUnitCounterError),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub enum ResourceFailure {
     Resource(ResourceAddress),
     Resources(Vec<ResourceAddress>),

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -11,7 +11,7 @@ use crate::model::*;
 use crate::wasm::InvokeError;
 
 /// Represents an error when executing a transaction.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum RuntimeError {
     /// Error when invoking a blueprint or component (recursive).
     InvokeError(Box<InvokeError>),

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -31,7 +31,7 @@ pub struct TransactionProcessorRunInput {
     pub instructions: Vec<ExecutableInstruction>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum TransactionProcessorError {
     InvalidRequestData(DecodeError),
     RuntimeError(RuntimeError),

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -31,7 +31,7 @@ pub struct TransactionProcessorRunInput {
     pub instructions: Vec<ExecutableInstruction>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum TransactionProcessorError {
     InvalidRequestData(DecodeError),
     RuntimeError(RuntimeError),

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -82,7 +82,7 @@ pub enum InvalidTable {
 }
 
 /// Represents an error when invoking an export of a Scrypto module.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub enum InvokeError {
     MemoryAllocError,
 

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -82,7 +82,7 @@ pub enum InvalidTable {
 }
 
 /// Represents an error when invoking an export of a Scrypto module.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum InvokeError {
     MemoryAllocError,
 

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -88,18 +88,18 @@ fn test_take_with_invalid_granularity() {
         .unwrap()
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
-    println!("{:?}", receipt);
 
     // Assert
-    assert_eq!(
-        receipt.result,
-        Err(RuntimeError::BucketError(
-            BucketError::ResourceContainerError(ResourceContainerError::InvalidAmount(
-                dec!("1.123"),
-                2
-            ))
-        ))
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::BucketError(BucketError::ResourceContainerError(
+            ResourceContainerError::InvalidAmount(amount, granularity),
+        )) = e
+        {
+            amount.eq(&dec!("1.123")) && *granularity == 2
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -123,18 +123,18 @@ fn test_take_with_negative_amount() {
         .unwrap()
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
-    println!("{:?}", receipt);
 
     // Assert
-    assert_eq!(
-        receipt.result,
-        Err(RuntimeError::BucketError(
-            BucketError::ResourceContainerError(ResourceContainerError::InvalidAmount(
-                dec!("-2"),
-                2
-            ))
-        ))
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::BucketError(BucketError::ResourceContainerError(
+            ResourceContainerError::InvalidAmount(amount, granularity),
+        )) = e
+        {
+            amount.eq(&dec!("-2")) && *granularity == 2
+        } else {
+            false
+        }
+    });
 }
 
 #[test]

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -69,11 +69,13 @@ fn invalid_blueprint_name_should_cause_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert_eq!(
-        error,
-        RuntimeError::BlueprintNotFound(package_address, "NonExistentBlueprint".to_string())
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::BlueprintNotFound(addr, blueprint) = e {
+            addr.eq(&package_address) && blueprint.eq("NonExistentBlueprint")
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -95,8 +97,13 @@ fn reentrancy_should_not_be_possible() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert_eq!(error, RuntimeError::ComponentReentrancy(component_address))
+    receipt.expect_err(|e| {
+        if let RuntimeError::ComponentReentrancy(address) = e {
+            address.eq(&component_address)
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -115,6 +122,11 @@ fn missing_component_address_should_cause_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert_eq!(error, RuntimeError::ComponentNotFound(component_address));
+    receipt.expect_err(|e| {
+        if let RuntimeError::ComponentNotFound(address) = e {
+            address.eq(&component_address)
+        } else {
+            false
+        }
+    });
 }

--- a/radix-engine/tests/kv_store.rs
+++ b/radix-engine/tests/kv_store.rs
@@ -27,11 +27,12 @@ fn dangling_key_value_store_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let runtime_error = receipt.result.expect_err("Should be runtime error");
-    assert_eq!(
-        runtime_error,
-        RuntimeError::ResourceCheckFailure(ResourceFailure::UnclaimedKeyValueStore)
-    );
+    receipt.expect_err(|e| {
+        matches!(
+            e,
+            RuntimeError::ResourceCheckFailure(ResourceFailure::UnclaimedKeyValueStore)
+        )
+    });
 }
 
 #[test]

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -34,13 +34,14 @@ fn missing_memory_should_cause_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be error.");
-    assert_eq!(
-        error,
-        RuntimeError::PackageError(PackageError::InvalidWasm(PrepareError::InvalidMemory(
-            InvalidMemory::NoMemorySection
-        )))
-    );
+    receipt.expect_err(|e| {
+        matches!(
+            e,
+            &RuntimeError::PackageError(PackageError::InvalidWasm(PrepareError::InvalidMemory(
+                InvalidMemory::NoMemorySection
+            )))
+        )
+    });
 }
 
 #[test]
@@ -56,11 +57,13 @@ fn large_return_len_should_cause_memory_access_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert_eq!(
-        error,
-        RuntimeError::InvokeError(InvokeError::MemoryAccessError.into())
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::InvokeError(b) = e {
+            matches!(**b, InvokeError::MemoryAccessError)
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -76,11 +79,13 @@ fn overflow_return_len_should_cause_memory_access_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert_eq!(
-        error,
-        RuntimeError::InvokeError(InvokeError::MemoryAccessError.into())
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::InvokeError(b) = e {
+            matches!(**b, InvokeError::MemoryAccessError)
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -97,10 +102,7 @@ fn zero_return_len_should_cause_data_validation_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    if !matches!(error, RuntimeError::InvokeError(_)) {
-        panic!("{} should be data validation error", error);
-    }
+    receipt.expect_err(|e| matches!(e, RuntimeError::InvokeError(_)));
 }
 
 #[test]
@@ -147,11 +149,12 @@ fn test_basic_package_missing_export() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let error = receipt.result.expect_err("Should be an error.");
-    assert!(matches!(
-        error,
-        RuntimeError::PackageError(PackageError::InvalidWasm(
-            PrepareError::MissingExport { .. }
-        ))
-    ))
+    receipt.expect_err(|e| {
+        matches!(
+            e,
+            RuntimeError::PackageError(PackageError::InvalidWasm(
+                PrepareError::MissingExport { .. }
+            ))
+        )
+    });
 }

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -251,13 +251,9 @@ fn cant_move_restricted_proof() {
         .unwrap()
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
-    println!("{:?}", receipt);
 
     // Assert
-    assert_eq!(
-        receipt.result,
-        Err(RuntimeError::CantMoveRestrictedProof(1025))
-    );
+    receipt.expect_err(|e| matches!(e, RuntimeError::CantMoveRestrictedProof(_)));
 }
 
 #[test]

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -59,14 +59,17 @@ fn mint_with_bad_granularity_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    let runtime_error = receipt.result.expect_err("Should be runtime error");
-    assert_eq!(
-        runtime_error,
-        RuntimeError::ResourceManagerError(ResourceManagerError::InvalidAmount(
-            Decimal::from("0.1"),
-            0
-        ))
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::ResourceManagerError(ResourceManagerError::InvalidAmount(
+            amount,
+            granularity,
+        )) = e
+        {
+            amount.eq(&Decimal::from("0.1")) && *granularity == 0
+        } else {
+            false
+        }
+    });
 }
 
 #[test]
@@ -89,9 +92,10 @@ fn mint_too_much_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    let runtime_error = receipt.result.expect_err("Should be runtime error");
-    assert_eq!(
-        runtime_error,
-        RuntimeError::ResourceManagerError(ResourceManagerError::MaxMintAmountExceeded)
-    );
+    receipt.expect_err(|e| {
+        matches!(
+            e,
+            RuntimeError::ResourceManagerError(ResourceManagerError::MaxMintAmountExceeded)
+        )
+    })
 }

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -126,13 +126,13 @@ fn dangling_vault_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    let runtime_error = receipt.result.expect_err("Should be runtime error");
-    assert_eq!(
-        runtime_error,
-        RuntimeError::ResourceCheckFailure(ResourceFailure::Resource(
-            receipt.new_resource_addresses[0]
-        ))
-    );
+    receipt.expect_err(|e| {
+        if let RuntimeError::ResourceCheckFailure(ResourceFailure::Resource(addr)) = e {
+            addr.eq(&receipt.new_resource_addresses[0])
+        } else {
+            false
+        }
+    });
 }
 
 #[test]

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -172,8 +172,8 @@ pub fn handle_manifest<O: std::io::Write>(
                 writeln!(out, "{:?}", receipt).map_err(Error::IOError)?;
             }
 
-            if let Err(error) = &receipt.result {
-                Err(Error::TransactionExecutionError(error.clone()))
+            if let Err(error) = receipt.result {
+                Err(Error::TransactionExecutionError(error))
             } else {
                 let mut configs = get_configs()?;
                 configs.nonce = nonce + 1;


### PR DESCRIPTION
The requirement of RuntimeErrors to be cloneable is not allowing us to save some non-cloneable information in errors. This PR removes cloning from errors since it is not really needed.