### PR TITLE
Fix `NonFungibleId` and `NonFungibleAddress` in manifest.

### DIFF
--- a/scrypto/src/resource/non_fungible_id.rs
+++ b/scrypto/src/resource/non_fungible_id.rs
@@ -66,8 +66,8 @@ impl TryFrom<&[u8]> for NonFungibleId {
     type Error = ParseNonFungibleIdError;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        let value = ScryptoValue::from_slice(slice)
-            .map_err(|_| ParseNonFungibleIdError::InvalidValue)?;
+        let value =
+            ScryptoValue::from_slice(slice).map_err(|_| ParseNonFungibleIdError::InvalidValue)?;
         Ok(Self(value.raw))
     }
 }

--- a/scrypto/src/resource/non_fungible_id.rs
+++ b/scrypto/src/resource/non_fungible_id.rs
@@ -66,7 +66,7 @@ impl TryFrom<&[u8]> for NonFungibleId {
     type Error = ParseNonFungibleIdError;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        let value = ScryptoValue::from_slice_no_custom_values(slice)
+        let value = ScryptoValue::from_slice(slice)
             .map_err(|_| ParseNonFungibleIdError::InvalidValue)?;
         Ok(Self(value.raw))
     }

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1078,8 +1078,11 @@ mod tests {
                 arg: to_struct!(
                     NonFungibleId(scrypto_encode(&scrypto::dec!("2"))),
                     NonFungibleId(scrypto_encode(&String::from("Scrypto"))),
-                    NonFungibleAddress::new(RADIX_TOKEN, NonFungibleId(scrypto_encode(&String::from("Scrypto")))),
-                    // TODO: In the future, we should neither be able to create a `NonFungibleId` of a bucket or pass 
+                    NonFungibleAddress::new(
+                        RADIX_TOKEN,
+                        NonFungibleId(scrypto_encode(&String::from("Scrypto")))
+                    ),
+                    // TODO: In the future, we should neither be able to create a `NonFungibleId` of a bucket or pass
                     // that through the manifest.
                     NonFungibleId(scrypto_encode(&scrypto::resource::Bucket(512)))
                 )

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1068,6 +1068,24 @@ mod tests {
             }
         );
         generate_instruction_ok!(
+            r#"CALL_METHOD  ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")  "refill"  NonFungibleId("a1200000000000c84e676dc11b000000000000000000000000000000000000000000000000")  NonFungibleId("0c070000005363727970746f")  NonFungibleAddress("030000000000000000000000000000000000000000000000000000040c070000005363727970746f")  NonFungibleId("b10400000000020000");"#,
+            Instruction::CallMethod {
+                component_address: ComponentAddress::from_str(
+                    "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum".into()
+                )
+                .unwrap(),
+                method_name: "refill".to_string(),
+                arg: to_struct!(
+                    NonFungibleId(scrypto_encode(&scrypto::dec!("2"))),
+                    NonFungibleId(scrypto_encode(&String::from("Scrypto"))),
+                    NonFungibleAddress::new(RADIX_TOKEN, NonFungibleId(scrypto_encode(&String::from("Scrypto")))),
+                    // TODO: In the future, we should neither be able to create a `NonFungibleId` of a bucket or pass 
+                    // that through the manifest.
+                    NonFungibleId(scrypto_encode(&scrypto::resource::Bucket(512)))
+                )
+            }
+        );
+        generate_instruction_ok!(
             r#"CALL_METHOD_WITH_ALL_RESOURCES  ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch";"#,
             Instruction::CallMethodWithAllResources {
                 component_address: ComponentAddress::from_str(


### PR DESCRIPTION
Currently, if a `NonFungibleId` is created of a `Decimal` or any Scrypto type, it can not be passed through the transaction manifest. 

This means that `NonFungibleId`s of certain types can be created, and can have NFTs created of them, but the `NonFungibleId` can not be passed through the manifest. 

This is because the implementation of the `TryFrom<&[u8]>` trait used `ScryptoValue::from_slice_no_custom_values` to create a `ScryptoValue` out of the slice. Since `NonFungibleId`s can now be any vector of SBOR bytes, we should use `ScryptoValue::from_slice`.