### PR TITLE
fix: Preview doesn't assume local sim

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,11 @@ cd "$(dirname "$0")"
 
 (cd sbor; cargo build; cargo test --no-run)
 (cd sbor-derive; cargo build; cargo test --no-run)
-(cd sbor-tests; cargo build; cargo test --no-run)
+(cd sbor-tests; cargo build; cargo test --no-run; cargo bench --no-run)
 (cd scrypto; cargo build; cargo test --no-run)
 (cd scrypto-derive; cargo build; cargo test --no-run)
 (cd scrypto-tests; cargo build; cargo test --no-run)
-(cd radix-engine; cargo build; cargo test --no-run)
+(cd radix-engine; cargo build; cargo test --no-run; cargo bench --no-run)
 (cd radix-engine-stores; cargo build; cargo test --no-run)
 (cd transaction; cargo build; cargo test --no-run)
 (cd simulator; cargo build; cargo test --no-run)

--- a/radix-engine/benches/transaction.rs
+++ b/radix-engine/benches/transaction.rs
@@ -81,7 +81,7 @@ fn bench_transaction_validation(c: &mut Criterion) {
         b.iter(|| {
             let intent_hash_manager = TestIntentHashManager::new();
             let config: ValidationConfig = ValidationConfig {
-                network: NetworkDefinition::local_simulator(),
+                network: &NetworkDefinition::local_simulator(),
                 current_epoch: 1,
                 max_cost_unit_limit: 10_000_000,
                 min_tip_percentage: 0,

--- a/radix-engine/src/transaction/preview_executor.rs
+++ b/radix-engine/src/transaction/preview_executor.rs
@@ -1,3 +1,4 @@
+use scrypto::core::NetworkDefinition;
 use transaction::errors::TransactionValidationError;
 use transaction::model::PreviewIntent;
 use transaction::validation::IntentHashManager;
@@ -24,7 +25,7 @@ pub enum PreviewError {
     TransactionValidationError(TransactionValidationError),
 }
 
-pub struct PreviewExecutor<'s, 'w, S, W, I, IHM>
+pub struct PreviewExecutor<'s, 'w, 'n, S, W, I, IHM>
 where
     S: ReadableSubstateStore + WriteableSubstateStore,
     W: WasmEngine<I>,
@@ -35,10 +36,11 @@ where
     wasm_engine: &'w mut W,
     wasm_instrumenter: &'w mut WasmInstrumenter,
     intent_hash_manager: &'w IHM,
+    network: &'n NetworkDefinition,
     phantom1: PhantomData<I>,
 }
 
-impl<'s, 'w, S, W, I, IHM> PreviewExecutor<'s, 'w, S, W, I, IHM>
+impl<'s, 'w, 'n, S, W, I, IHM> PreviewExecutor<'s, 'w, 'n, S, W, I, IHM>
 where
     S: ReadableSubstateStore + WriteableSubstateStore,
     W: WasmEngine<I>,
@@ -50,12 +52,14 @@ where
         wasm_engine: &'w mut W,
         wasm_instrumenter: &'w mut WasmInstrumenter,
         intent_hash_manager: &'w IHM,
+        network: &'n NetworkDefinition,
     ) -> Self {
         PreviewExecutor {
             substate_store,
             wasm_engine,
             wasm_instrumenter,
             intent_hash_manager,
+            network,
             phantom1: PhantomData,
         }
     }
@@ -66,7 +70,7 @@ where
     ) -> Result<PreviewResult, PreviewError> {
         // TODO: construct validation config based on current world state
         let validation_params = ValidationConfig {
-            network: NetworkDefinition::local_simulator(),
+            network: self.network,
             current_epoch: 1,
             max_cost_unit_limit: DEFAULT_MAX_COST_UNIT_LIMIT,
             min_tip_percentage: 0,

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -15,11 +15,13 @@ fn test_transaction_preview_cost_estimate() {
     // Arrange
     let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
     let mut test_runner = TestRunner::new(true, &mut substate_store);
-    let (validated_transaction, preview_intent) = prepare_test_tx_and_preview_intent(&test_runner);
+    let network = NetworkDefinition::local_simulator();
+    let (validated_transaction, preview_intent) =
+        prepare_test_tx_and_preview_intent(&test_runner, &network);
 
     // Act & Assert: Execute the preview, followed by a normal execution.
     // Ensure that both succeed and that the preview result provides an accurate cost estimate
-    let preview_result = test_runner.execute_preview(preview_intent);
+    let preview_result = test_runner.execute_preview(preview_intent, &network);
     let preview_receipt = preview_result.unwrap().receipt;
     preview_receipt.expect_commit_success();
 
@@ -35,6 +37,7 @@ fn test_transaction_preview_cost_estimate() {
 
 fn prepare_test_tx_and_preview_intent(
     test_runner: &TestRunner<TypedInMemorySubstateStore>,
+    network: &NetworkDefinition,
 ) -> (ValidatedTransaction, PreviewIntent) {
     let notary_priv_key = EcdsaPrivateKey::from_u64(2).unwrap();
     let tx_signer_priv_key = EcdsaPrivateKey::from_u64(3).unwrap();
@@ -42,7 +45,7 @@ fn prepare_test_tx_and_preview_intent(
     let notarized_transaction = TransactionBuilder::new()
         .header(TransactionHeader {
             version: 1,
-            network_id: NetworkDefinition::local_simulator().id,
+            network_id: network.id,
             start_epoch_inclusive: 0,
             end_epoch_exclusive: 99,
             nonce: test_runner.next_transaction_nonce(),
@@ -65,7 +68,7 @@ fn prepare_test_tx_and_preview_intent(
         notarized_transaction.clone(),
         &TestIntentHashManager::new(),
         &ValidationConfig {
-            network: NetworkDefinition::local_simulator(),
+            network: &network,
             current_epoch: 1,
             max_cost_unit_limit: 10_000_000,
             min_tip_percentage: 0,

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -21,7 +21,7 @@ fn test_normal_transaction_flow() {
     let mut wasm_instrumenter = WasmInstrumenter::new();
     let intent_hash_manager = TestIntentHashManager::new();
     let validation_params = ValidationConfig {
-        network: NetworkDefinition::local_simulator(),
+        network: &NetworkDefinition::local_simulator(),
         current_epoch: 1,
         max_cost_unit_limit: DEFAULT_COST_UNIT_LIMIT,
         min_tip_percentage: 0,

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -202,6 +202,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     pub fn execute_preview(
         &mut self,
         preview_intent: PreviewIntent,
+        network: &NetworkDefinition,
     ) -> Result<PreviewResult, PreviewError> {
         let node_id = self.create_child_node(0);
         let substate_store = &mut self.execution_stores.get_output_store(node_id);
@@ -211,6 +212,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             &mut self.wasm_engine,
             &mut self.wasm_instrumenter,
             &self.intent_hash_manager,
+            network,
         )
         .execute(preview_intent)
     }

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -10,8 +10,8 @@ use crate::errors::{SignatureValidationError, *};
 use crate::model::*;
 use crate::validation::*;
 
-pub struct ValidationConfig {
-    pub network: NetworkDefinition,
+pub struct ValidationConfig<'n> {
+    pub network: &'n NetworkDefinition,
     pub current_epoch: u64,
     pub max_cost_unit_limit: u32,
     pub min_tip_percentage: u32,
@@ -396,7 +396,7 @@ mod tests {
         ($result: expr, ($version: expr, $start_epoch: expr, $end_epoch: expr, $nonce: expr, $signers: expr, $notary: expr)) => {{
             let mut intent_hash_manager: TestIntentHashManager = TestIntentHashManager::new();
             let config: ValidationConfig = ValidationConfig {
-                network: NetworkDefinition::local_simulator(),
+                network: &NetworkDefinition::local_simulator(),
                 current_epoch: 1,
                 max_cost_unit_limit: 10_000_000,
                 min_tip_percentage: 0,
@@ -467,7 +467,7 @@ mod tests {
     fn test_valid_preview() {
         let mut intent_hash_manager: TestIntentHashManager = TestIntentHashManager::new();
         let config: ValidationConfig = ValidationConfig {
-            network: NetworkDefinition::local_simulator(),
+            network: &NetworkDefinition::local_simulator(),
             current_epoch: 1,
             max_cost_unit_limit: 10_000_000,
             min_tip_percentage: 0,


### PR DESCRIPTION
Preview tests were breaking when I integrated with the engine - this is why.

Have removed the hardcoding of network in preview too.