### PR TITLE
Add missed costings

### DIFF
--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -899,42 +899,54 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match node_id {
-                    RENodeId::Bucket(_) => SystemApiCostingEntry::BorrowFromHeap,
-                    RENodeId::Proof(_) => SystemApiCostingEntry::BorrowFromHeap,
-                    RENodeId::Worktop => SystemApiCostingEntry::BorrowFromHeap,
-                    RENodeId::Vault(_) => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::Bucket(_) => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    RENodeId::Proof(_) => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    RENodeId::Worktop => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    RENodeId::Vault(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::Component(_) => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::Component(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::KeyValueStore(_) => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::KeyValueStore(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::ResourceManager(_) => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::ResourceManager(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::Package(_) => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::Package(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::System => SystemApiCostingEntry::BorrowFromStore {
+                    RENodeId::System => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
                 }
             }),
-            "borrow",
+            "borrow_substate",
         )?;
 
         let node_pointer = Self::current_frame(&self.call_frames)
@@ -960,62 +972,74 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match substate_id {
-                    SubstateId::Bucket(_) => SystemApiCostingEntry::BorrowFromHeap,
-                    SubstateId::Proof(_) => SystemApiCostingEntry::BorrowFromHeap,
-                    SubstateId::Worktop => SystemApiCostingEntry::BorrowFromHeap,
-                    SubstateId::Vault(_) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::Bucket(_) => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    SubstateId::Proof(_) => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    SubstateId::Worktop => SystemApiCostingEntry::BorrowSubstate {
+                        // TODO: figure out loaded state and size
+                        loaded: true,
+                        size: 0,
+                    },
+                    SubstateId::Vault(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ComponentState(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::ComponentState(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ComponentInfo(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::ComponentInfo(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::KeyValueStoreSpace(_) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::KeyValueStoreSpace(_) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::KeyValueStoreEntry(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::KeyValueStoreEntry(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ResourceManager(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::ResourceManager(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::NonFungibleSpace(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::NonFungibleSpace(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::NonFungible(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::NonFungible(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::Package(..) => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::Package(..) => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::System => SystemApiCostingEntry::BorrowFromStore {
+                    SubstateId::System => SystemApiCostingEntry::BorrowSubstate {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
                 }
             }),
-            "borrow",
+            "borrow_substate",
         )?;
 
         // Authorization
@@ -1047,31 +1071,41 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match &val_ref {
-                    NativeSubstateRef::Stack(..) => SystemApiCostingEntry::Return { size: 0 },
+                    NativeSubstateRef::Stack(..) => {
+                        SystemApiCostingEntry::ReturnSubstate { size: 0 }
+                    }
                     NativeSubstateRef::Track(substate_id, _) => match substate_id {
-                        SubstateId::Vault(_) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::Vault(_) => SystemApiCostingEntry::ReturnSubstate { size: 0 },
                         SubstateId::KeyValueStoreSpace(_) => {
-                            SystemApiCostingEntry::Return { size: 0 }
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
                         }
                         SubstateId::KeyValueStoreEntry(_, _) => {
-                            SystemApiCostingEntry::Return { size: 0 }
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
                         }
-                        SubstateId::ResourceManager(_) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::Package(_) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::ResourceManager(_) => {
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
+                        }
+                        SubstateId::Package(_) => SystemApiCostingEntry::ReturnSubstate { size: 0 },
                         SubstateId::NonFungibleSpace(_) => {
-                            SystemApiCostingEntry::Return { size: 0 }
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
                         }
-                        SubstateId::NonFungible(_, _) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::ComponentInfo(..) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::ComponentState(_) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::System => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::Bucket(..) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::Proof(..) => SystemApiCostingEntry::Return { size: 0 },
-                        SubstateId::Worktop => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::NonFungible(_, _) => {
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
+                        }
+                        SubstateId::ComponentInfo(..) => {
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
+                        }
+                        SubstateId::ComponentState(_) => {
+                            SystemApiCostingEntry::ReturnSubstate { size: 0 }
+                        }
+                        SubstateId::System => SystemApiCostingEntry::ReturnSubstate { size: 0 },
+                        SubstateId::Bucket(..) => SystemApiCostingEntry::ReturnSubstate { size: 0 },
+                        SubstateId::Proof(..) => SystemApiCostingEntry::ReturnSubstate { size: 0 },
+                        SubstateId::Worktop => SystemApiCostingEntry::ReturnSubstate { size: 0 },
                     },
                 }
             }),
-            "return",
+            "return_substate",
         )?;
 
         val_ref.return_to_location(&mut self.call_frames, &mut self.track);
@@ -1081,7 +1115,11 @@ where
     fn node_drop(&mut self, node_id: &RENodeId) -> Result<HeapRootRENode, FeeReserveError> {
         trace!(self, Level::Debug, "Dropping value: {:?}", node_id);
 
-        // TODO: costing
+        self.fee_reserve.consume(
+            self.fee_table
+                .system_api_cost(SystemApiCostingEntry::DropNode { size: 0 }),
+            "drop_node",
+        )?;
 
         // TODO: Authorization
 
@@ -1101,7 +1139,7 @@ where
                     .system_api_cost(SystemApiCostingEntry::CreateNode {
                         size: 0, // TODO: get size of the value
                     }),
-                "create",
+                "create_node",
             )
             .map_err(RuntimeError::CostingError)?;
 
@@ -1179,7 +1217,7 @@ where
                     .system_api_cost(SystemApiCostingEntry::GlobalizeNode {
                         size: 0, // TODO: get size of the value
                     }),
-                "globalize",
+                "globalize_node",
             )
             .map_err(RuntimeError::CostingError)?;
 
@@ -1270,10 +1308,11 @@ where
         // Costing
         self.fee_reserve
             .consume(
-                self.fee_table.system_api_cost(SystemApiCostingEntry::Read {
-                    size: 0, // TODO: get size of the value
-                }),
-                "read",
+                self.fee_table
+                    .system_api_cost(SystemApiCostingEntry::ReadSubstate {
+                        size: 0, // TODO: get size of the value
+                    }),
+                "read_substate",
             )
             .map_err(RuntimeError::CostingError)?;
 
@@ -1303,7 +1342,16 @@ where
     fn substate_take(&mut self, substate_id: SubstateId) -> Result<ScryptoValue, RuntimeError> {
         trace!(self, Level::Debug, "Removing value data: {:?}", substate_id);
 
-        // TODO: Costing
+        // Costing
+        self.fee_reserve
+            .consume(
+                self.fee_table
+                    .system_api_cost(SystemApiCostingEntry::TakeSubstate {
+                        size: 0, // TODO: get size of the value
+                    }),
+                "read_substate",
+            )
+            .map_err(RuntimeError::CostingError)?;
 
         // Authorization
         if !Self::current_frame(&self.call_frames)
@@ -1341,10 +1389,10 @@ where
         self.fee_reserve
             .consume(
                 self.fee_table
-                    .system_api_cost(SystemApiCostingEntry::Write {
+                    .system_api_cost(SystemApiCostingEntry::WriteSubstate {
                         size: 0, // TODO: get size of the value
                     }),
-                "write",
+                "write_substate",
             )
             .map_err(RuntimeError::CostingError)?;
 
@@ -1428,7 +1476,16 @@ where
         access_rule: scrypto::resource::AccessRule,
         proof_ids: Vec<ProofId>,
     ) -> Result<bool, RuntimeError> {
-        // TODO: costing
+        // Costing
+        self.fee_reserve
+            .consume(
+                self.fee_table
+                    .system_api_cost(SystemApiCostingEntry::CheckAccessRule {
+                        size: proof_ids.len() as u32,
+                    }),
+                "check_access_rule",
+            )
+            .map_err(RuntimeError::CostingError)?;
 
         let proofs = proof_ids
             .iter()

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -899,35 +899,35 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match node_id {
-                    RENodeId::Bucket(_) => SystemApiCostingEntry::BorrowLocal,
-                    RENodeId::Proof(_) => SystemApiCostingEntry::BorrowLocal,
-                    RENodeId::Worktop => SystemApiCostingEntry::BorrowLocal,
-                    RENodeId::Vault(_) => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::Bucket(_) => SystemApiCostingEntry::BorrowFromHeap,
+                    RENodeId::Proof(_) => SystemApiCostingEntry::BorrowFromHeap,
+                    RENodeId::Worktop => SystemApiCostingEntry::BorrowFromHeap,
+                    RENodeId::Vault(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::Component(_) => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::Component(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::KeyValueStore(_) => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::KeyValueStore(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::ResourceManager(_) => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::ResourceManager(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::Package(_) => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::Package(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    RENodeId::System => SystemApiCostingEntry::BorrowGlobal {
+                    RENodeId::System => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
@@ -960,55 +960,55 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match substate_id {
-                    SubstateId::Bucket(_) => SystemApiCostingEntry::BorrowLocal,
-                    SubstateId::Proof(_) => SystemApiCostingEntry::BorrowLocal,
-                    SubstateId::Worktop => SystemApiCostingEntry::BorrowLocal,
-                    SubstateId::Vault(_) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::Bucket(_) => SystemApiCostingEntry::BorrowFromHeap,
+                    SubstateId::Proof(_) => SystemApiCostingEntry::BorrowFromHeap,
+                    SubstateId::Worktop => SystemApiCostingEntry::BorrowFromHeap,
+                    SubstateId::Vault(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ComponentState(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::ComponentState(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ComponentInfo(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::ComponentInfo(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::KeyValueStoreSpace(_) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::KeyValueStoreSpace(_) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::KeyValueStoreEntry(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::KeyValueStoreEntry(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::ResourceManager(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::ResourceManager(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::NonFungibleSpace(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::NonFungibleSpace(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::NonFungible(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::NonFungible(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::Package(..) => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::Package(..) => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
                     },
-                    SubstateId::System => SystemApiCostingEntry::BorrowGlobal {
+                    SubstateId::System => SystemApiCostingEntry::BorrowFromStore {
                         // TODO: figure out loaded state and size
                         loaded: false,
                         size: 0,
@@ -1047,35 +1047,27 @@ where
         self.fee_reserve.consume(
             self.fee_table.system_api_cost({
                 match &val_ref {
-                    NativeSubstateRef::Stack(..) => SystemApiCostingEntry::ReturnLocal,
+                    NativeSubstateRef::Stack(..) => SystemApiCostingEntry::Return { size: 0 },
                     NativeSubstateRef::Track(substate_id, _) => match substate_id {
-                        SubstateId::Vault(_) => SystemApiCostingEntry::ReturnGlobal { size: 0 },
+                        SubstateId::Vault(_) => SystemApiCostingEntry::Return { size: 0 },
                         SubstateId::KeyValueStoreSpace(_) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
+                            SystemApiCostingEntry::Return { size: 0 }
                         }
                         SubstateId::KeyValueStoreEntry(_, _) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
+                            SystemApiCostingEntry::Return { size: 0 }
                         }
-                        SubstateId::ResourceManager(_) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
-                        }
-                        SubstateId::Package(_) => SystemApiCostingEntry::ReturnGlobal { size: 0 },
+                        SubstateId::ResourceManager(_) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::Package(_) => SystemApiCostingEntry::Return { size: 0 },
                         SubstateId::NonFungibleSpace(_) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
+                            SystemApiCostingEntry::Return { size: 0 }
                         }
-                        SubstateId::NonFungible(_, _) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
-                        }
-                        SubstateId::ComponentInfo(..) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
-                        }
-                        SubstateId::ComponentState(_) => {
-                            SystemApiCostingEntry::ReturnGlobal { size: 0 }
-                        }
-                        SubstateId::System => SystemApiCostingEntry::ReturnGlobal { size: 0 },
-                        SubstateId::Bucket(..) => SystemApiCostingEntry::ReturnGlobal { size: 0 },
-                        SubstateId::Proof(..) => SystemApiCostingEntry::ReturnGlobal { size: 0 },
-                        SubstateId::Worktop => SystemApiCostingEntry::ReturnGlobal { size: 0 },
+                        SubstateId::NonFungible(_, _) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::ComponentInfo(..) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::ComponentState(_) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::System => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::Bucket(..) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::Proof(..) => SystemApiCostingEntry::Return { size: 0 },
+                        SubstateId::Worktop => SystemApiCostingEntry::Return { size: 0 },
                     },
                 }
             }),
@@ -1106,7 +1098,7 @@ where
         self.fee_reserve
             .consume(
                 self.fee_table
-                    .system_api_cost(SystemApiCostingEntry::Create {
+                    .system_api_cost(SystemApiCostingEntry::CreateNode {
                         size: 0, // TODO: get size of the value
                     }),
                 "create",
@@ -1184,7 +1176,7 @@ where
         self.fee_reserve
             .consume(
                 self.fee_table
-                    .system_api_cost(SystemApiCostingEntry::Globalize {
+                    .system_api_cost(SystemApiCostingEntry::GlobalizeNode {
                         size: 0, // TODO: get size of the value
                     }),
                 "globalize",

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -1054,7 +1054,7 @@ where
             .actor
             .is_substate_readable(substate_id)
         {
-            panic!("Trying to read value which is not visible.")
+            panic!("Trying to read substate which is not visible.")
         }
 
         let node_id = SubstateProperties::get_node_id(substate_id);
@@ -1310,7 +1310,12 @@ where
     }
 
     fn substate_read(&mut self, substate_id: SubstateId) -> Result<ScryptoValue, RuntimeError> {
-        trace!(self, Level::Debug, "Reading value data: {:?}", substate_id);
+        trace!(
+            self,
+            Level::Debug,
+            "Reading substate data: {:?}",
+            substate_id
+        );
 
         // Costing
         self.fee_reserve
@@ -1347,7 +1352,7 @@ where
     }
 
     fn substate_take(&mut self, substate_id: SubstateId) -> Result<ScryptoValue, RuntimeError> {
-        trace!(self, Level::Debug, "Removing value data: {:?}", substate_id);
+        trace!(self, Level::Debug, "Taking substate: {:?}", substate_id);
 
         // Costing
         self.fee_reserve
@@ -1390,7 +1395,12 @@ where
         substate_id: SubstateId,
         value: ScryptoValue,
     ) -> Result<(), RuntimeError> {
-        trace!(self, Level::Debug, "Writing value data: {:?}", substate_id);
+        trace!(
+            self,
+            Level::Debug,
+            "Writing substate data: {:?}",
+            substate_id
+        );
 
         // Costing
         self.fee_reserve

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -1203,7 +1203,7 @@ where
                 let component_address = node_id.into();
                 substates.insert(
                     SubstateId::ComponentInfo(component_address),
-                    Substate::Component(component),
+                    Substate::ComponentInfo(component),
                 );
                 substates.insert(
                     SubstateId::ComponentState(component_address),

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -246,6 +246,13 @@ where
                             .track
                             .read_substate(SubstateId::Package(package_address))
                             .package();
+                        self.fee_reserve
+                            .consume(
+                                self.fee_table.wasm_instantiation_per_byte()
+                                    * package.code().len() as u32,
+                                "instantiate_wasm",
+                            )
+                            .map_err(RuntimeError::CostingError)?;
                         let wasm_metering_params = self.fee_table.wasm_metering_params();
                         let instrumented_code = self
                             .wasm_instrumenter

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -84,7 +84,7 @@ impl NativeInterpreter {
             (
                 Some(Receiver::Ref(RENodeId::Component(component_address))),
                 NativeFnIdentifier::Component(component_fn),
-            ) => Component::main(component_address, component_fn, input, system_api)
+            ) => ComponentInfo::main(component_address, component_fn, input, system_api)
                 .map_err(RuntimeError::ComponentError),
             (
                 Some(Receiver::Ref(RENodeId::ResourceManager(resource_address))),

--- a/radix-engine/src/engine/node.rs
+++ b/radix-engine/src/engine/node.rs
@@ -10,7 +10,7 @@ use crate::model::*;
 pub enum Substate {
     System(System),
     Resource(ResourceManager),
-    Component(Component),
+    ComponentInfo(ComponentInfo),
     ComponentState(ComponentState),
     Package(ValidatedPackage),
     Vault(Vault),
@@ -75,8 +75,8 @@ impl Substate {
         }
     }
 
-    pub fn component(&self) -> &Component {
-        if let Substate::Component(component) = self {
+    pub fn component_info(&self) -> &ComponentInfo {
+        if let Substate::ComponentInfo(component) = self {
             component
         } else {
             match self {
@@ -90,8 +90,8 @@ impl Substate {
         }
     }
 
-    pub fn component_mut(&mut self) -> &mut Component {
-        if let Substate::Component(component) = self {
+    pub fn component_mut(&mut self) -> &mut ComponentInfo {
+        if let Substate::ComponentInfo(component) = self {
             component
         } else {
             panic!("Not a component");
@@ -135,9 +135,9 @@ impl Into<Substate> for ValidatedPackage {
     }
 }
 
-impl Into<Substate> for Component {
+impl Into<Substate> for ComponentInfo {
     fn into(self) -> Substate {
-        Substate::Component(self)
+        Substate::ComponentInfo(self)
     }
 }
 
@@ -171,12 +171,12 @@ impl Into<Substate> for KeyValueStoreEntryWrapper {
     }
 }
 
-impl Into<Component> for Substate {
-    fn into(self) -> Component {
-        if let Substate::Component(component) = self {
+impl Into<ComponentInfo> for Substate {
+    fn into(self) -> ComponentInfo {
+        if let Substate::ComponentInfo(component) = self {
             component
         } else {
-            panic!("Not a component");
+            panic!("Not a component info");
         }
     }
 }
@@ -247,7 +247,7 @@ pub enum HeapRENode {
     Proof(Proof),
     Vault(Vault),
     KeyValueStore(HeapKeyValueStore),
-    Component(Component, ComponentState),
+    Component(ComponentInfo, ComponentState),
     Worktop(Worktop),
     Package(ValidatedPackage),
     Resource(ResourceManager, Option<HashMap<NonFungibleId, NonFungible>>),
@@ -328,16 +328,16 @@ impl HeapRENode {
         }
     }
 
-    pub fn component(&self) -> &Component {
+    pub fn component_info(&self) -> &ComponentInfo {
         match self {
-            HeapRENode::Component(component, ..) => component,
+            HeapRENode::Component(component_info, ..) => component_info,
             _ => panic!("Expected to be a store"),
         }
     }
 
-    pub fn component_mut(&mut self) -> &mut Component {
+    pub fn component_info_mut(&mut self) -> &mut ComponentInfo {
         match self {
-            HeapRENode::Component(component, ..) => component,
+            HeapRENode::Component(component_info, ..) => component_info,
             _ => panic!("Expected to be a store"),
         }
     }

--- a/radix-engine/src/engine/node_ref.rs
+++ b/radix-engine/src/engine/node_ref.rs
@@ -180,10 +180,10 @@ impl NativeSubstateRef {
         }
     }
 
-    pub fn component(&mut self) -> &mut Component {
+    pub fn component_info(&mut self) -> &mut ComponentInfo {
         match self {
             NativeSubstateRef::Stack(root, _frame_id, _root_id, maybe_child) => {
-                root.get_node_mut(maybe_child.as_ref()).component_mut()
+                root.get_node_mut(maybe_child.as_ref()).component_info_mut()
             }
             _ => panic!("Expecting to be a component"),
         }
@@ -308,12 +308,12 @@ impl<'f, 's> RENodeRef<'f, 's> {
         }
     }
 
-    pub fn component_info(&self) -> &Component {
+    pub fn component_info(&self) -> &ComponentInfo {
         match self {
             RENodeRef::Stack(value, id) => id
                 .as_ref()
                 .map_or(value.root(), |v| value.non_root(v))
-                .component(),
+                .component_info(),
             RENodeRef::Track(track, node_id) => {
                 let substate_id = match node_id {
                     RENodeId::Component(component_address) => {
@@ -321,7 +321,7 @@ impl<'f, 's> RENodeRef<'f, 's> {
                     }
                     _ => panic!("Unexpected"),
                 };
-                track.read_substate(substate_id).component()
+                track.read_substate(substate_id).component_info()
             }
         }
     }
@@ -354,7 +354,9 @@ impl<'f, 's> RENodeRefMut<'f, 's> {
         substate_id: &SubstateId,
     ) -> Result<ScryptoValue, RuntimeError> {
         match substate_id {
-            SubstateId::ComponentInfo(..) => Ok(ScryptoValue::from_typed(&self.component().info())),
+            SubstateId::ComponentInfo(..) => {
+                Ok(ScryptoValue::from_typed(&self.component_info().info()))
+            }
             SubstateId::ComponentState(..) => {
                 Ok(ScryptoValue::from_slice(self.component_state().state())
                     .expect("Expected to decode"))
@@ -621,9 +623,11 @@ impl<'f, 's> RENodeRefMut<'f, 's> {
         }
     }
 
-    pub fn component(&mut self) -> &Component {
+    pub fn component_info(&mut self) -> &ComponentInfo {
         match self {
-            RENodeRefMut::Stack(re_value, id) => re_value.get_node_mut(id.as_ref()).component(),
+            RENodeRefMut::Stack(re_value, id) => {
+                re_value.get_node_mut(id.as_ref()).component_info()
+            }
             RENodeRefMut::Track(track, node_id) => {
                 let substate_id = match node_id {
                     RENodeId::Component(component_address) => {
@@ -632,7 +636,7 @@ impl<'f, 's> RENodeRefMut<'f, 's> {
                     _ => panic!("Unexpeceted"),
                 };
                 let component_val = track.read_substate(substate_id);
-                component_val.component()
+                component_val.component_info()
             }
         }
     }

--- a/radix-engine/src/engine/wasm_runtime.rs
+++ b/radix-engine/src/engine/wasm_runtime.rs
@@ -11,7 +11,7 @@ use scrypto::values::ScryptoValue;
 use crate::engine::{HeapKeyValueStore, RuntimeError};
 use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::*;
-use crate::model::{Component, ComponentState};
+use crate::model::{ComponentInfo, ComponentState};
 use crate::wasm::*;
 
 /// A glue between system api (call frame and track abstraction) and WASM.
@@ -94,9 +94,10 @@ where
                 // TODO: Check state against blueprint schema
 
                 // Create component
-                let component = Component::new(package_address, blueprint_name, Vec::new());
+                let component_info =
+                    ComponentInfo::new(package_address, blueprint_name, Vec::new());
                 let component_state = ComponentState::new(state);
-                HeapRENode::Component(component, component_state)
+                HeapRENode::Component(component_info, component_state)
             }
             ScryptoRENode::KeyValueStore => HeapRENode::KeyValueStore(HeapKeyValueStore::new()),
         };

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -65,6 +65,7 @@ pub enum SystemApiCostingEntry<'a> {
 }
 
 pub struct FeeTable {
+    tx_base_fee: u32,
     tx_decoding_per_byte: u32,
     tx_manifest_verification_per_byte: u32,
     tx_signature_verification_per_sig: u32,
@@ -78,6 +79,7 @@ pub struct FeeTable {
 impl FeeTable {
     pub fn new() -> Self {
         Self {
+            tx_base_fee: 10_000,
             tx_decoding_per_byte: 4,
             tx_manifest_verification_per_byte: 1,
             tx_signature_verification_per_sig: 3750,
@@ -90,6 +92,10 @@ impl FeeTable {
                 512,
             ),
         }
+    }
+
+    pub fn tx_base_fee(&self) -> u32 {
+        self.tx_base_fee
     }
 
     pub fn tx_decoding_per_byte(&self) -> u32 {

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -28,26 +28,24 @@ pub enum SystemApiCostingEntry<'a> {
      */
     /// Creates a RENode.
     CreateNode { size: u32 },
-    /// Drops a heap RENode
-    DropHeapNode { size: u32 },
-    /// Drops a store RENode
-    DropStoreNode { size: u32 },
+    /// Drops a RENode
+    DropNode { size: u32 },
     /// Globalizes a RENode.
     GlobalizeNode { size: u32 },
 
     /*
      * Substate
      */
-    /// Borrows a substate from heap
-    BorrowFromHeap,
-    /// Borrows a substate from store
-    BorrowFromStore { loaded: bool, size: u32 },
+    /// Borrows a substate
+    BorrowSubstate { loaded: bool, size: u32 },
     /// Returns a substate.
-    Return { size: u32 },
+    ReturnSubstate { size: u32 },
     /// Reads the data of a Substate
-    Read { size: u32 },
+    TakeSubstate { size: u32 },
+    /// Reads the data of a Substate
+    ReadSubstate { size: u32 },
     /// Updates the data of a Substate
-    Write { size: u32 },
+    WriteSubstate { size: u32 },
 
     /*
      * Misc
@@ -63,7 +61,7 @@ pub enum SystemApiCostingEntry<'a> {
     /// Emits a log.
     EmitLog { size: u32 },
     /// Checks if an access rule can be satisfied by the given proofs.
-    CheckAccessRule,
+    CheckAccessRule { size: u32 },
 }
 
 pub struct FeeTable {
@@ -229,28 +227,27 @@ impl FeeTable {
             }
 
             SystemApiCostingEntry::CreateNode { .. } => self.fixed_medium,
+            SystemApiCostingEntry::DropNode { .. } => self.fixed_medium,
             SystemApiCostingEntry::GlobalizeNode { size } => self.fixed_high + 200 * size,
-            SystemApiCostingEntry::DropHeapNode { .. } => self.fixed_low,
-            SystemApiCostingEntry::DropStoreNode { .. } => self.fixed_high,
 
-            SystemApiCostingEntry::BorrowFromHeap => self.fixed_medium,
-            SystemApiCostingEntry::BorrowFromStore { loaded, size } => {
+            SystemApiCostingEntry::BorrowSubstate { loaded, size } => {
                 if loaded {
                     self.fixed_high
                 } else {
                     self.fixed_low + 100 * size
                 }
             }
-            SystemApiCostingEntry::Return { size } => self.fixed_low + 100 * size,
-            SystemApiCostingEntry::Read { .. } => self.fixed_medium,
-            SystemApiCostingEntry::Write { .. } => self.fixed_medium,
+            SystemApiCostingEntry::ReturnSubstate { size } => self.fixed_low + 100 * size,
+            SystemApiCostingEntry::TakeSubstate { .. } => self.fixed_medium,
+            SystemApiCostingEntry::ReadSubstate { .. } => self.fixed_medium,
+            SystemApiCostingEntry::WriteSubstate { .. } => self.fixed_medium,
 
             SystemApiCostingEntry::ReadEpoch => self.fixed_low,
             SystemApiCostingEntry::ReadTransactionHash => self.fixed_low,
             SystemApiCostingEntry::ReadTransactionNetwork => self.fixed_low,
             SystemApiCostingEntry::GenerateUuid => self.fixed_low,
             SystemApiCostingEntry::EmitLog { size } => self.fixed_low + 10 * size,
-            SystemApiCostingEntry::CheckAccessRule => self.fixed_medium,
+            SystemApiCostingEntry::CheckAccessRule { .. } => self.fixed_medium,
         }
     }
 }

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -83,7 +83,7 @@ impl FeeTable {
             tx_decoding_per_byte: 4, // TODO: linear costing is suitable for PUBLISH_PACKAGE manifest; need to bill "blobs" separately
             tx_manifest_verification_per_byte: 1,
             tx_signature_verification_per_sig: 3750,
-            wasm_instantiation_per_byte: 1,  // TODO: this is currently costing too much!!!
+            wasm_instantiation_per_byte: 1, // TODO: this is currently costing too much!!!
             fixed_low: 100,
             fixed_medium: 500,
             fixed_high: 1000,

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -80,7 +80,7 @@ impl FeeTable {
     pub fn new() -> Self {
         Self {
             tx_base_fee: 10_000,
-            tx_decoding_per_byte: 4, // TODO: linear costing is suitable for PUBLISH_PACKAGE manifest; need to bill "blobs" separately
+            tx_decoding_per_byte: 3, // TODO: linear costing is suitable for PUBLISH_PACKAGE manifest; need to bill "blobs" separately
             tx_manifest_verification_per_byte: 1,
             tx_signature_verification_per_sig: 3750,
             wasm_instantiation_per_byte: 1, // TODO: this is currently costing too much!!!

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -80,10 +80,10 @@ impl FeeTable {
     pub fn new() -> Self {
         Self {
             tx_base_fee: 10_000,
-            tx_decoding_per_byte: 4,
+            tx_decoding_per_byte: 4, // TODO: linear costing is suitable for PUBLISH_PACKAGE manifest; need to bill "blobs" separately
             tx_manifest_verification_per_byte: 1,
             tx_signature_verification_per_sig: 3750,
-            wasm_instantiation_per_byte: 500,
+            wasm_instantiation_per_byte: 1,  // TODO: this is currently costing too much!!!
             fixed_low: 100,
             fixed_medium: 500,
             fixed_high: 1000,

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -90,12 +90,13 @@ fn create_genesis(mut track: Track) -> TrackReceipt {
     let system_vault = Vault::new(minted_xrd);
     track.create_uuid_substate(SubstateId::Vault(XRD_VAULT_ID), system_vault);
 
-    let system_component = Component::new(SYSTEM_PACKAGE, SYSTEM_COMPONENT_NAME.to_owned(), vec![]);
+    let system_component_info =
+        ComponentInfo::new(SYSTEM_PACKAGE, SYSTEM_COMPONENT_NAME.to_owned(), vec![]);
     let system_component_state =
         ComponentState::new(scrypto_encode(&SystemComponentState { xrd: XRD_VAULT }));
     track.create_uuid_substate(
         SubstateId::ComponentInfo(SYSTEM_COMPONENT),
-        system_component,
+        system_component_info,
     );
     track.create_uuid_substate(
         SubstateId::ComponentState(SYSTEM_COMPONENT),

--- a/radix-engine/src/model/abi_extractor.rs
+++ b/radix-engine/src/model/abi_extractor.rs
@@ -36,10 +36,10 @@ pub fn export_abi_by_component<S: ReadableSubstateStore>(
         .ok_or(RuntimeError::RENodeNotFound(RENodeId::Component(
             component_address,
         )))?;
-    let component = component_value.component();
+    let component_info = component_value.component_info();
     export_abi(
         substate_store,
-        component.package_address(),
-        component.blueprint_name(),
+        component_info.package_address(),
+        component_info.blueprint_name(),
     )
 }

--- a/radix-engine/src/model/component.rs
+++ b/radix-engine/src/model/component.rs
@@ -43,13 +43,13 @@ impl ComponentState {
 
 /// A component is an instance of blueprint.
 #[derive(Debug, Clone, TypeId, Encode, Decode, PartialEq, Eq)]
-pub struct Component {
+pub struct ComponentInfo {
     package_address: PackageAddress,
     blueprint_name: String,
     access_rules: Vec<AccessRules>,
 }
 
-impl Component {
+impl ComponentInfo {
     pub fn new(
         package_address: PackageAddress,
         blueprint_name: String,
@@ -141,8 +141,8 @@ impl Component {
                 let mut ref_mut = system_api
                     .substate_borrow_mut(&substate_id)
                     .map_err(ComponentError::CostingError)?;
-                let component = ref_mut.component();
-                component.access_rules.push(input.access_rules);
+                let component_info = ref_mut.component_info();
+                component_info.access_rules.push(input.access_rules);
                 system_api
                     .substate_return_mut(ref_mut)
                     .map_err(ComponentError::CostingError)?;

--- a/radix-engine/src/model/mod.rs
+++ b/radix-engine/src/model/mod.rs
@@ -19,7 +19,7 @@ pub use abi_extractor::*;
 pub use auth_converter::convert;
 pub use auth_zone::{AuthZone, AuthZoneError};
 pub use bucket::{Bucket, BucketError};
-pub use component::{Component, ComponentError, ComponentState};
+pub use component::{ComponentError, ComponentInfo, ComponentState};
 pub use method_authorization::{
     HardAuthRule, HardProofRule, HardResourceOrNonFungible, MethodAuthorization,
     MethodAuthorizationError,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -139,21 +139,21 @@ where
         fee_reserve
             .consume(
                 fee_table.tx_decoding_per_byte() * transaction.transaction_payload_size() as u32,
-                "tx_decoding",
+                "decode_transaction",
             )
             .expect("System loan should cover this");
         fee_reserve
             .consume(
                 fee_table.tx_manifest_verification_per_byte()
                     * transaction.transaction_payload_size() as u32,
-                "tx_manifest_verification",
+                "verify_manifest",
             )
             .expect("System loan should cover this");
         fee_reserve
             .consume(
                 fee_table.tx_signature_verification_per_sig()
                     * transaction.signer_public_keys().len() as u32,
-                "tx_signature_verification",
+                "verify_signatures",
             )
             .expect("System loan should cover this");
 

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -137,6 +137,9 @@ where
         // 2. Apply pre-execution costing
         let fee_table = FeeTable::new();
         fee_reserve
+            .consume(fee_table.tx_base_fee(), "base_fee")
+            .expect("System loan should cover this");
+        fee_reserve
             .consume(
                 fee_table.tx_decoding_per_byte() * transaction.transaction_payload_size() as u32,
                 "decode_transaction",

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -163,20 +163,21 @@ fn test_basic_transfer() {
 
     // Assert
     assert_eq!(
-        3300 /* borrow_substate */
-            + 1500 /* create_node */
-            + 2668 /* decode_transaction */
-            + 1000 /* drop_node */
-            + 1895 /* invoke_function */
-            + 2215 /* invoke_method */
-            + 5000 /* read_substate */
-            + 600 /* return_substate */
-            + 1000 /* run_function */
-            + 5200 /* run_method */
-            + 300928 /* run_wasm */
-            + 667 /* verify_manifest */
-            + 3750 /* verify_signatures */
-            + 3000, /* write_substate */
+        10000 /* base_fee */
+        + 3300 /* borrow_substate */
+        + 1500 /* create_node */
+        + 2668 /* decode_transaction */
+        + 1000 /* drop_node */
+        + 1895 /* invoke_function */
+        + 2215 /* invoke_method */
+        + 5000 /* read_substate */
+        + 600 /* return_substate */
+        + 1000 /* run_function */
+        + 5200 /* run_method */
+        + 300928 /* run_wasm */
+        + 667 /* verify_manifest */
+        + 3750 /* verify_signatures */
+        + 3000, /* write_substate */
         receipt.fee_summary.cost_unit_consumed
     );
 }

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -163,19 +163,20 @@ fn test_basic_transfer() {
 
     // Assert
     assert_eq!(
-        1800 /* borrow */
-            + 3000 /* create */
+        3300 /* borrow_substate */
+            + 1500 /* create_node */
+            + 2668 /* decode_transaction */
+            + 1000 /* drop_node */
             + 1895 /* invoke_function */
             + 2215 /* invoke_method */
-            + 5000 /* read */
-            + 1800 /* return */
+            + 5000 /* read_substate */
+            + 600 /* return_substate */
             + 1000 /* run_function */
             + 5200 /* run_method */
             + 300928 /* run_wasm */
-            + 2668 /* tx_decoding */
-            + 667 /* tx_manifest_verification */
-            + 3750 /* tx_signature_verification */
-            + 3000, /* write */
+            + 667 /* verify_manifest */
+            + 3750 /* verify_signatures */
+            + 3000, /* write_substate */
         receipt.fee_summary.cost_unit_consumed
     );
 }

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -166,7 +166,7 @@ fn test_basic_transfer() {
         10000 /* base_fee */
         + 3300 /* borrow_substate */
         + 1500 /* create_node */
-        + 2668 /* decode_transaction */
+        + 2001 /* decode_transaction */
         + 1000 /* drop_node */
         + 627435 /* instantiate_wasm */
         + 1895 /* invoke_function */

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -168,6 +168,7 @@ fn test_basic_transfer() {
         + 1500 /* create_node */
         + 2668 /* decode_transaction */
         + 1000 /* drop_node */
+        + 627435 /* instantiate_wasm */
         + 1895 /* invoke_function */
         + 2215 /* invoke_method */
         + 5000 /* read_substate */

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -73,7 +73,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     pub fn inspect_component(
         &mut self,
         component_address: ComponentAddress,
-    ) -> Option<radix_engine::model::Component> {
+    ) -> Option<radix_engine::model::ComponentInfo> {
         self.execution_stores
             .get_output_store(0)
             .get_substate(&SubstateId::ComponentInfo(component_address))

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -63,7 +63,7 @@ pub fn dump_component<T: ReadableSubstateStore + QueryableSubstateStore, O: std:
 ) -> Result<(), DisplayError> {
     let bech32_encoder = Bech32Encoder::new_from_network(&Network::LocalSimulator);
 
-    let component: Option<Component> = substate_store
+    let component: Option<ComponentInfo> = substate_store
         .get_substate(&SubstateId::ComponentInfo(component_address))
         .map(|s| s.substate)
         .map(|s| s.into());


### PR DESCRIPTION
- Renamed fee table entries to be consistent with our architecture
- Added costing for `drop_node`, `take_substate`, `check_access_rule`, and `instantiate_wasm`
- Added transaction base fee
- Renamed `Component` to `ComponentInfo` (`rust-analyzer` complains by wrongly linking to the `Component` in Scrypto)