### PR TITLE
Improved Proof Validation

### DIFF
--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -46,7 +46,7 @@ pub enum ProofValidationMode {
     /// Specifies that the `Proof` should be validating for containing a specific `NonFungibleAddress`.
     ValidateContainsNonFungible(NonFungibleAddress),
 
-    /// Specifies that the `Proof` should be validated against a single resource address and a set of `NonFungibleId`s 
+    /// Specifies that the `Proof` should be validated against a single resource address and a set of `NonFungibleId`s
     /// to ensure that the `Proof` contains all of the NonFungibles in the set.
     ValidateContainsNonFungibles(ResourceAddress, BTreeSet<NonFungibleId>),
 
@@ -145,7 +145,10 @@ impl Proof {
                 self.validate_contains_non_fungible_id(non_fungible_address.non_fungible_id())?;
                 Ok(())
             }
-            ProofValidationMode::ValidateContainsNonFungibles(resource_address, non_fungible_ids) => {
+            ProofValidationMode::ValidateContainsNonFungibles(
+                resource_address,
+                non_fungible_ids,
+            ) => {
                 self.validate_resource_address(resource_address)?;
                 self.validate_contains_non_fungible_ids(&non_fungible_ids)?;
                 Ok(())

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -33,6 +33,43 @@ pub struct ProofCloneInput {}
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Proof(pub ProofId);
 
+// TODO: Evaluate if we should have a ProofValidationModeBuilder to construct more complex validation modes.
+/// Specifies the validation mode that should be used for validating a `Proof`.
+pub enum ProofValidationMode {
+    /// Specifies that the `Proof` should be validated against a single `ResourceAddress`.
+    ValidateResourceAddress(ResourceAddress),
+
+    /// Specifies that the `Proof` should have its resource address validated against a set of `ResourceAddress`es. If
+    /// the `Proof`'s resource address belongs to the set, then its valid.
+    ValidateResourceAddressBelongsTo(BTreeSet<ResourceAddress>),
+
+    /// Specifies that the `Proof` should be validated against a single `ResourceAddress` and `NonFungibleId` pair.
+    ValidateNonFungibleId(ResourceAddress, NonFungibleId),
+
+    /// Specifies that the `Proof` should be validated against a single `ResourceAddress` and a set of `NonFungibleId`s.
+    /// If the `Proof`'s resource address matches that specified, and the `NonFungibleId`s of the proof all belong to
+    /// the provided set, then it is valid.
+    ValidateNonFungibleIdBelongsTo(ResourceAddress, BTreeSet<NonFungibleId>),
+
+    /// Specifies that the `Proof` should be validated for the amount of resources that it contains.
+    ValidateAmount(ResourceAddress, Decimal),
+}
+
+impl From<ResourceAddress> for ProofValidationMode {
+    fn from(resource_address: ResourceAddress) -> Self {
+        Self::ValidateResourceAddress(resource_address)
+    }
+}
+
+impl From<NonFungibleAddress> for ProofValidationMode {
+    fn from(non_fungible_address: NonFungibleAddress) -> Self {
+        Self::ValidateNonFungibleId(
+            non_fungible_address.resource_address(),
+            non_fungible_address.non_fungible_id(),
+        )
+    }
+}
+
 impl Clone for Proof {
     sfunctions! {
         Receiver::ProofRef(self.0) => {
@@ -54,7 +91,7 @@ impl Proof {
     ///
     /// ```ignore
     /// let proof: Proof = bucket.create_proof();
-    /// match proof.validate_proof(admin_badge) {
+    /// match proof.validate_proof(admin_badge_resource_address) {
     ///     Ok(validated_proof) => {
     ///         info!(
     ///             "Validation successful. Proof has a resource address of {} and amount of {}",
@@ -67,16 +104,17 @@ impl Proof {
     ///     },
     /// }
     /// ```
-    pub fn validate_proof(
+    pub fn validate_proof<T>(
         self,
-        expected_resource_address: ResourceAddress,
-    ) -> Result<ValidatedProof, ValidateProofError> {
-        if self.resource_address() == expected_resource_address {
-            Ok(ValidatedProof(self))
-        } else {
-            Err(ValidateProofError::ProofResourceAddressValidationError(
-                self,
-            ))
+        validation_mode: T,
+    ) -> Result<ValidatedProof, (Self, ProofValidationError)>
+    where
+        T: Into<ProofValidationMode>,
+    {
+        let validation_mode: ProofValidationMode = validation_mode.into();
+        match self.validate(validation_mode) {
+            Ok(()) => Ok(ValidatedProof(self)),
+            Err(error) => Err((self, error)),
         }
     }
 
@@ -96,8 +134,108 @@ impl Proof {
         validated_proof.into()
     }
 
+    fn validate(&self, validation_mode: ProofValidationMode) -> Result<(), ProofValidationError> {
+        match validation_mode {
+            ProofValidationMode::ValidateResourceAddress(resource_address) => {
+                self.validate_resource_address(resource_address)?;
+                Ok(())
+            }
+            ProofValidationMode::ValidateResourceAddressBelongsTo(resource_addresses) => {
+                self.validate_resource_address_belongs_to(&resource_addresses)?;
+                Ok(())
+            }
+            ProofValidationMode::ValidateNonFungibleId(resource_address, non_fungible_id) => {
+                self.validate_resource_address(resource_address)?;
+                self.validate_non_fungible_id(non_fungible_id)?;
+                Ok(())
+            }
+            ProofValidationMode::ValidateNonFungibleIdBelongsTo(
+                resource_address,
+                non_fungible_ids,
+            ) => {
+                self.validate_resource_address(resource_address)?;
+                self.validate_non_fungible_id_belongs_to(&non_fungible_ids)?;
+                Ok(())
+            }
+            ProofValidationMode::ValidateAmount(resource_address, amount) => {
+                self.validate_resource_address(resource_address)?;
+                self.validate_amount(amount)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_resource_address(
+        &self,
+        resource_address: ResourceAddress,
+    ) -> Result<(), ProofValidationError> {
+        if self.resource_address() == resource_address {
+            Ok(())
+        } else {
+            Err(ProofValidationError::InvalidResourceAddress(
+                resource_address,
+            ))
+        }
+    }
+
+    fn validate_resource_address_belongs_to(
+        &self,
+        resource_addresses: &BTreeSet<ResourceAddress>,
+    ) -> Result<(), ProofValidationError> {
+        if resource_addresses.contains(&self.resource_address()) {
+            Ok(())
+        } else {
+            Err(ProofValidationError::ResourceAddressDoesNotBelongToList)
+        }
+    }
+
+    fn validate_non_fungible_id(
+        &self,
+        non_fungible_id: NonFungibleId,
+    ) -> Result<(), ProofValidationError> {
+        let non_fungible_ids = self.non_fungible_ids();
+        if non_fungible_ids.len() != 1 {
+            return Err(ProofValidationError::DoesNotContainOneNonFungible);
+        }
+
+        if non_fungible_ids.get(&non_fungible_id).is_some() {
+            Ok(())
+        } else {
+            Err(ProofValidationError::InvalidNonFungibleId(non_fungible_id))
+        }
+    }
+
+    fn validate_non_fungible_id_belongs_to(
+        &self,
+        expected_non_fungible_ids: &BTreeSet<NonFungibleId>,
+    ) -> Result<(), ProofValidationError> {
+        let actual_non_fungible_ids = self.non_fungible_ids();
+        let contains_all_non_fungible_ids = expected_non_fungible_ids
+            .iter()
+            .all(|non_fungible_id| actual_non_fungible_ids.get(non_fungible_id).is_some());
+        if contains_all_non_fungible_ids {
+            Ok(())
+        } else {
+            Err(ProofValidationError::NonFungibleIdsNotSubsetOfList)
+        }
+    }
+
+    fn validate_amount(&self, amount: Decimal) -> Result<(), ProofValidationError> {
+        if self.amount() == amount {
+            Ok(())
+        } else {
+            Err(ProofValidationError::InvalidAmount(amount))
+        }
+    }
+
     sfunctions! {
         Receiver::ProofRef(self.0) => {
+            fn amount(&self) -> Decimal {
+                ProofGetAmountInput {}
+            }
+            fn non_fungible_ids(&self) -> BTreeSet<NonFungibleId> {
+                ProofGetNonFungibleIdsInput {}
+            }
             fn resource_address(&self) -> ResourceAddress {
                 ProofGetResourceAddressInput {}
             }
@@ -225,15 +363,20 @@ impl fmt::Display for ParseProofError {
 
 /// Represents an error when validating proof.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ValidateProofError {
-    ProofResourceAddressValidationError(Proof),
+pub enum ProofValidationError {
+    InvalidResourceAddress(ResourceAddress),
+    ResourceAddressDoesNotBelongToList,
+    DoesNotContainOneNonFungible,
+    InvalidNonFungibleId(NonFungibleId),
+    NonFungibleIdsNotSubsetOfList,
+    InvalidAmount(Decimal),
 }
 
 #[cfg(not(feature = "alloc"))]
-impl std::error::Error for ValidateProofError {}
+impl std::error::Error for ProofValidationError {}
 
 #[cfg(not(feature = "alloc"))]
-impl fmt::Display for ValidateProofError {
+impl fmt::Display for ProofValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -49,7 +49,7 @@ pub enum ProofValidationMode {
     /// Specifies that the `Proof` should be validated against a single `ResourceAddress` and a set of `NonFungibleId`s.
     /// If the `Proof`'s resource address matches that specified, and the `NonFungibleId`s of the proof all belong to
     /// the provided set, then it is valid.
-    ValidateNonFungibleIdBelongsTo(ResourceAddress, BTreeSet<NonFungibleId>),
+    ValidateNonFungibleIdsSubsetOf(ResourceAddress, BTreeSet<NonFungibleId>),
 
     /// Specifies that the `Proof` should be validated for the amount of resources that it contains.
     ValidateAmount(ResourceAddress, Decimal),
@@ -149,7 +149,7 @@ impl Proof {
                 self.validate_non_fungible_id(non_fungible_id)?;
                 Ok(())
             }
-            ProofValidationMode::ValidateNonFungibleIdBelongsTo(
+            ProofValidationMode::ValidateNonFungibleIdsSubsetOf(
                 resource_address,
                 non_fungible_ids,
             ) => {

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -192,7 +192,7 @@ impl Proof {
         if self.non_fungible_ids().get(&non_fungible_id).is_some() {
             Ok(())
         } else {
-            Err(ProofValidationError::InvalidNonFungibleId(non_fungible_id))
+            Err(ProofValidationError::NonFungibleIdNotFound)
         }
     }
 
@@ -207,7 +207,7 @@ impl Proof {
         if contains_all_non_fungible_ids {
             Ok(())
         } else {
-            Err(ProofValidationError::NonFungibleIdsNotSubsetOfList)
+            Err(ProofValidationError::NonFungibleIdNotFound)
         }
     }
 
@@ -358,8 +358,7 @@ pub enum ProofValidationError {
     InvalidResourceAddress(ResourceAddress),
     ResourceAddressDoesNotBelongToList,
     DoesNotContainOneNonFungible,
-    InvalidNonFungibleId(NonFungibleId),
-    NonFungibleIdsNotSubsetOfList,
+    NonFungibleIdNotFound,
     InvalidAmount(Decimal),
 }
 


### PR DESCRIPTION
This PR adds a number of different proof validation modes that can be used with the `Proof` type. In addition to adding more complex ways of performing proof validation, this PR still keeps the 90% case (validating against a resource address) fairly easy and frictionless. 
