### PR TITLE
Feature/remove worktop from call frame

### DIFF
--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -17,6 +17,7 @@ use scrypto::values::*;
 use transaction::model::*;
 use transaction::validation::*;
 
+use crate::engine::ResourceFailure;
 use crate::engine::{RuntimeError, RuntimeError::ProofNotFound, SystemApi};
 use crate::model::worktop::{
     WorktopAssertContainsAmountInput, WorktopAssertContainsInput,
@@ -513,6 +514,15 @@ impl TransactionProcessor {
                     }
                     .map_err(TransactionProcessorError::RuntimeError)?;
                     outputs.push(result);
+                }
+
+                // check resource
+                if !worktop.is_empty() {
+                    return Err(TransactionProcessorError::RuntimeError(
+                        RuntimeError::ResourceCheckFailure(ResourceFailure::Resources(
+                            worktop.resource_addresses(),
+                        )),
+                    ));
                 }
 
                 Ok(ScryptoValue::from_typed(

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -26,6 +26,8 @@ use crate::model::worktop::{
 use crate::model::TransactionProcessorError::InvalidMethod;
 use crate::wasm::*;
 
+use super::Worktop;
+
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct TransactionProcessorRunInput {
     pub instructions: Vec<ExecutableInstruction>,
@@ -72,6 +74,7 @@ impl TransactionProcessor {
                 let mut bucket_id_mapping = HashMap::new();
                 let mut outputs = Vec::new();
                 let mut id_allocator = IdAllocator::new(IdSpace::Transaction);
+                let mut worktop = Worktop::new();
 
                 for inst in &input.instructions.clone() {
                     let result = match inst {
@@ -79,14 +82,15 @@ impl TransactionProcessor {
                             .new_bucket_id()
                             .map_err(RuntimeError::IdAllocationError)
                             .and_then(|new_id| {
-                                system_api
-                                    .invoke_snode(
-                                        SNodeRef::WorktopRef,
-                                        "take_all".to_string(),
+                                worktop
+                                    .main(
+                                        "take_all",
                                         ScryptoValue::from_typed(&WorktopTakeAllInput {
                                             resource_address: *resource_address,
                                         }),
+                                        system_api,
                                     )
+                                    .map_err(RuntimeError::WorktopError)
                                     .map(|rtn| {
                                         let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -100,15 +104,16 @@ impl TransactionProcessor {
                             .new_bucket_id()
                             .map_err(RuntimeError::IdAllocationError)
                             .and_then(|new_id| {
-                                system_api
-                                    .invoke_snode(
-                                        SNodeRef::WorktopRef,
-                                        "take_amount".to_string(),
+                                worktop
+                                    .main(
+                                        "take_amount",
                                         ScryptoValue::from_typed(&WorktopTakeAmountInput {
                                             amount: *amount,
                                             resource_address: *resource_address,
                                         }),
+                                        system_api,
                                     )
+                                    .map_err(RuntimeError::WorktopError)
                                     .map(|rtn| {
                                         let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -122,15 +127,16 @@ impl TransactionProcessor {
                             .new_bucket_id()
                             .map_err(RuntimeError::IdAllocationError)
                             .and_then(|new_id| {
-                                system_api
-                                    .invoke_snode(
-                                        SNodeRef::WorktopRef,
-                                        "take_non_fungibles".to_string(),
+                                worktop
+                                    .main(
+                                        "take_non_fungibles",
                                         ScryptoValue::from_typed(&WorktopTakeNonFungiblesInput {
                                             ids: ids.clone(),
                                             resource_address: *resource_address,
                                         }),
+                                        system_api,
                                     )
+                                    .map_err(RuntimeError::WorktopError)
                                     .map(|rtn| {
                                         let bucket_id = *rtn.bucket_ids.iter().next().unwrap().0;
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -140,46 +146,55 @@ impl TransactionProcessor {
                         ExecutableInstruction::ReturnToWorktop { bucket_id } => bucket_id_mapping
                             .remove(bucket_id)
                             .map(|real_id| {
-                                system_api.invoke_snode(
-                                    SNodeRef::WorktopRef,
-                                    "put".to_string(),
-                                    ScryptoValue::from_typed(&WorktopPutInput {
-                                        bucket: scrypto::resource::Bucket(real_id),
-                                    }),
-                                )
+                                worktop
+                                    .main(
+                                        "put",
+                                        ScryptoValue::from_typed(&WorktopPutInput {
+                                            bucket: scrypto::resource::Bucket(real_id),
+                                        }),
+                                        system_api,
+                                    )
+                                    .map_err(RuntimeError::WorktopError)
                             })
                             .unwrap_or(Err(RuntimeError::BucketNotFound(*bucket_id))),
                         ExecutableInstruction::AssertWorktopContains { resource_address } => {
-                            system_api.invoke_snode(
-                                SNodeRef::WorktopRef,
-                                "assert_contains".to_string(),
-                                ScryptoValue::from_typed(&WorktopAssertContainsInput {
-                                    resource_address: *resource_address,
-                                }),
-                            )
+                            worktop
+                                .main(
+                                    "assert_contains",
+                                    ScryptoValue::from_typed(&WorktopAssertContainsInput {
+                                        resource_address: *resource_address,
+                                    }),
+                                    system_api,
+                                )
+                                .map_err(RuntimeError::WorktopError)
                         }
                         ExecutableInstruction::AssertWorktopContainsByAmount {
                             amount,
                             resource_address,
-                        } => system_api.invoke_snode(
-                            SNodeRef::WorktopRef,
-                            "assert_contains_amount".to_string(),
-                            ScryptoValue::from_typed(&WorktopAssertContainsAmountInput {
-                                amount: *amount,
-                                resource_address: *resource_address,
-                            }),
-                        ),
+                        } => worktop
+                            .main(
+                                "assert_contains_amount",
+                                ScryptoValue::from_typed(&WorktopAssertContainsAmountInput {
+                                    amount: *amount,
+                                    resource_address: *resource_address,
+                                }),
+                                system_api,
+                            )
+                            .map_err(RuntimeError::WorktopError),
                         ExecutableInstruction::AssertWorktopContainsByIds {
                             ids,
                             resource_address,
-                        } => system_api.invoke_snode(
-                            SNodeRef::WorktopRef,
-                            "assert_contains_non_fungibles".to_string(),
-                            ScryptoValue::from_typed(&WorktopAssertContainsNonFungiblesInput {
-                                ids: ids.clone(),
-                                resource_address: *resource_address,
-                            }),
-                        ),
+                        } => worktop
+                            .main(
+                                "assert_contains_non_fungibles",
+                                ScryptoValue::from_typed(&WorktopAssertContainsNonFungiblesInput {
+                                    ids: ids.clone(),
+                                    resource_address: *resource_address,
+                                }),
+                                system_api,
+                            )
+                            .map_err(RuntimeError::WorktopError),
+
                         ExecutableInstruction::PopFromAuthZone {} => id_allocator
                             .new_proof_id()
                             .map_err(RuntimeError::IdAllocationError)
@@ -380,14 +395,15 @@ impl TransactionProcessor {
                                 }
                                 // Auto move into worktop
                                 for (bucket_id, _) in &result.bucket_ids {
-                                    system_api
-                                        .invoke_snode(
-                                            SNodeRef::WorktopRef,
-                                            "put".to_string(),
+                                    worktop
+                                        .main(
+                                            "put",
                                             ScryptoValue::from_typed(&WorktopPutInput {
                                                 bucket: scrypto::resource::Bucket(*bucket_id),
                                             }),
+                                            system_api,
                                         )
+                                        .map_err(RuntimeError::WorktopError)
                                         .unwrap(); // TODO: Remove unwrap
                                 }
                                 Ok(result)
@@ -425,14 +441,15 @@ impl TransactionProcessor {
                                 }
                                 // Auto move into worktop
                                 for (bucket_id, _) in &result.bucket_ids {
-                                    system_api
-                                        .invoke_snode(
-                                            SNodeRef::WorktopRef,
-                                            "put".to_string(),
+                                    worktop
+                                        .main(
+                                            "put",
                                             ScryptoValue::from_typed(&WorktopPutInput {
                                                 bucket: scrypto::resource::Bucket(*bucket_id),
                                             }),
+                                            system_api,
                                         )
+                                        .map_err(RuntimeError::WorktopError)
                                         .unwrap(); // TODO: Remove unwrap
                                 }
                                 Ok(result)
@@ -459,11 +476,13 @@ impl TransactionProcessor {
                                         )
                                         .unwrap();
                                 }
-                                system_api.invoke_snode(
-                                    SNodeRef::WorktopRef,
-                                    "drain".to_string(),
-                                    ScryptoValue::from_typed(&WorktopDrainInput {}),
-                                )
+                                worktop
+                                    .main(
+                                        "drain",
+                                        ScryptoValue::from_typed(&WorktopDrainInput {}),
+                                        system_api,
+                                    )
+                                    .map_err(RuntimeError::WorktopError)
                             })
                             .and_then(|result| {
                                 let mut buckets = Vec::new();

--- a/scrypto/src/core/invocation.rs
+++ b/scrypto/src/core/invocation.rs
@@ -12,7 +12,6 @@ pub enum SNodeRef {
     SystemStatic,
     PackageStatic,
     AuthZoneRef,
-    WorktopRef,
     Scrypto(ScryptoActor),
     ResourceStatic,
     ResourceRef(ResourceAddress),


### PR DESCRIPTION
Worktop can be implemented within transaction processor (actually only needed by transaction processor) using existing system api. 

This PR removes worktop from call frame to reduce the number of value types RE needs to manages at runtime.