### PR TITLE
Feature/shroud resource data

### DIFF
--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -671,7 +671,13 @@ impl<'s, S: SubstateStore> Track<'s, S> {
             self.resource_managers.keys().cloned().collect();
         for resource_address in resource_addresses {
             let resource_manager = self.resource_managers.remove(&resource_address).unwrap();
-
+            
+            // Unshrouds shrouded resources
+            let mut resource_info = resource_manager.value;
+            if resource_info.is_shrouded() {
+                resource_info.unshroud();
+            }
+        
             if let Some(prev_id) = resource_manager.prev_id {
                 receipt.down(prev_id);
             }
@@ -680,7 +686,7 @@ impl<'s, S: SubstateStore> Track<'s, S> {
 
             self.substate_store.put_encoded_substate(
                 &resource_address,
-                &resource_manager.value,
+                &resource_info,
                 phys_id,
             );
         }

--- a/radix-engine/src/model/resource_manager.rs
+++ b/radix-engine/src/model/resource_manager.rs
@@ -418,7 +418,7 @@ impl ResourceManager {
             "is_shrouded" => Ok(ScryptoValue::from_value(&self.is_shrouded())),
             "shroud" => { 
                 self.shroud();
-                Ok(ScryptoValue::from_value(&self.is_shrouded()))
+                Ok(ScryptoValue::from_value(&()))
             }
             "method_auth" => {
                 let method: ResourceMethod = scrypto_decode(&args.remove(0).raw)

--- a/scrypto/src/resource/non_fungible.rs
+++ b/scrypto/src/resource/non_fungible.rs
@@ -12,7 +12,7 @@ pub struct NonFungible<T: NonFungibleData> {
 impl<T: NonFungibleData> From<NonFungibleAddress> for NonFungible<T> {
     fn from(address: NonFungibleAddress) -> Self {
         Self {
-            address,
+            address: address.clone(),
             data: PhantomData,
         }
     }

--- a/scrypto/src/resource/resource_manager.rs
+++ b/scrypto/src/resource/resource_manager.rs
@@ -43,6 +43,28 @@ impl ResourceAddress {}
 pub struct ResourceManager(pub(crate) ResourceAddress);
 
 impl ResourceManager {
+    /// Returns whether the resource is shrouded or not
+    pub fn is_shrouded(&self) -> bool {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::ResourceRef(self.0),
+            function: "is_shrouded".to_string(),
+            args: args![],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
+    /// Shrouds resource
+    pub fn shroud(&self) -> () {
+        let input = InvokeSNodeInput {
+            snode_ref: SNodeRef::ResourceRef(self.0),
+            function: "shroud".to_string(),
+            args: args![],
+        };
+        let output: InvokeSNodeOutput = call_engine(INVOKE_SNODE, input);
+        scrypto_decode(&output.rtn).unwrap()
+    }
+
     /// Mints fungible resources
     pub fn mint<T: Into<Decimal>>(&self, amount: T) -> Bucket {
         let input = InvokeSNodeInput {


### PR DESCRIPTION

This feature adds two new functions to the Resource Manager for Non-Fungible Tokens: `shroud` and `is_shrouded`.

The `shroud` feature prevents Components from accessing the data of an NFT within a single transaction. When a transaction is finished, all shrouding will be removed.  

The purpose of shrouding data is to prevent manipulation of information embedded within an NFT's data. 

Take, for example, an NFT Mint:

If the data of the NFT is known at any point before the transaction ends, a user can regulate the state of that NFT's data by failing any transactions with unwanted NFT data, and pass any transactions with desired data. 

Typically, this is resolved by artificial scarcity, large transaction fees, and not setting NFT data until after all NFTs are minted, and setting NFT data for all NFTs at once. If the NFT data is not yet known when the NFT is minted, a user cannot ensure specific data is selected. However, this is very inefficient. Additionally, power is centralized towards the entity which sets the NFT data.  

This is a big issue for many use cases, because of how further NFTs belonging that group cannot be minted without centralization. Because the data of the NFT must be able to be set while minting of NFTs are also occurring, the power to choose NFT data for themselves goes to either the centralized entity setting the NFT Data formula or the minters of the NFT. 

By "shrouding" an NFT's data before the user has it returned, both the creation of the data of an NFT and minting of the NFT itself can freely occur within the same transaction, without a possibility of artificially altering that data. This decentralizes the process, and opens up NFT Mints to be continuous.

This process can be applied to any system which even semi-randomly gives out or changes data embedded within NFT Data, in a scenario in which randomness is desired. If randomness is not desired, then allowing users to mitigate the innate randomness of the network through unshrouded data assertions is fine, and still works the same as before. A few specific systems which would use shrouding are:
- Oracles, especially for random numbers
- Games hosted on the network
- Gambling, where a return should not be able to be guaranteed

As for my implementation itself I believe it is quite sound as it is not very technically complex. This implementation passed all of my resim testing, but I have not added any formal tests, so those need to be done. For the future, I hope to expand the shrouding system to expand into a number of asset returns such as the amount of a resource, which can be used in a similar way. 

Feedback would be appreciated, thank you!