### PR TITLE
Bugfix: transaction network fees

### DIFF
--- a/radix-engine/src/engine/call_frame.rs
+++ b/radix-engine/src/engine/call_frame.rs
@@ -2251,8 +2251,13 @@ where
         Ok(self.track.transaction_hash())
     }
 
-    fn get_transaction_network(&mut self) -> Network {
-        self.track.transaction_network()
+    fn transaction_network(&mut self) -> Result<Network, CostUnitCounterError> {
+        self.cost_unit_counter.consume(
+            self.fee_table
+                .system_api_cost(SystemApiCostingEntry::ReadTransactionHash),
+            "read_transaction_network",
+        )?;
+        Ok(self.track.transaction_network())
     }
 
     fn generate_uuid(&mut self) -> Result<u128, CostUnitCounterError> {

--- a/radix-engine/src/engine/system_api.rs
+++ b/radix-engine/src/engine/system_api.rs
@@ -62,7 +62,7 @@ where
 
     fn transaction_hash(&mut self) -> Result<Hash, CostUnitCounterError>;
 
-    fn get_transaction_network(&mut self) -> Network;
+    fn transaction_network(&mut self) -> Result<Network, CostUnitCounterError>;
 
     fn generate_uuid(&mut self) -> Result<u128, CostUnitCounterError>;
 

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -40,6 +40,9 @@ pub enum SystemApiCostingEntry<'a> {
     /// Read the transaction hash.
     ReadTransactionHash,
 
+    /// Read the transaction network.
+    ReadTransactionNetwork,
+
     /// Generates a UUID.
     GenerateUuid,
 
@@ -225,6 +228,7 @@ impl FeeTable {
             SystemApiCostingEntry::Write { .. } => self.fixed_medium,
             SystemApiCostingEntry::ReadEpoch => self.fixed_low,
             SystemApiCostingEntry::ReadTransactionHash => self.fixed_low,
+            SystemApiCostingEntry::ReadTransactionNetwork => self.fixed_low,
             SystemApiCostingEntry::GenerateUuid => self.fixed_low,
             SystemApiCostingEntry::EmitLog { size } => self.fixed_low + 10 * size,
             SystemApiCostingEntry::CheckAccessRule => self.fixed_medium,

--- a/radix-engine/src/model/system.rs
+++ b/radix-engine/src/model/system.rs
@@ -72,7 +72,9 @@ impl System {
                 let _: SystemGetTransactionNetworkInput =
                     scrypto_decode(&arg.raw).map_err(|e| SystemError::InvalidRequestData(e))?;
                 Ok(ScryptoValue::from_typed(
-                    &system_api.get_transaction_network(),
+                    &system_api
+                        .transaction_network()
+                        .map_err(SystemError::CostingError)?,
                 ))
             }
             _ => Err(InvalidMethod),


### PR DESCRIPTION
The `transaction_netwotk()` method in the system API was implemented in the middle of the implementation of fees; therefore, it accidentally did not consume any fees. This PR makes it consume fees equal to the amount consumed by the `transaction_hash()` since both are cashed by the track. 