### PR TITLE
Helpful functions for TransactionReceipt on RadixEngine

### DIFF
--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -82,10 +82,10 @@ impl TransactionReceipt {
         }
     }
 
-    pub fn expect_commit_success(&self) -> &[u8] {
+    pub fn expect_commit_success(&self) -> &Vec<Vec<u8>> {
         match &self.result {
             TransactionResult::Commit(c) => match &c.outcome {
-                TransactionOutcome::Success(x) => &x[1][..],
+                TransactionOutcome::Success(x) => x,
                 TransactionOutcome::Failure(err) => {
                     panic!("Expected success but was failed:\n{:?}", err)
                 }
@@ -99,8 +99,8 @@ impl TransactionReceipt {
             TransactionResult::Commit(c) => match &c.outcome {
                 TransactionOutcome::Success(_) => {
                     panic!("Expected failure but was success")
-                },
-                TransactionOutcome::Failure(err) => err
+                }
+                TransactionOutcome::Failure(err) => err,
             },
             TransactionResult::Reject(_) => panic!("Transaction was rejected"),
         }
@@ -126,11 +126,10 @@ impl TransactionReceipt {
         }
     }
 
-    pub fn output<T: Decode>(&self) -> T {
-
-        scrypto_decode::<T>(self.expect_commit_success()).expect("Wrong transaction output type!")
-
-    } 
+    pub fn output<T: Decode>(&self, nth: usize) -> T {
+        scrypto_decode::<T>(&self.expect_commit_success()[nth][..])
+            .expect("Wrong instruction output type!")
+    }
 
     pub fn new_package_addresses(&self) -> &Vec<PackageAddress> {
         let commit = self.expect_commit();

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -74,8 +74,20 @@ impl TransactionReceipt {
             TransactionResult::Reject(_) => panic!("Transaction was rejected"),
         }
     }
+    
+    pub fn expect_commit_success(&self) -> bool {
+        match &self.result {
+            TransactionResult::Commit(c) => match &c.outcome {
+                TransactionOutcome::Success(x) => true,
+                TransactionOutcome::Failure(err) => {
+                    false
+                }
+            },
+            TransactionResult::Reject(_) => panic!("Transaction was rejected"),
+        }
+    }
 
-    pub fn expect_commit_success<T: Decode>(&self) -> T {
+    pub fn output<T: Decode>(&self) -> T {
         match &self.result {
             TransactionResult::Commit(c) => match &c.outcome {
                 TransactionOutcome::Success(x) => scrypto_decode::<T>(&x[1][..]).expect("Wrong transaction output type!"),

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -75,10 +75,10 @@ impl TransactionReceipt {
         }
     }
 
-    pub fn expect_commit_success<T>(&self) -> T {
+    pub fn expect_commit_success<T: Decode>(&self) -> T {
         match &self.result {
             TransactionResult::Commit(c) => match &c.outcome {
-                TransactionOutcome::Success(x) => scrypto_decode::<T>(&x[1][..]),
+                TransactionOutcome::Success(x) => scrypto_decode::<T>(&x[1][..]).expect("Wrong transaction output type!"),
                 TransactionOutcome::Failure(err) => {
                     panic!("Expected success but was failed:\n{:?}", err)
                 }

--- a/radix-engine/tests/abi.rs
+++ b/radix-engine/tests/abi.rs
@@ -27,7 +27,7 @@ fn test_invalid_access_rule_methods() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::ComponentError(
@@ -62,7 +62,7 @@ fn test_arg(method_name: &str, args: Vec<u8>, expected_result: ExpectedResult) {
             receipt.expect_commit_success();
         }
         ExpectedResult::InvalidInput => {
-            receipt.expect_commit_failure(|e| {
+            receipt.expect_specific_failure(|e| {
                 matches!(
                     e,
                     RuntimeError::KernelError(KernelError::InvalidFnInput { .. })
@@ -70,7 +70,7 @@ fn test_arg(method_name: &str, args: Vec<u8>, expected_result: ExpectedResult) {
             });
         }
         ExpectedResult::InvalidOutput => {
-            receipt.expect_commit_failure(|e| {
+            receipt.expect_specific_failure(|e| {
                 matches!(
                     e,
                     RuntimeError::KernelError(KernelError::InvalidFnOutput { .. })

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -75,7 +75,7 @@ fn cannot_withdraw_from_other_account() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(is_auth_error);
+    receipt.expect_specific_failure(is_auth_error);
 }
 
 #[test]

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -30,7 +30,7 @@ fn test_auth_rule<'s, S: ReadableSubstateStore + WriteableSubstateStore>(
     if should_succeed {
         receipt.expect_commit_success();
     } else {
-        receipt.expect_commit_failure(is_auth_error);
+        receipt.expect_specific_failure(is_auth_error);
     }
 }
 
@@ -306,5 +306,5 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(is_auth_error)
+    receipt.expect_specific_failure(is_auth_error)
 }

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -61,7 +61,7 @@ fn cannot_make_cross_component_call_without_authorization() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(is_auth_error);
+    receipt.expect_specific_failure(is_auth_error);
 }
 
 #[test]

--- a/radix-engine/tests/authorization_dynamic.rs
+++ b/radix-engine/tests/authorization_dynamic.rs
@@ -70,7 +70,7 @@ fn test_dynamic_auth(
     if should_succeed {
         receipt2.expect_commit_success();
     } else {
-        receipt2.expect_commit_failure(is_auth_error);
+        receipt2.expect_specific_failure(is_auth_error);
     }
 }
 
@@ -125,7 +125,7 @@ fn test_dynamic_authlist(
     if should_succeed {
         receipt.expect_commit_success();
     } else {
-        receipt.expect_commit_failure(is_auth_error);
+        receipt.expect_specific_failure(is_auth_error);
     }
 }
 
@@ -247,7 +247,7 @@ fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
     let receipt = test_runner.execute_manifest(manifest2, vec![other_public_key]);
 
     // Assert
-    receipt.expect_commit_failure(is_auth_error);
+    receipt.expect_specific_failure(is_auth_error);
 }
 
 #[test]

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -85,7 +85,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
 
     // Assert
     if expect_err {
-        receipt.expect_commit_failure(is_auth_error);
+        receipt.expect_specific_failure(is_auth_error);
     } else {
         receipt.expect_commit_success();
     }

--- a/radix-engine/tests/authorization_vault.rs
+++ b/radix-engine/tests/authorization_vault.rs
@@ -22,7 +22,7 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(is_auth_error);
+    receipt.expect_specific_failure(is_auth_error);
 }
 
 #[test]

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -114,7 +114,7 @@ fn test_take_with_invalid_granularity() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::ApplicationError(ApplicationError::BucketError(
             BucketError::ResourceContainerError(ResourceContainerError::InvalidAmount(
                 amount,
@@ -154,7 +154,7 @@ fn test_take_with_negative_amount() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::ApplicationError(ApplicationError::BucketError(
             BucketError::ResourceContainerError(ResourceContainerError::InvalidAmount(
                 amount,

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -65,7 +65,7 @@ fn invalid_blueprint_name_should_cause_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::BlueprintNotFound(addr, blueprint)) = e {
             addr.eq(&package_address) && blueprint.eq("NonExistentBlueprint")
         } else {
@@ -99,7 +99,7 @@ fn reentrancy_should_not_be_possible() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::Reentrancy(SubstateId::ComponentState(
             address,
         ))) = e

--- a/radix-engine/tests/data_access.rs
+++ b/radix-engine/tests/data_access.rs
@@ -25,7 +25,7 @@ fn should_not_be_able_to_read_component_state_after_creation() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::SubstateReadNotReadable(..))
@@ -53,7 +53,7 @@ fn should_not_be_able_to_write_component_state_after_creation() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::SubstateWriteNotWriteable(..))
@@ -104,7 +104,7 @@ fn should_not_be_able_to_write_component_info() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::SubstateWriteNotWriteable(..))

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -230,7 +230,7 @@ fn test_fee_accounting_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::WorktopError(
@@ -322,7 +322,7 @@ fn test_contingent_fee_accounting_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key1, public_key2]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::WorktopError(

--- a/radix-engine/tests/frame.rs
+++ b/radix-engine/tests/frame.rs
@@ -43,7 +43,7 @@ fn test_max_call_depth_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::MaxCallDepthLimitReached)

--- a/radix-engine/tests/invalid_stored_values.rs
+++ b/radix-engine/tests/invalid_stored_values.rs
@@ -24,7 +24,7 @@ fn stored_bucket_in_committed_component_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(e, RuntimeError::KernelError(KernelError::ValueNotAllowed))
     });
 }
@@ -49,7 +49,7 @@ fn stored_bucket_in_owned_component_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(e, RuntimeError::KernelError(KernelError::ValueNotAllowed))
     });
 }

--- a/radix-engine/tests/kernel_globalize.rs
+++ b/radix-engine/tests/kernel_globalize.rs
@@ -21,7 +21,7 @@ fn should_not_be_able_to_globalize_key_value_store() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeGlobalizeTypeNotAllowed(
@@ -46,7 +46,7 @@ fn should_not_be_able_to_globalize_bucket() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeGlobalizeTypeNotAllowed(
@@ -71,7 +71,7 @@ fn should_not_be_able_to_globalize_proof() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeGlobalizeTypeNotAllowed(RENodeId::Proof(
@@ -96,7 +96,7 @@ fn should_not_be_able_to_globalize_vault() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeGlobalizeTypeNotAllowed(RENodeId::Vault(

--- a/radix-engine/tests/kernel_node_create.rs
+++ b/radix-engine/tests/kernel_node_create.rs
@@ -25,7 +25,7 @@ fn should_not_be_able_to_node_create_with_invalid_blueprint() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeCreateInvalidPermission)
@@ -53,7 +53,7 @@ fn should_not_be_able_to_node_create_with_invalid_package() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeCreateInvalidPermission)

--- a/radix-engine/tests/kv_store.rs
+++ b/radix-engine/tests/kv_store.rs
@@ -60,7 +60,7 @@ fn cyclic_map_fails_execution() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::SubstateReadSubstateNotFound(_))
@@ -83,7 +83,7 @@ fn self_cyclic_map_fails_execution() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::SubstateReadSubstateNotFound(..))
@@ -120,7 +120,7 @@ fn cannot_remove_key_value_stores() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::StoredNodeRemoved(_))
@@ -157,7 +157,7 @@ fn cannot_overwrite_key_value_stores() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::StoredNodeRemoved(_))
@@ -300,7 +300,7 @@ fn cannot_directly_reference_inserted_vault() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::InvokeMethodInvalidReceiver(RENodeId::Vault(_)))
@@ -328,7 +328,7 @@ fn cannot_directly_reference_vault_after_container_moved() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::InvokeMethodInvalidReceiver(RENodeId::Vault(_)))
@@ -356,7 +356,7 @@ fn cannot_directly_reference_vault_after_container_stored() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::InvokeMethodInvalidReceiver(RENodeId::Vault(_)))

--- a/radix-engine/tests/leaks.rs
+++ b/radix-engine/tests/leaks.rs
@@ -20,7 +20,7 @@ fn dangling_component_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Component))
@@ -43,7 +43,7 @@ fn dangling_bucket_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Bucket))
@@ -66,7 +66,7 @@ fn dangling_vault_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Vault))
@@ -89,7 +89,7 @@ fn dangling_worktop_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Worktop))
@@ -112,7 +112,7 @@ fn dangling_kv_store_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::KeyValueStore))
@@ -140,7 +140,7 @@ fn dangling_bucket_with_proof_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Bucket))

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -88,7 +88,7 @@ fn local_component_with_access_rules_should_not_be_callable() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ModuleError(ModuleError::AuthorizationError { .. })
@@ -182,7 +182,7 @@ fn recursion_bomb_to_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::MaxCallDepthLimitReached)
@@ -244,7 +244,7 @@ fn recursion_bomb_2_to_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::MaxCallDepthLimitReached)

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -48,7 +48,7 @@ fn test_loop_out_of_cost_unit() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(is_costing_error)
+    receipt.expect_specific_failure(is_costing_error)
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn test_recursion_stack_overflow() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(is_wasm_error)
+    receipt.expect_specific_failure(is_wasm_error)
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn test_grow_memory_out_of_cost_unit() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(is_costing_error)
+    receipt.expect_specific_failure(is_costing_error)
 }
 
 #[test]

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -50,7 +50,7 @@ fn missing_memory_should_cause_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             &RuntimeError::ApplicationError(ApplicationError::PackageError(
@@ -77,7 +77,7 @@ fn large_return_len_should_cause_memory_access_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
             matches!(**b, WasmInvokeError::MemoryAccessError)
         } else {
@@ -101,7 +101,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
             matches!(**b, WasmInvokeError::MemoryAccessError)
         } else {
@@ -126,7 +126,7 @@ fn zero_return_len_should_cause_data_validation_error() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::WasmInvokeError(_))
@@ -186,7 +186,7 @@ fn test_basic_package_missing_export() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::PackageError(

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -267,7 +267,7 @@ fn cant_move_restricted_proof() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::CantMoveRestrictedProof)
@@ -301,7 +301,7 @@ fn cant_move_locked_bucket() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::CantMoveLockedBucket)

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -56,7 +56,7 @@ fn mint_with_bad_granularity_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         if let RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(
             ResourceManagerError::InvalidAmount(amount, granularity),
         )) = e
@@ -90,7 +90,7 @@ fn mint_too_much_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(

--- a/radix-engine/tests/system.rs
+++ b/radix-engine/tests/system.rs
@@ -42,7 +42,7 @@ fn test_set_epoch_without_system_auth_fails() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ModuleError(ModuleError::AuthorizationError { .. })

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -48,7 +48,7 @@ fn test_state_track_failure() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::ApplicationError(ApplicationError::WorktopError(_))

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -26,7 +26,7 @@ fn non_existent_vault_in_component_creation_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeCreateNodeNotFound(RENodeId::Vault(_)))
@@ -58,7 +58,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeNotFound(RENodeId::Vault(_)))
@@ -86,7 +86,7 @@ fn non_existent_vault_in_key_value_store_creation_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeNotFound(RENodeId::Vault(_)))
@@ -122,7 +122,7 @@ fn non_existent_vault_in_committed_key_value_store_should_fail() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeNotFound(RENodeId::Vault(_)))
@@ -168,7 +168,7 @@ fn invalid_double_ownership_of_vault() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::RENodeCreateNodeNotFound(RENodeId::Vault(_)))
@@ -223,7 +223,7 @@ fn cannot_overwrite_vault_in_map() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::StoredNodeRemoved(RENodeId::Vault(_)))
@@ -283,7 +283,7 @@ fn cannot_remove_vaults() {
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::StoredNodeRemoved(RENodeId::Vault(_)))

--- a/radix-engine/tests/worktop.rs
+++ b/radix-engine/tests/worktop.rs
@@ -22,7 +22,7 @@ fn test_worktop_resource_leak() {
     let receipt = test_runner.execute_manifest(manifest, vec![public_key]);
 
     // Assert
-    receipt.expect_commit_failure(|e| {
+    receipt.expect_specific_failure(|e| {
         matches!(
             e,
             RuntimeError::KernelError(KernelError::DropFailure(DropFailure::Worktop))


### PR DESCRIPTION
I have reorganized the functions on TransactionReceipt a bit and included 4 more helpful functions:

+ `expect_commit_success()` now returned the exact encrypted transaction output (Last time, the function return a Vector with index [0] return only `[0]`? and index [1] return the transaction output).

+ `expect_commit_failure()` now returned the `RuntimeError` of transaction failure.

+ Change the last `expect_commit_failure()` into `expect_specific_failure()` .

+ Add `fn output()` return the decoded type (user choice) of transaction output (if success).

+ Add 3 functions return the new package, component, resource addresses on the transaction.