### PR TITLE
Add non_fungible_id() convenience method for bucket/vault/proofs

### DIFF
--- a/radix-engine/tests/non_fungible/src/lib.rs
+++ b/radix-engine/tests/non_fungible/src/lib.rs
@@ -171,6 +171,20 @@ blueprint! {
             (bucket, non_fungible_bucket)
         }
 
+        pub fn get_non_fungible_id_bucket() -> (Bucket, Bucket) {
+            let mut bucket = Self::create_non_fungible_fixed();
+            let non_fungible_bucket = bucket.take(1);
+            assert_eq!(
+                non_fungible_bucket.non_fungible_id(),
+                NonFungibleId::from_u32(1)
+            );
+            assert_eq!(
+                bucket.non_fungible_id(),
+                NonFungibleId::from_u32(2)
+            );
+            (bucket, non_fungible_bucket)
+        }
+
         pub fn get_non_fungible_ids_vault() -> Bucket {
             let mut vault = Vault::with_bucket(Self::create_non_fungible_fixed());
             let non_fungible_bucket = vault.take(1);
@@ -181,6 +195,23 @@ blueprint! {
             assert_eq!(
                 vault.non_fungible_ids(),
                 BTreeSet::from([NonFungibleId::from_u32(2), NonFungibleId::from_u32(3)])
+            );
+
+            NonFungibleTest { vault }.instantiate().globalize();
+
+            non_fungible_bucket
+        }
+
+        pub fn get_non_fungible_id_vault() -> Bucket {
+            let mut vault = Vault::with_bucket(Self::create_non_fungible_fixed());
+            let non_fungible_bucket = vault.take(1);
+            assert_eq!(
+                non_fungible_bucket.non_fungible_id(),
+                NonFungibleId::from_u32(1)
+            );
+            assert_eq!(
+                vault.non_fungible_id(),
+                NonFungibleId::from_u32(2)
             );
 
             NonFungibleTest { vault }.instantiate().globalize();

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -393,6 +393,32 @@ fn create_mutable_vault_with_get_nonfungible_ids() {
 }
 
 #[test]
+fn create_mutable_vault_with_get_nonfungible_id() {
+    // Arrange
+    let mut ledger = InMemorySubstateStore::with_bootstrap();
+    let mut executor = TransactionExecutor::new(&mut ledger, true);
+    let package = executor
+        .publish_package(&compile_package!(format!("./tests/{}", "vault")))
+        .unwrap();
+
+    // Act
+    let transaction = TransactionBuilder::new()
+        .call_function(
+            package,
+            "VaultTest",
+            "new_vault_with_get_non_fungible_id",
+            vec![],
+        )
+        .build(executor.get_nonce([]))
+        .sign([]);
+    let receipt = executor.validate_and_execute(&transaction).unwrap();
+
+    // Assert
+    receipt.result.expect("Should be okay");
+}
+
+
+#[test]
 fn create_mutable_vault_with_get_amount() {
     // Arrange
     let mut ledger = InMemorySubstateStore::with_bootstrap();

--- a/radix-engine/tests/vault/src/vault.rs
+++ b/radix-engine/tests/vault/src/vault.rs
@@ -160,6 +160,20 @@ blueprint! {
             .globalize()
         }
 
+        pub fn new_vault_with_get_non_fungible_id() -> ComponentAddress {
+            let vault = Self::create_non_fungible_vault();
+            let _id = vault.non_fungible_id();
+            let vaults = LazyMap::new();
+            let vault_vector = Vec::new();
+            VaultTest {
+                vault,
+                vaults,
+                vault_vector,
+            }
+            .instantiate()
+            .globalize()
+        }
+
         pub fn new_vault_with_get_amount() -> ComponentAddress {
             let vault = Self::create_non_fungible_vault();
             let _amount = vault.amount();

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -152,6 +152,19 @@ impl Bucket {
             .collect()
     }
 
+    /// Returns a singleton non-fungible id
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton bucket
+    pub fn non_fungible_id(&self) -> NonFungibleId {
+        let non_fungible_ids = self.non_fungible_ids();
+        if non_fungible_ids.len() != 1 {
+            panic!("Expecting singleton NFT vault");
+        }
+        self.non_fungible_ids().into_iter().next().unwrap()
+    }
+
+
     /// Returns a singleton non-fungible.
     ///
     /// # Panics

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -100,6 +100,19 @@ impl Proof {
             .collect()
     }
 
+    /// Returns a singleton non-fungible id
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton bucket
+    pub fn non_fungible_id(&self) -> NonFungibleId {
+        let non_fungible_ids = self.non_fungible_ids();
+        if non_fungible_ids.len() != 1 {
+            panic!("Expecting singleton NFT vault");
+        }
+        self.non_fungible_ids().into_iter().next().unwrap()
+    }
+
+
     /// Returns a singleton non-fungible.
     ///
     /// # Panics

--- a/scrypto/src/resource/vault.rs
+++ b/scrypto/src/resource/vault.rs
@@ -185,6 +185,18 @@ impl Vault {
             .collect()
     }
 
+    /// Returns a singleton non-fungible id
+    ///
+    /// # Panics
+    /// Panics if this is not a singleton bucket
+    pub fn non_fungible_id(&self) -> NonFungibleId {
+        let non_fungible_ids = self.non_fungible_ids();
+        if non_fungible_ids.len() != 1 {
+            panic!("Expecting singleton NFT vault");
+        }
+        self.non_fungible_ids().into_iter().next().unwrap()
+    }
+
     /// Returns a singleton non-fungible.
     ///
     /// # Panics


### PR DESCRIPTION
I often find myself get the first `NonFungibleId`. Why cant I use `non_fungible().id()`? Because it assumes I have knowledge of the struct. In cases where you dont have knowledge of this, this would be a nice simple addition. Its also consistent with the api combinations of having `non_fungibles()` and `non_fungible()` so it makes sense to have `non_fungible_ids` and `non_fungible_id`