### PR TITLE
Update format.sh to use global scrypto CLI

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -18,7 +18,10 @@ cd "$(dirname "$0")"
 (cd simulator; cargo fmt)
 (cd transaction; cargo fmt)
 
-scrypto="cargo run --manifest-path $PWD/simulator/Cargo.toml --bin scrypto $@ --"
+# We use a globally loaded scrypto CLI so that this script works even if the code doesn't compile at present
+# It's also a little faster. If you wish to use the local version instead, swap out the below line.
+# scrypto="cargo run --manifest-path $PWD/simulator/Cargo.toml --bin scrypto $@ --"
+scrypto="scrypto"
 
 (cd assets/account; $scrypto fmt)
 (cd assets/system; $scrypto fmt)


### PR DESCRIPTION
The ./format.sh script now works again even if the code doesn't compile