### PR TITLE
Feature: Encodeable Transaction Receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,23 @@ Documentation: https://docs.radixdlt.com/main/scrypto/introduction.html
 ## Installation
 
 1. Install Rust - this requires Rust 1.60+ (if rust is already installed, upgrade with `rustup update`)
-   * Windows:
-       * Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)
-       * Install "Desktop development with C++" with [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-       * Install [LLVM 13.0.1](https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.exe) (make sure you tick the option that adds LLVM to the system PATH)
-   * Linux and macOS:
-       * Make sure a C++ compiler and LLVM is installed (`sudo apt install build-essential llvm` with Ubuntu)
-       * Install Rust compiler
-       ```
-       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-       ```
+    * Windows:
+        * Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)
+        * Install "Desktop development with C++" with [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
+        * Install [LLVM 13.0.1](https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.exe) (make sure you tick the option that adds LLVM to the system PATH)
+    *  macOS:
+        * Make sure you have the xcode command line tools: `xcode-select --install`.
+        * Install cmake: `brew install cmake`
+        * Install the Rust compiler: 
+        ```bash
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        ```
+    * Linux:
+        * Make sure a C++ compiler and LLVM is installed (`sudo apt install build-essential llvm`).
+        * Install the Rust compiler:
+        ```bash
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        ```
 2. Enable `cargo` in the current shell:
    * Windows:
        * Start a new PowerShell

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -8,7 +8,7 @@ use crate::wasm::WasmError;
 use sbor::*;
 
 /// Represents an error which causes a tranasction to be rejected.
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum RejectionError {
     SuccessButFeeLoanNotRepaid,
     ErrorBeforeFeeLoanRepaid(RuntimeError),

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -101,7 +101,7 @@ pub enum KernelError {
     DropFailure(DropFailure),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Encode, Decode, TypeId)]
 pub enum ModuleError {
     AuthorizationError {
         function: FnIdentifier,
@@ -111,6 +111,23 @@ pub enum ModuleError {
 
     CostingError(FeeReserveError),
 }
+
+#[derive(Debug)]
+pub enum InvokeError<E> {
+    Error(E),
+    Downstream(RuntimeError),
+}
+
+impl<E> InvokeError<E> {
+    pub fn error(error: E) -> Self {
+        InvokeError::Error(error)
+    }
+
+    pub fn downstream(runtime_error: RuntimeError) -> Self {
+        InvokeError::Downstream(runtime_error)
+    }
+}
+
 
 #[derive(Debug)]
 pub enum ApplicationError {

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -4,7 +4,7 @@ use crate::engine::REActor;
 use crate::fee::FeeReserveError;
 use crate::model::*;
 use crate::types::*;
-use crate::wasm::{WasmError, WasmInvokeError};
+use crate::wasm::{WasmError};
 use sbor::*;
 
 /// Represents an error which causes a tranasction to be rejected.
@@ -31,18 +31,6 @@ pub enum RuntimeError {
 
     /// An error occurred within application logic, like the RE models.
     ApplicationError(ApplicationError),
-}
-
-impl From<WasmInvokeError> for RuntimeError {
-    fn from(e: WasmInvokeError) -> Self {
-        // Flatten error code for more readable transaction receipt
-        match e {
-            WasmInvokeError::Error(wasm_error) => {
-                RuntimeError::KernelError(KernelError::WasmError(wasm_error))
-            }
-            WasmInvokeError::DownstreamError(runtime_error) => runtime_error,
-        }
-    }
 }
 
 #[derive(Debug, Encode, Decode, TypeId)]

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -5,6 +5,7 @@ use crate::fee::FeeReserveError;
 use crate::model::*;
 use crate::types::*;
 use crate::wasm::{WasmError, WasmInvokeError};
+use sbor::*;
 
 /// Represents an error which causes a tranasction to be rejected.
 #[derive(Debug)]
@@ -44,7 +45,7 @@ impl From<WasmInvokeError> for RuntimeError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Encode, Decode, TypeId)]
 pub enum KernelError {
     // invocation
     WasmError(WasmError),
@@ -58,7 +59,6 @@ pub enum KernelError {
     },
     InvalidFnOutput {
         fn_identifier: FnIdentifier,
-        output: Value,
     },
 
     // ID allocation
@@ -135,7 +135,7 @@ pub enum ApplicationError {
     AuthZoneError(AuthZoneError),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Encode, Decode, TypeId)]
 pub enum DropFailure {
     System,
     Resource,

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -4,7 +4,7 @@ use crate::engine::REActor;
 use crate::fee::FeeReserveError;
 use crate::model::*;
 use crate::types::*;
-use crate::wasm::{WasmError};
+use crate::wasm::WasmError;
 use sbor::*;
 
 /// Represents an error which causes a tranasction to be rejected.
@@ -42,12 +42,8 @@ pub enum KernelError {
     InvokeMethodInvalidReferenceReturn(RENodeId),
     MaxCallDepthLimitReached,
     MethodNotFound(FnIdentifier),
-    InvalidFnInput {
-        fn_identifier: FnIdentifier,
-    },
-    InvalidFnOutput {
-        fn_identifier: FnIdentifier,
-    },
+    InvalidFnInput { fn_identifier: FnIdentifier },
+    InvalidFnOutput { fn_identifier: FnIdentifier },
 
     // ID allocation
     IdAllocationError(IdAllocationError),
@@ -115,7 +111,6 @@ impl<E> InvokeError<E> {
         InvokeError::Downstream(runtime_error)
     }
 }
-
 
 #[derive(Debug)]
 pub enum ApplicationError {

--- a/radix-engine/src/engine/errors.rs
+++ b/radix-engine/src/engine/errors.rs
@@ -21,7 +21,7 @@ impl fmt::Display for RejectionError {
 }
 
 /// Represents an error when executing a transaction.
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum RuntimeError {
     /// An error occurred within the kernel.
     KernelError(KernelError),
@@ -112,7 +112,7 @@ impl<E> InvokeError<E> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum ApplicationError {
     TransactionProcessorError(TransactionProcessorError),
 

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -331,7 +331,6 @@ where
                                 blueprint_name,
                                 ident,
                             },
-                            output: output.dom,
                         }))
                     } else {
                         Ok(output)

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -308,11 +308,11 @@ where
                             Box::new(RadixEngineWasmRuntime::new(scrypto_actor, self));
                         instance
                             .invoke_export(&export_name, &input, &mut runtime)
-                            .map_err(|e| {
-                                match e {
-                                    InvokeError::Error(e) => RuntimeError::KernelError(KernelError::WasmError(e)),
-                                    InvokeError::Downstream(runtime_error) => runtime_error,
+                            .map_err(|e| match e {
+                                InvokeError::Error(e) => {
+                                    RuntimeError::KernelError(KernelError::WasmError(e))
                                 }
+                                InvokeError::Downstream(runtime_error) => runtime_error,
                             })?
                     };
 

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -310,10 +310,12 @@ where
                             .invoke_export(&export_name, &input, &mut runtime)
                             .map_err(|e| match e {
                                 // Flatten error code for more readable transaction receipt
-                                WasmInvokeError::RuntimeError(e) => e,
-                                e @ _ => RuntimeError::KernelError(KernelError::WasmInvokeError(
-                                    e.into(),
-                                )),
+                                WasmInvokeError::DownstreamError(e) => e,
+                                e @ _ => {
+                                    RuntimeError::KernelError(KernelError::WasmInvokeError(
+                                        e.into(),
+                                    ))
+                                },
                             })?
                     };
 

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -308,14 +308,9 @@ where
                             Box::new(RadixEngineWasmRuntime::new(scrypto_actor, self));
                         instance
                             .invoke_export(&export_name, &input, &mut runtime)
-                            .map_err(|e| match e {
-                                // Flatten error code for more readable transaction receipt
-                                WasmInvokeError::DownstreamError(e) => e,
-                                e @ _ => {
-                                    RuntimeError::KernelError(KernelError::WasmInvokeError(
-                                        e.into(),
-                                    ))
-                                },
+                            .map_err(|e| {
+                                let runtime_error: RuntimeError = e.into();
+                                runtime_error
                             })?
                     };
 

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -309,8 +309,10 @@ where
                         instance
                             .invoke_export(&export_name, &input, &mut runtime)
                             .map_err(|e| {
-                                let runtime_error: RuntimeError = e.into();
-                                runtime_error
+                                match e {
+                                    InvokeError::Error(e) => RuntimeError::KernelError(KernelError::WasmError(e)),
+                                    InvokeError::Downstream(runtime_error) => runtime_error,
+                                }
                             })?
                     };
 

--- a/radix-engine/src/engine/modules/execution_trace.rs
+++ b/radix-engine/src/engine/modules/execution_trace.rs
@@ -3,7 +3,7 @@ use crate::fee::FeeReserve;
 use crate::model::*;
 use crate::types::*;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, TypeId, Encode, Decode)]
 pub struct ResourceChange {
     pub resource_address: ResourceAddress,
     pub component_address: ComponentAddress,

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -63,7 +63,12 @@ impl NativeInterpreter {
                 .map_err(|e| RuntimeError::ApplicationError(ApplicationError::ProofError(e))),
             (Some(Receiver::Ref(RENodeId::Worktop)), NativeFnIdentifier::Worktop(worktop_fn)) => {
                 Worktop::main(worktop_fn, input, system_api)
-                    .map_err(|e| RuntimeError::ApplicationError(ApplicationError::WorktopError(e)))
+                    .map_err(|e| {
+                        match e {
+                            InvokeError::Downstream(runtime_error) => runtime_error,
+                            InvokeError::Error(worktop_error) => RuntimeError::ApplicationError(ApplicationError::WorktopError(worktop_error)),
+                        }
+                    })
             }
             (
                 Some(Receiver::Ref(RENodeId::Vault(vault_id))),

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -23,7 +23,12 @@ impl NativeInterpreter {
         match (receiver, fn_identifier) {
             (None, NativeFnIdentifier::TransactionProcessor(transaction_processor_fn)) => {
                 TransactionProcessor::static_main(transaction_processor_fn, input, system_api)
-                    .map_err(|e| e.to_runtime_error())
+                    .map_err(|e| {
+                        match e {
+                            InvokeError::Downstream(runtime_error) => runtime_error,
+                            InvokeError::Error(e) => RuntimeError::ApplicationError(ApplicationError::TransactionProcessorError(e)),
+                        }
+                    })
             }
             (None, NativeFnIdentifier::Package(package_fn)) => {
                 ValidatedPackage::static_main(package_fn, input, system_api)

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -97,7 +97,14 @@ impl NativeInterpreter {
                 }),
             (Some(Receiver::Ref(RENodeId::System)), NativeFnIdentifier::System(system_fn)) => {
                 System::main(system_fn, input, system_api)
-                    .map_err(|e| RuntimeError::ApplicationError(ApplicationError::SystemError(e)))
+                    .map_err(|e| {
+                        match e {
+                            InvokeError::Downstream(runtime_error) => runtime_error,
+                            InvokeError::Error(e) => RuntimeError::ApplicationError(
+                                ApplicationError::SystemError(e),
+                            ),
+                        }
+                    })
             }
             _ => {
                 return Err(RuntimeError::KernelError(KernelError::MethodNotFound(

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -49,12 +49,20 @@ impl NativeInterpreter {
                 })
             }
             (Some(Receiver::Consumed(node_id)), NativeFnIdentifier::Bucket(bucket_fn)) => {
-                Bucket::consuming_main(node_id, bucket_fn, input, system_api)
-                    .map_err(|e| RuntimeError::ApplicationError(ApplicationError::BucketError(e)))
+                Bucket::consuming_main(node_id, bucket_fn, input, system_api).map_err(|e| match e {
+                    InvokeError::Downstream(runtime_error) => runtime_error,
+                    InvokeError::Error(e) => {
+                        RuntimeError::ApplicationError(ApplicationError::BucketError(e))
+                    }
+                })
             }
             (Some(Receiver::Consumed(node_id)), NativeFnIdentifier::Proof(proof_fn)) => {
-                Proof::main_consume(node_id, proof_fn, input, system_api)
-                    .map_err(|e| RuntimeError::ApplicationError(ApplicationError::ProofError(e)))
+                Proof::main_consume(node_id, proof_fn, input, system_api).map_err(|e| match e {
+                    InvokeError::Downstream(runtime_error) => runtime_error,
+                    InvokeError::Error(e) => {
+                        RuntimeError::ApplicationError(ApplicationError::ProofError(e))
+                    }
+                })
             }
             (Some(Receiver::CurrentAuthZone), NativeFnIdentifier::AuthZone(auth_zone_fn)) => {
                 AuthZone::main(
@@ -68,13 +76,21 @@ impl NativeInterpreter {
             (
                 Some(Receiver::Ref(RENodeId::Bucket(bucket_id))),
                 NativeFnIdentifier::Bucket(bucket_fn),
-            ) => Bucket::main(bucket_id, bucket_fn, input, system_api)
-                .map_err(|e| RuntimeError::ApplicationError(ApplicationError::BucketError(e))),
+            ) => Bucket::main(bucket_id, bucket_fn, input, system_api).map_err(|e| match e {
+                InvokeError::Downstream(runtime_error) => runtime_error,
+                InvokeError::Error(e) => {
+                    RuntimeError::ApplicationError(ApplicationError::BucketError(e))
+                }
+            }),
             (
                 Some(Receiver::Ref(RENodeId::Proof(proof_id))),
                 NativeFnIdentifier::Proof(proof_fn),
-            ) => Proof::main(proof_id, proof_fn, input, system_api)
-                .map_err(|e| RuntimeError::ApplicationError(ApplicationError::ProofError(e))),
+            ) => Proof::main(proof_id, proof_fn, input, system_api).map_err(|e| match e {
+                InvokeError::Downstream(runtime_error) => runtime_error,
+                InvokeError::Error(e) => {
+                    RuntimeError::ApplicationError(ApplicationError::ProofError(e))
+                }
+            }),
             (Some(Receiver::Ref(RENodeId::Worktop)), NativeFnIdentifier::Worktop(worktop_fn)) => {
                 Worktop::main(worktop_fn, input, system_api).map_err(|e| match e {
                     InvokeError::Downstream(runtime_error) => runtime_error,
@@ -91,8 +107,14 @@ impl NativeInterpreter {
             (
                 Some(Receiver::Ref(RENodeId::Component(component_address))),
                 NativeFnIdentifier::Component(component_fn),
-            ) => ComponentInfo::main(component_address, component_fn, input, system_api)
-                .map_err(|e| RuntimeError::ApplicationError(ApplicationError::ComponentError(e))),
+            ) => ComponentInfo::main(component_address, component_fn, input, system_api).map_err(
+                |e| match e {
+                    InvokeError::Downstream(runtime_error) => runtime_error,
+                    InvokeError::Error(e) => {
+                        RuntimeError::ApplicationError(ApplicationError::ComponentError(e))
+                    }
+                },
+            ),
             (
                 Some(Receiver::Ref(RENodeId::ResourceManager(resource_address))),
                 NativeFnIdentifier::ResourceManager(resource_manager_fn),

--- a/radix-engine/src/engine/native_interpreter.rs
+++ b/radix-engine/src/engine/native_interpreter.rs
@@ -6,6 +6,75 @@ use crate::wasm::*;
 
 pub struct NativeInterpreter;
 
+impl<E: Into<ApplicationError>> Into<RuntimeError> for InvokeError<E> {
+    fn into(self) -> RuntimeError {
+        match self {
+            InvokeError::Downstream(runtime_error) => runtime_error,
+            InvokeError::Error(e) => RuntimeError::ApplicationError(e.into()),
+        }
+    }
+}
+
+impl Into<ApplicationError> for TransactionProcessorError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::TransactionProcessorError(self)
+    }
+}
+
+impl Into<ApplicationError> for PackageError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::PackageError(self)
+    }
+}
+
+impl Into<ApplicationError> for ResourceManagerError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::ResourceManagerError(self)
+    }
+}
+
+impl Into<ApplicationError> for BucketError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::BucketError(self)
+    }
+}
+
+impl Into<ApplicationError> for ProofError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::ProofError(self)
+    }
+}
+
+impl Into<ApplicationError> for AuthZoneError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::AuthZoneError(self)
+    }
+}
+
+impl Into<ApplicationError> for WorktopError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::WorktopError(self)
+    }
+}
+
+impl Into<ApplicationError> for VaultError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::VaultError(self)
+    }
+}
+
+impl Into<ApplicationError> for ComponentError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::ComponentError(self)
+    }
+}
+
+impl Into<ApplicationError> for SystemError {
+    fn into(self) -> ApplicationError {
+        ApplicationError::SystemError(self)
+    }
+}
+
 impl NativeInterpreter {
     pub fn run<'s, Y, W, I, R>(
         receiver: Option<Receiver>,
@@ -23,46 +92,20 @@ impl NativeInterpreter {
         match (receiver, fn_identifier) {
             (None, NativeFnIdentifier::TransactionProcessor(transaction_processor_fn)) => {
                 TransactionProcessor::static_main(transaction_processor_fn, input, system_api)
-                    .map_err(|e| match e {
-                        InvokeError::Downstream(runtime_error) => runtime_error,
-                        InvokeError::Error(e) => RuntimeError::ApplicationError(
-                            ApplicationError::TransactionProcessorError(e),
-                        ),
-                    })
+                    .map_err(|e| e.into())
             }
             (None, NativeFnIdentifier::Package(package_fn)) => {
-                ValidatedPackage::static_main(package_fn, input, system_api).map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::PackageError(e))
-                    }
-                })
+                ValidatedPackage::static_main(package_fn, input, system_api).map_err(|e| e.into())
             }
             (None, NativeFnIdentifier::ResourceManager(resource_manager_fn)) => {
-                ResourceManager::static_main(resource_manager_fn, input, system_api).map_err(|e| {
-                    match e {
-                        InvokeError::Downstream(runtime_error) => runtime_error,
-                        InvokeError::Error(e) => RuntimeError::ApplicationError(
-                            ApplicationError::ResourceManagerError(e),
-                        ),
-                    }
-                })
+                ResourceManager::static_main(resource_manager_fn, input, system_api)
+                    .map_err(|e| e.into())
             }
             (Some(Receiver::Consumed(node_id)), NativeFnIdentifier::Bucket(bucket_fn)) => {
-                Bucket::consuming_main(node_id, bucket_fn, input, system_api).map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::BucketError(e))
-                    }
-                })
+                Bucket::consuming_main(node_id, bucket_fn, input, system_api).map_err(|e| e.into())
             }
             (Some(Receiver::Consumed(node_id)), NativeFnIdentifier::Proof(proof_fn)) => {
-                Proof::main_consume(node_id, proof_fn, input, system_api).map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::ProofError(e))
-                    }
-                })
+                Proof::main_consume(node_id, proof_fn, input, system_api).map_err(|e| e.into())
             }
             (Some(Receiver::CurrentAuthZone), NativeFnIdentifier::AuthZone(auth_zone_fn)) => {
                 AuthZone::main(
@@ -71,76 +114,35 @@ impl NativeInterpreter {
                     input,
                     system_api,
                 )
-                .map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::AuthZoneError(e))
-                    }
-                })
+                .map_err(|e| e.into())
             }
             (
                 Some(Receiver::Ref(RENodeId::Bucket(bucket_id))),
                 NativeFnIdentifier::Bucket(bucket_fn),
-            ) => Bucket::main(bucket_id, bucket_fn, input, system_api).map_err(|e| match e {
-                InvokeError::Downstream(runtime_error) => runtime_error,
-                InvokeError::Error(e) => {
-                    RuntimeError::ApplicationError(ApplicationError::BucketError(e))
-                }
-            }),
+            ) => Bucket::main(bucket_id, bucket_fn, input, system_api).map_err(|e| e.into()),
             (
                 Some(Receiver::Ref(RENodeId::Proof(proof_id))),
                 NativeFnIdentifier::Proof(proof_fn),
-            ) => Proof::main(proof_id, proof_fn, input, system_api).map_err(|e| match e {
-                InvokeError::Downstream(runtime_error) => runtime_error,
-                InvokeError::Error(e) => {
-                    RuntimeError::ApplicationError(ApplicationError::ProofError(e))
-                }
-            }),
+            ) => Proof::main(proof_id, proof_fn, input, system_api).map_err(|e| e.into()),
             (Some(Receiver::Ref(RENodeId::Worktop)), NativeFnIdentifier::Worktop(worktop_fn)) => {
-                Worktop::main(worktop_fn, input, system_api).map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(worktop_error) => RuntimeError::ApplicationError(
-                        ApplicationError::WorktopError(worktop_error),
-                    ),
-                })
+                Worktop::main(worktop_fn, input, system_api).map_err(|e| e.into())
             }
             (
                 Some(Receiver::Ref(RENodeId::Vault(vault_id))),
                 NativeFnIdentifier::Vault(vault_fn),
-            ) => Vault::main(vault_id, vault_fn, input, system_api).map_err(|e| match e {
-                InvokeError::Downstream(runtime_error) => runtime_error,
-                InvokeError::Error(e) => {
-                    RuntimeError::ApplicationError(ApplicationError::VaultError(e))
-                }
-            }),
+            ) => Vault::main(vault_id, vault_fn, input, system_api).map_err(|e| e.into()),
             (
                 Some(Receiver::Ref(RENodeId::Component(component_address))),
                 NativeFnIdentifier::Component(component_fn),
-            ) => ComponentInfo::main(component_address, component_fn, input, system_api).map_err(
-                |e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::ComponentError(e))
-                    }
-                },
-            ),
+            ) => ComponentInfo::main(component_address, component_fn, input, system_api)
+                .map_err(|e| e.into()),
             (
                 Some(Receiver::Ref(RENodeId::ResourceManager(resource_address))),
                 NativeFnIdentifier::ResourceManager(resource_manager_fn),
             ) => ResourceManager::main(resource_address, resource_manager_fn, input, system_api)
-                .map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(e))
-                    }
-                }),
+                .map_err(|e| e.into()),
             (Some(Receiver::Ref(RENodeId::System)), NativeFnIdentifier::System(system_fn)) => {
-                System::main(system_fn, input, system_api).map_err(|e| match e {
-                    InvokeError::Downstream(runtime_error) => runtime_error,
-                    InvokeError::Error(e) => {
-                        RuntimeError::ApplicationError(ApplicationError::SystemError(e))
-                    }
-                })
+                System::main(system_fn, input, system_api).map_err(|e| e.into())
             }
             _ => {
                 return Err(RuntimeError::KernelError(KernelError::MethodNotFound(

--- a/radix-engine/src/engine/wasm_runtime.rs
+++ b/radix-engine/src/engine/wasm_runtime.rs
@@ -193,8 +193,8 @@ where
     R: FeeReserve,
 {
     fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, WasmInvokeError> {
-        let input: RadixEngineInput =
-            scrypto_decode(&input.raw).map_err(|_| WasmInvokeError::Error(WasmError::InvalidRadixEngineInput))?;
+        let input: RadixEngineInput = scrypto_decode(&input.raw)
+            .map_err(|_| WasmInvokeError::Error(WasmError::InvalidRadixEngineInput))?;
         match input {
             RadixEngineInput::InvokeFunction(fn_identifier, input_bytes) => {
                 self.handle_invoke_function(fn_identifier, input_bytes)

--- a/radix-engine/src/engine/wasm_runtime.rs
+++ b/radix-engine/src/engine/wasm_runtime.rs
@@ -1,7 +1,7 @@
 use crate::engine::RuntimeError;
 use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::*;
-use crate::model::{ComponentInfo, ComponentState, HeapKeyValueStore};
+use crate::model::{ComponentInfo, ComponentState, HeapKeyValueStore, InvokeError};
 use crate::types::*;
 use crate::wasm::*;
 
@@ -192,9 +192,9 @@ where
     I: WasmInstance,
     R: FeeReserve,
 {
-    fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, WasmInvokeError> {
+    fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, InvokeError<WasmError>> {
         let input: RadixEngineInput = scrypto_decode(&input.raw)
-            .map_err(|_| WasmInvokeError::Error(WasmError::InvalidRadixEngineInput))?;
+            .map_err(|_| InvokeError::Error(WasmError::InvalidRadixEngineInput))?;
         match input {
             RadixEngineInput::InvokeFunction(fn_identifier, input_bytes) => {
                 self.handle_invoke_function(fn_identifier, input_bytes)
@@ -217,13 +217,13 @@ where
                 self.handle_check_access_rule(rule, proof_ids).map(encode)
             }
         }
-        .map_err(WasmInvokeError::DownstreamError)
+        .map_err(InvokeError::downstream)
     }
 
-    fn consume_cost_units(&mut self, n: u32) -> Result<(), WasmInvokeError> {
+    fn consume_cost_units(&mut self, n: u32) -> Result<(), InvokeError<WasmError>> {
         self.system_api
             .consume_cost_units(n)
-            .map_err(WasmInvokeError::DownstreamError)
+            .map_err(InvokeError::downstream)
     }
 }
 
@@ -239,13 +239,13 @@ impl NopWasmRuntime {
 }
 
 impl WasmRuntime for NopWasmRuntime {
-    fn main(&mut self, _input: ScryptoValue) -> Result<ScryptoValue, WasmInvokeError> {
+    fn main(&mut self, _input: ScryptoValue) -> Result<ScryptoValue, InvokeError<WasmError>> {
         Ok(ScryptoValue::unit())
     }
 
-    fn consume_cost_units(&mut self, n: u32) -> Result<(), WasmInvokeError> {
+    fn consume_cost_units(&mut self, n: u32) -> Result<(), InvokeError<WasmError>> {
         self.fee_reserve
             .consume(n, "run_wasm")
-            .map_err(|e| WasmInvokeError::Error(WasmError::CostingError(e)))
+            .map_err(|e| InvokeError::Error(WasmError::CostingError(e)))
     }
 }

--- a/radix-engine/src/engine/wasm_runtime.rs
+++ b/radix-engine/src/engine/wasm_runtime.rs
@@ -194,7 +194,7 @@ where
 {
     fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, WasmInvokeError> {
         let input: RadixEngineInput =
-            scrypto_decode(&input.raw).map_err(|_| WasmInvokeError::InvalidRadixEngineInput)?;
+            scrypto_decode(&input.raw).map_err(|_| WasmInvokeError::Error(WasmError::InvalidRadixEngineInput))?;
         match input {
             RadixEngineInput::InvokeFunction(fn_identifier, input_bytes) => {
                 self.handle_invoke_function(fn_identifier, input_bytes)
@@ -217,13 +217,13 @@ where
                 self.handle_check_access_rule(rule, proof_ids).map(encode)
             }
         }
-        .map_err(WasmInvokeError::RuntimeError)
+        .map_err(WasmInvokeError::DownstreamError)
     }
 
     fn consume_cost_units(&mut self, n: u32) -> Result<(), WasmInvokeError> {
         self.system_api
             .consume_cost_units(n)
-            .map_err(WasmInvokeError::RuntimeError)
+            .map_err(WasmInvokeError::DownstreamError)
     }
 }
 
@@ -246,6 +246,6 @@ impl WasmRuntime for NopWasmRuntime {
     fn consume_cost_units(&mut self, n: u32) -> Result<(), WasmInvokeError> {
         self.fee_reserve
             .consume(n, "run_wasm")
-            .map_err(WasmInvokeError::CostingError)
+            .map_err(|e| WasmInvokeError::Error(WasmError::CostingError(e)))
     }
 }

--- a/radix-engine/src/fee/fee_reserve.rs
+++ b/radix-engine/src/fee/fee_reserve.rs
@@ -3,7 +3,7 @@ use crate::fee::FeeSummary;
 use crate::model::ResourceContainer;
 use crate::types::*;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeId)]
 pub enum FeeReserveError {
     OutOfCostUnit,
     Overflow,

--- a/radix-engine/src/fee/fee_summary.rs
+++ b/radix-engine/src/fee/fee_summary.rs
@@ -1,7 +1,7 @@
 use crate::model::ResourceContainer;
 use crate::types::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct FeeSummary {
     /// Whether the system loan is fully repaid
     pub loan_fully_repaid: bool,

--- a/radix-engine/src/model/auth_zone.rs
+++ b/radix-engine/src/model/auth_zone.rs
@@ -1,12 +1,11 @@
-use crate::engine::{HeapRENode, RuntimeError, SystemApi};
+use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::FeeReserve;
-use crate::model::{Proof, ProofError};
+use crate::model::{InvokeError, Proof, ProofError};
 use crate::types::*;
 use crate::wasm::*;
 
 #[derive(Debug)]
 pub enum AuthZoneError {
-    RuntimeError(Box<RuntimeError>),
     EmptyAuthZone,
     ProofError(ProofError),
     CouldNotCreateProof,
@@ -31,9 +30,9 @@ impl AuthZone {
         Self { proofs: Vec::new() }
     }
 
-    fn pop(&mut self) -> Result<Proof, AuthZoneError> {
+    fn pop(&mut self) -> Result<Proof, InvokeError<AuthZoneError>> {
         if self.proofs.is_empty() {
-            return Err(AuthZoneError::EmptyAuthZone);
+            return Err(InvokeError::Error(AuthZoneError::EmptyAuthZone));
         }
 
         Ok(self.proofs.remove(self.proofs.len() - 1))
@@ -57,9 +56,9 @@ impl AuthZone {
         &self,
         resource_address: ResourceAddress,
         resource_type: ResourceType,
-    ) -> Result<Proof, AuthZoneError> {
+    ) -> Result<Proof, InvokeError<AuthZoneError>> {
         Proof::compose(&self.proofs, resource_address, resource_type)
-            .map_err(AuthZoneError::ProofError)
+            .map_err(|e| InvokeError::Error(AuthZoneError::ProofError(e)))
     }
 
     fn create_proof_by_amount(
@@ -67,9 +66,9 @@ impl AuthZone {
         amount: Decimal,
         resource_address: ResourceAddress,
         resource_type: ResourceType,
-    ) -> Result<Proof, AuthZoneError> {
+    ) -> Result<Proof, InvokeError<AuthZoneError>> {
         Proof::compose_by_amount(&self.proofs, amount, resource_address, resource_type)
-            .map_err(AuthZoneError::ProofError)
+            .map_err(|e| InvokeError::Error(AuthZoneError::ProofError(e)))
     }
 
     fn create_proof_by_ids(
@@ -77,9 +76,9 @@ impl AuthZone {
         ids: &BTreeSet<NonFungibleId>,
         resource_address: ResourceAddress,
         resource_type: ResourceType,
-    ) -> Result<Proof, AuthZoneError> {
+    ) -> Result<Proof, InvokeError<AuthZoneError>> {
         Proof::compose_by_ids(&self.proofs, ids, resource_address, resource_type)
-            .map_err(AuthZoneError::ProofError)
+            .map_err(|e| InvokeError::Error(AuthZoneError::ProofError(e)))
     }
 
     pub fn main<'s, Y, W, I, R>(
@@ -87,7 +86,7 @@ impl AuthZone {
         auth_zone_fn: AuthZoneFnIdentifier,
         args: ScryptoValue,
         system_api: &mut Y,
-    ) -> Result<ScryptoValue, AuthZoneError>
+    ) -> Result<ScryptoValue, InvokeError<AuthZoneError>>
     where
         Y: SystemApi<'s, W, I, R>,
         W: WasmEngine<I>,
@@ -96,24 +95,24 @@ impl AuthZone {
     {
         match auth_zone_fn {
             AuthZoneFnIdentifier::Pop => {
-                let _: AuthZonePopInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let _: AuthZonePopInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let auth_zone = system_api.auth_zone(auth_zone_frame_id);
                 let proof = auth_zone.pop()?;
                 let proof_id = system_api
                     .node_create(HeapRENode::Proof(proof))
-                    .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Proof(
                     proof_id,
                 )))
             }
             AuthZoneFnIdentifier::Push => {
-                let input: AuthZonePushInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let input: AuthZonePushInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let mut proof: Proof = system_api
                     .node_drop(&RENodeId::Proof(input.proof.0))
-                    .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 proof.change_to_unrestricted();
 
@@ -122,12 +121,12 @@ impl AuthZone {
                 Ok(ScryptoValue::from_typed(&()))
             }
             AuthZoneFnIdentifier::CreateProof => {
-                let input: AuthZoneCreateProofInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let input: AuthZoneCreateProofInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let resource_type = {
                     let value = system_api
                         .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                        .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?;
+                        .map_err(InvokeError::Downstream)?;
                     let resource_manager = value.resource_manager();
                     resource_manager.resource_type()
                 };
@@ -135,19 +134,19 @@ impl AuthZone {
                 let proof = auth_zone.create_proof(input.resource_address, resource_type)?;
                 let proof_id = system_api
                     .node_create(HeapRENode::Proof(proof))
-                    .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Proof(
                     proof_id,
                 )))
             }
             AuthZoneFnIdentifier::CreateProofByAmount => {
-                let input: AuthZoneCreateProofByAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let input: AuthZoneCreateProofByAmountInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let resource_type = {
                     let value = system_api
                         .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                        .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?;
+                        .map_err(InvokeError::Downstream)?;
                     let resource_manager = value.resource_manager();
                     resource_manager.resource_type()
                 };
@@ -159,19 +158,19 @@ impl AuthZone {
                 )?;
                 let proof_id = system_api
                     .node_create(HeapRENode::Proof(proof))
-                    .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Proof(
                     proof_id,
                 )))
             }
             AuthZoneFnIdentifier::CreateProofByIds => {
-                let input: AuthZoneCreateProofByIdsInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let input: AuthZoneCreateProofByIdsInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let resource_type = {
                     let value = system_api
                         .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                        .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?;
+                        .map_err(InvokeError::Downstream)?;
                     let resource_manager = value.resource_manager();
                     resource_manager.resource_type()
                 };
@@ -183,15 +182,15 @@ impl AuthZone {
                 )?;
                 let proof_id = system_api
                     .node_create(HeapRENode::Proof(proof))
-                    .map_err(|e| AuthZoneError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Proof(
                     proof_id,
                 )))
             }
             AuthZoneFnIdentifier::Clear => {
-                let _: AuthZoneClearInput =
-                    scrypto_decode(&args.raw).map_err(|e| AuthZoneError::InvalidRequestData(e))?;
+                let _: AuthZoneClearInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(AuthZoneError::InvalidRequestData(e)))?;
                 let auth_zone = system_api.auth_zone(auth_zone_frame_id);
                 auth_zone.clear();
                 Ok(ScryptoValue::from_typed(&()))

--- a/radix-engine/src/model/auth_zone.rs
+++ b/radix-engine/src/model/auth_zone.rs
@@ -4,7 +4,7 @@ use crate::model::{InvokeError, Proof, ProofError};
 use crate::types::*;
 use crate::wasm::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum AuthZoneError {
     EmptyAuthZone,
     ProofError(ProofError),

--- a/radix-engine/src/model/bucket.rs
+++ b/radix-engine/src/model/bucket.rs
@@ -6,7 +6,7 @@ use crate::model::{
 use crate::types::*;
 use crate::wasm::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum BucketError {
     InvalidDivisibility,
     InvalidRequestData(DecodeError),

--- a/radix-engine/src/model/bucket.rs
+++ b/radix-engine/src/model/bucket.rs
@@ -1,14 +1,13 @@
-use crate::engine::{HeapRENode, RuntimeError, SystemApi};
+use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::FeeReserve;
 use crate::model::{
-    Proof, ProofError, ResourceContainer, ResourceContainerError, ResourceContainerId,
+    InvokeError, Proof, ProofError, ResourceContainer, ResourceContainerError, ResourceContainerId,
 };
 use crate::types::*;
 use crate::wasm::*;
 
 #[derive(Debug)]
 pub enum BucketError {
-    RuntimeError(Box<RuntimeError>),
     InvalidDivisibility,
     InvalidRequestData(DecodeError),
     CouldNotCreateBucket,
@@ -155,7 +154,7 @@ impl Bucket {
         bucket_fn: BucketFnIdentifier,
         args: ScryptoValue,
         system_api: &mut Y,
-    ) -> Result<ScryptoValue, BucketError>
+    ) -> Result<ScryptoValue, InvokeError<BucketError>>
     where
         Y: SystemApi<'s, W, I, R>,
         W: WasmEngine<I>,
@@ -165,88 +164,88 @@ impl Bucket {
         let substate_id = SubstateId::Bucket(bucket_id);
         let mut node_ref = system_api
             .substate_borrow_mut(&substate_id)
-            .map_err(|e| BucketError::RuntimeError(Box::new(e)))?;
+            .map_err(InvokeError::Downstream)?;
         let bucket0 = node_ref.bucket();
 
         let rtn = match bucket_fn {
             BucketFnIdentifier::Take => {
-                let input: BucketTakeInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let input: BucketTakeInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 let container = bucket0
                     .take(input.amount)
-                    .map_err(BucketError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(BucketError::ResourceContainerError(e)))?;
                 let bucket_id = system_api
                     .node_create(HeapRENode::Bucket(Bucket::new(container)))
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Bucket(
                     bucket_id,
                 )))
             }
             BucketFnIdentifier::TakeNonFungibles => {
-                let input: BucketTakeNonFungiblesInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let input: BucketTakeNonFungiblesInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 let container = bucket0
                     .take_non_fungibles(&input.ids)
-                    .map_err(BucketError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(BucketError::ResourceContainerError(e)))?;
                 let bucket_id = system_api
                     .node_create(HeapRENode::Bucket(Bucket::new(container)))
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Bucket(
                     bucket_id,
                 )))
             }
             BucketFnIdentifier::GetNonFungibleIds => {
-                let _: BucketGetNonFungibleIdsInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let _: BucketGetNonFungibleIdsInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 let ids = bucket0
                     .total_ids()
-                    .map_err(BucketError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(BucketError::ResourceContainerError(e)))?;
                 Ok(ScryptoValue::from_typed(&ids))
             }
             BucketFnIdentifier::Put => {
-                let input: BucketPutInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let input: BucketPutInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 let other_bucket = system_api
                     .node_drop(&RENodeId::Bucket(input.bucket.0))
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 bucket0
                     .put(other_bucket)
-                    .map_err(BucketError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(BucketError::ResourceContainerError(e)))?;
                 Ok(ScryptoValue::from_typed(&()))
             }
             BucketFnIdentifier::GetAmount => {
-                let _: BucketGetAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let _: BucketGetAmountInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 Ok(ScryptoValue::from_typed(&bucket0.total_amount()))
             }
             BucketFnIdentifier::GetResourceAddress => {
-                let _: BucketGetResourceAddressInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let _: BucketGetResourceAddressInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 Ok(ScryptoValue::from_typed(&bucket0.resource_address()))
             }
             BucketFnIdentifier::CreateProof => {
-                let _: BucketCreateProofInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let _: BucketCreateProofInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
                 let proof = bucket0
                     .create_proof(bucket_id)
-                    .map_err(BucketError::ProofError)?;
+                    .map_err(|e| InvokeError::Error(BucketError::ProofError(e)))?;
                 let proof_id = system_api
                     .node_create(HeapRENode::Proof(proof))
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Proof(
                     proof_id,
                 )))
             }
-            _ => Err(BucketError::MethodNotFound(bucket_fn)),
+            _ => Err(InvokeError::Error(BucketError::MethodNotFound(bucket_fn))),
         }?;
 
         system_api
             .substate_return_mut(node_ref)
-            .map_err(|e| BucketError::RuntimeError(Box::new(e)))?;
+            .map_err(InvokeError::Downstream)?;
 
         Ok(rtn)
     }
@@ -256,7 +255,7 @@ impl Bucket {
         bucket_fn: BucketFnIdentifier,
         args: ScryptoValue,
         system_api: &mut Y,
-    ) -> Result<ScryptoValue, BucketError>
+    ) -> Result<ScryptoValue, InvokeError<BucketError>>
     where
         Y: SystemApi<'s, W, I, R>,
         W: WasmEngine<I>,
@@ -265,12 +264,12 @@ impl Bucket {
     {
         match bucket_fn {
             BucketFnIdentifier::Burn => {
-                let _: ConsumingBucketBurnInput =
-                    scrypto_decode(&args.raw).map_err(|e| BucketError::InvalidRequestData(e))?;
+                let _: ConsumingBucketBurnInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(BucketError::InvalidRequestData(e)))?;
 
                 let bucket: Bucket = system_api
                     .node_drop(&node_id)
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?
+                    .map_err(InvokeError::Downstream)?
                     .into();
 
                 // Notify resource manager, TODO: Should not need to notify manually
@@ -278,7 +277,7 @@ impl Bucket {
                 let resource_substate_id = SubstateId::ResourceManager(resource_address);
                 let mut value = system_api
                     .substate_borrow_mut(&resource_substate_id)
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?;
+                    .map_err(InvokeError::Downstream)?;
                 let resource_manager = value.resource_manager();
                 resource_manager.burn(bucket.total_amount());
                 if matches!(resource_manager.resource_type(), ResourceType::NonFungible) {
@@ -289,16 +288,16 @@ impl Bucket {
                         let address = SubstateId::NonFungible(resource_address, id);
                         system_api
                             .substate_take(address)
-                            .map_err(|e| BucketError::RuntimeError(Box::new(e)))?;
+                            .map_err(InvokeError::Downstream)?;
                     }
                 }
                 system_api
                     .substate_return_mut(value)
-                    .map_err(|e| BucketError::RuntimeError(Box::new(e)))?;
+                    .map_err(InvokeError::Downstream)?;
 
                 Ok(ScryptoValue::from_typed(&()))
             }
-            _ => Err(BucketError::MethodNotFound(bucket_fn)),
+            _ => Err(InvokeError::Error(BucketError::MethodNotFound(bucket_fn))),
         }
     }
 }

--- a/radix-engine/src/model/component.rs
+++ b/radix-engine/src/model/component.rs
@@ -4,7 +4,7 @@ use crate::model::{convert, InvokeError, MethodAuthorization};
 use crate::types::*;
 use crate::wasm::{WasmEngine, WasmInstance};
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum ComponentError {
     InvalidRequestData(DecodeError),
     BlueprintFunctionNotFound(String),

--- a/radix-engine/src/model/mod.rs
+++ b/radix-engine/src/model/mod.rs
@@ -17,6 +17,7 @@ mod vault;
 mod worktop;
 mod wrappers;
 
+pub use crate::engine::InvokeError;
 pub use abi_extractor::*;
 pub use auth_converter::convert;
 pub use auth_zone::{AuthZone, AuthZoneError};
@@ -40,4 +41,3 @@ pub use validated_package::{PackageError, ValidatedPackage};
 pub use vault::{Vault, VaultError};
 pub use worktop::{Worktop, WorktopError};
 pub use wrappers::*;
-pub use crate::engine::InvokeError;

--- a/radix-engine/src/model/mod.rs
+++ b/radix-engine/src/model/mod.rs
@@ -40,3 +40,4 @@ pub use validated_package::{PackageError, ValidatedPackage};
 pub use vault::{Vault, VaultError};
 pub use worktop::{Worktop, WorktopError};
 pub use wrappers::*;
+pub use crate::engine::InvokeError;

--- a/radix-engine/src/model/package_extractor.rs
+++ b/radix-engine/src/model/package_extractor.rs
@@ -1,12 +1,13 @@
 use crate::engine::NopWasmRuntime;
 use crate::fee::SystemLoanFeeReserve;
+use crate::model::InvokeError;
 use crate::types::*;
 use crate::wasm::*;
 
 #[derive(Debug)]
 pub enum ExtractAbiError {
     InvalidWasm(PrepareError),
-    FailedToExportBlueprintAbi(WasmInvokeError),
+    FailedToExportBlueprintAbi(InvokeError<WasmError>),
     AbiDecodeError(DecodeError),
     InvalidBlueprintAbi,
 }

--- a/radix-engine/src/model/proof.rs
+++ b/radix-engine/src/model/proof.rs
@@ -21,7 +21,7 @@ pub struct Proof {
     evidence: HashMap<ResourceContainerId, (Rc<RefCell<ResourceContainer>>, LockedAmountOrIds)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum ProofError {
     /// Error produced by a resource container.
     ResourceContainerError(ResourceContainerError),

--- a/radix-engine/src/model/resource.rs
+++ b/radix-engine/src/model/resource.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 
 /// Represents an error when manipulating resources in a container.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, TypeId, Encode, Decode)]
 pub enum ResourceContainerError {
     /// Resource addresses do not match.
     ResourceAddressNotMatching,

--- a/radix-engine/src/model/system.rs
+++ b/radix-engine/src/model/system.rs
@@ -28,16 +28,16 @@ impl System {
     {
         match system_fn {
             SystemFnIdentifier::GetCurrentEpoch => {
-                let _: SystemGetCurrentEpochInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
+                let _: SystemGetCurrentEpochInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
                 let node_ref = system_api
                     .borrow_node(&RENodeId::System)
                     .map_err(InvokeError::Downstream)?;
                 Ok(ScryptoValue::from_typed(&node_ref.system().epoch))
             }
             SystemFnIdentifier::SetEpoch => {
-                let SystemSetEpochInput { epoch } =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
+                let SystemSetEpochInput { epoch } = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
                 let mut system_node_ref = system_api
                     .substate_borrow_mut(&SubstateId::System)
                     .map_err(InvokeError::Downstream)?;
@@ -48,8 +48,8 @@ impl System {
                 Ok(ScryptoValue::from_typed(&()))
             }
             SystemFnIdentifier::GetTransactionHash => {
-                let _: SystemGetTransactionHashInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
+                let _: SystemGetTransactionHashInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(SystemError::InvalidRequestData(e)))?;
                 Ok(ScryptoValue::from_typed(
                     &system_api
                         .transaction_hash()

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -4,12 +4,12 @@ use transaction::validation::*;
 
 use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::FeeReserve;
-use crate::model::InvokeError;
 use crate::model::worktop::{
     WorktopAssertContainsAmountInput, WorktopAssertContainsInput,
     WorktopAssertContainsNonFungiblesInput, WorktopDrainInput, WorktopPutInput,
     WorktopTakeAllInput, WorktopTakeAmountInput, WorktopTakeNonFungiblesInput,
 };
+use crate::model::InvokeError;
 use crate::types::*;
 use crate::wasm::*;
 
@@ -82,8 +82,10 @@ impl TransactionProcessor {
     {
         match transaction_processor_fn {
             TransactionProcessorFnIdentifier::Run => {
-                let input: TransactionProcessorRunInput = scrypto_decode(&call_data.raw)
-                    .map_err(|e| InvokeError::Error(TransactionProcessorError::InvalidRequestData(e)))?;
+                let input: TransactionProcessorRunInput =
+                    scrypto_decode(&call_data.raw).map_err(|e| {
+                        InvokeError::Error(TransactionProcessorError::InvalidRequestData(e))
+                    })?;
 
                 let mut proof_id_mapping = HashMap::new();
                 let mut bucket_id_mapping = HashMap::new();
@@ -98,7 +100,9 @@ impl TransactionProcessor {
                     let result = match inst {
                         ExecutableInstruction::TakeFromWorktop { resource_address } => id_allocator
                             .new_bucket_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -122,7 +126,9 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_bucket_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -147,7 +153,9 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_bucket_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -182,7 +190,9 @@ impl TransactionProcessor {
                                     )
                                     .map_err(InvokeError::Downstream)
                             })
-                            .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::BucketNotFound(*bucket_id)))),
+                            .unwrap_or(Err(InvokeError::Error(
+                                TransactionProcessorError::BucketNotFound(*bucket_id),
+                            ))),
                         ExecutableInstruction::AssertWorktopContains { resource_address } => {
                             system_api
                                 .invoke_method(
@@ -229,7 +239,9 @@ impl TransactionProcessor {
 
                         ExecutableInstruction::PopFromAuthZone {} => id_allocator
                             .new_proof_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -260,7 +272,9 @@ impl TransactionProcessor {
                         }
                         ExecutableInstruction::PushToAuthZone { proof_id } => proof_id_mapping
                             .remove(proof_id)
-                            .ok_or(InvokeError::Error(TransactionProcessorError::ProofNotFound(*proof_id)))
+                            .ok_or(InvokeError::Error(
+                                TransactionProcessorError::ProofNotFound(*proof_id),
+                            ))
                             .and_then(|real_id| {
                                 system_api
                                     .invoke_method(
@@ -277,7 +291,11 @@ impl TransactionProcessor {
                         ExecutableInstruction::CreateProofFromAuthZone { resource_address } => {
                             id_allocator
                                 .new_proof_id()
-                                .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                                .map_err(|e| {
+                                    InvokeError::Error(
+                                        TransactionProcessorError::IdAllocationError(e),
+                                    )
+                                })
                                 .and_then(|new_id| {
                                     system_api
                                         .invoke_method(
@@ -304,7 +322,9 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_proof_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -331,7 +351,9 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_proof_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -353,13 +375,17 @@ impl TransactionProcessor {
                             }),
                         ExecutableInstruction::CreateProofFromBucket { bucket_id } => id_allocator
                             .new_proof_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 bucket_id_mapping
                                     .get(bucket_id)
                                     .cloned()
                                     .map(|real_bucket_id| (new_id, real_bucket_id))
-                                    .ok_or(InvokeError::Error(TransactionProcessorError::BucketNotFound(new_id)))
+                                    .ok_or(InvokeError::Error(
+                                        TransactionProcessorError::BucketNotFound(new_id),
+                                    ))
                             })
                             .and_then(|(new_id, real_bucket_id)| {
                                 system_api
@@ -379,7 +405,9 @@ impl TransactionProcessor {
                             }),
                         ExecutableInstruction::CloneProof { proof_id } => id_allocator
                             .new_proof_id()
-                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
+                            .map_err(|e| {
+                                InvokeError::Error(TransactionProcessorError::IdAllocationError(e))
+                            })
                             .and_then(|new_id| {
                                 proof_id_mapping
                                     .get(proof_id)
@@ -402,9 +430,9 @@ impl TransactionProcessor {
                                                 ))
                                             })
                                     })
-                                    .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::ProofNotFound(
-                                        *proof_id,
-                                    ))))
+                                    .unwrap_or(Err(InvokeError::Error(
+                                        TransactionProcessorError::ProofNotFound(*proof_id),
+                                    )))
                             }),
                         ExecutableInstruction::DropProof { proof_id } => proof_id_mapping
                             .remove(proof_id)
@@ -419,7 +447,9 @@ impl TransactionProcessor {
                                     )
                                     .map_err(InvokeError::Downstream)
                             })
-                            .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::ProofNotFound(*proof_id)))),
+                            .unwrap_or(Err(InvokeError::Error(
+                                TransactionProcessorError::ProofNotFound(*proof_id),
+                            ))),
                         ExecutableInstruction::DropAllProofs => {
                             for (_, real_id) in proof_id_mapping.drain() {
                                 system_api
@@ -615,22 +645,24 @@ impl TransactionProcessor {
                                             .map_err(InvokeError::Downstream)
                                     })
                             }),
-                        ExecutableInstruction::PublishPackage { package } => scrypto_decode::<
-                            Package,
-                        >(
-                            package
-                        )
-                        .map_err(|e| InvokeError::Error(TransactionProcessorError::InvalidPackage(e)))
-                        .and_then(|package| {
-                            system_api
-                                .invoke_function(
-                                    FnIdentifier::Native(NativeFnIdentifier::Package(
-                                        PackageFnIdentifier::Publish,
-                                    )),
-                                    ScryptoValue::from_typed(&PackagePublishInput { package }),
-                                )
-                                .map_err(InvokeError::Downstream)
-                        }),
+                        ExecutableInstruction::PublishPackage { package } => {
+                            scrypto_decode::<Package>(package)
+                                .map_err(|e| {
+                                    InvokeError::Error(TransactionProcessorError::InvalidPackage(e))
+                                })
+                                .and_then(|package| {
+                                    system_api
+                                        .invoke_function(
+                                            FnIdentifier::Native(NativeFnIdentifier::Package(
+                                                PackageFnIdentifier::Publish,
+                                            )),
+                                            ScryptoValue::from_typed(&PackagePublishInput {
+                                                package,
+                                            }),
+                                        )
+                                        .map_err(InvokeError::Downstream)
+                                })
+                        }
                     }?;
                     outputs.push(result);
                 }

--- a/radix-engine/src/model/transaction_processor.rs
+++ b/radix-engine/src/model/transaction_processor.rs
@@ -2,9 +2,9 @@ use transaction::errors::IdAllocationError;
 use transaction::model::*;
 use transaction::validation::*;
 
-use crate::engine::ApplicationError;
-use crate::engine::{HeapRENode, RuntimeError, SystemApi};
+use crate::engine::{HeapRENode, SystemApi};
 use crate::fee::FeeReserve;
+use crate::model::InvokeError;
 use crate::model::worktop::{
     WorktopAssertContainsAmountInput, WorktopAssertContainsInput,
     WorktopAssertContainsNonFungiblesInput, WorktopDrainInput, WorktopPutInput,
@@ -20,34 +20,14 @@ pub struct TransactionProcessorRunInput {
     pub instructions: Vec<ExecutableInstruction>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum TransactionProcessorError {
-    RuntimeError(Box<RuntimeError>), // error propagation
     InvalidRequestData(DecodeError),
     InvalidMethod,
     BucketNotFound(BucketId),
     ProofNotFound(ProofId),
     IdAllocationError(IdAllocationError),
     InvalidPackage(DecodeError),
-}
-
-impl TransactionProcessorError {
-    /// Wraps into a runtime error unless it's already a runtime error.
-    ///
-    /// TODO: Is this really a good idea?
-    pub fn to_runtime_error(self) -> RuntimeError {
-        match self {
-            TransactionProcessorError::RuntimeError(e) => *e,
-            e @ TransactionProcessorError::InvalidRequestData(_)
-            | e @ TransactionProcessorError::InvalidMethod
-            | e @ TransactionProcessorError::BucketNotFound(_)
-            | e @ TransactionProcessorError::ProofNotFound(_)
-            | e @ TransactionProcessorError::IdAllocationError(_)
-            | e @ TransactionProcessorError::InvalidPackage(_) => {
-                RuntimeError::ApplicationError(ApplicationError::TransactionProcessorError(e))
-            }
-        }
-    }
 }
 
 pub struct TransactionProcessor {}
@@ -57,15 +37,15 @@ impl TransactionProcessor {
         proof_id_mapping: &mut HashMap<ProofId, ProofId>,
         bucket_id_mapping: &mut HashMap<BucketId, BucketId>,
         mut value: ScryptoValue,
-    ) -> Result<ScryptoValue, TransactionProcessorError> {
+    ) -> Result<ScryptoValue, InvokeError<TransactionProcessorError>> {
         value
             .replace_ids(proof_id_mapping, bucket_id_mapping)
             .map_err(|e| match e {
                 ScryptoValueReplaceError::BucketIdNotFound(bucket_id) => {
-                    TransactionProcessorError::BucketNotFound(bucket_id)
+                    InvokeError::Error(TransactionProcessorError::BucketNotFound(bucket_id))
                 }
                 ScryptoValueReplaceError::ProofIdNotFound(proof_id) => {
-                    TransactionProcessorError::ProofNotFound(proof_id)
+                    InvokeError::Error(TransactionProcessorError::ProofNotFound(proof_id))
                 }
             })?;
         Ok(value)
@@ -93,7 +73,7 @@ impl TransactionProcessor {
         transaction_processor_fn: TransactionProcessorFnIdentifier,
         call_data: ScryptoValue,
         system_api: &mut Y,
-    ) -> Result<ScryptoValue, TransactionProcessorError>
+    ) -> Result<ScryptoValue, InvokeError<TransactionProcessorError>>
     where
         Y: SystemApi<'s, W, I, R>,
         W: WasmEngine<I>,
@@ -103,7 +83,7 @@ impl TransactionProcessor {
         match transaction_processor_fn {
             TransactionProcessorFnIdentifier::Run => {
                 let input: TransactionProcessorRunInput = scrypto_decode(&call_data.raw)
-                    .map_err(|e| TransactionProcessorError::InvalidRequestData(e))?;
+                    .map_err(|e| InvokeError::Error(TransactionProcessorError::InvalidRequestData(e)))?;
 
                 let mut proof_id_mapping = HashMap::new();
                 let mut bucket_id_mapping = HashMap::new();
@@ -112,13 +92,13 @@ impl TransactionProcessor {
 
                 let _worktop_id = system_api
                     .node_create(HeapRENode::Worktop(Worktop::new()))
-                    .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))?;
+                    .map_err(InvokeError::Downstream)?;
 
                 for inst in &input.instructions.clone() {
                     let result = match inst {
                         ExecutableInstruction::TakeFromWorktop { resource_address } => id_allocator
                             .new_bucket_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -130,9 +110,7 @@ impl TransactionProcessor {
                                             resource_address: *resource_address,
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let bucket_id = Self::first_bucket(&rtn);
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -144,7 +122,7 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_bucket_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -157,9 +135,7 @@ impl TransactionProcessor {
                                             resource_address: *resource_address,
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let bucket_id = Self::first_bucket(&rtn);
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -171,7 +147,7 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_bucket_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -184,9 +160,7 @@ impl TransactionProcessor {
                                             resource_address: *resource_address,
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let bucket_id = Self::first_bucket(&rtn);
                                         bucket_id_mapping.insert(new_id, bucket_id);
@@ -206,11 +180,9 @@ impl TransactionProcessor {
                                             bucket: scrypto::resource::Bucket(real_id),
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                             })
-                            .unwrap_or(Err(TransactionProcessorError::BucketNotFound(*bucket_id))),
+                            .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::BucketNotFound(*bucket_id)))),
                         ExecutableInstruction::AssertWorktopContains { resource_address } => {
                             system_api
                                 .invoke_method(
@@ -222,7 +194,7 @@ impl TransactionProcessor {
                                         resource_address: *resource_address,
                                     }),
                                 )
-                                .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))
+                                .map_err(InvokeError::Downstream)
                         }
                         ExecutableInstruction::AssertWorktopContainsByAmount {
                             amount,
@@ -238,7 +210,7 @@ impl TransactionProcessor {
                                     resource_address: *resource_address,
                                 }),
                             )
-                            .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e))),
+                            .map_err(InvokeError::Downstream),
                         ExecutableInstruction::AssertWorktopContainsByIds {
                             ids,
                             resource_address,
@@ -253,11 +225,11 @@ impl TransactionProcessor {
                                     resource_address: *resource_address,
                                 }),
                             )
-                            .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e))),
+                            .map_err(InvokeError::Downstream),
 
                         ExecutableInstruction::PopFromAuthZone {} => id_allocator
                             .new_proof_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -267,9 +239,7 @@ impl TransactionProcessor {
                                         )),
                                         ScryptoValue::from_typed(&AuthZonePopInput {}),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let proof_id = Self::first_proof(&rtn);
                                         proof_id_mapping.insert(new_id, proof_id);
@@ -286,11 +256,11 @@ impl TransactionProcessor {
                                     )),
                                     ScryptoValue::from_typed(&AuthZoneClearInput {}),
                                 )
-                                .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))
+                                .map_err(InvokeError::Downstream)
                         }
                         ExecutableInstruction::PushToAuthZone { proof_id } => proof_id_mapping
                             .remove(proof_id)
-                            .ok_or(TransactionProcessorError::ProofNotFound(*proof_id))
+                            .ok_or(InvokeError::Error(TransactionProcessorError::ProofNotFound(*proof_id)))
                             .and_then(|real_id| {
                                 system_api
                                     .invoke_method(
@@ -302,14 +272,12 @@ impl TransactionProcessor {
                                             proof: scrypto::resource::Proof(real_id),
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                             }),
                         ExecutableInstruction::CreateProofFromAuthZone { resource_address } => {
                             id_allocator
                                 .new_proof_id()
-                                .map_err(TransactionProcessorError::IdAllocationError)
+                                .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                                 .and_then(|new_id| {
                                     system_api
                                         .invoke_method(
@@ -321,9 +289,7 @@ impl TransactionProcessor {
                                                 resource_address: *resource_address,
                                             }),
                                         )
-                                        .map_err(|e| {
-                                            TransactionProcessorError::RuntimeError(Box::new(e))
-                                        })
+                                        .map_err(InvokeError::Downstream)
                                         .map(|rtn| {
                                             let proof_id = Self::first_proof(&rtn);
                                             proof_id_mapping.insert(new_id, proof_id);
@@ -338,7 +304,7 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_proof_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -353,9 +319,7 @@ impl TransactionProcessor {
                                             },
                                         ),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let proof_id = Self::first_proof(&rtn);
                                         proof_id_mapping.insert(new_id, proof_id);
@@ -367,7 +331,7 @@ impl TransactionProcessor {
                             resource_address,
                         } => id_allocator
                             .new_proof_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 system_api
                                     .invoke_method(
@@ -380,9 +344,7 @@ impl TransactionProcessor {
                                             resource_address: *resource_address,
                                         }),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let proof_id = Self::first_proof(&rtn);
                                         proof_id_mapping.insert(new_id, proof_id);
@@ -391,13 +353,13 @@ impl TransactionProcessor {
                             }),
                         ExecutableInstruction::CreateProofFromBucket { bucket_id } => id_allocator
                             .new_proof_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 bucket_id_mapping
                                     .get(bucket_id)
                                     .cloned()
                                     .map(|real_bucket_id| (new_id, real_bucket_id))
-                                    .ok_or(TransactionProcessorError::BucketNotFound(new_id))
+                                    .ok_or(InvokeError::Error(TransactionProcessorError::BucketNotFound(new_id)))
                             })
                             .and_then(|(new_id, real_bucket_id)| {
                                 system_api
@@ -408,9 +370,7 @@ impl TransactionProcessor {
                                         )),
                                         ScryptoValue::from_typed(&BucketCreateProofInput {}),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .map(|rtn| {
                                         let proof_id = Self::first_proof(&rtn);
                                         proof_id_mapping.insert(new_id, proof_id);
@@ -419,7 +379,7 @@ impl TransactionProcessor {
                             }),
                         ExecutableInstruction::CloneProof { proof_id } => id_allocator
                             .new_proof_id()
-                            .map_err(TransactionProcessorError::IdAllocationError)
+                            .map_err(|e| InvokeError::Error(TransactionProcessorError::IdAllocationError(e)))
                             .and_then(|new_id| {
                                 proof_id_mapping
                                     .get(proof_id)
@@ -433,9 +393,7 @@ impl TransactionProcessor {
                                                 )),
                                                 ScryptoValue::from_typed(&ProofCloneInput {}),
                                             )
-                                            .map_err(|e| {
-                                                TransactionProcessorError::RuntimeError(Box::new(e))
-                                            })
+                                            .map_err(InvokeError::Downstream)
                                             .map(|v| {
                                                 let cloned_proof_id = Self::first_proof(&v);
                                                 proof_id_mapping.insert(new_id, cloned_proof_id);
@@ -444,9 +402,9 @@ impl TransactionProcessor {
                                                 ))
                                             })
                                     })
-                                    .unwrap_or(Err(TransactionProcessorError::ProofNotFound(
+                                    .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::ProofNotFound(
                                         *proof_id,
-                                    )))
+                                    ))))
                             }),
                         ExecutableInstruction::DropProof { proof_id } => proof_id_mapping
                             .remove(proof_id)
@@ -459,11 +417,9 @@ impl TransactionProcessor {
                                         )),
                                         ScryptoValue::from_typed(&ConsumingProofDropInput {}),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                             })
-                            .unwrap_or(Err(TransactionProcessorError::ProofNotFound(*proof_id))),
+                            .unwrap_or(Err(InvokeError::Error(TransactionProcessorError::ProofNotFound(*proof_id)))),
                         ExecutableInstruction::DropAllProofs => {
                             for (_, real_id) in proof_id_mapping.drain() {
                                 system_api
@@ -474,9 +430,7 @@ impl TransactionProcessor {
                                         )),
                                         ScryptoValue::from_typed(&ConsumingProofDropInput {}),
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })?;
+                                    .map_err(InvokeError::Downstream)?;
                             }
                             system_api
                                 .invoke_method(
@@ -486,7 +440,7 @@ impl TransactionProcessor {
                                     )),
                                     ScryptoValue::from_typed(&AuthZoneClearInput {}),
                                 )
-                                .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))
+                                .map_err(InvokeError::Downstream)
                         }
                         ExecutableInstruction::CallFunction {
                             package_address,
@@ -510,9 +464,7 @@ impl TransactionProcessor {
                                         },
                                         call_data,
                                     )
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                             })
                             .and_then(|result| {
                                 // Auto move into auth_zone
@@ -527,9 +479,7 @@ impl TransactionProcessor {
                                                 proof: scrypto::resource::Proof(*proof_id),
                                             }),
                                         )
-                                        .map_err(|e| {
-                                            TransactionProcessorError::RuntimeError(Box::new(e))
-                                        })?;
+                                        .map_err(InvokeError::Downstream)?;
                                 }
                                 // Auto move into worktop
                                 for (bucket_id, _) in &result.bucket_ids {
@@ -543,9 +493,7 @@ impl TransactionProcessor {
                                                 bucket: scrypto::resource::Bucket(*bucket_id),
                                             }),
                                         )
-                                        .map_err(|e| {
-                                            TransactionProcessorError::RuntimeError(Box::new(e))
-                                        })?;
+                                        .map_err(InvokeError::Downstream)?;
                                 }
                                 Ok(result)
                             })
@@ -565,9 +513,7 @@ impl TransactionProcessor {
                                 // TODO: Move this into preprocessor step
                                 system_api
                                     .substate_read(SubstateId::ComponentInfo(*component_address))
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .and_then(|s| {
                                         let (package_address, blueprint_name): (
                                             PackageAddress,
@@ -586,9 +532,7 @@ impl TransactionProcessor {
                                                 },
                                                 call_data,
                                             )
-                                            .map_err(|e| {
-                                                TransactionProcessorError::RuntimeError(Box::new(e))
-                                            })
+                                            .map_err(InvokeError::Downstream)
                                     })
                             })
                             .and_then(|result| {
@@ -604,9 +548,7 @@ impl TransactionProcessor {
                                                 proof: scrypto::resource::Proof(*proof_id),
                                             }),
                                         )
-                                        .map_err(|e| {
-                                            TransactionProcessorError::RuntimeError(Box::new(e))
-                                        })?;
+                                        .map_err(InvokeError::Downstream)?;
                                 }
                                 // Auto move into worktop
                                 for (bucket_id, _) in &result.bucket_ids {
@@ -620,9 +562,7 @@ impl TransactionProcessor {
                                                 bucket: scrypto::resource::Bucket(*bucket_id),
                                             }),
                                         )
-                                        .map_err(|e| {
-                                            TransactionProcessorError::RuntimeError(Box::new(e))
-                                        })?;
+                                        .map_err(InvokeError::downstream)?;
                                 }
                                 Ok(result)
                             })
@@ -638,7 +578,7 @@ impl TransactionProcessor {
                                 )),
                                 ScryptoValue::from_typed(&WorktopDrainInput {}),
                             )
-                            .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))
+                            .map_err(InvokeError::Downstream)
                             .and_then(|result| {
                                 let mut buckets = Vec::new();
                                 for (bucket_id, _) in result.bucket_ids {
@@ -651,9 +591,7 @@ impl TransactionProcessor {
                                 // TODO: Move this into preprocessor step
                                 system_api
                                     .substate_read(SubstateId::ComponentInfo(*component_address))
-                                    .map_err(|e| {
-                                        TransactionProcessorError::RuntimeError(Box::new(e))
-                                    })
+                                    .map_err(InvokeError::Downstream)
                                     .and_then(|s| {
                                         let (package_address, blueprint_name): (
                                             PackageAddress,
@@ -674,9 +612,7 @@ impl TransactionProcessor {
                                                     "Failed to decode ComponentInfo substate",
                                                 ),
                                             )
-                                            .map_err(|e| {
-                                                TransactionProcessorError::RuntimeError(Box::new(e))
-                                            })
+                                            .map_err(InvokeError::Downstream)
                                     })
                             }),
                         ExecutableInstruction::PublishPackage { package } => scrypto_decode::<
@@ -684,7 +620,7 @@ impl TransactionProcessor {
                         >(
                             package
                         )
-                        .map_err(|e| TransactionProcessorError::InvalidPackage(e))
+                        .map_err(|e| InvokeError::Error(TransactionProcessorError::InvalidPackage(e)))
                         .and_then(|package| {
                             system_api
                                 .invoke_function(
@@ -693,7 +629,7 @@ impl TransactionProcessor {
                                     )),
                                     ScryptoValue::from_typed(&PackagePublishInput { package }),
                                 )
-                                .map_err(|e| TransactionProcessorError::RuntimeError(Box::new(e)))
+                                .map_err(InvokeError::Downstream)
                         }),
                     }?;
                     outputs.push(result);

--- a/radix-engine/src/model/vault.rs
+++ b/radix-engine/src/model/vault.rs
@@ -7,7 +7,7 @@ use crate::model::{
 use crate::types::*;
 use crate::wasm::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum VaultError {
     InvalidRequestData(DecodeError),
     ResourceContainerError(ResourceContainerError),

--- a/radix-engine/src/model/worktop.rs
+++ b/radix-engine/src/model/worktop.rs
@@ -222,8 +222,8 @@ impl Worktop {
 
         let rtn = match worktop_fn {
             WorktopFnIdentifier::Put => {
-                let input: WorktopPutInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopPutInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let bucket = system_api
                     .node_drop(&RENodeId::Bucket(input.bucket.0))
                     .map_err(|e| InvokeError::Downstream(e))?
@@ -234,8 +234,8 @@ impl Worktop {
                 Ok(ScryptoValue::from_typed(&()))
             }
             WorktopFnIdentifier::TakeAmount => {
-                let input: WorktopTakeAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopTakeAmountInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take(input.amount, input.resource_address)
                     .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
@@ -261,8 +261,8 @@ impl Worktop {
                 )))
             }
             WorktopFnIdentifier::TakeAll => {
-                let input: WorktopTakeAllInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopTakeAllInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take_all(input.resource_address)
                     .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
@@ -289,8 +289,8 @@ impl Worktop {
                 )))
             }
             WorktopFnIdentifier::TakeNonFungibles => {
-                let input: WorktopTakeNonFungiblesInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopTakeNonFungiblesInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take_non_fungibles(&input.ids, input.resource_address)
                     .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
@@ -317,8 +317,8 @@ impl Worktop {
                 )))
             }
             WorktopFnIdentifier::AssertContains => {
-                let input: WorktopAssertContainsInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopAssertContainsInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if worktop.total_amount(input.resource_address).is_zero() {
                     Err(InvokeError::Error(WorktopError::AssertionFailed))
                 } else {
@@ -326,8 +326,8 @@ impl Worktop {
                 }
             }
             WorktopFnIdentifier::AssertContainsAmount => {
-                let input: WorktopAssertContainsAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopAssertContainsAmountInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if worktop.total_amount(input.resource_address) < input.amount {
                     Err(InvokeError::Error(WorktopError::AssertionFailed))
                 } else {
@@ -335,8 +335,8 @@ impl Worktop {
                 }
             }
             WorktopFnIdentifier::AssertContainsNonFungibles => {
-                let input: WorktopAssertContainsNonFungiblesInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let input: WorktopAssertContainsNonFungiblesInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if !worktop
                     .total_ids(input.resource_address)
                     .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?
@@ -348,8 +348,8 @@ impl Worktop {
                 }
             }
             WorktopFnIdentifier::Drain => {
-                let _: WorktopDrainInput =
-                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
+                let _: WorktopDrainInput = scrypto_decode(&args.raw)
+                    .map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let mut buckets = Vec::new();
                 for (_, container) in worktop.containers.drain() {
                     let container = container

--- a/radix-engine/src/model/worktop.rs
+++ b/radix-engine/src/model/worktop.rs
@@ -53,7 +53,7 @@ pub struct Worktop {
     containers: HashMap<ResourceAddress, Rc<RefCell<ResourceContainer>>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum WorktopError {
     InvalidRequestData(DecodeError),
     MethodNotFound(String),

--- a/radix-engine/src/model/worktop.rs
+++ b/radix-engine/src/model/worktop.rs
@@ -1,4 +1,4 @@
-use crate::engine::{DropFailure, HeapRENode, RuntimeError, SystemApi};
+use crate::engine::{DropFailure, HeapRENode, InvokeError, SystemApi};
 use crate::fee::FeeReserve;
 use crate::model::{Bucket, ResourceContainer, ResourceContainerError};
 use crate::types::*;
@@ -55,7 +55,6 @@ pub struct Worktop {
 
 #[derive(Debug)]
 pub enum WorktopError {
-    RuntimeError(Box<RuntimeError>),
     InvalidRequestData(DecodeError),
     MethodNotFound(String),
     ResourceContainerError(ResourceContainerError),
@@ -209,7 +208,7 @@ impl Worktop {
         worktop_fn: WorktopFnIdentifier,
         args: ScryptoValue,
         system_api: &mut Y,
-    ) -> Result<ScryptoValue, WorktopError>
+    ) -> Result<ScryptoValue, InvokeError<WorktopError>>
     where
         Y: SystemApi<'s, W, I, R>,
         W: WasmEngine<I>,
@@ -218,35 +217,35 @@ impl Worktop {
     {
         let mut node_ref = system_api
             .substate_borrow_mut(&SubstateId::Worktop)
-            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?;
+            .map_err(InvokeError::downstream)?;
         let worktop = node_ref.worktop();
 
         let rtn = match worktop_fn {
             WorktopFnIdentifier::Put => {
                 let input: WorktopPutInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let bucket = system_api
                     .node_drop(&RENodeId::Bucket(input.bucket.0))
-                    .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?
+                    .map_err(|e| InvokeError::Downstream(e))?
                     .into();
                 worktop
                     .put(bucket)
-                    .map_err(WorktopError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
                 Ok(ScryptoValue::from_typed(&()))
             }
             WorktopFnIdentifier::TakeAmount => {
                 let input: WorktopTakeAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take(input.amount, input.resource_address)
-                    .map_err(WorktopError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
                 let resource_container = if let Some(container) = maybe_container {
                     container
                 } else {
                     let resource_type = {
                         let node_ref = system_api
                             .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?;
+                            .map_err(|e| InvokeError::Downstream(e))?;
                         let resource_manager = node_ref.resource_manager();
                         resource_manager.resource_type()
                     };
@@ -255,7 +254,7 @@ impl Worktop {
                 };
                 let bucket_id = system_api
                     .node_create(HeapRENode::Bucket(Bucket::new(resource_container)))
-                    .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?
+                    .map_err(|e| InvokeError::Downstream(e))?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Bucket(
                     bucket_id,
@@ -263,17 +262,17 @@ impl Worktop {
             }
             WorktopFnIdentifier::TakeAll => {
                 let input: WorktopTakeAllInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take_all(input.resource_address)
-                    .map_err(WorktopError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
                 let resource_container = if let Some(container) = maybe_container {
                     container
                 } else {
                     let resource_type = {
                         let node_ref = system_api
                             .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?;
+                            .map_err(|e| InvokeError::Downstream(e))?;
                         let resource_manager = node_ref.resource_manager();
                         resource_manager.resource_type()
                     };
@@ -283,7 +282,7 @@ impl Worktop {
 
                 let bucket_id = system_api
                     .node_create(HeapRENode::Bucket(Bucket::new(resource_container)))
-                    .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?
+                    .map_err(|e| InvokeError::Downstream(e))?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Bucket(
                     bucket_id,
@@ -291,17 +290,17 @@ impl Worktop {
             }
             WorktopFnIdentifier::TakeNonFungibles => {
                 let input: WorktopTakeNonFungiblesInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let maybe_container = worktop
                     .take_non_fungibles(&input.ids, input.resource_address)
-                    .map_err(WorktopError::ResourceContainerError)?;
+                    .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
                 let resource_container = if let Some(container) = maybe_container {
                     container
                 } else {
                     let resource_type = {
                         let node_ref = system_api
                             .borrow_node(&RENodeId::ResourceManager(input.resource_address))
-                            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?;
+                            .map_err(|e| InvokeError::Downstream(e))?;
                         let resource_manager = node_ref.resource_manager();
                         resource_manager.resource_type()
                     };
@@ -311,7 +310,7 @@ impl Worktop {
 
                 let bucket_id = system_api
                     .node_create(HeapRENode::Bucket(Bucket::new(resource_container)))
-                    .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?
+                    .map_err(|e| InvokeError::Downstream(e))?
                     .into();
                 Ok(ScryptoValue::from_typed(&scrypto::resource::Bucket(
                     bucket_id,
@@ -319,48 +318,48 @@ impl Worktop {
             }
             WorktopFnIdentifier::AssertContains => {
                 let input: WorktopAssertContainsInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if worktop.total_amount(input.resource_address).is_zero() {
-                    Err(WorktopError::AssertionFailed)
+                    Err(InvokeError::Error(WorktopError::AssertionFailed))
                 } else {
                     Ok(ScryptoValue::from_typed(&()))
                 }
             }
             WorktopFnIdentifier::AssertContainsAmount => {
                 let input: WorktopAssertContainsAmountInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if worktop.total_amount(input.resource_address) < input.amount {
-                    Err(WorktopError::AssertionFailed)
+                    Err(InvokeError::Error(WorktopError::AssertionFailed))
                 } else {
                     Ok(ScryptoValue::from_typed(&()))
                 }
             }
             WorktopFnIdentifier::AssertContainsNonFungibles => {
                 let input: WorktopAssertContainsNonFungiblesInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 if !worktop
                     .total_ids(input.resource_address)
-                    .map_err(WorktopError::ResourceContainerError)?
+                    .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?
                     .is_superset(&input.ids)
                 {
-                    Err(WorktopError::AssertionFailed)
+                    Err(InvokeError::Error(WorktopError::AssertionFailed))
                 } else {
                     Ok(ScryptoValue::from_typed(&()))
                 }
             }
             WorktopFnIdentifier::Drain => {
                 let _: WorktopDrainInput =
-                    scrypto_decode(&args.raw).map_err(|e| WorktopError::InvalidRequestData(e))?;
+                    scrypto_decode(&args.raw).map_err(|e| InvokeError::Error(WorktopError::InvalidRequestData(e)))?;
                 let mut buckets = Vec::new();
                 for (_, container) in worktop.containers.drain() {
                     let container = container
                         .borrow_mut()
                         .take_all_liquid()
-                        .map_err(WorktopError::ResourceContainerError)?;
+                        .map_err(|e| InvokeError::Error(WorktopError::ResourceContainerError(e)))?;
                     if !container.is_empty() {
                         let bucket_id = system_api
                             .node_create(HeapRENode::Bucket(Bucket::new(container)))
-                            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?
+                            .map_err(|e| InvokeError::Downstream(e))?
                             .into();
                         buckets.push(scrypto::resource::Bucket(bucket_id));
                     }
@@ -371,7 +370,7 @@ impl Worktop {
 
         system_api
             .substate_return_mut(node_ref)
-            .map_err(|e| WorktopError::RuntimeError(Box::new(e)))?;
+            .map_err(|e| InvokeError::Downstream(e))?;
 
         Ok(rtn)
     }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -7,25 +7,25 @@ use crate::fee::FeeSummary;
 use crate::state_manager::StateDiff;
 use crate::types::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct TransactionContents {
     pub instructions: Vec<ExecutableInstruction>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct TransactionExecution {
     pub fee_summary: FeeSummary,
     pub application_logs: Vec<(Level, String)>,
 }
 
 /// Captures whether a transaction should be committed, and its other results
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum TransactionResult {
     Commit(CommitResult),
     Reject(RejectResult),
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct CommitResult {
     pub outcome: TransactionOutcome,
     pub state_updates: StateDiff,
@@ -34,25 +34,26 @@ pub struct CommitResult {
 }
 
 /// Captures whether a transaction's commit outcome is Success or Failure
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub enum TransactionOutcome {
     Success(Vec<Vec<u8>>),
     Failure(RuntimeError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct EntityChanges {
     pub new_package_addresses: Vec<PackageAddress>,
     pub new_component_addresses: Vec<ComponentAddress>,
     pub new_resource_addresses: Vec<ResourceAddress>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, TypeId, Encode, Decode)]
 pub struct RejectResult {
     pub error: RejectionError,
 }
 
 /// Represents a transaction receipt.
+#[derive(TypeId, Encode, Decode)]
 pub struct TransactionReceipt {
     pub contents: TransactionContents,
     pub execution: TransactionExecution, // THIS FIELD IS USEFUL FOR DEBUGGING EVEN IF THE TRANSACTION IS REJECTED

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -5,7 +5,7 @@ use crate::model::InvokeError;
 use crate::types::*;
 
 /// Represents an error when validating a WASM file.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, TypeId, Encode, Decode)]
 pub enum PrepareError {
     /// Failed to deserialize.
     /// See https://webassembly.github.io/spec/core/syntax/index.html
@@ -49,13 +49,13 @@ pub enum PrepareError {
     NotCompilable,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, TypeId, Encode, Decode)]
 pub enum InvalidImport {
     /// The import is not allowed
     ImportNotAllowed,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, TypeId, Encode, Decode)]
 pub enum InvalidMemory {
     /// The wasm module has no memory section.
     NoMemorySection,
@@ -69,7 +69,7 @@ pub enum InvalidMemory {
     MemoryNotExported,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, TypeId, Encode, Decode)]
 pub enum InvalidTable {
     /// More than one table defined, against WebAssembly MVP spec
     MoreThanOneTable,

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -79,28 +79,36 @@ pub enum InvalidTable {
     InitialTableSizeLimitExceeded,
 }
 
+
+#[derive(Debug)]
+pub enum WasmError {
+    MemoryAllocError,
+    MemoryAccessError,
+    InvalidScryptoValue(DecodeError),
+    WasmError(String),
+    FunctionNotFound,
+    InvalidRadixEngineInput,
+    MissingReturnData,
+    InvalidReturnData,
+    CostingError(FeeReserveError),
+}
+
+impl fmt::Display for WasmError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl HostError for WasmError {}
+
+#[cfg(not(feature = "alloc"))]
+impl std::error::Error for WasmError {}
+
 /// Represents an error when invoking an export of a Scrypto module.
 #[derive(Debug)]
 pub enum WasmInvokeError {
-    MemoryAllocError,
-
-    MemoryAccessError,
-
-    InvalidScryptoValue(DecodeError),
-
-    WasmError(String),
-
-    RuntimeError(RuntimeError),
-
-    FunctionNotFound,
-
-    InvalidRadixEngineInput,
-
-    MissingReturnData,
-
-    InvalidReturnData,
-
-    CostingError(FeeReserveError),
+    Error(WasmError),
+    DownstreamError(RuntimeError),
 }
 
 impl fmt::Display for WasmInvokeError {

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -1,9 +1,7 @@
 use wasmi::HostError;
 
-// TODO: this is the only place which introduces circular dependency.
-// From WASM's perspective, they are host errors. We need a better solution to handle this.
-use crate::engine::RuntimeError;
 use crate::fee::FeeReserveError;
+use crate::model::InvokeError;
 use crate::types::*;
 
 /// Represents an error when validating a WASM file.
@@ -79,6 +77,7 @@ pub enum InvalidTable {
     InitialTableSizeLimitExceeded,
 }
 
+/// Represents an error when invoking an export of a Scrypto module.
 #[derive(Debug, Encode, Decode, TypeId)]
 pub enum WasmError {
     MemoryAllocError,
@@ -103,20 +102,13 @@ impl HostError for WasmError {}
 #[cfg(not(feature = "alloc"))]
 impl std::error::Error for WasmError {}
 
-/// Represents an error when invoking an export of a Scrypto module.
-#[derive(Debug)]
-pub enum WasmInvokeError {
-    Error(WasmError),
-    DownstreamError(RuntimeError),
-}
-
-impl fmt::Display for WasmInvokeError {
+impl fmt::Display for InvokeError<WasmError> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl HostError for WasmInvokeError {}
+impl HostError for InvokeError<WasmError> {}
 
 #[cfg(not(feature = "alloc"))]
-impl std::error::Error for WasmInvokeError {}
+impl std::error::Error for InvokeError<WasmError> {}

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -79,7 +79,6 @@ pub enum InvalidTable {
     InitialTableSizeLimitExceeded,
 }
 
-
 #[derive(Debug, Encode, Decode, TypeId)]
 pub enum WasmError {
     MemoryAllocError,

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -80,7 +80,7 @@ pub enum InvalidTable {
 }
 
 
-#[derive(Debug)]
+#[derive(Debug, Encode, Decode, TypeId)]
 pub enum WasmError {
     MemoryAllocError,
     MemoryAccessError,

--- a/radix-engine/src/wasm/traits.rs
+++ b/radix-engine/src/wasm/traits.rs
@@ -1,6 +1,6 @@
+use crate::model::InvokeError;
 use sbor::rust::boxed::Box;
 use scrypto::values::ScryptoValue;
-use crate::model::InvokeError;
 
 use crate::wasm::errors::*;
 

--- a/radix-engine/src/wasm/traits.rs
+++ b/radix-engine/src/wasm/traits.rs
@@ -1,13 +1,14 @@
 use sbor::rust::boxed::Box;
 use scrypto::values::ScryptoValue;
+use crate::model::InvokeError;
 
 use crate::wasm::errors::*;
 
 /// Represents the runtime that can be invoked by Scrypto modules.
 pub trait WasmRuntime {
-    fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, WasmInvokeError>;
+    fn main(&mut self, input: ScryptoValue) -> Result<ScryptoValue, InvokeError<WasmError>>;
 
-    fn consume_cost_units(&mut self, n: u32) -> Result<(), WasmInvokeError>;
+    fn consume_cost_units(&mut self, n: u32) -> Result<(), InvokeError<WasmError>>;
 }
 
 /// Represents an instantiated, invokable Scrypto module.
@@ -24,7 +25,7 @@ pub trait WasmInstance {
         func_name: &str,
         args: &ScryptoValue,
         runtime: &mut Box<dyn WasmRuntime + 'r>,
-    ) -> Result<ScryptoValue, WasmInvokeError>;
+    ) -> Result<ScryptoValue, InvokeError<WasmError>>;
 }
 
 /// A Scrypto WASM engine validates, instruments and runs Scrypto modules.

--- a/radix-engine/src/wasm/wasmer.rs
+++ b/radix-engine/src/wasm/wasmer.rs
@@ -180,7 +180,7 @@ impl WasmInstance for WasmerInstance {
             *guard = runtime as *mut _ as usize;
         }
 
-        let pointer = send_value(&self.instance, args)?;
+        let pointer = send_value(&self.instance, args).map_err(InvokeError::Error)?;
         let result = self
             .instance
             .exports
@@ -196,7 +196,7 @@ impl WasmInstance for WasmerInstance {
                     .ok_or(InvokeError::Error(WasmError::MissingReturnData))?
                     .i32()
                     .ok_or(InvokeError::Error(WasmError::InvalidReturnData))?;
-                read_value(&self.instance, ptr as usize)
+                read_value(&self.instance, ptr as usize).map_err(InvokeError::Error)
             }
             Err(e) => {
                 let e_str = format!("{:?}", e);

--- a/radix-engine/src/wasm/wasmer.rs
+++ b/radix-engine/src/wasm/wasmer.rs
@@ -135,7 +135,7 @@ impl WasmerModule {
             let runtime: &mut Box<dyn WasmRuntime> = unsafe { &mut *(*ptr as *mut _) };
             runtime
                 .consume_cost_units(cost_unit as u32)
-                .map_err(|e| RuntimeError::user(Box::new(e)))
+                .map_err(|e| RuntimeError::user(Box::new(WasmInvokeError::Error(e))))
         }
 
         // env

--- a/radix-engine/src/wasm/wasmer.rs
+++ b/radix-engine/src/wasm/wasmer.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
+use crate::model::InvokeError;
 use wasmer::{
     imports, Function, HostEnvInitError, Instance, LazyInit, Module, RuntimeError, Store,
     Universal, Val, WasmerEnv,
 };
 use wasmer_compiler_singlepass::Singlepass;
-use crate::model::InvokeError;
 
 use crate::types::*;
 use crate::wasm::constants::*;

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -84,7 +84,7 @@ impl WasmiModule {
 }
 
 impl<'a, 'b, 'r> WasmiExternals<'a, 'b, 'r> {
-    pub fn send_value(&mut self, value: &ScryptoValue) -> Result<RuntimeValue, WasmInvokeError> {
+    pub fn send_value(&mut self, value: &ScryptoValue) -> Result<RuntimeValue, WasmError> {
         let result = self.instance.module_ref.clone().invoke_export(
             EXPORT_SCRYPTO_ALLOC,
             &[RuntimeValue::I32((value.raw.len()) as i32)],
@@ -102,30 +102,30 @@ impl<'a, 'b, 'r> WasmiExternals<'a, 'b, 'r> {
             }
         }
 
-        Err(WasmInvokeError::MemoryAllocError)
+        Err(WasmError::MemoryAllocError)
     }
 
-    pub fn read_value(&self, ptr: usize) -> Result<ScryptoValue, WasmInvokeError> {
+    pub fn read_value(&self, ptr: usize) -> Result<ScryptoValue, WasmError> {
         let len = self
             .instance
             .memory_ref
             .get_value::<u32>(ptr as u32)
-            .map_err(|_| WasmInvokeError::MemoryAccessError)? as usize;
+            .map_err(|_| WasmError::MemoryAccessError)? as usize;
 
         let start = ptr
             .checked_add(4)
-            .ok_or(WasmInvokeError::MemoryAccessError)?;
+            .ok_or(WasmError::MemoryAccessError)?;
         let end = start
             .checked_add(len)
-            .ok_or(WasmInvokeError::MemoryAccessError)?;
+            .ok_or(WasmError::MemoryAccessError)?;
 
         let direct = self.instance.memory_ref.direct_access();
         let buffer = direct.as_ref();
         if end > buffer.len() {
-            return Err(WasmInvokeError::MemoryAccessError);
+            return Err(WasmError::MemoryAccessError);
         }
 
-        ScryptoValue::from_slice(&buffer[start..end]).map_err(WasmInvokeError::InvalidScryptoValue)
+        ScryptoValue::from_slice(&buffer[start..end]).map_err(WasmError::InvalidScryptoValue)
     }
 }
 
@@ -151,7 +151,7 @@ impl<'a, 'b, 'r> Externals for WasmiExternals<'a, 'b, 'r> {
                     .map(|_| Option::None)
                     .map_err(|e| e.into())
             }
-            _ => Err(WasmInvokeError::FunctionNotFound.into()),
+            _ => Err(WasmError::FunctionNotFound.into()),
         }
     }
 }
@@ -168,7 +168,7 @@ impl WasmInstance for WasmiInstance {
             runtime,
         };
 
-        let pointer = externals.send_value(args)?;
+        let pointer = externals.send_value(args).map_err(WasmInvokeError::Error)?;
         let result = self
             .module_ref
             .clone()
@@ -182,13 +182,13 @@ impl WasmInstance for WasmiInstance {
                     Some(host_error) => *host_error
                         .downcast::<WasmInvokeError>()
                         .expect("Failed to downcast error into WasmInvokeError"),
-                    None => WasmInvokeError::WasmError(e_str),
+                    None => WasmInvokeError::Error(WasmError::WasmError(e_str)),
                 }
             })?
-            .ok_or(WasmInvokeError::MissingReturnData)?;
+            .ok_or(WasmInvokeError::Error(WasmError::MissingReturnData))?;
         match rtn {
-            RuntimeValue::I32(ptr) => externals.read_value(ptr as usize),
-            _ => Err(WasmInvokeError::InvalidReturnData),
+            RuntimeValue::I32(ptr) => externals.read_value(ptr as usize).map_err(WasmInvokeError::Error),
+            _ => Err(WasmInvokeError::Error(WasmError::InvalidReturnData)),
         }
     }
 }

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -112,12 +112,8 @@ impl<'a, 'b, 'r> WasmiExternals<'a, 'b, 'r> {
             .get_value::<u32>(ptr as u32)
             .map_err(|_| WasmError::MemoryAccessError)? as usize;
 
-        let start = ptr
-            .checked_add(4)
-            .ok_or(WasmError::MemoryAccessError)?;
-        let end = start
-            .checked_add(len)
-            .ok_or(WasmError::MemoryAccessError)?;
+        let start = ptr.checked_add(4).ok_or(WasmError::MemoryAccessError)?;
+        let end = start.checked_add(len).ok_or(WasmError::MemoryAccessError)?;
 
         let direct = self.instance.memory_ref.direct_access();
         let buffer = direct.as_ref();
@@ -187,7 +183,9 @@ impl WasmInstance for WasmiInstance {
             })?
             .ok_or(WasmInvokeError::Error(WasmError::MissingReturnData))?;
         match rtn {
-            RuntimeValue::I32(ptr) => externals.read_value(ptr as usize).map_err(WasmInvokeError::Error),
+            RuntimeValue::I32(ptr) => externals
+                .read_value(ptr as usize)
+                .map_err(WasmInvokeError::Error),
             _ => Err(WasmInvokeError::Error(WasmError::InvalidReturnData)),
         }
     }

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -1,5 +1,5 @@
-use wasmi::*;
 use crate::model::InvokeError;
+use wasmi::*;
 
 use crate::types::*;
 use crate::wasm::constants::*;

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -78,8 +78,8 @@ fn large_return_len_should_cause_memory_access_error() {
 
     // Assert
     receipt.expect_specific_failure(|e| {
-        if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
-            matches!(**b, WasmInvokeError::Error(WasmError::MemoryAccessError))
+        if let RuntimeError::KernelError(KernelError::WasmError(b)) = e {
+            matches!(*b, WasmError::MemoryAccessError)
         } else {
             false
         }
@@ -102,8 +102,8 @@ fn overflow_return_len_should_cause_memory_access_error() {
 
     // Assert
     receipt.expect_specific_failure(|e| {
-        if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
-            matches!(**b, WasmInvokeError::Error(WasmError::MemoryAccessError))
+        if let RuntimeError::KernelError(KernelError::WasmError(b)) = e {
+            matches!(*b, WasmError::MemoryAccessError)
         } else {
             false
         }
@@ -127,10 +127,7 @@ fn zero_return_len_should_cause_data_validation_error() {
 
     // Assert
     receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::KernelError(KernelError::WasmInvokeError(_))
-        )
+        matches!(e, RuntimeError::KernelError(KernelError::WasmError(_)))
     });
 }
 

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -79,7 +79,7 @@ fn large_return_len_should_cause_memory_access_error() {
     // Assert
     receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
-            matches!(**b, WasmInvokeError::MemoryAccessError)
+            matches!(**b, WasmInvokeError::Error(WasmError::MemoryAccessError))
         } else {
             false
         }
@@ -103,7 +103,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
     // Assert
     receipt.expect_specific_failure(|e| {
         if let RuntimeError::KernelError(KernelError::WasmInvokeError(b)) = e {
-            matches!(**b, WasmInvokeError::MemoryAccessError)
+            matches!(**b, WasmInvokeError::Error(WasmError::MemoryAccessError))
         } else {
             false
         }

--- a/sbor/src/decode.rs
+++ b/sbor/src/decode.rs
@@ -9,9 +9,10 @@ use crate::rust::string::String;
 use crate::rust::string::ToString;
 use crate::rust::vec::Vec;
 use crate::type_id::*;
+use sbor::*;
 
 /// Represents an error ocurred during decoding.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeId)]
 pub enum DecodeError {
     Underflow { required: usize, remaining: usize },
 

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -557,10 +557,7 @@ pub fn is_costing_error(e: &RuntimeError) -> bool {
 }
 
 pub fn is_wasm_error(e: &RuntimeError) -> bool {
-    matches!(
-        e,
-        RuntimeError::KernelError(KernelError::WasmInvokeError(_))
-    )
+    matches!(e, RuntimeError::KernelError(KernelError::WasmError(_)))
 }
 
 pub fn wat2wasm(wat: &str) -> Vec<u8> {

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,7 @@ echo "Testing with std..."
 (cd scrypto-derive; cargo test)
 (cd scrypto-tests; cargo test)
 (cd radix-engine; cargo test)
+(cd radix-engine; cargo test --features wasmer)
 (cd transaction; cargo test)
 
 echo "Testing with no_std..."

--- a/transaction/src/errors.rs
+++ b/transaction/src/errors.rs
@@ -1,6 +1,6 @@
 use sbor::describe::Type;
 use sbor::rust::string::String;
-use sbor::DecodeError;
+use sbor::*;
 use scrypto::component::{ComponentAddress, PackageAddress};
 use scrypto::engine::types::*;
 
@@ -23,7 +23,7 @@ pub enum SignatureValidationError {
     DuplicateSigner,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeId)]
 pub enum IdAllocationError {
     OutOfID,
 }


### PR DESCRIPTION
This PR makes a few refactors in order to allow transaction receipts to be SBOR encoded/decoded. Most notably an `InvokeError` enum is implemented to allow us to catch downstream `RuntimeErrors` rather than using Box.