### PR TITLE
Support expression in transaction processor

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -29,7 +29,7 @@ fn test_hello() {
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
-        .call_method(account_component, "deposit_batch", args!(Expression::new("ALL_WORKTOP_RESOURCES")))
+        .call_method(account_component, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);

--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -29,7 +29,7 @@ fn test_hello() {
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
-        .call_method_with_all_resources(account_component, "deposit_batch")
+        .call_method(account_component, "deposit_batch", args!(Expression::new("ALL_WORKTOP_RESOURCES")))
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);

--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -29,7 +29,7 @@ fn test_hello() {
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
-        .call_method(account_component, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(account_component, "deposit_batch", args!(Expression::new("ENTIRE_WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -32,7 +32,11 @@ fn test_hello() {
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .call_method(component, "free_token", args!())
-        .call_method_with_all_resources(account_component, "deposit_batch")
+        .call_method(
+            account_component,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);
     println!("{:?}\n", receipt);

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -35,7 +35,7 @@ fn test_hello() {
         .call_method(
             account_component,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -35,7 +35,7 @@ fn test_hello() {
         .call_method(
             account_component,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![public_key]);

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -57,11 +57,7 @@ fn bench_transfer(c: &mut Criterion) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(1.into(), RADIX_TOKEN, account1)
-        .call_method(
-            account2,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
 
     // Loop

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -57,7 +57,11 @@ fn bench_transfer(c: &mut Criterion) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(1.into(), RADIX_TOKEN, account1)
-        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
 
     // Loop

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -57,7 +57,11 @@ fn bench_transfer(c: &mut Criterion) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(1.into(), RADIX_TOKEN, account1)
-        .call_method_with_all_resources(account2, "deposit_batch")
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
 
     // Loop

--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -69,7 +69,11 @@ fn bench_transaction_validation(c: &mut Criterion) {
         .manifest(
             ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .withdraw_from_account_by_amount(1u32.into(), RADIX_TOKEN, account1)
-                .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
+                .call_method(
+                    account2,
+                    "deposit_batch",
+                    args!(Expression::new("ENTIRE_WORKTOP")),
+                )
                 .build(),
         )
         .notarize(&signer)

--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -69,11 +69,7 @@ fn bench_transaction_validation(c: &mut Criterion) {
         .manifest(
             ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .withdraw_from_account_by_amount(1u32.into(), RADIX_TOKEN, account1)
-                .call_method(
-                    account2,
-                    "deposit_batch",
-                    args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-                )
+                .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
                 .build(),
         )
         .notarize(&signer)

--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -69,7 +69,11 @@ fn bench_transaction_validation(c: &mut Criterion) {
         .manifest(
             ManifestBuilder::new(&NetworkDefinition::local_simulator())
                 .withdraw_from_account_by_amount(1u32.into(), RADIX_TOKEN, account1)
-                .call_method_with_all_resources(account2, "deposit_batch")
+                .call_method(
+                    account2,
+                    "deposit_batch",
+                    args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                )
                 .build(),
         )
         .notarize(&signer)

--- a/radix-engine/src/model/auth_zone.rs
+++ b/radix-engine/src/model/auth_zone.rs
@@ -43,6 +43,10 @@ impl AuthZone {
         self.proofs.push(proof);
     }
 
+    pub fn drain(&mut self) -> Vec<Proof> {
+        self.proofs.drain(0..).collect()
+    }
+
     pub fn clear(&mut self) {
         loop {
             if let Some(proof) = self.proofs.pop() {

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -84,7 +84,7 @@ impl TransactionProcessor {
         let mut value = args.dom;
         for (expression, path) in args.expressions {
             match expression.0.as_str() {
-                "WORKTOP" => {
+                "ENTIRE_WORKTOP" => {
                     let buckets = system_api
                         .invoke_method(
                             Receiver::Ref(RENodeId::Worktop),

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -84,7 +84,7 @@ impl TransactionProcessor {
         let mut value = args.dom;
         for (expression, path) in args.expressions {
             match expression.0.as_str() {
-                "ALL_WORKTOP_RESOURCES" => {
+                "WORKTOP" => {
                     let buckets = system_api
                         .invoke_method(
                             Receiver::Ref(RENodeId::Worktop),

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -19,7 +19,11 @@ fn can_withdraw_from_my_account() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .call_method(other_account, "balance", args!(RADIX_TOKEN))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -50,7 +54,11 @@ fn can_withdraw_non_fungible_from_my_account() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(resource_address, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -68,7 +76,11 @@ fn cannot_withdraw_from_other_account() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, other_account)
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
 
     // Act

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -22,7 +22,7 @@ fn can_withdraw_from_my_account() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .call_method(other_account, "balance", args!(RADIX_TOKEN))
         .build();
@@ -57,7 +57,7 @@ fn can_withdraw_non_fungible_from_my_account() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -76,7 +76,11 @@ fn cannot_withdraw_from_other_account() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, other_account)
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
 
     // Act

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -22,7 +22,7 @@ fn can_withdraw_from_my_account() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .call_method(other_account, "balance", args!(RADIX_TOKEN))
         .build();
@@ -57,7 +57,7 @@ fn can_withdraw_non_fungible_from_my_account() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -76,11 +76,7 @@ fn cannot_withdraw_from_other_account() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, other_account)
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
 
     // Act

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -25,7 +25,7 @@ fn test_auth_rule<'s, S: ReadableSubstateStore + WriteableSubstateStore>(
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, signer_public_keys.to_vec());
@@ -243,12 +243,13 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
                 builder.pop_from_auth_zone(|builder, proof_id| builder.drop_proof(proof_id));
                 builder
             });
+            builder.return_to_worktop(bucket_id);
             builder
         })
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -277,12 +278,13 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
                 builder.pop_from_auth_zone(|builder, proof_id| builder.drop_proof(proof_id));
                 builder
             });
+            builder.return_to_worktop(bucket_id);
             builder
         })
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -311,12 +313,13 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
                 builder.pop_from_auth_zone(|builder, proof_id| builder.drop_proof(proof_id));
                 builder
             });
+            builder.return_to_worktop(bucket_id);
             builder
         })
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -22,7 +22,11 @@ fn test_auth_rule<'s, S: ReadableSubstateStore + WriteableSubstateStore>(
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .withdraw_from_account(RADIX_TOKEN, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, signer_public_keys.to_vec());
 
@@ -241,7 +245,11 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
             });
             builder
         })
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -271,7 +279,11 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
             });
             builder
         })
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -301,7 +313,11 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
             });
             builder
         })
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -25,7 +25,7 @@ fn test_auth_rule<'s, S: ReadableSubstateStore + WriteableSubstateStore>(
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, signer_public_keys.to_vec());
@@ -249,7 +249,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -284,7 +284,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -319,7 +319,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -112,11 +112,7 @@ fn can_make_cross_component_call_with_authorization() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .withdraw_from_account_by_ids(&BTreeSet::from([auth_id.clone()]), auth, account)
-        .call_method(
-            my_component,
-            "put_auth",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(my_component, "put_auth", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -112,7 +112,11 @@ fn can_make_cross_component_call_with_authorization() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .withdraw_from_account_by_ids(&BTreeSet::from([auth_id.clone()]), auth, account)
-        .call_method_with_all_resources(my_component, "put_auth")
+        .call_method(
+            my_component,
+            "put_auth",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -112,7 +112,11 @@ fn can_make_cross_component_call_with_authorization() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .withdraw_from_account_by_ids(&BTreeSet::from([auth_id.clone()]), auth, account)
-        .call_method(my_component, "put_auth", args!(Expression::new("WORKTOP")))
+        .call_method(
+            my_component,
+            "put_auth",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -58,15 +58,27 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
     match action {
         Action::Mint => builder
             .mint(Decimal::from("1.0"), token_address)
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            ),
         Action::Burn => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
             .burn(Decimal::from("1.0"), token_address)
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            ),
         Action::Withdraw => builder
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            ),
         Action::Deposit => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
@@ -77,7 +89,11 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
                     args!(scrypto::resource::Bucket(bucket_id)),
                 )
             })
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            ),
     };
 
     let manifest = builder.build();

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -58,27 +58,15 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
     match action {
         Action::Mint => builder
             .mint(Decimal::from("1.0"), token_address)
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            ),
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
         Action::Burn => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
             .burn(Decimal::from("1.0"), token_address)
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            ),
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
         Action::Withdraw => builder
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            ),
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
         Action::Deposit => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
@@ -89,11 +77,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
                     args!(scrypto::resource::Bucket(bucket_id)),
                 )
             })
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            ),
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP"))),
     };
 
     let manifest = builder.build();

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -58,15 +58,27 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
     match action {
         Action::Mint => builder
             .mint(Decimal::from("1.0"), token_address)
-            .call_method_with_all_resources(account, "deposit_batch"),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            ),
         Action::Burn => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
             .burn(Decimal::from("1.0"), token_address)
-            .call_method_with_all_resources(account, "deposit_batch"),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            ),
         Action::Withdraw => builder
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
-            .call_method_with_all_resources(account, "deposit_batch"),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            ),
         Action::Deposit => builder
             .create_proof_from_account(withdraw_auth, account)
             .withdraw_from_account_by_amount(Decimal::from("1.0"), token_address, account)
@@ -77,7 +89,11 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
                     args!(scrypto::resource::Bucket(bucket_id)),
                 )
             })
-            .call_method_with_all_resources(account, "deposit_batch"),
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            ),
     };
 
     let manifest = builder.build();

--- a/radix-engine/tests/authorization_vault.rs
+++ b/radix-engine/tests/authorization_vault.rs
@@ -17,7 +17,11 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(Decimal::one(), token_resource_address, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -54,7 +58,11 @@ fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
         )
         .withdraw_from_account_by_amount(Decimal::one(), token_resource_address, account)
         .pop_from_auth_zone(|builder, proof_id| builder.drop_proof(proof_id))
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/authorization_vault.rs
+++ b/radix-engine/tests/authorization_vault.rs
@@ -20,7 +20,7 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -67,7 +67,7 @@ fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -17,11 +17,7 @@ fn test_bucket_internal(method_name: &str) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(package_address, "BucketTest", method_name, args!())
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -87,11 +83,7 @@ fn test_bucket_of_badges() {
         .call_function(package_address, "BadgeTest", "split", args!())
         .call_function(package_address, "BadgeTest", "borrow", args!())
         .call_function(package_address, "BadgeTest", "query", args!())
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();
@@ -183,25 +175,23 @@ fn create_empty_bucket() {
     let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut store);
     let (public_key, _, account) = test_runner.new_account();
+    let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
-        .take_from_worktop(scrypto::prelude::RADIX_TOKEN, |builder, _bucket_id| builder)
+        .take_from_worktop(scrypto::prelude::RADIX_TOKEN, |builder, bucket_id| {
+            builder.return_to_worktop(bucket_id)
+        })
         .take_from_worktop_by_amount(
             Decimal::zero(),
             scrypto::prelude::RADIX_TOKEN,
-            |builder, _bucket_id| builder,
+            |builder, bucket_id| builder.return_to_worktop(bucket_id),
         )
         .take_from_worktop_by_ids(
             &BTreeSet::new(),
-            scrypto::prelude::RADIX_TOKEN,
-            |builder, _bucket_id| builder,
-        )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            non_fungible_resource,
+            |builder, bucket_id| builder.return_to_worktop(bucket_id),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -17,7 +17,11 @@ fn test_bucket_internal(method_name: &str) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(package_address, "BucketTest", method_name, args!())
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -83,7 +87,11 @@ fn test_bucket_of_badges() {
         .call_function(package_address, "BadgeTest", "split", args!())
         .call_function(package_address, "BadgeTest", "borrow", args!())
         .call_function(package_address, "BadgeTest", "query", args!())
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();
@@ -190,7 +198,11 @@ fn create_empty_bucket() {
             scrypto::prelude::RADIX_TOKEN,
             |builder, _bucket_id| builder,
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -17,7 +17,11 @@ fn test_bucket_internal(method_name: &str) {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .call_function(package_address, "BucketTest", method_name, args!())
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -83,7 +87,11 @@ fn test_bucket_of_badges() {
         .call_function(package_address, "BadgeTest", "split", args!())
         .call_function(package_address, "BadgeTest", "borrow", args!())
         .call_function(package_address, "BadgeTest", "query", args!())
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -39,7 +39,11 @@ fn test_component() {
         )
         .call_method(component, "get_component_state", args!())
         .call_method(component, "put_component_state", args!())
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt2 = test_runner.execute_manifest(manifest2, vec![public_key]);
     receipt2.expect_commit_success();

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -39,7 +39,11 @@ fn test_component() {
         )
         .call_method(component, "get_component_state", args!())
         .call_method(component, "put_component_state", args!())
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt2 = test_runner.execute_manifest(manifest2, vec![public_key]);
     receipt2.expect_commit_success();

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -39,11 +39,7 @@ fn test_component() {
         )
         .call_method(component, "get_component_state", args!())
         .call_method(component, "put_component_state", args!())
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt2 = test_runner.execute_manifest(manifest2, vec![public_key]);
     receipt2.expect_commit_success();

--- a/radix-engine/tests/core.rs
+++ b/radix-engine/tests/core.rs
@@ -29,11 +29,7 @@ fn test_call() {
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .call_function(package_address, "MoveTest", "move_bucket", args![])
         .call_function(package_address, "MoveTest", "move_proof", args![])
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/core.rs
+++ b/radix-engine/tests/core.rs
@@ -29,7 +29,11 @@ fn test_call() {
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .call_function(package_address, "MoveTest", "move_bucket", args![])
         .call_function(package_address, "MoveTest", "move_proof", args![])
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/core.rs
+++ b/radix-engine/tests/core.rs
@@ -29,7 +29,11 @@ fn test_call() {
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .call_function(package_address, "MoveTest", "move_bucket", args![])
         .call_function(package_address, "MoveTest", "move_proof", args![])
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -191,11 +191,7 @@ fn test_fee_accounting_success() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method(
-            account2,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -228,11 +224,7 @@ fn test_fee_accounting_failure() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method(
-            account2,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
         .assert_worktop_contains_by_amount(1.into(), RADIX_TOKEN)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -191,7 +191,11 @@ fn test_fee_accounting_success() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method_with_all_resources(account2, "deposit_batch")
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -224,7 +228,11 @@ fn test_fee_accounting_failure() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method_with_all_resources(account2, "deposit_batch")
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .assert_worktop_contains_by_amount(1.into(), RADIX_TOKEN)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -191,7 +191,11 @@ fn test_fee_accounting_success() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -224,7 +228,11 @@ fn test_fee_accounting_failure() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(66.into(), RADIX_TOKEN, account1)
-        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .assert_worktop_contains_by_amount(1.into(), RADIX_TOKEN)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -149,7 +149,11 @@ fn recursion_bomb() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -177,7 +181,11 @@ fn recursion_bomb_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -211,7 +219,11 @@ fn recursion_bomb_2() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -239,7 +251,11 @@ fn recursion_bomb_2_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -149,7 +149,11 @@ fn recursion_bomb() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -177,7 +181,11 @@ fn recursion_bomb_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -211,7 +219,11 @@ fn recursion_bomb_2() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -239,7 +251,11 @@ fn recursion_bomb_2_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -149,11 +149,7 @@ fn recursion_bomb() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -181,11 +177,7 @@ fn recursion_bomb_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -219,11 +211,7 @@ fn recursion_bomb_2() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -251,11 +239,7 @@ fn recursion_bomb_2_to_failure() {
                 args!(scrypto::resource::Bucket(bucket_id)),
             )
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -156,11 +156,7 @@ fn test_basic_transfer() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(100.into(), RADIX_TOKEN, account1)
-        .call_method(
-            account2,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key1]);
 

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -169,17 +169,17 @@ fn test_basic_transfer() {
         10000 /* base_fee */
         + 3300 /* borrow_substate */
         + 1500 /* create_node */
-        + 1938 /* decode_transaction */
+        + 1959 /* decode_transaction */
         + 1000 /* drop_node */
         + 605313 /* instantiate_wasm */
-        + 1895 /* invoke_function */
+        + 1930 /* invoke_function */
         + 2215 /* invoke_method */
         + 5000 /* read_substate */
         + 600 /* return_substate */
         + 1000 /* run_function */
         + 5200 /* run_method */
         + 274170 /* run_wasm */
-        + 646 /* verify_manifest */
+        + 653 /* verify_manifest */
         + 3750 /* verify_signatures */
         + 3000, /* write_substate */
         receipt.execution.fee_summary.cost_unit_consumed

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -1,7 +1,7 @@
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use scrypto::args;
 use scrypto::core::NetworkDefinition;
-use scrypto::prelude::{Package, RADIX_TOKEN, SYS_FAUCET_COMPONENT};
+use scrypto::prelude::{Expression, Package, RADIX_TOKEN, SYS_FAUCET_COMPONENT};
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
@@ -156,7 +156,11 @@ fn test_basic_transfer() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(100.into(), RADIX_TOKEN, account1)
-        .call_method_with_all_resources(account2, "deposit_batch")
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key1]);
 

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -156,7 +156,11 @@ fn test_basic_transfer() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account1)
         .withdraw_from_account_by_amount(100.into(), RADIX_TOKEN, account1)
-        .call_method(account2, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account2,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key1]);
 

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -21,11 +21,7 @@ fn create_non_fungible_mutable() {
             "create_non_fungible_mutable",
             args!(),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -48,11 +44,7 @@ fn can_burn_non_fungible() {
             "create_burnable_non_fungible",
             args!(),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success();
@@ -76,11 +68,7 @@ fn can_burn_non_fungible() {
             "verify_does_not_exist",
             args!(non_fungible_address),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -139,11 +127,7 @@ fn test_non_fungible() {
             "get_non_fungible_ids_vault",
             args!(),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();
@@ -164,11 +148,7 @@ fn test_singleton_non_fungible() {
             "singleton_non_fungible",
             args!(),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -21,7 +21,11 @@ fn create_non_fungible_mutable() {
             "create_non_fungible_mutable",
             args!(),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -44,7 +48,11 @@ fn can_burn_non_fungible() {
             "create_burnable_non_fungible",
             args!(),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success();
@@ -68,7 +76,11 @@ fn can_burn_non_fungible() {
             "verify_does_not_exist",
             args!(non_fungible_address),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -127,7 +139,11 @@ fn test_non_fungible() {
             "get_non_fungible_ids_vault",
             args!(),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();
@@ -148,7 +164,11 @@ fn test_singleton_non_fungible() {
             "singleton_non_fungible",
             args!(),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -21,7 +21,11 @@ fn create_non_fungible_mutable() {
             "create_non_fungible_mutable",
             args!(),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -44,7 +48,11 @@ fn can_burn_non_fungible() {
             "create_burnable_non_fungible",
             args!(),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success();
@@ -68,7 +76,11 @@ fn can_burn_non_fungible() {
             "verify_does_not_exist",
             args!(non_fungible_address),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -127,7 +139,11 @@ fn test_non_fungible() {
             "get_non_fungible_ids_vault",
             args!(),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();
@@ -148,7 +164,11 @@ fn test_singleton_non_fungible() {
             "singleton_non_fungible",
             args!(),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     receipt.expect_commit_success();

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -26,7 +26,11 @@ fn can_create_clone_and_drop_bucket_proof() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);
@@ -168,7 +172,11 @@ fn can_use_bucket_for_authorization() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -26,7 +26,11 @@ fn can_create_clone_and_drop_bucket_proof() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);
@@ -168,7 +172,11 @@ fn can_use_bucket_for_authorization() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -26,11 +26,7 @@ fn can_create_clone_and_drop_bucket_proof() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);
@@ -172,11 +168,7 @@ fn can_use_bucket_for_authorization() {
             &test_runner.export_abi(package_address, "BucketProof"),
         )
         .unwrap()
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/proof/src/receiver.rs
+++ b/radix-engine/tests/proof/src/receiver.rs
@@ -6,6 +6,12 @@ blueprint! {
     }
 
     impl Receiver {
+        pub fn assert_first_proof(mut proofs: Vec<Proof>, amount: Decimal, resource_address: ResourceAddress) {
+            let proof = proofs.remove(0).unsafe_skip_proof_validation();
+            assert_eq!(proof.amount(), amount);
+            assert_eq!(proof.resource_address(), resource_address);
+        }
+
         pub fn assert_amount(proof: Proof, amount: Decimal, resource_address: ResourceAddress) {
             let proof = proof.unsafe_skip_proof_validation();
             assert_eq!(proof.amount(), amount);

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -26,7 +26,11 @@ fn test_resource_manager() {
             "update_resource_metadata",
             args!(),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -51,7 +55,11 @@ fn mint_with_bad_granularity_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!("0.1")),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -85,7 +93,11 @@ fn mint_too_much_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!(100_000_000_001i128)),
         )
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -26,11 +26,7 @@ fn test_resource_manager() {
             "update_resource_metadata",
             args!(),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -55,11 +51,7 @@ fn mint_with_bad_granularity_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!("0.1")),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -93,11 +85,7 @@ fn mint_too_much_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!(100_000_000_001i128)),
         )
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -26,7 +26,11 @@ fn test_resource_manager() {
             "update_resource_metadata",
             args!(),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -51,7 +55,11 @@ fn mint_with_bad_granularity_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!("0.1")),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -85,7 +93,11 @@ fn mint_too_much_should_fail() {
             "create_fungible_and_mint",
             args!(0u8, dec!(100_000_000_001i128)),
         )
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -9,7 +9,11 @@ fn self_transfer_txn(account: ComponentAddress, amount: Decimal) -> TransactionM
     ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(amount, RADIX_TOKEN, account)
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build()
 }
 

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -9,7 +9,11 @@ fn self_transfer_txn(account: ComponentAddress, amount: Decimal) -> TransactionM
     ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(amount, RADIX_TOKEN, account)
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build()
 }
 

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -9,11 +9,7 @@ fn self_transfer_txn(account: ComponentAddress, amount: Decimal) -> TransactionM
     ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account_by_amount(amount, RADIX_TOKEN, account)
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build()
 }
 

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -60,15 +60,27 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ENTIRE_WORKTOP")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -60,27 +60,15 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method(
-            account,
-            "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-        )
+        .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -60,15 +60,27 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .create_proof_from_auth_zone(RADIX_TOKEN, |builder, proof_id| {
             builder.push_to_auth_zone(proof_id)
         })
-        .call_method_with_all_resources(account, "deposit_batch")
+        .call_method(
+            account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
     println!("{:?}", receipt);

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -111,6 +111,32 @@ fn test_transaction_can_end_with_proofs_remaining_in_auth_zone() {
     receipt.expect_commit_success();
 }
 
+#[test]
+fn test_entire_auth_zone() {
+    // Arrange
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(true, &mut store);
+    let (public_key, _, account) = test_runner.new_account();
+    let package_address = test_runner.extract_and_publish_package("proof");
+
+    // Act
+    let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
+        .lock_fee(dec!("10"), account)
+        .create_proof_from_account_by_amount(dec!("1"), RADIX_TOKEN, account)
+        .call_function(
+            package_address,
+            "Receiver",
+            "assert_first_proof",
+            args!(Expression::new("ENTIRE_AUTH_ZONE"), dec!("1"), RADIX_TOKEN),
+        )
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
+    println!("{:?}", receipt);
+
+    // Assert
+    receipt.expect_commit_success();
+}
+
 fn create_transaction() -> Vec<u8> {
     // create key pairs
     let sk1 = EcdsaPrivateKey::from_u64(1).unwrap();

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -20,7 +20,7 @@ fn test_state_track_success() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -49,7 +49,7 @@ fn test_state_track_failure() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            args!(Expression::new("WORKTOP")),
         )
         .assert_worktop_contains_by_amount(Decimal::from(5), RADIX_TOKEN)
         .build();

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -17,7 +17,11 @@ fn test_state_track_success() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
@@ -42,7 +46,11 @@ fn test_state_track_failure() {
     let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
         .lock_fee(10.into(), account)
         .withdraw_from_account(RADIX_TOKEN, account)
-        .call_method_with_all_resources(other_account, "deposit_batch")
+        .call_method(
+            other_account,
+            "deposit_batch",
+            args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+        )
         .assert_worktop_contains_by_amount(Decimal::from(5), RADIX_TOKEN)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -20,7 +20,7 @@ fn test_state_track_success() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
@@ -49,7 +49,7 @@ fn test_state_track_failure() {
         .call_method(
             other_account,
             "deposit_batch",
-            args!(Expression::new("WORKTOP")),
+            args!(Expression::new("ENTIRE_WORKTOP")),
         )
         .assert_worktop_contains_by_amount(Decimal::from(5), RADIX_TOKEN)
         .build();

--- a/scrypto-abi/src/types.rs
+++ b/scrypto-abi/src/types.rs
@@ -82,10 +82,12 @@ pub enum ScryptoType {
     NonFungibleId,
     NonFungibleAddress,
     ResourceAddress,
+
+    Expression,
 }
 
 // Need to update `scrypto-derive/src/import.rs` after changing the table below
-const MAPPING: [(ScryptoType, u8, &str); 17] = [
+const MAPPING: [(ScryptoType, u8, &str); 18] = [
     (ScryptoType::PackageAddress, 0x80, "PackageAddress"), // 128
     (ScryptoType::ComponentAddress, 0x81, "ComponentAddress"), // 129
     (ScryptoType::Component, 0x82, "ComponentAddress"),    // 130
@@ -103,6 +105,7 @@ const MAPPING: [(ScryptoType, u8, &str); 17] = [
     (ScryptoType::NonFungibleId, 0xb4, "NonFungibleId"),   // 180
     (ScryptoType::NonFungibleAddress, 0xb5, "NonFungibleAddress"), // 181
     (ScryptoType::ResourceAddress, 0xb6, "ResourceAddress"), // 182
+    (ScryptoType::Expression, 0xc1, "Expression"),         // 193
 ];
 
 impl ScryptoType {

--- a/scrypto-derive/src/import.rs
+++ b/scrypto-derive/src/import.rs
@@ -328,6 +328,7 @@ fn get_native_type(ty: &des::Type) -> Result<(Type, Vec<Item>)> {
                 ScryptoType::NonFungibleId => "::scrypto::resource::NonFungibleId",
                 ScryptoType::NonFungibleAddress => "::scrypto::resource::NonFungibleAddress",
                 ScryptoType::ResourceAddress => "::scrypto::resource::ResourceAddress",
+                ScryptoType::Expression => "::scrypto::core::Expression",
             };
 
             let ty: Type = parse_str(canonical_name).unwrap();

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -298,7 +298,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .create_proof_from_account(auth, account)
             .call_function(package, "ResourceCreator", function, args!(token, set_auth))
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         self.execute_manifest(manifest, vec![signer_public_key])
             .expect_commit_success();
@@ -328,7 +332,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_token",
                 args!(mint_auth, burn_auth, withdraw_auth, admin_auth),
             )
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -359,7 +367,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_burn",
                 args!(auth_resource_address),
             )
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -387,7 +399,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_transfer",
                 args![auth_resource_address],
             )
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -410,7 +426,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_non_fungible_fixed",
                 args!(),
             )
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -435,7 +455,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_fungible_fixed",
                 args!(amount, divisibility),
             )
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -465,7 +489,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 &self.export_abi(package_address, blueprint_name),
             )
             .unwrap()
-            .call_method_with_all_resources(account, "deposit_batch")
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![signer_public_key]);
         receipt.expect_commit_success();

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -298,11 +298,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .create_proof_from_account(auth, account)
             .call_function(package, "ResourceCreator", function, args!(token, set_auth))
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         self.execute_manifest(manifest, vec![signer_public_key])
             .expect_commit_success();
@@ -332,11 +328,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_token",
                 args!(mint_auth, burn_auth, withdraw_auth, admin_auth),
             )
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -367,11 +359,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_burn",
                 args!(auth_resource_address),
             )
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -399,11 +387,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_transfer",
                 args![auth_resource_address],
             )
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -426,11 +410,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_non_fungible_fixed",
                 args!(),
             )
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -455,11 +435,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_fungible_fixed",
                 args!(amount, divisibility),
             )
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -489,11 +465,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 &self.export_abi(package_address, blueprint_name),
             )
             .unwrap()
-            .call_method(
-                account,
-                "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
-            )
+            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
             .build();
         let receipt = self.execute_manifest(manifest, vec![signer_public_key]);
         receipt.expect_commit_success();

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -298,7 +298,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .create_proof_from_account(auth, account)
             .call_function(package, "ResourceCreator", function, args!(token, set_auth))
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         self.execute_manifest(manifest, vec![signer_public_key])
             .expect_commit_success();
@@ -328,7 +332,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_token",
                 args!(mint_auth, burn_auth, withdraw_auth, admin_auth),
             )
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -359,7 +367,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_burn",
                 args!(auth_resource_address),
             )
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -387,7 +399,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_restricted_transfer",
                 args![auth_resource_address],
             )
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -410,7 +426,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_non_fungible_fixed",
                 args!(),
             )
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -435,7 +455,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 "create_fungible_fixed",
                 args!(amount, divisibility),
             )
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -465,7 +489,11 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
                 &self.export_abi(package_address, blueprint_name),
             )
             .unwrap()
-            .call_method(account, "deposit_batch", args!(Expression::new("WORKTOP")))
+            .call_method(
+                account,
+                "deposit_batch",
+                args!(Expression::new("ENTIRE_WORKTOP")),
+            )
             .build();
         let receipt = self.execute_manifest(manifest, vec![signer_public_key]);
         receipt.expect_commit_success();

--- a/scrypto/src/core/expression.rs
+++ b/scrypto/src/core/expression.rs
@@ -11,6 +11,12 @@ use crate::abi::*;
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Expression(pub String);
 
+impl Expression {
+    pub fn new(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
 //========
 // error
 //========

--- a/scrypto/src/core/expression.rs
+++ b/scrypto/src/core/expression.rs
@@ -1,0 +1,101 @@
+use sbor::rust::borrow::ToOwned;
+use sbor::rust::convert::TryFrom;
+use sbor::rust::fmt;
+use sbor::rust::str::FromStr;
+use sbor::rust::string::String;
+use sbor::rust::vec::Vec;
+use sbor::*;
+
+use crate::abi::*;
+
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Expression(pub String);
+
+//========
+// error
+//========
+
+/// Represents an error when parsing Expression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseExpressionError {
+    InvalidUtf8,
+}
+
+#[cfg(not(feature = "alloc"))]
+impl std::error::Error for ParseExpressionError {}
+
+#[cfg(not(feature = "alloc"))]
+impl fmt::Display for ParseExpressionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+//========
+// binary
+//========
+
+impl TryFrom<&[u8]> for Expression {
+    type Error = ParseExpressionError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self(
+            String::from_utf8(slice.to_vec()).map_err(|_| Self::Error::InvalidUtf8)?,
+        ))
+    }
+}
+
+impl Expression {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
+    }
+}
+
+scrypto_type!(Expression, ScryptoType::Expression, Vec::new());
+
+//======
+// text
+//======
+
+impl FromStr for Expression {
+    type Err = ParseExpressionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl fmt::Display for Expression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for Expression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sbor::rust::format;
+    use sbor::rust::string::ToString;
+
+    #[test]
+    fn test_from_to_string() {
+        let name = "hello";
+        let s = Expression::from_str(name).unwrap();
+        assert_eq!(s.to_string(), name);
+        assert_eq!(format!("{:?}", s), name);
+        assert_eq!(format!("{}", s), name);
+    }
+
+    #[test]
+    fn test_from_to_bytes() {
+        let s = Expression("hello".to_owned());
+        let s2 = Expression::try_from(s.to_vec().as_slice()).unwrap();
+        assert_eq!(s2, s);
+    }
+}

--- a/scrypto/src/core/mod.rs
+++ b/scrypto/src/core/mod.rs
@@ -1,5 +1,6 @@
 mod actor;
 mod data;
+mod expression;
 mod invocation;
 mod level;
 mod logger;
@@ -8,6 +9,7 @@ mod runtime;
 
 pub use actor::ScryptoActor;
 pub use data::*;
+pub use expression::*;
 pub use invocation::*;
 pub use level::Level;
 pub use logger::Logger;

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -66,7 +66,7 @@ impl CallFunction {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -66,7 +66,7 @@ impl CallFunction {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -62,7 +63,11 @@ impl CallFunction {
                 &export_abi(self.package_address, &self.blueprint_name)?,
             )
             .map_err(Error::TransactionConstructionError)?
-            .call_method_with_all_resources(default_account, "deposit_batch")
+            .call_method(
+                default_account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -64,7 +64,7 @@ impl CallMethod {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -64,7 +64,7 @@ impl CallMethod {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -60,7 +61,11 @@ impl CallMethod {
                 &export_abi_by_component(self.component_address)?,
             )
             .map_err(Error::TransactionConstructionError)?
-            .call_method_with_all_resources(default_account, "deposit_batch")
+            .call_method(
+                default_account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -52,7 +52,7 @@ impl Mint {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -52,7 +52,7 @@ impl Mint {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -48,7 +49,11 @@ impl Mint {
         let manifest = manifest_builder
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .mint(self.amount, self.resource_address)
-            .call_method_with_all_resources(default_account, "deposit_batch")
+            .call_method(
+                default_account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -70,7 +70,7 @@ impl NewBadgeFixed {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -70,7 +70,7 @@ impl NewBadgeFixed {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -66,7 +67,11 @@ impl NewBadgeFixed {
         let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .new_badge_fixed(metadata, self.total_supply)
-            .call_method_with_all_resources(default_account, "deposit_batch")
+            .call_method(
+                default_account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -70,7 +70,7 @@ impl NewTokenFixed {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -66,7 +67,11 @@ impl NewTokenFixed {
         let manifest = ManifestBuilder::new(&NetworkDefinition::local_simulator())
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .new_token_fixed(metadata, self.total_supply)
-            .call_method_with_all_resources(default_account, "deposit_batch")
+            .call_method(
+                default_account,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -70,7 +70,7 @@ impl NewTokenFixed {
             .call_method(
                 default_account,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use radix_engine::types::*;
+use scrypto::prelude::Expression;
 use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
@@ -51,7 +52,11 @@ impl Transfer {
         let manifest = manifest_builder
             .lock_fee(100.into(), SYS_FAUCET_COMPONENT)
             .withdraw_from_account_by_amount(self.amount, self.resource_address, default_account)
-            .call_method_with_all_resources(self.recipient, "deposit_batch")
+            .call_method(
+                self.recipient,
+                "deposit_batch",
+                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+            )
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -55,7 +55,7 @@ impl Transfer {
             .call_method(
                 self.recipient,
                 "deposit_batch",
-                args!(Expression::new("WORKTOP")),
+                args!(Expression::new("ENTIRE_WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -55,7 +55,7 @@ impl Transfer {
             .call_method(
                 self.recipient,
                 "deposit_batch",
-                args!(Expression::new("ALL_WORKTOP_RESOURCES")),
+                args!(Expression::new("WORKTOP")),
             )
             .build();
         handle_manifest(

--- a/simulator/tests/m1.rtm
+++ b/simulator/tests/m1.rtm
@@ -4,4 +4,4 @@ CALL_METHOD ComponentAddress("${account}") "lock_fee" Decimal("10");
 CALL_FUNCTION PackageAddress("${package}") "Hello" "instantiate_hello";
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("WORKTOP");
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/simulator/tests/m1.rtm
+++ b/simulator/tests/m1.rtm
@@ -4,4 +4,4 @@ CALL_METHOD ComponentAddress("${account}") "lock_fee" Decimal("10");
 CALL_FUNCTION PackageAddress("${package}") "Hello" "instantiate_hello";
 
 # Clean up - deposit resources
-CALL_METHOD_WITH_ALL_RESOURCES ComponentAddress("${account}") "deposit_batch";
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");

--- a/simulator/tests/m1.rtm
+++ b/simulator/tests/m1.rtm
@@ -4,4 +4,4 @@ CALL_METHOD ComponentAddress("${account}") "lock_fee" Decimal("10");
 CALL_FUNCTION PackageAddress("${package}") "Hello" "instantiate_hello";
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("WORKTOP");

--- a/simulator/tests/m2.rtm
+++ b/simulator/tests/m2.rtm
@@ -32,4 +32,4 @@ DROP_PROOF Proof("proof4");
 DROP_PROOF Proof("proof5");
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("WORKTOP");
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/simulator/tests/m2.rtm
+++ b/simulator/tests/m2.rtm
@@ -32,4 +32,4 @@ DROP_PROOF Proof("proof4");
 DROP_PROOF Proof("proof5");
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("WORKTOP");

--- a/simulator/tests/m2.rtm
+++ b/simulator/tests/m2.rtm
@@ -32,4 +32,4 @@ DROP_PROOF Proof("proof4");
 DROP_PROOF Proof("proof5");
 
 # Clean up - deposit resources
-CALL_METHOD_WITH_ALL_RESOURCES ComponentAddress("${account}") "deposit_batch";
+CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");

--- a/transaction/examples/complex.rtm
+++ b/transaction/examples/complex.rtm
@@ -24,7 +24,7 @@ RETURN_TO_WORKTOP Bucket("some_xrd");
 TAKE_FROM_WORKTOP_BY_IDS Set<NonFungibleId>(NonFungibleId("0905000000"), NonFungibleId("0907000000")) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
 
 # Cancel all buckets and move resources to account
-CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("WORKTOP");
+CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");
 
 # Drop all proofs
 DROP_ALL_PROOFS;

--- a/transaction/examples/complex.rtm
+++ b/transaction/examples/complex.rtm
@@ -24,7 +24,7 @@ RETURN_TO_WORKTOP Bucket("some_xrd");
 TAKE_FROM_WORKTOP_BY_IDS Set<NonFungibleId>(NonFungibleId("0905000000"), NonFungibleId("0907000000")) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
 
 # Cancel all buckets and move resources to account
-CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");
+CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("WORKTOP");
 
 # Drop all proofs
 DROP_ALL_PROOFS;

--- a/transaction/examples/complex.rtm
+++ b/transaction/examples/complex.rtm
@@ -24,7 +24,7 @@ RETURN_TO_WORKTOP Bucket("some_xrd");
 TAKE_FROM_WORKTOP_BY_IDS Set<NonFungibleId>(NonFungibleId("0905000000"), NonFungibleId("0907000000")) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
 
 # Cancel all buckets and move resources to account
-CALL_METHOD_WITH_ALL_RESOURCES ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch";
+CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ALL_WORKTOP_RESOURCES");
 
 # Drop all proofs
 DROP_ALL_PROOFS;

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -110,9 +110,6 @@ impl ManifestBuilder {
                 let scrypt_value = ScryptoValue::from_slice(&args).unwrap();
                 self.id_validator.move_resources(&scrypt_value).unwrap();
             }
-            Instruction::CallMethodWithAllResources { .. } => {
-                self.id_validator.move_all_buckets().unwrap();
-            }
             Instruction::PublishPackage { .. } => {}
         }
 
@@ -411,22 +408,6 @@ impl ManifestBuilder {
                 args: args_from_bytes_vec!(arguments),
             })
             .0)
-    }
-
-    /// Calls a method with all the resources on worktop.
-    ///
-    /// The callee method must have only one parameter with type `Vec<Bucket>`; otherwise,
-    /// a runtime failure is triggered.
-    pub fn call_method_with_all_resources(
-        &mut self,
-        component_address: ComponentAddress,
-        method: &str,
-    ) -> &mut Self {
-        self.add_instruction(Instruction::CallMethodWithAllResources {
-            component_address,
-            method: method.into(),
-        })
-        .0
     }
 
     /// Publishes a package.

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -144,6 +144,7 @@ pub enum Type {
     Proof,
     NonFungibleId,
     NonFungibleAddress,
+    Expression,
 
     /* Bytes is a convenient way of producing `Vec<u8>` */
     Bytes,
@@ -187,6 +188,7 @@ pub enum Value {
     Proof(Box<Value>),
     NonFungibleId(Box<Value>),
     NonFungibleAddress(Box<Value>),
+    Expression(Box<Value>),
 
     Bytes(Vec<u8>),
 }
@@ -226,6 +228,7 @@ impl Value {
             Value::Proof(_) => Type::Proof,
             Value::NonFungibleId(_) => Type::NonFungibleId,
             Value::NonFungibleAddress(_) => Type::NonFungibleAddress,
+            Value::Expression(_) => Type::Expression,
             Value::Bytes(_) => Type::List,
         }
     }

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -91,11 +91,6 @@ pub enum Instruction {
         args: Vec<Value>,
     },
 
-    CallMethodWithAllResources {
-        component_address: Value,
-        method: Value,
-    },
-
     PublishPackage {
         package: Value,
     },

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -287,19 +287,6 @@ pub fn decompile(
 
                 buf.push_str(";\n");
             }
-            Instruction::CallMethodWithAllResources {
-                component_address,
-                method,
-            } => {
-                id_validator
-                    .move_all_buckets()
-                    .map_err(DecompileError::IdValidationError)?;
-                buf.push_str(&format!(
-                    "CALL_METHOD_WITH_ALL_RESOURCES ComponentAddress(\"{}\") \"{}\";\n",
-                    bech32_encoder.encode_component_address(&component_address),
-                    method
-                ));
-            }
             Instruction::PublishPackage { package } => {
                 buf.push_str(&format!(
                     "PUBLISH_PACKAGE Bytes(\"{}\");\n",

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1013,10 +1013,10 @@ mod tests {
             }
         );
         generate_value_ok!(
-            r#"Expression("ALL_WORKTOP_RESOURCES")"#,
+            r#"Expression("WORKTOP")"#,
             Value::Custom {
                 type_id: ScryptoType::Expression.id(),
-                bytes: scrypto::core::Expression("ALL_WORKTOP_RESOURCES".to_owned()).to_vec()
+                bytes: scrypto::core::Expression("WORKTOP".to_owned()).to_vec()
             }
         );
     }
@@ -1219,7 +1219,7 @@ mod tests {
                 Instruction::CallMethod {
                     component_address: component1,
                     method_name: "deposit_batch".into(),
-                    args: args!(Expression("ALL_WORKTOP_RESOURCES".to_owned()))
+                    args: args!(Expression("WORKTOP".to_owned()))
                 },
                 Instruction::DropAllProofs,
                 Instruction::PublishPackage {

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1013,10 +1013,10 @@ mod tests {
             }
         );
         generate_value_ok!(
-            r#"Expression("WORKTOP")"#,
+            r#"Expression("ENTIRE_WORKTOP")"#,
             Value::Custom {
                 type_id: ScryptoType::Expression.id(),
-                bytes: scrypto::core::Expression("WORKTOP".to_owned()).to_vec()
+                bytes: scrypto::core::Expression("ENTIRE_WORKTOP".to_owned()).to_vec()
             }
         );
     }
@@ -1219,7 +1219,7 @@ mod tests {
                 Instruction::CallMethod {
                     component_address: component1,
                     method_name: "deposit_batch".into(),
-                    args: args!(Expression("WORKTOP".to_owned()))
+                    args: args!(Expression("ENTIRE_WORKTOP".to_owned()))
                 },
                 Instruction::DropAllProofs,
                 Instruction::PublishPackage {

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -70,6 +70,7 @@ pub enum TokenKind {
     Proof,
     NonFungibleId,
     NonFungibleAddress,
+    Expression,
 
     /* Punctuations */
     OpenParenthesis,
@@ -394,6 +395,7 @@ impl Lexer {
             "Proof" => Ok(TokenKind::Proof),
             "NonFungibleId" => Ok(TokenKind::NonFungibleId),
             "NonFungibleAddress" => Ok(TokenKind::NonFungibleAddress),
+            "Expression" => Ok(TokenKind::Expression),
 
             "Some" => Ok(TokenKind::Some),
             "None" => Ok(TokenKind::None),

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -103,7 +103,6 @@ pub enum TokenKind {
     DropAllProofs,
     CallFunction,
     CallMethod,
-    CallMethodWithAllResources,
     PublishPackage,
 }
 
@@ -425,7 +424,6 @@ impl Lexer {
             "DROP_ALL_PROOFS" => Ok(TokenKind::DropAllProofs),
             "CALL_FUNCTION" => Ok(TokenKind::CallFunction),
             "CALL_METHOD" => Ok(TokenKind::CallMethod),
-            "CALL_METHOD_WITH_ALL_RESOURCES" => Ok(TokenKind::CallMethodWithAllResources),
             "PUBLISH_PACKAGE" => Ok(TokenKind::PublishPackage),
 
             s @ _ => Err(LexerError::UnknownIdentifier(s.into())),

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -210,7 +210,8 @@ impl Parser {
             | TokenKind::Bucket
             | TokenKind::Proof
             | TokenKind::NonFungibleId
-            | TokenKind::NonFungibleAddress => self.parse_scrypto_types(),
+            | TokenKind::NonFungibleAddress
+            | TokenKind::Expression => self.parse_scrypto_types(),
             TokenKind::Bytes => self.parse_bytes(),
             _ => Err(ParserError::UnexpectedToken(token)),
         }
@@ -332,6 +333,7 @@ impl Parser {
             TokenKind::NonFungibleAddress => {
                 Ok(Value::NonFungibleAddress(self.parse_values_one()?.into()))
             }
+            TokenKind::Expression => Ok(Value::Expression(self.parse_values_one()?.into())),
             _ => Err(ParserError::UnexpectedToken(token)),
         }
     }
@@ -421,6 +423,7 @@ impl Parser {
             TokenKind::Bucket => Ok(Type::Bucket),
             TokenKind::Proof => Ok(Type::Proof),
             TokenKind::NonFungibleId => Ok(Type::NonFungibleId),
+            TokenKind::Expression => Ok(Type::Expression),
             _ => Err(ParserError::UnexpectedToken(token)),
         }
     }

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -157,10 +157,6 @@ impl Parser {
                     values
                 },
             },
-            TokenKind::CallMethodWithAllResources => Instruction::CallMethodWithAllResources {
-                component_address: self.parse_value()?,
-                method: self.parse_value()?,
-            },
             TokenKind::PublishPackage => Instruction::PublishPackage {
                 package: self.parse_value()?,
             },
@@ -708,18 +704,6 @@ mod tests {
                     Value::NonFungibleId(Value::String("00".into()).into()),
                     Value::Proof(Value::String("admin_auth".into()).into())
                 ]
-            }
-        );
-        parse_instruction_ok!(
-            r#"CALL_METHOD_WITH_ALL_RESOURCES  ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch";"#,
-            Instruction::CallMethodWithAllResources {
-                component_address: Value::ComponentAddress(
-                    Value::String(
-                        "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064".into()
-                    )
-                    .into()
-                ),
-                method: Value::String("deposit_batch".into()),
             }
         );
     }

--- a/transaction/src/model/executable.rs
+++ b/transaction/src/model/executable.rs
@@ -73,10 +73,6 @@ pub enum ExecutableInstruction {
         method_name: String,
         args: Vec<u8>,
     },
-    CallMethodWithAllResources {
-        component_address: ComponentAddress,
-        method: String,
-    },
     PublishPackage {
         package: Vec<u8>,
     },

--- a/transaction/src/model/instruction.rs
+++ b/transaction/src/model/instruction.rs
@@ -98,12 +98,6 @@ pub enum Instruction {
         args: Vec<u8>,
     },
 
-    /// Calls a component method with all resources owned by the transaction.
-    CallMethodWithAllResources {
-        component_address: ComponentAddress,
-        method: String,
-    },
-
     /// Publishes a package.
     PublishPackage { package: Vec<u8> },
 }

--- a/transaction/src/model/test_transaction.rs
+++ b/transaction/src/model/test_transaction.rs
@@ -137,13 +137,6 @@ impl TestTransaction {
                     method_name,
                     args,
                 },
-                Instruction::CallMethodWithAllResources {
-                    component_address,
-                    method,
-                } => ExecutableInstruction::CallMethodWithAllResources {
-                    component_address,
-                    method,
-                },
                 Instruction::PublishPackage { package } => {
                     ExecutableInstruction::PublishPackage { package }
                 }

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -270,18 +270,6 @@ impl TransactionValidator {
                         args,
                     });
                 }
-                Instruction::CallMethodWithAllResources {
-                    component_address,
-                    method,
-                } => {
-                    id_validator
-                        .move_all_buckets()
-                        .map_err(TransactionValidationError::IdValidationError)?;
-                    instructions.push(ExecutableInstruction::CallMethodWithAllResources {
-                        component_address,
-                        method,
-                    });
-                }
                 Instruction::PublishPackage { package } => {
                     instructions.push(ExecutableInstruction::PublishPackage { package });
                 }


### PR DESCRIPTION
- Removed `CALL_METHOD_WITH_ALL_WORKTOP_RESOURCES` instruction
- Added `Expression` Scrypto value which is evaluated by `TransactionProcessor` at runtime
    * Example: `Expression("ENTIRE_WORKTOP")`