### PR TITLE
The square root of a Decimal.

### DIFF
--- a/scrypto/src/math/decimal.rs
+++ b/scrypto/src/math/decimal.rs
@@ -193,7 +193,7 @@ macro_rules! decimals {
                     }
                     
                     /// The square root of a Decimal. Uses a standard Babylonian method.
-                    fn sqrt(&self) -> Option<Self> { 
+                    pub fn sqrt(&self) -> Option<Self> { 
                         if self.is_negative() {
                             return None;
                         }


### PR DESCRIPTION
The square root of a Decimal. Uses a standard Babylonian method.
Referring to [this](https://docs.rs/rust_decimal/latest/src/rust_decimal/maths.rs.html#328) implementation.
Related to #431