### PR TITLE
Misc Alphanet Improvements

### DIFF
--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -85,7 +85,7 @@ impl TransactionValidator {
         })
     }
 
-    fn validate_intent<I: IntentHashManager>(
+    pub fn validate_intent<I: IntentHashManager>(
         intent: &TransactionIntent,
         intent_hash_manager: &I,
         config: &ValidationConfig,
@@ -272,7 +272,7 @@ impl TransactionValidator {
         return Ok(instructions);
     }
 
-    fn validate_header(
+    pub fn validate_header(
         intent: &TransactionIntent,
         config: &ValidationConfig,
     ) -> Result<(), HeaderValidationError> {
@@ -312,7 +312,7 @@ impl TransactionValidator {
         Ok(())
     }
 
-    fn validate_signatures(
+    pub fn validate_signatures(
         transaction: &NotarizedTransaction,
     ) -> Result<HashSet<PublicKey>, SignatureValidationError> {
         // TODO: split into static validation part and runtime validation part to support more signatures
@@ -349,7 +349,7 @@ impl TransactionValidator {
         Ok(signers)
     }
 
-    fn validate_call_data(
+    pub fn validate_call_data(
         call_data: &[u8],
         id_validator: &mut IdValidator,
     ) -> Result<(), CallDataValidationError> {


### PR DESCRIPTION
This PR introduces a number of miscellaneous alphanet improvements mostly in relation to the [transaction library](https://github.com/radixdlt/transaction-library).

1. Made some of the validation functions in the `TransactionValidator` structs public to be able to use them in the transaction library.
2. The `ValidationConfig` does not need to have a reference to a `NetworkDefinition` when all it needs is a network id. 