### PR TITLE
Make into great again

### DIFF
--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -461,6 +461,14 @@ fn generate_stubs(
             pub component: ::scrypto::component::Component,
         }
 
+        impl From<ComponentAddress> for #value_ident {
+            fn from(component: ComponentAddress) -> Self {
+                Self {
+                    component: ::scrypto::component::Component::from(component)
+                }
+            }
+        }
+
         impl ::scrypto::component::LocalComponent for #value_ident {
             fn package_address(&self) -> PackageAddress {
                 self.component.package_address()
@@ -645,6 +653,14 @@ mod tests {
                     pub component: ::scrypto::component::Component,
                 }
 
+                impl From<ComponentAddress> for TestComponent {
+                    fn from(component: ComponentAddress) -> Self {
+                        Self {
+                            component: ::scrypto::component::Component::from(component)
+                        }
+                    }
+                }
+
                 impl ::scrypto::component::LocalComponent for TestComponent {
                     fn package_address(&self) -> PackageAddress {
                         self.component.package_address()
@@ -725,6 +741,14 @@ mod tests {
                 #[derive(::sbor::TypeId, ::sbor::Encode, ::sbor::Decode, ::sbor::Describe)]
                 pub struct TestComponent {
                     pub component: ::scrypto::component::Component,
+                }
+
+                impl From<ComponentAddress> for TestComponent {
+                    fn from(component: ComponentAddress) -> Self {
+                        Self {
+                            component: ::scrypto::component::Component::from(component)
+                        }
+                    }
                 }
 
                 impl ::scrypto::component::LocalComponent for TestComponent {

--- a/scrypto/src/component/component.rs
+++ b/scrypto/src/component/component.rs
@@ -91,6 +91,13 @@ impl TryFrom<&[u8]> for Component {
     }
 }
 
+impl From<ComponentAddress> for Component {
+    fn from(component: ComponentAddress) -> Self {
+        let component_address = ComponentAddress::try_from(component.to_vec().as_slice()).unwrap();
+        Self(component_address)
+    }
+}
+
 impl Component {
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()


### PR DESCRIPTION
Hope we can bring this convenience back again :D

This allows us to do:

```rust
let test_component: TestComponent = self.test_component_address.into();
```