### PR TITLE
Cleanup output ids

### DIFF
--- a/radix-engine/src/engine/call_frame.rs
+++ b/radix-engine/src/engine/call_frame.rs
@@ -131,7 +131,6 @@ pub fn insert_non_root_nodes<'s>(track: &mut Track<'s>, values: HashMap<ValueId,
             RENode::KeyValueStore(store) => {
                 let id = id.into();
                 let address = Address::KeyValueStoreSpace(id);
-                track.create_key_space(address.clone());
                 for (k, v) in store.store {
                     track.set_key_value(address.clone(), k, KeyValueStoreEntryWrapper(Some(v.raw)));
                 }
@@ -2090,8 +2089,6 @@ where
 
         if let Some(non_fungibles) = maybe_non_fungibles {
             let resource_address: ResourceAddress = address.clone().into();
-            self.track
-                .create_key_space(Address::NonFungibleSpace(resource_address));
             let parent_address = Address::NonFungibleSpace(resource_address.clone());
             for (id, non_fungible) in non_fungibles {
                 self.track.set_key_value(

--- a/radix-engine/src/engine/track.rs
+++ b/radix-engine/src/engine/track.rs
@@ -77,10 +77,6 @@ impl<'s> Track<'s> {
         self.state_track.put_substate(address, value.into());
     }
 
-    pub fn create_key_space(&mut self, address: Address) {
-        self.state_track.put_space(address);
-    }
-
     // TODO: to read/write a value owned by track requires three coordinated steps:
     // 1. Attempt to acquire the lock
     // 2. Apply the operation

--- a/radix-engine/src/ledger/memory.rs
+++ b/radix-engine/src/ledger/memory.rs
@@ -8,14 +8,12 @@ use crate::ledger::{OutputValue, WriteableSubstateStore};
 #[derive(Debug, PartialEq, Eq)]
 pub struct InMemorySubstateStore {
     substates: HashMap<Address, OutputValue>,
-    spaces: HashMap<Address, OutputId>,
 }
 
 impl InMemorySubstateStore {
     pub fn new() -> Self {
         Self {
             substates: HashMap::new(),
-            spaces: HashMap::new(),
         }
     }
 
@@ -35,21 +33,10 @@ impl ReadableSubstateStore for InMemorySubstateStore {
     fn get_substate(&self, address: &Address) -> Option<OutputValue> {
         self.substates.get(address).cloned()
     }
-
-    fn get_space(&self, address: &Address) -> OutputId {
-        self.spaces
-            .get(address)
-            .cloned()
-            .expect("Expected space does not exist")
-    }
 }
 
 impl WriteableSubstateStore for InMemorySubstateStore {
     fn put_substate(&mut self, address: Address, substate: OutputValue) {
         self.substates.insert(address, substate);
-    }
-
-    fn put_space(&mut self, address: Address, output_id: OutputId) {
-        self.spaces.insert(address, output_id);
     }
 }

--- a/radix-engine/src/ledger/memory.rs
+++ b/radix-engine/src/ledger/memory.rs
@@ -2,12 +2,12 @@ use sbor::rust::collections::HashMap;
 
 use crate::engine::Address;
 use crate::ledger::*;
-use crate::ledger::{Output, WriteableSubstateStore};
+use crate::ledger::{OutputValue, WriteableSubstateStore};
 
 /// A substate store that stores all substates in host memory.
 #[derive(Debug, PartialEq, Eq)]
 pub struct InMemorySubstateStore {
-    substates: HashMap<Address, Output>,
+    substates: HashMap<Address, OutputValue>,
     spaces: HashMap<Address, OutputId>,
 }
 
@@ -32,7 +32,7 @@ impl Default for InMemorySubstateStore {
 }
 
 impl ReadableSubstateStore for InMemorySubstateStore {
-    fn get_substate(&self, address: &Address) -> Option<Output> {
+    fn get_substate(&self, address: &Address) -> Option<OutputValue> {
         self.substates.get(address).cloned()
     }
 
@@ -45,7 +45,7 @@ impl ReadableSubstateStore for InMemorySubstateStore {
 }
 
 impl WriteableSubstateStore for InMemorySubstateStore {
-    fn put_substate(&mut self, address: Address, substate: Output) {
+    fn put_substate(&mut self, address: Address, substate: OutputValue) {
         self.substates.insert(address, substate);
     }
 

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -16,39 +16,25 @@ pub trait QueryableSubstateStore {
 }
 
 #[derive(Debug, Clone, Hash, TypeId, Encode, Decode, PartialEq, Eq)]
-pub struct OutputId(pub Hash, pub u32);
+pub struct OutputId {
+    pub address: Address,
+    pub substate_hash: Hash,
+    pub version: u32,
+}
 
 #[derive(Debug, Clone, Encode, Decode, TypeId, PartialEq, Eq)]
-pub struct Output {
+pub struct OutputValue {
     pub substate: Substate,
-    pub output_id: OutputId,
-}
-
-#[derive(Debug)]
-pub struct OutputIdGenerator {
-    tx_hash: Hash,
-    count: u32,
-}
-
-impl OutputIdGenerator {
-    pub fn new(tx_hash: Hash) -> Self {
-        Self { tx_hash, count: 0 }
-    }
-
-    pub fn next(&mut self) -> OutputId {
-        let value = self.count;
-        self.count = self.count + 1;
-        OutputId(self.tx_hash.clone(), value)
-    }
+    pub version: u32,
 }
 
 pub trait ReadableSubstateStore {
-    fn get_substate(&self, address: &Address) -> Option<Output>;
+    fn get_substate(&self, address: &Address) -> Option<OutputValue>;
     fn get_space(&self, address: &Address) -> OutputId;
 }
 
 pub trait WriteableSubstateStore {
-    fn put_substate(&mut self, address: Address, substate: Output);
+    fn put_substate(&mut self, address: Address, substate: OutputValue);
     fn put_space(&mut self, address: Address, output_id: OutputId);
 }
 

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -30,12 +30,10 @@ pub struct OutputValue {
 
 pub trait ReadableSubstateStore {
     fn get_substate(&self, address: &Address) -> Option<OutputValue>;
-    fn get_space(&self, address: &Address) -> OutputId;
 }
 
 pub trait WriteableSubstateStore {
     fn put_substate(&mut self, address: Address, substate: OutputValue);
-    fn put_space(&mut self, address: Address, output_id: OutputId);
 }
 
 pub trait SubstateStore: ReadableSubstateStore + WriteableSubstateStore {}

--- a/radix-engine/src/state_manager/commit_receipt.rs
+++ b/radix-engine/src/state_manager/commit_receipt.rs
@@ -1,13 +1,13 @@
 use sbor::rust::collections::*;
 use sbor::rust::vec::Vec;
-use sbor::*;
 
 use crate::ledger::*;
+use crate::state_manager::VirtualSubstateId;
 
 pub struct CommitReceipt {
-    pub virtual_down_substates: HashSet<HardVirtualSubstateId>,
-    pub down_substates: HashSet<OutputId>,
+    pub virtual_down_substates: HashSet<VirtualSubstateId>,
     pub virtual_up_substates: Vec<OutputId>,
+    pub down_substates: HashSet<OutputId>,
     pub up_substates: Vec<OutputId>,
 }
 
@@ -21,22 +21,19 @@ impl CommitReceipt {
         }
     }
 
-    pub fn virtual_down(&mut self, id: HardVirtualSubstateId) {
+    pub fn virtual_down(&mut self, id: VirtualSubstateId) {
         self.virtual_down_substates.insert(id);
-    }
-
-    pub fn down(&mut self, id: OutputId) {
-        self.down_substates.insert(id);
     }
 
     pub fn virtual_space_up(&mut self, id: OutputId) {
         self.up_substates.push(id);
     }
 
+    pub fn down(&mut self, id: OutputId) {
+        self.down_substates.insert(id);
+    }
+
     pub fn up(&mut self, id: OutputId) {
         self.up_substates.push(id);
     }
 }
-
-#[derive(Debug, Clone, Hash, TypeId, Encode, Decode, PartialEq, Eq)]
-pub struct HardVirtualSubstateId(pub OutputId, pub Vec<u8>);

--- a/radix-engine/src/state_manager/commit_receipt.rs
+++ b/radix-engine/src/state_manager/commit_receipt.rs
@@ -1,39 +1,32 @@
-use sbor::rust::collections::*;
 use sbor::rust::vec::Vec;
 
 use crate::ledger::*;
 use crate::state_manager::VirtualSubstateId;
 
 pub struct CommitReceipt {
-    pub virtual_down_substates: HashSet<VirtualSubstateId>,
-    pub virtual_up_substates: Vec<OutputId>,
-    pub down_substates: HashSet<OutputId>,
-    pub up_substates: Vec<OutputId>,
+    pub virtual_inputs: Vec<VirtualSubstateId>,
+    pub inputs: Vec<OutputId>,
+    pub outputs: Vec<OutputId>,
 }
 
 impl CommitReceipt {
     pub fn new() -> Self {
         CommitReceipt {
-            virtual_down_substates: HashSet::new(),
-            down_substates: HashSet::new(),
-            virtual_up_substates: Vec::new(),
-            up_substates: Vec::new(),
+            virtual_inputs: Vec::new(),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         }
     }
 
     pub fn virtual_down(&mut self, id: VirtualSubstateId) {
-        self.virtual_down_substates.insert(id);
-    }
-
-    pub fn virtual_space_up(&mut self, id: OutputId) {
-        self.up_substates.push(id);
+        self.virtual_inputs.push(id);
     }
 
     pub fn down(&mut self, id: OutputId) {
-        self.down_substates.insert(id);
+        self.inputs.push(id);
     }
 
     pub fn up(&mut self, id: OutputId) {
-        self.up_substates.push(id);
+        self.outputs.push(id);
     }
 }

--- a/radix-engine/src/state_manager/staging.rs
+++ b/radix-engine/src/state_manager/staging.rs
@@ -10,7 +10,7 @@ struct StagedSubstateStoreNode {
     parent_id: u64,
     locked: bool,
     spaces: IndexMap<Address, OutputId>,
-    outputs: IndexMap<Address, Output>,
+    outputs: IndexMap<Address, OutputValue>,
 }
 
 impl StagedSubstateStoreNode {
@@ -118,7 +118,7 @@ pub struct StagedSubstateStore<'t, 's, S: ReadableSubstateStore + WriteableSubst
 }
 
 impl<'t, 's, S: ReadableSubstateStore + WriteableSubstateStore> StagedSubstateStore<'t, 's, S> {
-    fn get_substate_recurse(&self, address: &Address, id: u64) -> Option<Output> {
+    fn get_substate_recurse(&self, address: &Address, id: u64) -> Option<OutputValue> {
         if id == 0 {
             return self.stores.parent.get_substate(address);
         }
@@ -150,7 +150,7 @@ impl<'t, 's, S: ReadableSubstateStore + WriteableSubstateStore> StagedSubstateSt
 impl<'t, 's, S: ReadableSubstateStore + WriteableSubstateStore> ReadableSubstateStore
     for StagedSubstateStore<'t, 's, S>
 {
-    fn get_substate(&self, address: &Address) -> Option<Output> {
+    fn get_substate(&self, address: &Address) -> Option<OutputValue> {
         self.get_substate_recurse(address, self.id)
     }
 
@@ -171,7 +171,7 @@ impl<'t, 's, S: ReadableSubstateStore + WriteableSubstateStore> WriteableSubstat
         }
     }
 
-    fn put_substate(&mut self, address: Address, output: Output) {
+    fn put_substate(&mut self, address: Address, output: OutputValue) {
         if self.id == 0 {
             self.stores.parent.put_substate(address, output);
         } else {

--- a/radix-engine/src/state_manager/state_diff.rs
+++ b/radix-engine/src/state_manager/state_diff.rs
@@ -13,7 +13,6 @@ pub struct VirtualSubstateId(pub Address, pub Vec<u8>);
 
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct StateDiff {
-    pub up_virtual_substates: BTreeSet<Address>,
     pub down_virtual_substates: Vec<VirtualSubstateId>,
     pub up_substates: BTreeMap<Address, OutputValue>,
     pub down_substates: Vec<OutputId>,
@@ -22,7 +21,6 @@ pub struct StateDiff {
 impl StateDiff {
     pub fn new() -> Self {
         Self {
-            up_virtual_substates: BTreeSet::new(),
             up_substates: BTreeMap::new(),
             down_virtual_substates: Vec::new(),
             down_substates: Vec::new(),
@@ -32,18 +30,7 @@ impl StateDiff {
     /// Applies the state changes to some substate store.
     pub fn commit<S: WriteableSubstateStore>(&self, store: &mut S) -> CommitReceipt {
         let mut receipt = CommitReceipt::new();
-        let mut virtual_outputs = HashMap::new();
 
-        for space_address in &self.up_virtual_substates {
-            let output_id = OutputId {
-                address: space_address.clone(),
-                substate_hash: hash(scrypto_encode(&())),
-                version: 0,
-            };
-            receipt.virtual_space_up(output_id.clone());
-            store.put_space(space_address.clone(), output_id.clone());
-            virtual_outputs.insert(space_address, output_id);
-        }
         for virtual_substate_id in &self.down_virtual_substates {
             receipt.virtual_down(virtual_substate_id.clone());
         }

--- a/radix-engine/src/state_manager/state_diff.rs
+++ b/radix-engine/src/state_manager/state_diff.rs
@@ -6,7 +6,6 @@ use scrypto::buffer::scrypto_encode;
 use scrypto::crypto::hash;
 
 use crate::engine::Address;
-use crate::engine::*;
 use crate::ledger::*;
 use crate::state_manager::CommitReceipt;
 use crate::state_manager::HardVirtualSubstateId;
@@ -23,8 +22,8 @@ pub struct VirtualSubstateId(pub SubstateParentId, pub Vec<u8>);
 #[derive(Debug, TypeId, Encode, Decode)]
 pub struct StateDiff {
     pub up_virtual_substates: BTreeSet<Address>,
-    pub up_substates: BTreeMap<Address, Substate>,
     pub down_virtual_substates: Vec<VirtualSubstateId>,
+    pub up_substates: BTreeMap<Address, OutputValue>,
     pub down_substates: Vec<OutputId>,
 }
 
@@ -40,19 +39,18 @@ impl StateDiff {
 
     /// Applies the state changes to some substate store.
     pub fn commit<S: WriteableSubstateStore>(&self, store: &mut S) -> CommitReceipt {
-        let hash = hash(scrypto_encode(self));
         let mut receipt = CommitReceipt::new();
-        let mut id_gen = OutputIdGenerator::new(hash);
         let mut virtual_outputs = HashMap::new();
 
         for space_address in &self.up_virtual_substates {
-            let output_id = id_gen.next();
+            let output_id = OutputId {
+                address: space_address.clone(),
+                substate_hash: hash(scrypto_encode(&())),
+                version: 0
+            };
             receipt.virtual_space_up(output_id.clone());
             store.put_space(space_address.clone(), output_id.clone());
             virtual_outputs.insert(space_address, output_id);
-        }
-        for output_id in &self.down_substates {
-            receipt.down(output_id.clone());
         }
         for VirtualSubstateId(parent_id, key) in &self.down_virtual_substates {
             let parent_hard_id = match parent_id {
@@ -62,16 +60,18 @@ impl StateDiff {
             let virtual_substate_id = HardVirtualSubstateId(parent_hard_id, key.clone());
             receipt.virtual_down(virtual_substate_id);
         }
-        for (address, value) in &self.up_substates {
-            let output_id = id_gen.next();
-            receipt.up(output_id.clone());
-            store.put_substate(
-                address.clone(),
-                Output {
-                    substate: value.clone(),
-                    output_id: output_id,
-                },
-            );
+
+        for output_id in &self.down_substates {
+            receipt.down(output_id.clone());
+        }
+        for (address, output_value) in &self.up_substates {
+            let output_id = OutputId {
+                address: address.clone(),
+                substate_hash: hash(scrypto_encode(&output_value.substate)),
+                version: output_value.version
+            };
+            receipt.up(output_id);
+            store.put_substate(address.clone(), output_value.clone());
         }
         receipt
     }

--- a/simulator/src/ledger/radix_engine_db.rs
+++ b/simulator/src/ledger/radix_engine_db.rs
@@ -89,7 +89,7 @@ impl QueryableSubstateStore for RadixEngineDB {
             }
 
             let local_key = key.split_at(key_size).1.to_vec();
-            let substate: Output = scrypto_decode(&value.to_vec()).unwrap();
+            let substate: OutputValue = scrypto_decode(&value.to_vec()).unwrap();
             items.insert(local_key, substate.substate);
         }
         items
@@ -97,7 +97,7 @@ impl QueryableSubstateStore for RadixEngineDB {
 }
 
 impl ReadableSubstateStore for RadixEngineDB {
-    fn get_substate(&self, address: &Address) -> Option<Output> {
+    fn get_substate(&self, address: &Address) -> Option<OutputValue> {
         self.read(address).map(|b| scrypto_decode(&b).unwrap())
     }
 
@@ -109,7 +109,7 @@ impl ReadableSubstateStore for RadixEngineDB {
 }
 
 impl WriteableSubstateStore for RadixEngineDB {
-    fn put_substate(&mut self, address: Address, substate: Output) {
+    fn put_substate(&mut self, address: Address, substate: OutputValue) {
         self.write(address, scrypto_encode(&substate));
     }
 

--- a/simulator/src/ledger/radix_engine_db.rs
+++ b/simulator/src/ledger/radix_engine_db.rs
@@ -100,20 +100,10 @@ impl ReadableSubstateStore for RadixEngineDB {
     fn get_substate(&self, address: &Address) -> Option<OutputValue> {
         self.read(address).map(|b| scrypto_decode(&b).unwrap())
     }
-
-    fn get_space(&self, address: &Address) -> OutputId {
-        self.read(address)
-            .map(|b| scrypto_decode(&b).unwrap())
-            .expect("Expected space does not exist")
-    }
 }
 
 impl WriteableSubstateStore for RadixEngineDB {
     fn put_substate(&mut self, address: Address, substate: OutputValue) {
         self.write(address, scrypto_encode(&substate));
-    }
-
-    fn put_space(&mut self, address: Address, output_id: OutputId) {
-        self.write(address, scrypto_encode(&output_id));
     }
 }


### PR DESCRIPTION
Replaced the `OutputId` derived from a CommittedTransactionHash with a simple incrementing version. This is possible with the assumption that `Address` is itself a unique identifier.

This simple change also allows us to remove an unneeded `spaces` database which we needed previously to maintain the `OutputId` of the space.