### PR TITLE
Transaction receipt neatening

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -24,7 +24,7 @@ fn test_hello() {
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);
     receipt.expect_success();
-    let component = receipt.new_component_addresses[0];
+    let component = receipt.expect_commit().entity_changes.new_component_addresses[0];
 
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -24,7 +24,10 @@ fn test_hello() {
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);
     receipt.expect_success();
-    let component = receipt.new_component_addresses[0];
+    let component = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/examples/no-std/tests/lib.rs
+++ b/examples/no-std/tests/lib.rs
@@ -38,6 +38,8 @@ fn test_say_hello() {
             &TestTransaction::new(manifest, 1, vec![public_key]),
             &ExecutionConfig::debug(),
         )
+        .expect_commit()
+        .entity_changes
         .new_package_addresses[0];
 
     // Test the `say_hello` function.

--- a/format.sh
+++ b/format.sh
@@ -18,22 +18,20 @@ cd "$(dirname "$0")"
 (cd simulator; cargo fmt)
 (cd transaction; cargo fmt)
 
-(cd assets/account; scrypto fmt)
-(cd assets/system; scrypto fmt)
+scrypto="cargo run --manifest-path $PWD/simulator/Cargo.toml --bin scrypto $@ --"
 
-# The below bash does the following:
-# - Find all Cargo.toml files within 2 subdirectories (identifying crates)
-# - Remove Cargo.toml suffix
-# - Run scrypto fmt at that path
+(cd assets/account; $scrypto fmt)
+(cd assets/system; $scrypto fmt)
+
 (cd examples;
     find . -maxdepth 2 -type f \( -name Cargo.toml \) -print \
     | awk '{print substr($1, 1, length($1)-length("Cargo.toml"))}' \
-    | xargs -n1 -I '{}' scrypto fmt --path {}
+    | xargs -n1 -I '{}' $scrypto fmt --path {}
 )
 (cd radix-engine/tests;
     find . -maxdepth 2 -type f \( -name Cargo.toml \) -print \
     | awk '{print substr($1, 1, length($1)-length("Cargo.toml"))}' \
-    | xargs -n1 -I '{}' scrypto fmt --path {}
+    | xargs -n1 -I '{}' $scrypto fmt --path {}
 )
 
 echo "All packages have been formatted."

--- a/format.sh
+++ b/format.sh
@@ -20,7 +20,20 @@ cd "$(dirname "$0")"
 
 (cd assets/account; scrypto fmt)
 (cd assets/system; scrypto fmt)
-(cd examples; find . -maxdepth 1 -type d \( ! -name . \) -print0 | xargs -0 -n1 -I '{}' scrypto fmt --path {})
-(cd radix-engine/tests; find . -maxdepth 1 -type d \( ! -name . \) -print0 | xargs -0 -n1 -I '{}' scrypto fmt --path {})
+
+# The below bash does the following:
+# - Find all Cargo.toml files within 2 subdirectories (identifying crates)
+# - Remove Cargo.toml suffix
+# - Run scrypto fmt at that path
+(cd examples;
+    find . -maxdepth 2 -type f \( -name Cargo.toml \) -print \
+    | awk '{print substr($1, 1, length($1)-length("Cargo.toml"))}' \
+    | xargs -n1 -I '{}' scrypto fmt --path {}
+)
+(cd radix-engine/tests;
+    find . -maxdepth 2 -type f \( -name Cargo.toml \) -print \
+    | awk '{print substr($1, 1, length($1)-length("Cargo.toml"))}' \
+    | xargs -n1 -I '{}' scrypto fmt --path {}
+)
 
 echo "All packages have been formatted."

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -41,12 +41,16 @@ fn bench_transfer(c: &mut Criterion) {
             &TestTransaction::new(manifest.clone(), 1, vec![public_key]),
             &ExecutionConfig::default(),
         )
+        .expect_commit()
+        .entity_changes
         .new_component_addresses[0];
     let account2 = executor
         .execute_and_commit(
             &TestTransaction::new(manifest, 2, vec![public_key]),
             &ExecutionConfig::default(),
         )
+        .expect_commit()
+        .entity_changes
         .new_component_addresses[0];
 
     // Create a transfer manifest

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -6,6 +6,24 @@ use crate::model::*;
 use crate::types::*;
 use crate::wasm::InvokeError;
 
+/// Represents an error which causes a tranasction to be rejected.
+#[derive(Debug)]
+pub enum RejectionError {
+    SuccessButFeeLoanNotRepaid,
+    ErrorBeforeFeeLoanRepaid(RuntimeError),
+    MismatchedNetwork {
+        transaction_network_id: u8,
+        expected_network_id: u8,
+    },
+}
+
+impl fmt::Display for RejectionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Represents an error when executing a transaction.
 #[derive(Debug)]
 pub enum RuntimeError {
     /// An error occurred within the kernel.

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -9,13 +9,11 @@ use crate::types::*;
 
 #[derive(Debug)]
 pub struct TransactionContents {
-    pub network_id: u8,
     pub instructions: Vec<ExecutableInstruction>,
 }
 
 #[derive(Debug)]
 pub struct TransactionExecution {
-    pub execution_network: NetworkDefinition,
     pub execution_time: Option<u128>,
     pub fee_summary: FeeSummary,
     pub application_logs: Vec<(Level, String)>,
@@ -248,11 +246,8 @@ impl fmt::Debug for TransactionReceipt {
                 .unwrap_or(String::from("?"))
         )?;
 
-        let bech32_encoder = Bech32Encoder::new(
-            &execution
-                .map(|e| &e.execution_network)
-                .unwrap_or(&NetworkDefinition::local_simulator()),
-        );
+        // TODO - Need to fix the hardcoding of local simulator HRPs for transaction receipts, and for address formatting
+        let bech32_encoder = Bech32Encoder::new(&NetworkDefinition::local_simulator());
         let instructions = &self.contents.instructions;
 
         write!(f, "\n{}", "Instructions:".bold().green())?;

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -2,51 +2,150 @@ use colored::*;
 use scrypto::core::NetworkDefinition;
 use transaction::model::*;
 
-use crate::engine::{ResourceChange, RuntimeError};
+use crate::engine::{RejectionError, ResourceChange, RuntimeError};
 use crate::fee::FeeSummary;
 use crate::state_manager::StateDiff;
 use crate::types::*;
 
 #[derive(Debug)]
-pub enum TransactionStatus {
-    Rejected,
-    Succeeded(Vec<Vec<u8>>),
-    Failed(RuntimeError),
+pub struct TransactionContents {
+    pub network_id: u8,
+    pub instructions: Vec<ExecutableInstruction>,
 }
 
-impl TransactionStatus {
+#[derive(Debug)]
+pub struct TransactionExecution {
+    pub execution_network: NetworkDefinition,
+    pub execution_time: Option<u128>,
+    pub fee_summary: FeeSummary,
+    pub application_logs: Vec<(Level, String)>,
+}
+
+/// Captures whether a transaction should be committed, and its other results
+#[derive(Debug)]
+pub enum TransactionResult {
+    Commit(CommitResult),
+    Reject(RejectResult),
+}
+
+#[derive(Debug)]
+pub struct CommitResult {
+    pub outcome: TransactionOutcome,
+    pub state_updates: StateDiff,
+    pub entity_changes: EntityChanges,
+    pub resource_changes: Vec<ResourceChange>,
+}
+
+/// Captures whether a transaction's commit outcome is Success or Failure
+#[derive(Debug)]
+pub enum TransactionOutcome {
+    Success(Vec<Vec<u8>>),
+    Failure(RuntimeError),
+}
+
+impl TransactionOutcome {
     pub fn is_success(&self) -> bool {
-        matches!(self, Self::Succeeded(..))
+        match self {
+            Self::Success(..) => true,
+            Self::Failure(..) => false,
+        }
     }
+}
+
+/// A flattened combination of the transaction's result and outcome
+#[derive(Debug)]
+pub enum TransactionStatus<'a> {
+    Success(&'a Vec<Vec<u8>>),
+    Failure(&'a RuntimeError),
+    Rejection(&'a RejectionError),
+}
+
+impl TransactionStatus<'_> {
+    pub fn is_success(&self) -> bool {
+        match self {
+            Self::Success(..) => true,
+            Self::Failure(..) => false,
+            Self::Rejection(..) => false,
+        }
+    }
+
     pub fn is_failure(&self) -> bool {
-        matches!(self, Self::Failed(..))
+        match self {
+            Self::Success(..) => false,
+            Self::Failure(..) => true,
+            Self::Rejection(..) => false,
+        }
     }
+
     pub fn is_rejection(&self) -> bool {
-        matches!(self, Self::Rejected)
+        match self {
+            Self::Success(..) => false,
+            Self::Failure(..) => false,
+            Self::Rejection(..) => true,
+        }
     }
+}
+
+impl TransactionResult {
+    pub fn is_success(&self) -> bool {
+        self.get_status().is_success()
+    }
+
+    pub fn is_failure(&self) -> bool {
+        self.get_status().is_failure()
+    }
+
+    pub fn is_rejection(&self) -> bool {
+        self.get_status().is_rejection()
+    }
+
+    pub fn get_status(&self) -> TransactionStatus {
+        match self {
+            TransactionResult::Commit(commit) => match &commit.outcome {
+                TransactionOutcome::Success(x) => TransactionStatus::Success(x),
+                TransactionOutcome::Failure(e) => TransactionStatus::Failure(e),
+            },
+            TransactionResult::Reject(rejection) => TransactionStatus::Rejection(&rejection.error),
+        }
+    }
+
+    pub fn get_commit_result(&self) -> Option<&CommitResult> {
+        match self {
+            TransactionResult::Commit(commit) => Some(commit),
+            TransactionResult::Reject(..) => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EntityChanges {
+    pub new_package_addresses: Vec<PackageAddress>,
+    pub new_component_addresses: Vec<ComponentAddress>,
+    pub new_resource_addresses: Vec<ResourceAddress>,
+}
+
+#[derive(Debug)]
+pub struct RejectResult {
+    pub error: RejectionError,
 }
 
 /// Represents a transaction receipt.
 pub struct TransactionReceipt {
-    pub status: TransactionStatus,
-    pub fee_summary: FeeSummary,
-    pub transaction_network: NetworkDefinition,
-    pub execution_time: Option<u128>,
-    pub instructions: Vec<ExecutableInstruction>,
-    pub application_logs: Vec<(Level, String)>,
-    pub new_package_addresses: Vec<PackageAddress>,
-    pub new_component_addresses: Vec<ComponentAddress>,
-    pub new_resource_addresses: Vec<ResourceAddress>,
-    pub state_updates: StateDiff,
-    pub resource_changes: Vec<ResourceChange>,
+    pub contents: TransactionContents,
+    pub execution: Option<TransactionExecution>,
+    pub result: TransactionResult,
 }
 
 impl TransactionReceipt {
     pub fn expect_success(&self) -> &Vec<Vec<u8>> {
-        match &self.status {
-            TransactionStatus::Succeeded(output) => output,
-            TransactionStatus::Failed(err) => panic!("Expected success but was:\n{:?}", err),
-            TransactionStatus::Rejected => panic!("Expected success but was rejection"),
+        match self.result.get_status() {
+            TransactionStatus::Success(x) => &x,
+            TransactionStatus::Failure(err) => {
+                panic!("Expected success but was failed:\n{:?}", err)
+            }
+            TransactionStatus::Rejection(err) => {
+                panic!("Expected success but was rejection:\n{:?}", err)
+            }
         }
     }
 
@@ -54,19 +153,42 @@ impl TransactionReceipt {
     where
         F: FnOnce(&RuntimeError) -> bool,
     {
-        if let TransactionStatus::Failed(e) = &self.status {
-            if !f(e) {
-                panic!("Expected failure but was different error:\n{:?}", self);
+        let failure_error = match self.result.get_status() {
+            TransactionStatus::Success(..) => panic!("Expected failure but was success"),
+            TransactionStatus::Failure(err) => err,
+            TransactionStatus::Rejection(err) => {
+                panic!("Expected failure but was rejection:\n{:?}", err)
             }
-        } else {
-            panic!("Expected failure but was:\n{:?}", self);
+        };
+
+        if !f(&failure_error) {
+            panic!(
+                "Expected specific failure but was different error:\n{:?}",
+                self
+            );
         }
     }
 
-    pub fn expect_rejection(&self) {
-        if !matches!(self.status, TransactionStatus::Rejected) {
-            panic!("Expected rejection but was:\n{:?}", self);
+    pub fn expect_rejection(&self) -> &RejectionError {
+        match self.result.get_status() {
+            TransactionStatus::Success(..) => panic!("Expected rejection but was success"),
+            TransactionStatus::Failure(err) => {
+                panic!("Expected rejection but was failed:\n{:?}", err)
+            }
+            TransactionStatus::Rejection(err) => err,
         }
+    }
+
+    pub fn expect_commit(&self) -> &CommitResult {
+        self.result
+            .get_commit_result()
+            .expect("The transaction was not set to be committed")
+    }
+
+    pub fn expect_executed(&self) -> &TransactionExecution {
+        self.execution
+            .as_ref()
+            .expect("The transaction was not executed")
     }
 }
 
@@ -82,51 +204,63 @@ macro_rules! prefix {
 
 impl fmt::Debug for TransactionReceipt {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let bech32_encoder = Bech32Encoder::new(&self.transaction_network);
+        let result = &self.result;
+        let execution = self.execution.as_ref();
+        let commit = result.get_commit_result();
 
         write!(
             f,
             "{} {}",
             "Transaction Status:".bold().green(),
-            match &self.status {
-                TransactionStatus::Succeeded(_) => "SUCCESS".blue(),
-                TransactionStatus::Failed(e) => format!("FAILURE: {}", e).red(),
-                TransactionStatus::Rejected => "REJECTION".red(),
-            }
+            match result.get_status() {
+                TransactionStatus::Success(..) => "COMMITTED SUCCESS".blue(),
+                TransactionStatus::Failure(e) => format!("COMMITTED FAILURE: {}", e).red(),
+                TransactionStatus::Rejection(e) => format!("REJECTION: {}", e).red(),
+            },
         )?;
 
-        write!(
-            f,
-            "\n{} {} XRD burned, {} XRD tipped to validators",
-            "Transaction Fee:".bold().green(),
-            self.fee_summary.burned,
-            self.fee_summary.tipped,
-        )?;
+        if let Some(fee_summary) = execution.map(|e| &e.fee_summary) {
+            write!(
+                f,
+                "\n{} {} XRD burned, {} XRD tipped to validators",
+                "Transaction Fee:".bold().green(),
+                fee_summary.burned,
+                fee_summary.tipped,
+            )?;
 
-        write!(
-            f,
-            "\n{} {} limit, {} consumed, {} XRD per cost unit",
-            "Cost Units:".bold().green(),
-            self.fee_summary.cost_unit_limit,
-            self.fee_summary.cost_unit_consumed,
-            self.fee_summary.cost_unit_price,
-        )?;
+            write!(
+                f,
+                "\n{} {} limit, {} consumed, {} XRD per cost unit",
+                "Cost Units:".bold().green(),
+                fee_summary.cost_unit_limit,
+                fee_summary.cost_unit_consumed,
+                fee_summary.cost_unit_price,
+            )?;
+        }
 
         write!(
             f,
             "\n{} {} ms",
             "Execution Time:".bold().green(),
-            self.execution_time
+            execution
+                .and_then(|v| v.execution_time)
                 .map(|v| v.to_string())
                 .unwrap_or(String::from("?"))
         )?;
 
+        let bech32_encoder = Bech32Encoder::new(
+            &execution
+                .map(|e| &e.execution_network)
+                .unwrap_or(&NetworkDefinition::local_simulator()),
+        );
+        let instructions = &self.contents.instructions;
+
         write!(f, "\n{}", "Instructions:".bold().green())?;
-        for (i, inst) in self.instructions.iter().enumerate() {
+        for (i, inst) in instructions.iter().enumerate() {
             write!(
                 f,
                 "\n{} {}",
-                prefix!(i, self.instructions),
+                prefix!(i, instructions),
                 match inst {
                     ExecutableInstruction::CallFunction {
                         package_address,
@@ -156,7 +290,7 @@ impl fmt::Debug for TransactionReceipt {
             )?;
         }
 
-        if let TransactionStatus::Succeeded(outputs) = &self.status {
+        if let TransactionStatus::Success(outputs) = &result.get_status() {
             write!(f, "\n{}", "Instruction Outputs:".bold().green())?;
             for (i, output) in outputs.iter().enumerate() {
                 write!(
@@ -168,61 +302,61 @@ impl fmt::Debug for TransactionReceipt {
             }
         }
 
-        write!(
-            f,
-            "\n{} {}",
-            "Logs:".bold().green(),
-            self.application_logs.len()
-        )?;
-        for (i, (level, msg)) in self.application_logs.iter().enumerate() {
-            let (l, m) = match level {
-                Level::Error => ("ERROR".red(), msg.red()),
-                Level::Warn => ("WARN".yellow(), msg.yellow()),
-                Level::Info => ("INFO".green(), msg.green()),
-                Level::Debug => ("DEBUG".cyan(), msg.cyan()),
-                Level::Trace => ("TRACE".normal(), msg.normal()),
-            };
-            write!(f, "\n{} [{:5}] {}", prefix!(i, self.application_logs), l, m)?;
+        if let Some(application_logs) = execution.map(|e| &e.application_logs) {
+            write!(f, "\n{} {}", "Logs:".bold().green(), application_logs.len())?;
+            for (i, (level, msg)) in application_logs.iter().enumerate() {
+                let (l, m) = match level {
+                    Level::Error => ("ERROR".red(), msg.red()),
+                    Level::Warn => ("WARN".yellow(), msg.yellow()),
+                    Level::Info => ("INFO".green(), msg.green()),
+                    Level::Debug => ("DEBUG".cyan(), msg.cyan()),
+                    Level::Trace => ("TRACE".normal(), msg.normal()),
+                };
+                write!(f, "\n{} [{:5}] {}", prefix!(i, application_logs), l, m)?;
+            }
         }
 
-        write!(
-            f,
-            "\n{} {}",
-            "New Entities:".bold().green(),
-            self.new_package_addresses.len()
-                + self.new_component_addresses.len()
-                + self.new_resource_addresses.len()
-        )?;
+        if let Some(entity_changes) = commit.map(|c| &c.entity_changes) {
+            write!(
+                f,
+                "\n{} {}",
+                "New Entities:".bold().green(),
+                entity_changes.new_package_addresses.len()
+                    + entity_changes.new_component_addresses.len()
+                    + entity_changes.new_resource_addresses.len()
+            )?;
 
-        for (i, package_address) in self.new_package_addresses.iter().enumerate() {
-            write!(
-                f,
-                "\n{} Package: {}",
-                prefix!(i, self.new_package_addresses),
-                bech32_encoder
-                    .encode_package_address(package_address)
-                    .unwrap()
-            )?;
-        }
-        for (i, component_address) in self.new_component_addresses.iter().enumerate() {
-            write!(
-                f,
-                "\n{} Component: {}",
-                prefix!(i, self.new_component_addresses),
-                bech32_encoder
-                    .encode_component_address(component_address)
-                    .unwrap()
-            )?;
-        }
-        for (i, resource_address) in self.new_resource_addresses.iter().enumerate() {
-            write!(
-                f,
-                "\n{} Resource: {}",
-                prefix!(i, self.new_resource_addresses),
-                bech32_encoder
-                    .encode_resource_address(resource_address)
-                    .unwrap()
-            )?;
+            for (i, package_address) in entity_changes.new_package_addresses.iter().enumerate() {
+                write!(
+                    f,
+                    "\n{} Package: {}",
+                    prefix!(i, entity_changes.new_package_addresses),
+                    bech32_encoder
+                        .encode_package_address(package_address)
+                        .unwrap()
+                )?;
+            }
+            for (i, component_address) in entity_changes.new_component_addresses.iter().enumerate()
+            {
+                write!(
+                    f,
+                    "\n{} Component: {}",
+                    prefix!(i, entity_changes.new_component_addresses),
+                    bech32_encoder
+                        .encode_component_address(component_address)
+                        .unwrap()
+                )?;
+            }
+            for (i, resource_address) in entity_changes.new_resource_addresses.iter().enumerate() {
+                write!(
+                    f,
+                    "\n{} Resource: {}",
+                    prefix!(i, entity_changes.new_resource_addresses),
+                    bech32_encoder
+                        .encode_resource_address(resource_address)
+                        .unwrap()
+                )?;
+            }
         }
 
         Ok(())

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -29,7 +29,7 @@ fn can_withdraw_from_my_account() {
     let other_account_balance: Decimal = scrypto_decode(&outputs[3]).unwrap();
     let transfer_amount = other_account_balance - 1_000_000 /* initial balance */;
     assert_resource_changes_for_transfer(
-        &receipt.resource_changes,
+        &receipt.expect_commit().resource_changes,
         RADIX_TOKEN,
         account,
         other_account,
@@ -102,8 +102,8 @@ fn account_to_bucket_to_account() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    assert!(receipt.resource_changes.is_empty());
     receipt.expect_success();
+    assert!(receipt.expect_commit().resource_changes.is_empty());
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn test_account_balance() {
     let outputs = receipt.expect_success();
 
     // Assert
-    assert!(receipt.resource_changes.is_empty());
+    assert!(receipt.expect_commit().resource_changes.is_empty());
     assert_eq!(
         outputs[1],
         ScryptoValue::from_typed(&Decimal::from(1000000)).raw

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -28,7 +28,10 @@ fn cannot_make_cross_component_call_without_authorization() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let secured_component = receipt.new_component_addresses[0];
+    let secured_component = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
@@ -41,7 +44,10 @@ fn cannot_make_cross_component_call_without_authorization() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let my_component = receipt.new_component_addresses[0];
+    let my_component = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -82,7 +88,10 @@ fn can_make_cross_component_call_with_authorization() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let secured_component = receipt.new_component_addresses[0];
+    let secured_component = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
@@ -95,7 +104,10 @@ fn can_make_cross_component_call_with_authorization() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let my_component = receipt.new_component_addresses[0];
+    let my_component = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)

--- a/radix-engine/tests/authorization_dynamic.rs
+++ b/radix-engine/tests/authorization_dynamic.rs
@@ -40,7 +40,10 @@ fn test_dynamic_auth(
         .build();
     let receipt1 = test_runner.execute_manifest(manifest1, vec![]);
     receipt1.expect_success();
-    let component = receipt1.new_component_addresses[0];
+    let component = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     if let Some(next_auth) = update_auth {
         let update_manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -106,7 +109,10 @@ fn test_dynamic_authlist(
         .build();
     let receipt0 = test_runner.execute_manifest(manifest1, vec![]);
     receipt0.expect_success();
-    let component = receipt0.new_component_addresses[0];
+    let component = receipt0
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -228,7 +234,10 @@ fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
         .build();
     let receipt1 = test_runner.execute_manifest(manifest1, vec![]);
     receipt1.expect_success();
-    let component = receipt1.new_component_addresses[0];
+    let component = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -258,7 +267,10 @@ fn chess_should_allow_second_player_to_move_after_first_player() {
         .build();
     let receipt1 = test_runner.execute_manifest(manifest1, vec![]);
     receipt1.expect_success();
-    let component = receipt1.new_component_addresses[0];
+    let component = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "make_move", args!())

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -23,7 +23,10 @@ fn test_component() {
     receipt1.expect_success();
 
     // Find the component address from receipt
-    let component = receipt1.new_component_addresses[0];
+    let component = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Call functions & methods
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -83,7 +86,10 @@ fn reentrancy_should_not_be_possible() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/radix-engine/tests/execution_trace.rs
+++ b/radix-engine/tests/execution_trace.rs
@@ -33,14 +33,16 @@ fn test_trace_resource_transfers() {
         ComponentAddress,
     ) = scrypto_decode(&output.get(1).unwrap()[..]).unwrap();
     /* There should be two resource changes, one for source component and one for target */
-    assert_eq!(2, receipt.resource_changes.len());
+    assert_eq!(2, receipt.expect_commit().resource_changes.len());
     assert!(receipt
+        .expect_commit()
         .resource_changes
         .iter()
         .any(|r| r.resource_address == resource_address
             && r.component_address == source_component
             && r.amount == -Decimal::from(transfer_amount)));
     assert!(receipt
+        .expect_commit()
         .resource_changes
         .iter()
         .any(|r| r.resource_address == resource_address

--- a/radix-engine/tests/external_bridge.rs
+++ b/radix-engine/tests/external_bridge.rs
@@ -36,7 +36,10 @@ fn test_external_bridges() {
     let receipt1 = test_runner.execute_manifest(manifest1, vec![]);
     receipt1.expect_success();
 
-    let target_component_address = receipt1.new_component_addresses[0];
+    let target_component_address = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Part 3 - Get the caller component address
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -51,7 +54,10 @@ fn test_external_bridges() {
     let receipt2 = test_runner.execute_manifest(manifest2, vec![]);
     receipt2.expect_success();
 
-    let caller_component_address = receipt2.new_component_addresses[0];
+    let caller_component_address = receipt2
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // ACT
     let manifest3 = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -34,7 +34,10 @@ where
             .build(),
         vec![public_key],
     );
-    let component_address = receipt1.new_component_addresses[0];
+    let component_address = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Run the provided manifest
     let manifest = f(component_address);
@@ -196,7 +199,7 @@ fn test_fee_accounting_success() {
     receipt.expect_success();
     let account1_new_balance = query_account_balance(&mut test_runner, account1, RADIX_TOKEN);
     let account2_new_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
-    let summary = receipt.fee_summary;
+    let summary = &receipt.expect_executed().fee_summary;
     assert_eq!(
         account1_new_balance,
         account1_balance
@@ -237,7 +240,7 @@ fn test_fee_accounting_failure() {
     });
     let account1_new_balance = query_account_balance(&mut test_runner, account1, RADIX_TOKEN);
     let account2_new_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
-    let summary = receipt.fee_summary;
+    let summary = &receipt.expect_executed().fee_summary;
     assert_eq!(
         account1_new_balance,
         account1_balance
@@ -288,7 +291,7 @@ fn test_contingent_fee_accounting_success() {
     receipt.expect_success();
     let account1_new_balance = query_account_balance(&mut test_runner, account1, RADIX_TOKEN);
     let account2_new_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
-    let summary = receipt.fee_summary;
+    let summary = &receipt.expect_executed().fee_summary;
     let effective_price =
         summary.cost_unit_price + summary.cost_unit_price * summary.tip_percentage / 100;
     let contingent_fee =
@@ -329,7 +332,7 @@ fn test_contingent_fee_accounting_failure() {
     });
     let account1_new_balance = query_account_balance(&mut test_runner, account1, RADIX_TOKEN);
     let account2_new_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
-    let summary = receipt.fee_summary;
+    let summary = &receipt.expect_executed().fee_summary;
     let effective_price =
         summary.cost_unit_price + summary.cost_unit_price * summary.tip_percentage / 100;
     assert_eq!(

--- a/radix-engine/tests/kv_store.rs
+++ b/radix-engine/tests/kv_store.rs
@@ -107,7 +107,10 @@ fn cannot_remove_key_value_stores() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -141,7 +144,10 @@ fn cannot_overwrite_key_value_stores() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -49,7 +49,7 @@ fn test_loop_out_of_cost_unit() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    assert_invoke_error!(receipt.status, InvokeError::CostingError { .. })
+    expect_invoke_error(&receipt, |err| matches!(err, InvokeError::CostingError(..)));
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn test_recursion_stack_overflow() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    assert_invoke_error!(receipt.status, InvokeError::WasmError { .. })
+    expect_invoke_error(&receipt, |err| matches!(err, InvokeError::WasmError(..)));
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn test_grow_memory_out_of_cost_unit() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    assert_invoke_error!(receipt.status, InvokeError::CostingError { .. })
+    expect_invoke_error(&receipt, |err| matches!(err, InvokeError::CostingError(..)));
 }
 
 #[test]
@@ -183,6 +183,6 @@ fn test_basic_transfer() {
         + 646 /* verify_manifest */
         + 3750 /* verify_signatures */
         + 3000, /* write_substate */
-        receipt.fee_summary.cost_unit_consumed
+        receipt.expect_executed().fee_summary.cost_unit_consumed
     );
 }

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -48,7 +48,10 @@ fn can_burn_non_fungible() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let resource_address = receipt.new_resource_addresses[0];
+    let resource_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_resource_addresses[0];
     let non_fungible_address =
         NonFungibleAddress::new(resource_address, NonFungibleId::from_u32(0));
     let mut ids = BTreeSet::new();

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -30,8 +30,11 @@ fn test_transaction_preview_cost_estimate() {
     receipt.expect_success();
 
     assert_eq!(
-        preview_receipt.fee_summary.cost_unit_consumed,
-        receipt.fee_summary.cost_unit_consumed
+        preview_receipt
+            .expect_executed()
+            .fee_summary
+            .cost_unit_consumed,
+        receipt.expect_executed().fee_summary.cost_unit_consumed
     );
 }
 

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -23,10 +23,8 @@ fn test_transaction_preview_cost_estimate() {
     let preview_receipt = preview_result.unwrap().receipt;
     preview_receipt.expect_success();
 
-    let receipt = test_runner.execute_transaction(
-        &validated_transaction,
-        &ExecutionConfig::with_network(NetworkDefinition::local_simulator()),
-    );
+    let receipt =
+        test_runner.execute_transaction(&validated_transaction, &ExecutionConfig::default());
     receipt.expect_success();
 
     assert_eq!(

--- a/radix-engine/tests/stored_external_component.rs
+++ b/radix-engine/tests/stored_external_component.rs
@@ -35,8 +35,14 @@ fn stored_component_addresses_are_invokable() {
         .build();
     let receipt1 = test_runner.execute_manifest(manifest1, vec![]);
     receipt1.expect_success();
-    let component0 = receipt1.new_component_addresses[0];
-    let component1 = receipt1.new_component_addresses[1];
+    let component0 = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
+    let component1 = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[1];
 
     // Act
     let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/radix-engine/tests/stored_local_component.rs
+++ b/radix-engine/tests/stored_local_component.rs
@@ -21,7 +21,10 @@ fn should_not_be_able_call_owned_components_directly() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[1];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[1];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -97,7 +100,10 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -129,7 +135,10 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -208,7 +217,10 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -240,7 +252,10 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_compon
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_success();
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -23,8 +23,11 @@ fn test_state_track_success() {
 
     // Assert
     receipt.expect_success();
-    assert_eq!(10, receipt.state_updates.down_substates.len());
-    assert_eq!(10, receipt.state_updates.up_substates.len());
+    assert_eq!(
+        10,
+        receipt.expect_commit().state_updates.down_substates.len()
+    );
+    assert_eq!(10, receipt.expect_commit().state_updates.up_substates.len());
 }
 
 #[test]
@@ -51,6 +54,9 @@ fn test_state_track_failure() {
             RuntimeError::ApplicationError(ApplicationError::WorktopError(_))
         )
     });
-    assert_eq!(1, receipt.state_updates.down_substates.len()); // only the vault is down
-    assert_eq!(1, receipt.state_updates.up_substates.len());
+    assert_eq!(
+        1,
+        receipt.expect_commit().state_updates.down_substates.len()
+    ); // only the vault is down
+    assert_eq!(1, receipt.expect_commit().state_updates.up_substates.len());
 }

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -45,7 +45,10 @@ fn non_existent_vault_in_committed_component_should_fail() {
         .call_function(package_address, "NonExistentVault", "new", args!())
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -102,7 +105,10 @@ fn non_existent_vault_in_committed_key_value_store_should_fail() {
         .call_function(package_address, "NonExistentVault", "new", args!())
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -204,7 +210,10 @@ fn cannot_overwrite_vault_in_map() {
         .call_function(package_address, "VaultTest", "new_vault_into_map", args!())
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -261,7 +270,10 @@ fn cannot_remove_vaults() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
@@ -295,7 +307,10 @@ fn can_push_vault_into_vector() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    let component_address = receipt.new_component_addresses[0];
+    let component_address = receipt
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
 
     // Act
     let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -246,7 +246,6 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .execute_and_commit(
                 &transaction,
                 &ExecutionConfig {
-                    network_definition: NetworkDefinition::local_simulator(),
                     cost_unit_price: DEFAULT_COST_UNIT_PRICE.parse().unwrap(),
                     max_call_depth: DEFAULT_MAX_CALL_DEPTH,
                     system_loan: DEFAULT_SYSTEM_LOAN,

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -1,8 +1,9 @@
 use radix_engine::constants::{
     DEFAULT_COST_UNIT_PRICE, DEFAULT_MAX_CALL_DEPTH, DEFAULT_SYSTEM_LOAN,
 };
-use radix_engine::engine::{ExecutionTrace, Kernel, ModuleError, SystemApi};
-use radix_engine::engine::{RuntimeError, Track};
+use radix_engine::engine::{
+    ExecutionTrace, Kernel, KernelError, ModuleError, RuntimeError, SystemApi, Track,
+};
 use radix_engine::fee::{FeeTable, SystemLoanFeeReserve};
 use radix_engine::ledger::*;
 use radix_engine::model::{export_abi, export_abi_by_component, extract_package};
@@ -11,7 +12,7 @@ use radix_engine::transaction::{
     ExecutionConfig, PreviewError, PreviewExecutor, PreviewResult, TransactionExecutor,
     TransactionReceipt,
 };
-use radix_engine::wasm::{DefaultWasmEngine, DefaultWasmInstance, WasmInstrumenter};
+use radix_engine::wasm::{DefaultWasmEngine, DefaultWasmInstance, InvokeError, WasmInstrumenter};
 use sbor::describe::Fields;
 use sbor::Type;
 use scrypto::abi::{BlueprintAbi, Fn};
@@ -123,7 +124,10 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_success();
 
-        receipt.new_component_addresses[0]
+        receipt
+            .expect_commit()
+            .entity_changes
+            .new_component_addresses[0]
     }
 
     pub fn new_account(&mut self) -> (EcdsaPublicKey, EcdsaPrivateKey, ComponentAddress) {
@@ -141,7 +145,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
 
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_success();
-        receipt.new_package_addresses[0]
+        receipt.expect_commit().entity_changes.new_package_addresses[0]
     }
 
     pub fn extract_and_publish_package(&mut self, name: &str) -> PackageAddress {
@@ -324,8 +328,13 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .call_method_with_all_resources(account, "deposit_batch")
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_success();
+
         (
-            receipt.new_resource_addresses[0],
+            receipt
+                .expect_commit()
+                .entity_changes
+                .new_resource_addresses[0],
             mint_auth,
             burn_auth,
             withdraw_auth,
@@ -350,7 +359,14 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .call_method_with_all_resources(account, "deposit_batch")
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
-        (auth_resource_address, receipt.new_resource_addresses[0])
+        receipt.expect_success();
+        (
+            auth_resource_address,
+            receipt
+                .expect_commit()
+                .entity_changes
+                .new_resource_addresses[0],
+        )
     }
 
     pub fn create_restricted_transfer_token(
@@ -371,7 +387,14 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .call_method_with_all_resources(account, "deposit_batch")
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
-        (auth_resource_address, receipt.new_resource_addresses[0])
+        receipt.expect_success();
+        (
+            auth_resource_address,
+            receipt
+                .expect_commit()
+                .entity_changes
+                .new_resource_addresses[0],
+        )
     }
 
     pub fn create_non_fungible_resource(&mut self, account: ComponentAddress) -> ResourceAddress {
@@ -388,7 +411,10 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_success();
-        receipt.new_resource_addresses[0]
+        receipt
+            .expect_commit()
+            .entity_changes
+            .new_resource_addresses[0]
     }
 
     pub fn create_fungible_resource(
@@ -409,7 +435,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .call_method_with_all_resources(account, "deposit_batch")
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
-        receipt.new_resource_addresses[0]
+        receipt.expect_success();
+        receipt
+            .expect_commit()
+            .entity_changes
+            .new_resource_addresses[0]
     }
 
     pub fn instantiate_component(
@@ -435,7 +465,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .call_method_with_all_resources(account, "deposit_batch")
             .build();
         let receipt = self.execute_manifest(manifest, vec![signer_public_key]);
-        receipt.new_component_addresses[0]
+        receipt.expect_success();
+        receipt
+            .expect_commit()
+            .entity_changes
+            .new_component_addresses[0]
     }
 
     pub fn set_current_epoch(&mut self, epoch: u64) {
@@ -517,24 +551,14 @@ pub fn is_auth_error(e: &RuntimeError) -> bool {
     )
 }
 
-#[macro_export]
-macro_rules! assert_invoke_error {
-    ($result:expr, $pattern:pat) => {{
-        let matches = match &$result {
-            radix_engine::transaction::TransactionStatus::Failed(
-                radix_engine::engine::RuntimeError::KernelError(
-                    radix_engine::engine::KernelError::InvokeError(e),
-                ),
-            ) => {
-                matches!(e.as_ref(), $pattern)
-            }
-            _ => false,
-        };
-
-        if !matches {
-            panic!("Expected invoke error but got: {:?}", $result);
-        }
-    }};
+pub fn expect_invoke_error<F>(receipt: &TransactionReceipt, f: F)
+where
+    F: FnOnce(&InvokeError) -> bool,
+{
+    receipt.expect_failure(|e| match e {
+        RuntimeError::KernelError(KernelError::InvokeError(err)) => f(err.as_ref()),
+        _default => false,
+    })
 }
 
 pub fn wat2wasm(wat: &str) -> Vec<u8> {

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -45,7 +45,10 @@ impl NewAccount {
         let bech32_encoder = Bech32Encoder::new(&NetworkDefinition::local_simulator());
 
         if let Some(receipt) = receipt {
-            let account = receipt.new_component_addresses[0];
+            let account = receipt
+                .expect_commit()
+                .entity_changes
+                .new_component_addresses[0];
             writeln!(out, "A new account has been created!").map_err(Error::IOError)?;
             writeln!(
                 out,

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -85,7 +85,9 @@ impl Publish {
                 writeln!(
                     out,
                     "Success! New Package: {}",
-                    receipt.new_package_addresses[0].to_string().green()
+                    receipt.expect_commit().entity_changes.new_package_addresses[0]
+                        .to_string()
+                        .green()
                 )
                 .map_err(Error::IOError)?;
             }

--- a/simulator/src/resim/error.rs
+++ b/simulator/src/resim/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
 
     TransactionExecutionError(RuntimeError),
 
-    TransactionRejected,
+    TransactionRejected(RejectionError),
 
     AbiExportError(RuntimeError),
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -177,7 +177,6 @@ pub fn handle_manifest<O: std::io::Write>(
             let receipt = executor.execute_and_commit(
                 &transaction,
                 &ExecutionConfig {
-                    network_definition: NetworkDefinition::local_simulator(),
                     cost_unit_price: DEFAULT_COST_UNIT_PRICE.parse().unwrap(),
                     max_call_depth: DEFAULT_MAX_CALL_DEPTH,
                     system_loan: DEFAULT_SYSTEM_LOAN,

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -51,8 +51,9 @@ use radix_engine::constants::*;
 use radix_engine::model::*;
 use radix_engine::transaction::ExecutionConfig;
 use radix_engine::transaction::TransactionExecutor;
+use radix_engine::transaction::TransactionOutcome;
 use radix_engine::transaction::TransactionReceipt;
-use radix_engine::transaction::TransactionStatus;
+use radix_engine::transaction::TransactionResult;
 use radix_engine::wasm::*;
 use radix_engine_stores::rocks_db::RadixEngineDB;
 use scrypto::abi;
@@ -189,15 +190,25 @@ pub fn handle_manifest<O: std::io::Write>(
                 writeln!(out, "{:?}", receipt).map_err(Error::IOError)?;
             }
 
-            match receipt.status {
-                TransactionStatus::Failed(error) => Err(Error::TransactionExecutionError(error)),
-                TransactionStatus::Succeeded(_) => {
-                    let mut configs = get_configs()?;
-                    configs.nonce = nonce + 1;
-                    set_configs(&configs)?;
-                    Ok(Some(receipt))
+            if receipt.result.is_success() {
+                let mut configs = get_configs()?;
+                configs.nonce = nonce + 1;
+                set_configs(&configs)?;
+                return Ok(Some(receipt));
+            }
+
+            match receipt.result {
+                TransactionResult::Commit(commit) => match commit.outcome {
+                    TransactionOutcome::Failure(error) => {
+                        Err(Error::TransactionExecutionError(error))
+                    }
+                    TransactionOutcome::Success(..) => {
+                        panic!("Success case handled above to appease borrowing rules")
+                    }
+                },
+                TransactionResult::Reject(rejection) => {
+                    Err(Error::TransactionRejected(rejection.error))
                 }
-                TransactionStatus::Rejected => Err(Error::TransactionRejected),
             }
         }
     }

--- a/transaction/src/model/executable.rs
+++ b/transaction/src/model/executable.rs
@@ -87,9 +87,6 @@ pub trait ExecutableTransaction {
     /// Returns the transaction hash, which must be globally unique.
     fn transaction_hash(&self) -> Hash;
 
-    /// Returns the transaction network id
-    fn transaction_network_id(&self) -> u8;
-
     /// Returns the transaction payload size.
     fn transaction_payload_size(&self) -> u32;
 

--- a/transaction/src/model/preview.rs
+++ b/transaction/src/model/preview.rs
@@ -47,10 +47,6 @@ impl ExecutableTransaction for ValidatedPreviewTransaction {
         self.transaction_hash
     }
 
-    fn transaction_network_id(&self) -> u8 {
-        self.preview_intent.intent.header.network_id
-    }
-
     fn transaction_payload_size(&self) -> u32 {
         // TODO: update the estimation after transaction specs are finalized
 

--- a/transaction/src/model/test_transaction.rs
+++ b/transaction/src/model/test_transaction.rs
@@ -163,10 +163,6 @@ impl ExecutableTransaction for TestTransaction {
         self.transaction.hash()
     }
 
-    fn transaction_network_id(&self) -> u8 {
-        self.transaction.signed_intent.intent.header.network_id
-    }
-
     fn transaction_payload_size(&self) -> u32 {
         self.transaction.to_bytes().len() as u32
     }

--- a/transaction/src/model/validated_transaction.rs
+++ b/transaction/src/model/validated_transaction.rs
@@ -18,10 +18,6 @@ impl ExecutableTransaction for ValidatedTransaction {
         self.transaction_hash
     }
 
-    fn transaction_network_id(&self) -> u8 {
-        self.transaction.signed_intent.intent.header.network_id
-    }
-
     fn transaction_payload_size(&self) -> u32 {
         self.transaction.to_bytes().len() as u32
     }


### PR DESCRIPTION
refactor: Improved Transaction Receipt

* TransactionReceipt is now separated into sub-parts.
* The result can be reject or commit. Commit includes Success and Failure outcomes.

The goal of these changes is two-fold:
* Support early returning from transaction executor on network mismatch (the assert I left in on my last PR, #454 )
* Better abstract the execution receipt to make more things optional, and to align with the commit intention