### PR TITLE
Fix for Proofs and Buckets wrapped with an Option.

### DIFF
--- a/radix-engine/tests/abi/Cargo.toml
+++ b/radix-engine/tests/abi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "arguments"
+name = "abi"
 version = "0.1.0"
 edition = "2021"
 

--- a/radix-engine/tests/arguments.rs
+++ b/radix-engine/tests/arguments.rs
@@ -1,0 +1,160 @@
+#[rustfmt::skip]
+pub mod test_runner;
+use crate::test_runner::TestRunner;
+
+use transaction::builder::ManifestBuilder;
+
+use scrypto::prelude::*;
+use scrypto::to_struct;
+
+#[test]
+fn vector_of_buckets_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
+            builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
+                builder.call_function(
+                    package_address,
+                    "Arguments",
+                    "vector_argument",
+                    to_struct!(vec![Bucket(bucket_id1), Bucket(bucket_id2),]),
+                )
+            })
+        })
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}
+
+#[test]
+fn tuple_of_buckets_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
+            builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
+                builder.call_function(
+                    package_address,
+                    "Arguments",
+                    "tuple_argument",
+                    to_struct!((Bucket(bucket_id1), Bucket(bucket_id2),)),
+                )
+            })
+        })
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}
+
+#[test]
+fn treemap_of_strings_and_buckets_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
+            builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
+                let mut map = BTreeMap::new();
+                map.insert("first".to_string(), Bucket(bucket_id1));
+                map.insert("second".to_string(), Bucket(bucket_id2));
+
+                builder.call_function(
+                    package_address,
+                    "Arguments",
+                    "treemap_argument",
+                    to_struct!(map),
+                )
+            })
+        })
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}
+
+#[test]
+fn hashmap_of_strings_and_buckets_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
+            builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
+                let mut map = HashMap::new();
+                map.insert("first".to_string(), Bucket(bucket_id1));
+                map.insert("second".to_string(), Bucket(bucket_id2));
+
+                builder.call_function(
+                    package_address,
+                    "Arguments",
+                    "hashmap_argument",
+                    to_struct!(map),
+                )
+            })
+        })
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}
+
+#[test]
+fn some_optional_bucket_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
+            builder.call_function(
+                package_address,
+                "Arguments",
+                "option_argument",
+                to_struct!(Some(Bucket(bucket_id))),
+            )
+        })
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}
+
+#[test]
+fn none_optional_bucket_argument_should_succeed() {
+    // Arrange
+    let mut test_runner = TestRunner::new(true);
+    let package_address = test_runner.extract_and_publish_package("arguments");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .call_function(
+            package_address,
+            "Arguments",
+            "option_argument",
+            to_struct!(Option::<Bucket>::None),
+        )
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_success()
+}

--- a/radix-engine/tests/arguments/Cargo.toml
+++ b/radix-engine/tests/arguments/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "arguments"
+name = "abi"
 version = "0.1.0"
 edition = "2021"
 

--- a/radix-engine/tests/arguments/Cargo.toml
+++ b/radix-engine/tests/arguments/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "abi"
+name = "arguments"
 version = "0.1.0"
 edition = "2021"
 

--- a/radix-engine/tests/arguments/src/lib.rs
+++ b/radix-engine/tests/arguments/src/lib.rs
@@ -1,0 +1,23 @@
+use scrypto::prelude::*;
+
+blueprint! {
+    struct Arguments {}
+
+    impl Arguments {
+        pub fn vector_argument(arg: Vec<Bucket>) -> Vec<Bucket> {
+            arg
+        }
+        pub fn tuple_argument(arg: (Bucket, Bucket)) -> (Bucket, Bucket) {
+            arg
+        }
+        pub fn treemap_argument(arg: BTreeMap<String, Bucket>) -> BTreeMap<String, Bucket> {
+            arg
+        }
+        pub fn hashmap_argument(arg: HashMap<String, Bucket>) -> HashMap<String, Bucket> {
+            arg
+        }
+        pub fn option_argument(arg: Option<Bucket>) -> Option<Bucket> {
+            arg
+        }
+    }
+}

--- a/sbor/src/path.rs
+++ b/sbor/src/path.rs
@@ -72,10 +72,22 @@ impl<'a> SborValueRetriever<'a> {
         }
 
         match value {
-            Value::Struct { fields } | Value::Enum { fields, .. } => self.get_from_vector(fields),
-            Value::Array { elements, .. } | Value::Vec { elements, .. } => {
-                self.get_from_vector(elements)
-            }
+            Value::Struct { fields: vec }
+            | Value::Enum { fields: vec, .. }
+            | Value::Array { elements: vec, .. }
+            | Value::Vec { elements: vec, .. }
+            | Value::Tuple { elements: vec, .. }
+            | Value::TreeSet { elements: vec, .. }
+            | Value::TreeMap { elements: vec, .. }
+            | Value::HashSet { elements: vec, .. }
+            | Value::HashMap { elements: vec, .. } => self.get_from_vector(vec),
+            Value::Option { value } => match value.as_ref() {
+                Option::Some(value) => Option::Some(value),
+                Option::None => Option::None,
+            },
+            Value::Result { value } => match value.as_ref() {
+                Ok(result) | Err(result) => Some(result),
+            },
             _ => Option::None,
         }
     }
@@ -93,12 +105,22 @@ impl<'a> SborValueRetriever<'a> {
         }
 
         match value {
-            Value::Struct { fields } | Value::Enum { fields, .. } => {
-                self.get_from_vector_mut(fields)
-            }
-            Value::Array { elements, .. } | Value::Vec { elements, .. } => {
-                self.get_from_vector_mut(elements)
-            }
+            Value::Struct { fields: vec }
+            | Value::Enum { fields: vec, .. }
+            | Value::Array { elements: vec, .. }
+            | Value::Vec { elements: vec, .. }
+            | Value::Tuple { elements: vec, .. }
+            | Value::TreeSet { elements: vec, .. }
+            | Value::TreeMap { elements: vec, .. }
+            | Value::HashSet { elements: vec, .. }
+            | Value::HashMap { elements: vec, .. } => self.get_from_vector_mut(vec),
+            Value::Option { value } => match value.as_mut() {
+                Option::Some(value) => Option::Some(value),
+                Option::None => Option::None,
+            },
+            Value::Result { value } => match value.as_mut() {
+                Ok(result) | Err(result) => Some(result),
+            },
             _ => Option::None,
         }
     }


### PR DESCRIPTION
This PR is in response to #366 where `Proof`s and `Bucket`s wrapped in `Option` would lead to a panic in the Radix Engine. 