### PR TITLE
Fix / Network definition neatening

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -18,7 +18,7 @@ fn test_hello() {
     let package_address = test_runner.publish_package(extract_package(compile_package!()).unwrap());
 
     // Test the `instantiate_hello` function.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_function(package_address, "Hello", "instantiate_hello", args!())
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
@@ -27,7 +27,7 @@ fn test_hello() {
     let component = receipt.expect_commit().entity_changes.new_component_addresses[0];
 
     // Test the `free_token` method.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
         .call_method_with_all_resources(account_component, "deposit_batch")
         .build();

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -18,7 +18,7 @@ fn test_hello() {
     let package_address = test_runner.publish_package(extract_package(compile_package!()).unwrap());
 
     // Test the `instantiate_hello` function.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_function(package_address, "Hello", "instantiate_hello", args!())
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
@@ -30,7 +30,7 @@ fn test_hello() {
         .new_component_addresses[0];
 
     // Test the `free_token` method.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
         .call_method_with_all_resources(account_component, "deposit_batch")
         .build();

--- a/examples/no-std/tests/lib.rs
+++ b/examples/no-std/tests/lib.rs
@@ -29,7 +29,7 @@ fn test_say_hello() {
     let public_key = private_key.public_key();
 
     // Publish package
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .publish_package(extract_package(include_package!("no_std").to_vec()).unwrap())
         .build();
@@ -43,7 +43,7 @@ fn test_say_hello() {
         .new_package_addresses[0];
 
     // Test the `say_hello` function.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "NoStd", "say_hello", args!())
         .build();

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -26,7 +26,7 @@ fn bench_transfer(c: &mut Criterion) {
     let public_key = private_key.public_key();
 
     // Create two accounts
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -54,7 +54,7 @@ fn bench_transfer(c: &mut Criterion) {
         .new_component_addresses[0];
 
     // Create a transfer manifest
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(1.into(), RADIX_TOKEN, account1)
         .call_method_with_all_resources(account2, "deposit_batch")

--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -67,7 +67,7 @@ fn bench_transaction_validation(c: &mut Criterion) {
             tip_percentage: 5,
         })
         .manifest(
-            ManifestBuilder::new(NetworkDefinition::local_simulator())
+            ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .withdraw_from_account_by_amount(1u32.into(), RADIX_TOKEN, account1)
                 .call_method_with_all_resources(account2, "deposit_batch")
                 .build(),

--- a/radix-engine/tests/abi.rs
+++ b/radix-engine/tests/abi.rs
@@ -15,7 +15,7 @@ fn test_invalid_access_rule_methods() {
     let package_address = test_runner.extract_and_publish_package("abi");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -50,7 +50,7 @@ fn test_arg(method_name: &str, args: Vec<u8>, expected_result: ExpectedResult) {
     let package_address = test_runner.extract_and_publish_package("abi");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "AbiComponent2", method_name, args)
         .build();

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -16,7 +16,7 @@ fn can_withdraw_from_my_account() {
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
         .call_method_with_all_resources(other_account, "deposit_batch")
@@ -47,7 +47,7 @@ fn can_withdraw_non_fungible_from_my_account() {
     let resource_address = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(resource_address, account)
         .call_method_with_all_resources(other_account, "deposit_batch")
@@ -65,7 +65,7 @@ fn cannot_withdraw_from_other_account() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, account) = test_runner.new_account();
     let (_, _, other_account) = test_runner.new_account();
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, other_account)
         .call_method_with_all_resources(account, "deposit_batch")
@@ -84,7 +84,7 @@ fn account_to_bucket_to_account() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, account) = test_runner.new_account();
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -113,7 +113,7 @@ fn test_account_balance() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, account1) = test_runner.new_account();
     let (_, _, account2) = test_runner.new_account();
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .call_method(account2, "balance", args!(RADIX_TOKEN))
         .build();

--- a/radix-engine/tests/arguments.rs
+++ b/radix-engine/tests/arguments.rs
@@ -14,7 +14,7 @@ fn vector_of_buckets_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
             builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
@@ -41,7 +41,7 @@ fn tuple_of_buckets_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
             builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
@@ -68,7 +68,7 @@ fn treemap_of_strings_and_buckets_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
             builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
@@ -94,7 +94,7 @@ fn hashmap_of_strings_and_buckets_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
             builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
@@ -120,7 +120,7 @@ fn some_optional_bucket_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
             builder.call_function(
@@ -145,7 +145,7 @@ fn none_optional_bucket_argument_should_succeed() {
     let package_address = test_runner.extract_and_publish_package("arguments");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -19,7 +19,7 @@ fn test_auth_rule<'s, S: ReadableSubstateStore + WriteableSubstateStore>(
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account(RADIX_TOKEN, account)
         .call_method_with_all_resources(other_account, "deposit_batch")
@@ -229,7 +229,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -259,7 +259,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -289,7 +289,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
         .take_from_worktop_by_amount(Decimal::from("0.9"), RADIX_TOKEN, |builder, bucket_id| {

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -17,7 +17,7 @@ fn cannot_make_cross_component_call_without_authorization() {
         AccessRules::new().method("get_component_state", rule!(require(auth_address.clone())));
 
     let package_address = test_runner.extract_and_publish_package("component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -33,7 +33,7 @@ fn cannot_make_cross_component_call_without_authorization() {
         .entity_changes
         .new_component_addresses[0];
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -50,7 +50,7 @@ fn cannot_make_cross_component_call_without_authorization() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             my_component,
@@ -77,7 +77,7 @@ fn can_make_cross_component_call_with_authorization() {
         AccessRules::new().method("get_component_state", rule!(require(auth_address.clone())));
 
     let package_address = test_runner.extract_and_publish_package("component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -93,7 +93,7 @@ fn can_make_cross_component_call_with_authorization() {
         .entity_changes
         .new_component_addresses[0];
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -109,7 +109,7 @@ fn can_make_cross_component_call_with_authorization() {
         .entity_changes
         .new_component_addresses[0];
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_ids(&BTreeSet::from([auth_id.clone()]), auth, account)
         .call_method_with_all_resources(my_component, "put_auth")
@@ -118,7 +118,7 @@ fn can_make_cross_component_call_with_authorization() {
     receipt.expect_success();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             my_component,

--- a/radix-engine/tests/authorization_dynamic.rs
+++ b/radix-engine/tests/authorization_dynamic.rs
@@ -29,7 +29,7 @@ fn test_dynamic_auth(
         .collect();
 
     let package = test_runner.extract_and_publish_package("component");
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package,
@@ -46,7 +46,7 @@ fn test_dynamic_auth(
         .new_component_addresses[0];
 
     if let Some(next_auth) = update_auth {
-        let update_manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let update_manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(10.into(), SYSTEM_COMPONENT)
             .call_method(
                 component,
@@ -60,7 +60,7 @@ fn test_dynamic_auth(
     }
 
     // Act
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "get_secret", args!())
         .build();
@@ -98,7 +98,7 @@ fn test_dynamic_authlist(
 
     // Arrange
     let package = test_runner.extract_and_publish_package("component");
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package,
@@ -115,7 +115,7 @@ fn test_dynamic_authlist(
         .new_component_addresses[0];
 
     // Act
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "get_secret", args!())
         .build();
@@ -228,7 +228,7 @@ fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
         NonFungibleId::from_bytes(other_public_key.to_vec()),
     );
     let players = [non_fungible_address, other_non_fungible_address];
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "Chess", "create_game", args!(players))
         .build();
@@ -240,7 +240,7 @@ fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
         .new_component_addresses[0];
 
     // Act
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "make_move", args!())
         .build();
@@ -261,7 +261,7 @@ fn chess_should_allow_second_player_to_move_after_first_player() {
     let non_fungible_address = NonFungibleAddress::from_public_key(&public_key);
     let other_non_fungible_address = NonFungibleAddress::from_public_key(&other_public_key);
     let players = [non_fungible_address, other_non_fungible_address];
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "Chess", "create_game", args!(players))
         .build();
@@ -271,7 +271,7 @@ fn chess_should_allow_second_player_to_move_after_first_player() {
         .expect_commit()
         .entity_changes
         .new_component_addresses[0];
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "make_move", args!())
         .build();
@@ -280,7 +280,7 @@ fn chess_should_allow_second_player_to_move_after_first_player() {
         .expect_success();
 
     // Act
-    let manifest3 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest3 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component, "make_move", args!())
         .build();

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -51,7 +51,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
     };
 
     // Act
-    let mut builder = ManifestBuilder::new(NetworkDefinition::local_simulator());
+    let mut builder = ManifestBuilder::new(&NetworkDefinition::local_simulator());
     builder.lock_fee(10.into(), SYSTEM_COMPONENT);
     builder.create_proof_from_account_by_amount(Decimal::one(), auth_to_use, account);
 

--- a/radix-engine/tests/authorization_vault.rs
+++ b/radix-engine/tests/authorization_vault.rs
@@ -14,7 +14,7 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     let (_, token_resource_address) = test_runner.create_restricted_transfer_token(account);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(Decimal::one(), token_resource_address, account)
         .call_method_with_all_resources(other_account, "deposit_batch")
@@ -36,7 +36,7 @@ fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
         test_runner.create_restricted_transfer_token(account);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_ids(
             &BTreeSet::from([NonFungibleId::from_u32(1)]),

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -14,7 +14,7 @@ fn test_bucket_internal(method_name: &str) {
     let package_address = test_runner.extract_and_publish_package("bucket");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(package_address, "BucketTest", method_name, args!())
         .call_method_with_all_resources(account, "deposit_batch")
@@ -77,7 +77,7 @@ fn test_bucket_of_badges() {
     let (public_key, _, account) = test_runner.new_account();
     let package_address = test_runner.extract_and_publish_package("bucket");
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(package_address, "BadgeTest", "combine", args!())
         .call_function(package_address, "BadgeTest", "split", args!())
@@ -99,7 +99,7 @@ fn test_take_with_invalid_granularity() {
     let package_address = test_runner.extract_and_publish_package("bucket");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function_with_abi(
             package_address,
@@ -139,7 +139,7 @@ fn test_take_with_negative_amount() {
     let package_address = test_runner.extract_and_publish_package("bucket");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function_with_abi(
             package_address,
@@ -177,7 +177,7 @@ fn create_empty_bucket() {
     let (public_key, _, account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .take_from_worktop(scrypto::prelude::RADIX_TOKEN, |builder, _bucket_id| builder)
         .take_from_worktop_by_amount(

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -15,7 +15,7 @@ fn test_component() {
     let package = test_runner.extract_and_publish_package("component");
 
     // Create component
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "ComponentTest", "create_component", args!())
         .build();
@@ -29,7 +29,7 @@ fn test_component() {
         .new_component_addresses[0];
 
     // Call functions & methods
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package,
@@ -53,7 +53,7 @@ fn invalid_blueprint_name_should_cause_error() {
     let package_address = test_runner.extract_and_publish_package("component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -80,7 +80,7 @@ fn reentrancy_should_not_be_possible() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "ReentrantComponent", "new", args!())
         .build();
@@ -92,7 +92,7 @@ fn reentrancy_should_not_be_possible() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "call_self", args!())
         .build();
@@ -124,7 +124,7 @@ fn missing_component_address_in_manifest_should_cause_rejection() {
         .unwrap();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "get_component_state", args!())
         .build();

--- a/radix-engine/tests/core.rs
+++ b/radix-engine/tests/core.rs
@@ -10,7 +10,7 @@ fn test_process_and_transaction() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("core");
 
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "CoreTest", "query", args![])
         .build();
@@ -25,7 +25,7 @@ fn test_call() {
     let (public_key, _, account) = test_runner.new_account();
     let package_address = test_runner.extract_and_publish_package("core");
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "MoveTest", "move_bucket", args![])
         .call_function(package_address, "MoveTest", "move_proof", args![])

--- a/radix-engine/tests/data_access.rs
+++ b/radix-engine/tests/data_access.rs
@@ -13,7 +13,7 @@ fn should_not_be_able_to_read_component_state_after_creation() {
     let package_address = test_runner.extract_and_publish_package("data_access");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -41,7 +41,7 @@ fn should_not_be_able_to_write_component_state_after_creation() {
     let package_address = test_runner.extract_and_publish_package("data_access");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -69,7 +69,7 @@ fn should_be_able_to_read_component_info() {
     let package_address = test_runner.extract_and_publish_package("data_access");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -92,7 +92,7 @@ fn should_not_be_able_to_write_component_info() {
     let package_address = test_runner.extract_and_publish_package("data_access");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/execution_trace.rs
+++ b/radix-engine/tests/execution_trace.rs
@@ -14,7 +14,7 @@ fn test_trace_resource_transfers() {
     let transfer_amount = 10u8;
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(
             package_address,

--- a/radix-engine/tests/external_bridge.rs
+++ b/radix-engine/tests/external_bridge.rs
@@ -24,7 +24,7 @@ fn test_external_bridges() {
         test_runner.extract_and_publish_package("external_blueprint_caller");
 
     // Part 2 - Get a target component address
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             target_package_address,
@@ -42,7 +42,7 @@ fn test_external_bridges() {
         .new_component_addresses[0];
 
     // Part 3 - Get the caller component address
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             caller_package_address,
@@ -60,7 +60,7 @@ fn test_external_bridges() {
         .new_component_addresses[0];
 
     // ACT
-    let manifest3 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest3 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             caller_component_address,
@@ -74,7 +74,7 @@ fn test_external_bridges() {
     receipt3.expect_success();
 
     // ACT
-    let manifest4 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest4 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             caller_component_address,

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -24,7 +24,7 @@ where
     // Publish package and instantiate component
     let package_address = test_runner.extract_and_publish_package("fee");
     let receipt1 = test_runner.execute_manifest(
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(10.into(), account)
             .withdraw_from_account_by_amount(1000.into(), RADIX_TOKEN, account)
             .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -47,7 +47,7 @@ where
 #[test]
 fn should_succeed_when_fee_is_paid() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(component_address, "lock_fee", args!(Decimal::from(10)))
             .build()
     });
@@ -58,7 +58,7 @@ fn should_succeed_when_fee_is_paid() {
 #[test]
 fn should_be_rejected_when_no_fee_is_paid() {
     let receipt =
-        run_manifest(|_| ManifestBuilder::new(NetworkDefinition::local_simulator()).build());
+        run_manifest(|_| ManifestBuilder::new(&NetworkDefinition::local_simulator()).build());
 
     receipt.expect_rejection();
 }
@@ -66,7 +66,7 @@ fn should_be_rejected_when_no_fee_is_paid() {
 #[test]
 fn should_be_rejected_when_insufficient_balance() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "lock_fee_with_empty_vault",
@@ -81,7 +81,7 @@ fn should_be_rejected_when_insufficient_balance() {
 #[test]
 fn should_be_rejected_when_non_xrd() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "lock_fee_with_doge",
@@ -96,7 +96,7 @@ fn should_be_rejected_when_non_xrd() {
 #[test]
 fn should_be_rejected_when_system_loan_is_not_fully_repaid() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "lock_fee",
@@ -111,7 +111,7 @@ fn should_be_rejected_when_system_loan_is_not_fully_repaid() {
 #[test]
 fn should_be_rejected_when_lock_fee_with_temp_vault() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "lock_fee_with_temp_vault",
@@ -126,7 +126,7 @@ fn should_be_rejected_when_lock_fee_with_temp_vault() {
 #[test]
 fn should_be_rejected_when_query_vault_and_lock_fee() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "query_vault_and_lock_fee",
@@ -141,7 +141,7 @@ fn should_be_rejected_when_query_vault_and_lock_fee() {
 #[test]
 fn should_succeed_when_lock_fee_and_query_vault() {
     let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new(NetworkDefinition::local_simulator())
+        ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .call_method(
                 component_address,
                 "lock_fee_and_query_vault",
@@ -188,7 +188,7 @@ fn test_fee_accounting_success() {
     let account2_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
         .call_method_with_all_resources(account2, "deposit_batch")
@@ -221,7 +221,7 @@ fn test_fee_accounting_failure() {
     let account2_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
         .call_method_with_all_resources(account2, "deposit_batch")
@@ -259,7 +259,7 @@ fn test_fee_accounting_rejection() {
     let account1_balance = query_account_balance(&mut test_runner, account1, RADIX_TOKEN);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(Decimal::from_str("0.000000000000000001").unwrap(), account1)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -281,7 +281,7 @@ fn test_contingent_fee_accounting_success() {
     let account2_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(dec!("10"), account1)
         .lock_contingent_fee(dec!("0.001"), account2)
         .build();
@@ -314,7 +314,7 @@ fn test_contingent_fee_accounting_failure() {
     let account2_balance = query_account_balance(&mut test_runner, account2, RADIX_TOKEN);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(dec!("10"), account1)
         .lock_contingent_fee(dec!("0.001"), account2)
         .assert_worktop_contains_by_amount(1.into(), RADIX_TOKEN)

--- a/radix-engine/tests/frame.rs
+++ b/radix-engine/tests/frame.rs
@@ -18,7 +18,7 @@ fn test_max_call_depth_success() {
     // * 1: Transaction Executor
     // * 2-16: Caller::call x 15
     // ============================
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Caller", "recursive", args!(15u32))
         .build();
@@ -36,7 +36,7 @@ fn test_max_call_depth_failure() {
     let package_address = test_runner.extract_and_publish_package("recursion");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Caller", "recursive", args!(16u32))
         .build();

--- a/radix-engine/tests/invalid_stored_values.rs
+++ b/radix-engine/tests/invalid_stored_values.rs
@@ -12,7 +12,7 @@ fn stored_bucket_in_committed_component_should_fail() {
     let package_address = test_runner.extract_and_publish_package("stored_values");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -36,7 +36,7 @@ fn stored_bucket_in_owned_component_should_fail() {
     let package_address = test_runner.extract_and_publish_package("stored_values");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/kernel_globalize.rs
+++ b/radix-engine/tests/kernel_globalize.rs
@@ -14,7 +14,7 @@ fn should_not_be_able_to_globalize_key_value_store() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Globalize", "globalize_kv_store", args!())
         .build();
@@ -39,7 +39,7 @@ fn should_not_be_able_to_globalize_bucket() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Globalize", "globalize_bucket", args!())
         .build();
@@ -64,7 +64,7 @@ fn should_not_be_able_to_globalize_proof() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Globalize", "globalize_proof", args!())
         .build();
@@ -89,7 +89,7 @@ fn should_not_be_able_to_globalize_vault() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Globalize", "globalize_vault", args!())
         .build();

--- a/radix-engine/tests/kernel_node_create.rs
+++ b/radix-engine/tests/kernel_node_create.rs
@@ -13,7 +13,7 @@ fn should_not_be_able_to_node_create_with_invalid_blueprint() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -41,7 +41,7 @@ fn should_not_be_able_to_node_create_with_invalid_package() {
     let package_address = test_runner.extract_and_publish_package("kernel");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/kv_store.rs
+++ b/radix-engine/tests/kv_store.rs
@@ -12,7 +12,7 @@ fn can_insert_in_child_nodes() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "SuperKeyValueStore", "new", args!())
         .build();
@@ -30,7 +30,7 @@ fn create_mutable_key_value_store_into_map_and_referencing_before_storing() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -53,7 +53,7 @@ fn cyclic_map_fails_execution() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "CyclicMap", "new", args!())
         .build();
@@ -76,7 +76,7 @@ fn self_cyclic_map_fails_execution() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "CyclicMap", "new_self_cyclic", args!())
         .build();
@@ -97,7 +97,7 @@ fn cannot_remove_key_value_stores() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("kv_store");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -113,7 +113,7 @@ fn cannot_remove_key_value_stores() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "clear_vector", args!())
         .build();
@@ -134,7 +134,7 @@ fn cannot_overwrite_key_value_stores() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("kv_store");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -150,7 +150,7 @@ fn cannot_overwrite_key_value_stores() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "overwrite_key_value_store", args!())
         .build();
@@ -173,7 +173,7 @@ fn create_key_value_store_and_get() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -196,7 +196,7 @@ fn create_key_value_store_and_put() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -219,7 +219,7 @@ fn can_reference_in_memory_vault() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -242,7 +242,7 @@ fn can_reference_deep_in_memory_value() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -265,7 +265,7 @@ fn can_reference_deep_in_memory_vault() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -288,7 +288,7 @@ fn cannot_directly_reference_inserted_vault() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -316,7 +316,7 @@ fn cannot_directly_reference_vault_after_container_moved() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -344,7 +344,7 @@ fn cannot_directly_reference_vault_after_container_stored() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -372,7 +372,7 @@ fn multiple_reads_should_work() {
     let package_address = test_runner.extract_and_publish_package("kv_store");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "MultipleReads", "multiple_reads", args!())
         .build();

--- a/radix-engine/tests/leaks.rs
+++ b/radix-engine/tests/leaks.rs
@@ -13,7 +13,7 @@ fn dangling_component_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Leaks", "dangling_component", args!())
         .build();
@@ -36,7 +36,7 @@ fn dangling_bucket_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Leaks", "dangling_bucket", args!())
         .build();
@@ -59,7 +59,7 @@ fn dangling_vault_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Leaks", "dangling_vault", args!())
         .build();
@@ -82,7 +82,7 @@ fn dangling_worktop_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Leaks", "get_bucket", args!())
         .build();
@@ -105,7 +105,7 @@ fn dangling_kv_store_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Leaks", "dangling_kv_store", args!())
         .build();
@@ -128,7 +128,7 @@ fn dangling_bucket_with_proof_should_fail() {
     let package_address = test_runner.extract_and_publish_package("leaks");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -13,7 +13,7 @@ fn local_component_should_return_correct_info() {
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -36,7 +36,7 @@ fn local_component_should_be_callable_read_only() {
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Secret", "read_local_component", args!())
         .build();
@@ -54,7 +54,7 @@ fn local_component_should_be_callable_with_write() {
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Secret", "write_local_component", args!())
         .build();
@@ -76,7 +76,7 @@ fn local_component_with_access_rules_should_not_be_callable() {
     let auth_address = NonFungibleAddress::new(auth_resource_address, auth_id);
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -108,7 +108,7 @@ fn local_component_with_access_rules_should_be_callable() {
     let auth_address = NonFungibleAddress::new(auth_resource_address, auth_id.clone());
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             account,
@@ -138,7 +138,7 @@ fn recursion_bomb() {
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(Decimal::from(10), RADIX_TOKEN, account)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -166,7 +166,7 @@ fn recursion_bomb_to_failure() {
     let package_address = test_runner.extract_and_publish_package("local_recursion");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(Decimal::from(100), RADIX_TOKEN, account)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -200,7 +200,7 @@ fn recursion_bomb_2() {
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(Decimal::from(10), RADIX_TOKEN, account)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -228,7 +228,7 @@ fn recursion_bomb_2_to_failure() {
     let package_address = test_runner.extract_and_publish_package("local_recursion");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(Decimal::from(100), RADIX_TOKEN, account)
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {

--- a/radix-engine/tests/math.rs
+++ b/radix-engine/tests/math.rs
@@ -13,7 +13,7 @@ fn test_integer_basic_ops() {
     let package_address = test_runner.extract_and_publish_package("math-ops-check");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -40,7 +40,7 @@ fn test_native_and_safe_integer_interop() {
     let package_address = test_runner.extract_and_publish_package("math-ops-check");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -19,7 +19,7 @@ fn test_loop() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -42,7 +42,7 @@ fn test_loop_out_of_cost_unit() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(45.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -66,7 +66,7 @@ fn test_recursion() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -89,7 +89,7 @@ fn test_recursion_stack_overflow() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -112,7 +112,7 @@ fn test_grow_memory() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -135,7 +135,7 @@ fn test_grow_memory_out_of_cost_unit() {
         blueprints: abi_single_fn_any_input_void_output("Test", "f"),
     };
     let package_address = test_runner.publish_package(package);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "Test", "f", args!())
         .build();
@@ -154,7 +154,7 @@ fn test_basic_transfer() {
     let (_, _, account2) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(100.into(), RADIX_TOKEN, account1)
         .call_method_with_all_resources(account2, "deposit_batch")

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -13,7 +13,7 @@ fn create_non_fungible_mutable() {
     let package = test_runner.extract_and_publish_package("non_fungible");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package,
@@ -36,7 +36,7 @@ fn can_burn_non_fungible() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, account) = test_runner.new_account();
     let package = test_runner.extract_and_publish_package("non_fungible");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package,
@@ -58,7 +58,7 @@ fn can_burn_non_fungible() {
     ids.insert(NonFungibleId::from_u32(0));
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account(resource_address, account)
         .burn_non_fungible(non_fungible_address.clone())
@@ -83,7 +83,7 @@ fn test_non_fungible() {
     let (public_key, _, account) = test_runner.new_account();
     let package_address = test_runner.extract_and_publish_package("non_fungible");
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -140,7 +140,7 @@ fn test_singleton_non_fungible() {
     let (public_key, _, account) = test_runner.new_account();
     let package_address = test_runner.extract_and_publish_package("non_fungible");
 
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -15,7 +15,7 @@ fn test_publish_package_from_scrypto() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let package = test_runner.extract_and_publish_package("package");
 
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "PackageTest", "publish", args!())
         .build();
@@ -43,7 +43,7 @@ fn missing_memory_should_cause_error() {
         code,
         blueprints: HashMap::new(),
     };
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .publish_package(package)
         .build();
@@ -70,7 +70,7 @@ fn large_return_len_should_cause_memory_access_error() {
     let package = test_runner.extract_and_publish_package("package");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "LargeReturnSize", "f", args!())
         .build();
@@ -94,7 +94,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
     let package = test_runner.extract_and_publish_package("package");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "MaxReturnSize", "f", args!())
         .build();
@@ -118,7 +118,7 @@ fn zero_return_len_should_cause_data_validation_error() {
     let package = test_runner.extract_and_publish_package("package");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "ZeroReturnSize", "f", args!())
         .build();
@@ -141,7 +141,7 @@ fn test_basic_package() {
         code,
         blueprints: HashMap::new(),
     };
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .publish_package(package)
         .build();
@@ -174,7 +174,7 @@ fn test_basic_package_missing_export() {
     // Act
     let code = wat2wasm(include_str!("wasm/basic_package.wat"));
     let package = Package { code, blueprints };
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .publish_package(package)
         .build();

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -55,7 +55,7 @@ fn prepare_test_tx_and_preview_intent(
             tip_percentage: 0,
         })
         .manifest(
-            ManifestBuilder::new(NetworkDefinition::local_simulator())
+            ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .lock_fee(10.into(), SYSTEM_COMPONENT)
                 .clear_auth_zone()
                 .build(),

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -15,7 +15,7 @@ fn can_create_clone_and_drop_bucket_proof() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -53,7 +53,7 @@ fn can_create_clone_and_drop_vault_proof() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             component_address,
@@ -87,7 +87,7 @@ fn can_create_clone_and_drop_vault_proof_by_amount() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method_with_abi(
             component_address,
@@ -129,7 +129,7 @@ fn can_create_clone_and_drop_vault_proof_by_ids() {
         NonFungibleId::from_u32(3),
     ]);
     let proof_ids = BTreeSet::from([NonFungibleId::from_u32(2)]);
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             component_address,
@@ -154,7 +154,7 @@ fn can_use_bucket_for_authorization() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -195,7 +195,7 @@ fn can_use_vault_for_authorization() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method_with_abi(
             component_address,
@@ -223,7 +223,7 @@ fn can_create_proof_from_account_and_pass_on() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -252,7 +252,7 @@ fn cant_move_restricted_proof() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -286,7 +286,7 @@ fn cant_move_locked_bucket() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function_with_abi(
             package_address,
@@ -328,7 +328,7 @@ fn can_compose_bucket_and_vault_proof() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(99.into(), resource_address, account)
         .take_from_worktop_by_amount(99.into(), resource_address, |builder, bucket_id| {
@@ -364,7 +364,7 @@ fn can_compose_bucket_and_vault_proof_by_amount() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_amount(99.into(), resource_address, account)
         .take_from_worktop_by_amount(99.into(), resource_address, |builder, bucket_id| {
@@ -399,7 +399,7 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account_by_ids(
             &BTreeSet::from([NonFungibleId::from_u32(2), NonFungibleId::from_u32(3)]),
@@ -445,7 +445,7 @@ fn can_create_vault_proof_by_amount_from_non_fungibles() {
     );
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             component_address,
@@ -469,7 +469,7 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
     let package_address = test_runner.extract_and_publish_package("proof");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .create_proof_from_account_by_ids(
             &BTreeSet::from([NonFungibleId::from_u32(1), NonFungibleId::from_u32(2)]),

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -15,7 +15,7 @@ fn test_resource_manager() {
     let package_address = test_runner.extract_and_publish_package("resource");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "ResourceTest", "create_fungible", args!())
         .call_function(package_address, "ResourceTest", "query", args!())
@@ -43,7 +43,7 @@ fn mint_with_bad_granularity_should_fail() {
     let package_address = test_runner.extract_and_publish_package("resource");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -77,7 +77,7 @@ fn mint_too_much_should_fail() {
     let package_address = test_runner.extract_and_publish_package("resource");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/stored_external_component.rs
+++ b/radix-engine/tests/stored_external_component.rs
@@ -13,7 +13,7 @@ fn stored_component_addresses_in_non_globalized_component_are_invokable() {
     let package = test_runner.extract_and_publish_package("stored_external_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "ExternalComponent", "create_and_call", args!())
         .build();
@@ -29,7 +29,7 @@ fn stored_component_addresses_are_invokable() {
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, _) = test_runner.new_account();
     let package = test_runner.extract_and_publish_package("stored_external_component");
-    let manifest1 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest1 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package, "ExternalComponent", "create", args!())
         .build();
@@ -45,7 +45,7 @@ fn stored_component_addresses_are_invokable() {
         .new_component_addresses[1];
 
     // Act
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component0, "func", args!())
         .build();
@@ -55,7 +55,7 @@ fn stored_component_addresses_are_invokable() {
     receipt2.expect_success();
 
     // Act
-    let manifest2 = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest2 = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component1, "func", args!())
         .build();

--- a/radix-engine/tests/stored_local_component.rs
+++ b/radix-engine/tests/stored_local_component.rs
@@ -10,7 +10,7 @@ fn should_not_be_able_call_owned_components_directly() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("local_component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -27,7 +27,7 @@ fn should_not_be_able_call_owned_components_directly() {
         .new_component_addresses[1];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "get_secret", args!())
         .build();
@@ -45,7 +45,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component()
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -68,7 +68,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component(
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -89,7 +89,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("local_component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -106,7 +106,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "parent_get_secret", args!())
         .build();
@@ -124,7 +124,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("local_component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -141,7 +141,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "parent_set_secret", args!(8888u32))
         .call_method(component_address, "parent_get_secret", args!())
@@ -162,7 +162,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_componen
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -185,7 +185,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_compone
     let package_address = test_runner.extract_and_publish_package("local_component");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -206,7 +206,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("local_component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -223,7 +223,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "parent_get_secret", args!())
         .build();
@@ -241,7 +241,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_compon
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("local_component");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -258,7 +258,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_compon
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "parent_set_secret", args!(8888u32))
         .call_method(component_address, "parent_get_secret", args!())

--- a/radix-engine/tests/system.rs
+++ b/radix-engine/tests/system.rs
@@ -13,7 +13,7 @@ fn test_get_epoch() {
     let package_address = test_runner.extract_and_publish_package("system");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "SystemTest", "get_epoch", args![])
         .build();
@@ -34,7 +34,7 @@ fn test_set_epoch_without_system_auth_fails() {
 
     // Act
     let epoch = 9876u64;
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "SystemTest", "set_epoch", args!(epoch))
         .call_function(package_address, "SystemTest", "get_epoch", args!())

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -6,7 +6,7 @@ use transaction::builder::ManifestBuilder;
 use transaction::model::*;
 
 fn self_transfer_txn(account: ComponentAddress, amount: Decimal) -> TransactionManifest {
-    ManifestBuilder::new(NetworkDefinition::local_simulator())
+    ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(amount, RADIX_TOKEN, account)
         .call_method_with_all_resources(account, "deposit_batch")

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -54,7 +54,7 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
     let (public_key, _, account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(dec!("10"), account)
         .create_proof_from_account(RADIX_TOKEN, account)
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
@@ -85,7 +85,7 @@ fn test_transaction_can_end_with_proofs_remaining_in_auth_zone() {
     let (public_key, _, account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(dec!("10"), account)
         .create_proof_from_account_by_amount(dec!("1"), RADIX_TOKEN, account)
         .create_proof_from_account_by_amount(dec!("1"), RADIX_TOKEN, account)
@@ -118,7 +118,7 @@ fn create_transaction() -> Vec<u8> {
             tip_percentage: 5,
         })
         .manifest(
-            ManifestBuilder::new(NetworkDefinition::local_simulator())
+            ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .lock_fee(10.into(), SYSTEM_COMPONENT)
                 .clear_auth_zone()
                 .build(),

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -14,7 +14,7 @@ fn test_state_track_success() {
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
         .call_method_with_all_resources(other_account, "deposit_batch")
@@ -39,7 +39,7 @@ fn test_state_track_failure() {
     let (_, _, other_account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
         .call_method_with_all_resources(other_account, "deposit_batch")

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -14,7 +14,7 @@ fn non_existent_vault_in_component_creation_should_fail() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -40,7 +40,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("vault");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "NonExistentVault", "new", args!())
         .build();
@@ -51,7 +51,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "create_non_existent_vault", args!())
         .build();
@@ -74,7 +74,7 @@ fn non_existent_vault_in_key_value_store_creation_should_fail() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -100,7 +100,7 @@ fn non_existent_vault_in_committed_key_value_store_should_fail() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("vault");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "NonExistentVault", "new", args!())
         .build();
@@ -111,7 +111,7 @@ fn non_existent_vault_in_committed_key_value_store_should_fail() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(
             component_address,
@@ -138,7 +138,7 @@ fn create_mutable_vault_into_map() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "VaultTest", "new_vault_into_map", args!())
         .build();
@@ -156,7 +156,7 @@ fn invalid_double_ownership_of_vault() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -184,7 +184,7 @@ fn create_mutable_vault_into_map_and_referencing_before_storing() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -205,7 +205,7 @@ fn cannot_overwrite_vault_in_map() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("vault");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "VaultTest", "new_vault_into_map", args!())
         .build();
@@ -216,7 +216,7 @@ fn cannot_overwrite_vault_in_map() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "overwrite_vault_in_map", args!())
         .build();
@@ -239,7 +239,7 @@ fn create_mutable_vault_into_vector() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -260,7 +260,7 @@ fn cannot_remove_vaults() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("vault");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -276,7 +276,7 @@ fn cannot_remove_vaults() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "clear_vector", args!())
         .build();
@@ -297,7 +297,7 @@ fn can_push_vault_into_vector() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let package_address = test_runner.extract_and_publish_package("vault");
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -313,7 +313,7 @@ fn can_push_vault_into_vector() {
         .new_component_addresses[0];
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_method(component_address, "push_vault_into_vector", args!())
         .build();
@@ -331,7 +331,7 @@ fn create_mutable_vault_with_take() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(package_address, "VaultTest", "new_vault_with_take", args!())
         .build();
@@ -349,7 +349,7 @@ fn create_mutable_vault_with_take_non_fungible() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -372,7 +372,7 @@ fn create_mutable_vault_with_get_nonfungible_ids() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -395,7 +395,7 @@ fn create_mutable_vault_with_get_nonfungible_id() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -418,7 +418,7 @@ fn create_mutable_vault_with_get_amount() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,
@@ -441,7 +441,7 @@ fn create_mutable_vault_with_get_resource_manager() {
     let package_address = test_runner.extract_and_publish_package("vault");
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .call_function(
             package_address,

--- a/radix-engine/tests/worktop.rs
+++ b/radix-engine/tests/worktop.rs
@@ -15,7 +15,7 @@ fn test_worktop_resource_leak() {
     let (public_key, _, account) = test_runner.new_account();
 
     // Act
-    let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYSTEM_COMPONENT)
         .withdraw_from_account(RADIX_TOKEN, account)
         .build();

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -113,7 +113,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     }
 
     pub fn new_account_with_auth_rule(&mut self, withdraw_auth: &AccessRule) -> ComponentAddress {
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
             .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
@@ -138,7 +138,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     }
 
     pub fn publish_package(&mut self, package: Package) -> PackageAddress {
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .publish_package(package)
             .build();
@@ -290,7 +290,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         signer_public_key: EcdsaPublicKey,
     ) {
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .create_proof_from_account(auth, account)
             .call_function(package, "ResourceCreator", function, args!(token, set_auth))
@@ -316,7 +316,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         let admin_auth = self.create_non_fungible_resource(account);
 
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function(
                 package,
@@ -347,7 +347,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     ) -> (ResourceAddress, ResourceAddress) {
         let auth_resource_address = self.create_non_fungible_resource(account);
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function(
                 package,
@@ -375,7 +375,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         let auth_resource_address = self.create_non_fungible_resource(account);
 
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function(
                 package,
@@ -398,7 +398,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
 
     pub fn create_non_fungible_resource(&mut self, account: ComponentAddress) -> ResourceAddress {
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function(
                 package,
@@ -423,7 +423,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         account: ComponentAddress,
     ) -> ResourceAddress {
         let package = self.extract_and_publish_package("resource_creator");
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function(
                 package,
@@ -450,7 +450,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
         account: ComponentAddress,
         signer_public_key: EcdsaPublicKey,
     ) -> ComponentAddress {
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_function_with_abi(
                 package_address,

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -41,7 +41,7 @@ impl CallFunction {
         let default_account = get_default_account()?;
         let proofs = self.proofs.clone().unwrap_or_default();
 
-        let mut manifest_builder = &mut ManifestBuilder::new(NetworkDefinition::local_simulator());
+        let mut manifest_builder = &mut ManifestBuilder::new(&NetworkDefinition::local_simulator());
         for resource_specifier in proofs {
             manifest_builder = manifest_builder
                 .create_proof_from_account_by_resource_specifier(

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -40,7 +40,7 @@ impl CallMethod {
         let default_account = get_default_account()?;
         let proofs = self.proofs.clone().unwrap_or_default();
 
-        let mut manifest_builder = &mut ManifestBuilder::new(NetworkDefinition::local_simulator());
+        let mut manifest_builder = &mut ManifestBuilder::new(&NetworkDefinition::local_simulator());
         for resource_specifier in proofs {
             manifest_builder = manifest_builder
                 .create_proof_from_account_by_resource_specifier(

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -35,7 +35,7 @@ impl Mint {
         let default_account = get_default_account()?;
         let proofs = self.proofs.clone().unwrap_or_default();
 
-        let mut manifest_builder = &mut ManifestBuilder::new(NetworkDefinition::local_simulator());
+        let mut manifest_builder = &mut ManifestBuilder::new(&NetworkDefinition::local_simulator());
         for resource_specifier in proofs {
             manifest_builder = manifest_builder
                 .create_proof_from_account_by_resource_specifier(

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -24,7 +24,7 @@ impl NewAccount {
         let public_key = private_key.public_key();
         let auth_address = NonFungibleAddress::from_public_key(&public_key);
         let withdraw_auth = rule!(require(auth_address));
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .call_method(SYSTEM_COMPONENT, "free_xrd", args!())
             .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -63,7 +63,7 @@ impl NewBadgeFixed {
             metadata.insert("icon_url".to_string(), icon_url);
         };
 
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .new_badge_fixed(metadata, self.total_supply)
             .call_method_with_all_resources(default_account, "deposit_batch")

--- a/simulator/src/resim/cmd_new_badge_mutable.rs
+++ b/simulator/src/resim/cmd_new_badge_mutable.rs
@@ -62,7 +62,7 @@ impl NewBadgeMutable {
             metadata.insert("icon_url".to_string(), icon_url);
         };
 
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .new_badge_mutable(metadata, self.minter_resource_address)
             .build();

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -63,7 +63,7 @@ impl NewTokenFixed {
             metadata.insert("icon_url".to_string(), icon_url);
         };
 
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .new_token_fixed(metadata, self.total_supply)
             .call_method_with_all_resources(default_account, "deposit_batch")

--- a/simulator/src/resim/cmd_new_token_mutable.rs
+++ b/simulator/src/resim/cmd_new_token_mutable.rs
@@ -62,7 +62,7 @@ impl NewTokenMutable {
             metadata.insert("icon_url".to_string(), icon_url);
         };
 
-        let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+        let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYSTEM_COMPONENT)
             .new_token_mutable(metadata, self.minter_resource_address)
             .build();

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -67,7 +67,7 @@ impl Publish {
             substate_store.put_substate(SubstateId::Package(package_address), output_value);
             writeln!(out, "Package updated!").map_err(Error::IOError)?;
         } else {
-            let manifest = ManifestBuilder::new(NetworkDefinition::local_simulator())
+            let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .lock_fee(100.into(), SYSTEM_COMPONENT)
                 .publish_package(package)
                 .build();

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -38,7 +38,7 @@ impl Transfer {
         let default_account = get_default_account()?;
         let proofs = self.proofs.clone().unwrap_or_default();
 
-        let mut manifest_builder = &mut ManifestBuilder::new(NetworkDefinition::local_simulator());
+        let mut manifest_builder = &mut ManifestBuilder::new(&NetworkDefinition::local_simulator());
         for resource_specifier in proofs {
             manifest_builder = manifest_builder
                 .create_proof_from_account_by_resource_specifier(

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -42,9 +42,9 @@ pub struct ManifestBuilder {
 
 impl ManifestBuilder {
     /// Starts a new transaction builder.
-    pub fn new(network: NetworkDefinition) -> Self {
+    pub fn new(network: &NetworkDefinition) -> Self {
         Self {
-            decoder: Bech32Decoder::new(&network),
+            decoder: Bech32Decoder::new(network),
             id_validator: IdValidator::new(),
             instructions: Vec::new(),
         }

--- a/transaction/src/builder/transaction_builder.rs
+++ b/transaction/src/builder/transaction_builder.rs
@@ -102,7 +102,7 @@ mod tests {
                 tip_percentage: 5,
             })
             .manifest(
-                ManifestBuilder::new(NetworkDefinition::local_simulator())
+                ManifestBuilder::new(&NetworkDefinition::local_simulator())
                     .clear_auth_zone()
                     .build(),
             )

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -520,7 +520,7 @@ mod tests {
                 tip_percentage: 5,
             })
             .manifest(
-                ManifestBuilder::new(NetworkDefinition::local_simulator())
+                ManifestBuilder::new(&NetworkDefinition::local_simulator())
                     .clear_auth_zone()
                     .build(),
             );


### PR DESCRIPTION
I realised there was something weird on the last PR - ManifestBuilder should have taken a &NetworkDefinition instead of NetworkDefinition.

This is now fixed - this is the only change.