### PR TITLE
Remove `FromStr` trait from the `ComponentAddress` type.

### DIFF
--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use scrypto::address::Bech32Decoder;
 use scrypto::core::Network;
 use scrypto::prelude::*;
 use transaction::builder::ManifestBuilder;
@@ -39,14 +40,18 @@ fn bench_ed25519_validation(c: &mut Criterion) {
 }
 
 fn bench_transaction_validation(c: &mut Criterion) {
-    let account1 = ComponentAddress::from_str(
-        "account_sim1qd5yl2lwcuk25q705sm9g7cven6f9kytjs8t2xvvggzq5d2mse",
-    )
-    .unwrap();
-    let account2 = ComponentAddress::from_str(
-        "account_sim1qdugngtu8y0e54zwe5j54mdwv3wnkse68u9840407zws6fzpn7",
-    )
-    .unwrap();
+    let bech32_decoder: Bech32Decoder = Bech32Decoder::new_from_network(&Network::LocalSimulator);
+
+    let account1 = bech32_decoder
+        .validate_and_decode_component_address(
+            "account_sim1qd5yl2lwcuk25q705sm9g7cven6f9kytjs8t2xvvggzq5d2mse",
+        )
+        .unwrap();
+    let account2 = bech32_decoder
+        .validate_and_decode_component_address(
+            "account_sim1qdugngtu8y0e54zwe5j54mdwv3wnkse68u9840407zws6fzpn7",
+        )
+        .unwrap();
     let signer = EcdsaPrivateKey::from_u64(1).unwrap();
 
     let transaction = TransactionBuilder::new()

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -1,5 +1,6 @@
 use radix_engine::engine::RuntimeError;
 use radix_engine::ledger::TypedInMemorySubstateStore;
+use scrypto::address::Bech32Decoder;
 use scrypto::core::Network;
 use scrypto::engine::types::SubstateId;
 use scrypto::prelude::*;
@@ -108,10 +109,11 @@ fn missing_component_address_in_manifest_should_cause_rejection() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let _ = test_runner.extract_and_publish_package("component");
-    let component_address = ComponentAddress::from_str(
-        "component_sim1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqph4dhmhs42ee03",
-    )
-    .unwrap();
+    let component_address = Bech32Decoder::new_from_network(&Network::LocalSimulator)
+        .validate_and_decode_component_address(
+            "component_sim1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqph4dhmhs42ee03",
+        )
+        .unwrap();
 
     // Act
     let manifest = ManifestBuilder::new(Network::LocalSimulator)

--- a/scrypto-tests/tests/import.rs
+++ b/scrypto-tests/tests/import.rs
@@ -273,7 +273,7 @@ blueprint! {
 #[test]
 #[should_panic] // asserts it compiles
 fn test_import_from_abi() {
-    let instance = Simple::from(ComponentAddress::from_str("").unwrap());
+    let instance = Simple::from(ComponentAddress([0; 27]));
 
     let arg1 = Floor { x: 5, y: 12 };
     let arg2 = (1u8, 2u16);

--- a/scrypto/src/component/component.rs
+++ b/scrypto/src/component/component.rs
@@ -103,14 +103,6 @@ scrypto_type!(Component, ScryptoType::Component, Vec::new());
 // text
 //======
 
-impl FromStr for Component {
-    type Err = AddressError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ComponentAddress::from_str(s).map(|a| Component(a))
-    }
-}
-
 impl fmt::Display for Component {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "{}", self.0)

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -326,7 +326,7 @@ fn create_custom_accounts() {
 }
 
 fn bridge_to_existing_account() {
-    let existing_account = CustomAccount::from(ComponentAddress::from_str("account_sim1qdencrktc8r4f2ek5qh98uvfn7ugyjlpsw6ayusqyx6syqd3ly").unwrap());
+    let existing_account = CustomAccount::from(component_address);
     let balance = existing_account.read_balance();
     // ...
 }
@@ -400,7 +400,7 @@ external_component! {
 }
 
 fn bridge_to_existing_account() {
-    let existing_account = AccountInterface::from(ComponentAddress::from_str("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064").unwrap());
+    let existing_account = AccountInterface::from(component_address);
     let balance = existing_account.read_balance();
     // ...
 }

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -294,7 +294,7 @@ You can also use this to make calls to the component itself.
 If you just wish to make calls to an instantiated component, see the [external_component]! macro.
 
 # Examples
-```
+```norun
 use scrypto::prelude::*;
 use sbor::{TypeId, Encode, Decode, Describe};
 
@@ -381,7 +381,7 @@ macro_rules! external_blueprint {
 Generates a bridge/stub to make cross-component calls.
 
 # Examples
-```
+```norun
 use scrypto::prelude::*;
 use sbor::{TypeId, Encode, Decode, Describe};
 

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1033,6 +1033,18 @@ mod tests {
 
     #[test]
     fn test_instructions() {
+        let bech32_decoder = Bech32Decoder::new_from_network(&Network::LocalSimulator);
+        let component1 = bech32_decoder
+            .validate_and_decode_component_address(
+                "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum",
+            )
+            .unwrap();
+        let component2 = bech32_decoder
+            .validate_and_decode_component_address(
+                "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064",
+            )
+            .unwrap();
+
         generate_instruction_ok!(
             r#"TAKE_FROM_WORKTOP_BY_AMOUNT  Decimal("1.0")  ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")  Bucket("xrd_bucket");"#,
             Instruction::TakeFromWorktopByAmount {
@@ -1077,10 +1089,7 @@ mod tests {
         generate_instruction_ok!(
             r#"CALL_METHOD  ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")  "refill";"#,
             Instruction::CallMethod {
-                component_address: ComponentAddress::from_str(
-                    "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum".into()
-                )
-                .unwrap(),
+                component_address: component1,
                 method_name: "refill".to_string(),
                 arg: to_struct!()
             }
@@ -1088,10 +1097,7 @@ mod tests {
         generate_instruction_ok!(
             r#"CALL_METHOD_WITH_ALL_RESOURCES  ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch";"#,
             Instruction::CallMethodWithAllResources {
-                component_address: ComponentAddress::from_str(
-                    "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064".into()
-                )
-                .unwrap(),
+                component_address: component2,
                 method: "deposit_batch".into(),
             }
         );
@@ -1122,16 +1128,25 @@ mod tests {
         };
         let encoded_package = scrypto_encode(&package);
 
+        let bech32_decoder = Bech32Decoder::new_from_network(&Network::LocalSimulator);
+        let component1 = bech32_decoder
+            .validate_and_decode_component_address(
+                "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064",
+            )
+            .unwrap();
+        let component2 = bech32_decoder
+            .validate_and_decode_component_address(
+                "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum",
+            )
+            .unwrap();
+
         assert_eq!(
             crate::manifest::compile(tx, &Network::LocalSimulator)
                 .unwrap()
                 .instructions,
             vec![
                 Instruction::CallMethod {
-                    component_address: ComponentAddress::from_str(
-                        "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064".into()
-                    )
-                    .unwrap(),
+                    component_address: component1,
                     method_name: "withdraw_by_amount".to_string(),
                     arg: to_struct!(
                         Decimal::from(5u32),
@@ -1149,10 +1164,7 @@ mod tests {
                     .unwrap(),
                 },
                 Instruction::CallMethod {
-                    component_address: ComponentAddress::from_str(
-                        "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum".into()
-                    )
-                    .unwrap(),
+                    component_address: component2,
                     method_name: "buy_gumball".to_string(),
                     arg: to_struct!(scrypto::resource::Bucket(512))
                 },
@@ -1180,10 +1192,7 @@ mod tests {
                 Instruction::DropProof { proof_id: 514 },
                 Instruction::DropProof { proof_id: 515 },
                 Instruction::CallMethod {
-                    component_address: ComponentAddress::from_str(
-                        "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064".into()
-                    )
-                    .unwrap(),
+                    component_address: component1,
                     method_name: "create_proof_by_amount".to_string(),
                     arg: to_struct!(
                         Decimal::from(5u32),
@@ -1207,10 +1216,7 @@ mod tests {
                     .unwrap()
                 },
                 Instruction::CallMethodWithAllResources {
-                    component_address: ComponentAddress::from_str(
-                        "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064".into()
-                    )
-                    .unwrap(),
+                    component_address: component1,
                     method: "deposit_batch".into(),
                 },
                 Instruction::DropAllProofs,
@@ -1218,10 +1224,7 @@ mod tests {
                     package: encoded_package.clone()
                 },
                 Instruction::CallMethod {
-                    component_address: ComponentAddress::from_str(
-                        "component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum".into()
-                    )
-                    .unwrap(),
+                    component_address: component2,
                     method_name: "complicated_method".to_string(),
                     arg: to_struct!(Decimal::from(1u32), PreciseDecimal::from(2u32))
                 },


### PR DESCRIPTION
As we have recently discussed, this is a small PR to remove the `FromStr` trait from the `ComponentAddress` type.