### PR TITLE
Alphanet Bugfix: Fix transaction panic

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -1,5 +1,4 @@
 use radix_engine::ledger::*;
-use radix_engine::model::extract_abi;
 use scrypto::core::NetworkDefinition;
 use scrypto::prelude::*;
 use scrypto_unit::*;

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -31,6 +31,9 @@ wasmer-compiler-singlepass = { version = "2.2.1", optional = true }
 wabt = { version = "0.10.0" }
 criterion = { version = "0.3", features = ["html_reports"] }
 scrypto-unit = { path = "../scrypto-unit" }
+rand = { version = "0.8.5" }
+rand_chacha = { version = "0.3.1" }
+rayon = "1.5.3"
 
 [[bench]]
 name = "radix_engine"

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -68,7 +68,7 @@ impl From<Error> for InvokeError<WasmError> {
             // Pass-through invoke errors
             Some(host_error) => *host_error
                 .downcast::<InvokeError<WasmError>>()
-                .expect("Failed to downcast error into WasmInvokeError"),
+                .expect("Failed to downcast error into InvokeError<WasmError>"),
             None => InvokeError::Error(WasmError::WasmError(e_str)),
         }
     }

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -61,6 +61,19 @@ impl ModuleImportResolver for WasmiEnvModule {
     }
 }
 
+impl From<Error> for InvokeError<WasmError> {
+    fn from(error: Error) -> Self {
+        let e_str = format!("{:?}", error);
+        match error.into_host_error() {
+            // Pass-through invoke errors
+            Some(host_error) => *host_error
+                .downcast::<InvokeError<WasmError>>()
+                .expect("Failed to downcast error into WasmInvokeError"),
+            None => InvokeError::Error(WasmError::WasmError(e_str)),
+        }
+    }
+}
+
 impl WasmiModule {
     fn instantiate(&self) -> WasmiInstance {
         // link with env module
@@ -85,25 +98,35 @@ impl WasmiModule {
 }
 
 impl<'a, 'b, 'r> WasmiExternals<'a, 'b, 'r> {
-    pub fn send_value(&mut self, value: &ScryptoValue) -> Result<RuntimeValue, WasmError> {
+    pub fn send_value(
+        &mut self,
+        value: &ScryptoValue,
+    ) -> Result<RuntimeValue, InvokeError<WasmError>> {
         let result = self.instance.module_ref.clone().invoke_export(
             EXPORT_SCRYPTO_ALLOC,
             &[RuntimeValue::I32((value.raw.len()) as i32)],
             self,
         );
 
-        if let Ok(Some(RuntimeValue::I32(ptr))) = result {
-            if self
-                .instance
-                .memory_ref
-                .set((ptr + 4) as u32, &value.raw)
-                .is_ok()
-            {
-                return Ok(RuntimeValue::I32(ptr));
+        match result {
+            Ok(rtn) => {
+                if let Some(RuntimeValue::I32(ptr)) = rtn {
+                    if self
+                        .instance
+                        .memory_ref
+                        .set((ptr + 4) as u32, &value.raw)
+                        .is_ok()
+                    {
+                        return Ok(RuntimeValue::I32(ptr));
+                    }
+                }
+
+                return Err(InvokeError::Error(WasmError::MemoryAllocError));
+            }
+            Err(e) => {
+                return Err(e.into());
             }
         }
-
-        Err(WasmError::MemoryAllocError)
     }
 
     pub fn read_value(&self, ptr: usize) -> Result<ScryptoValue, WasmError> {
@@ -165,7 +188,7 @@ impl WasmInstance for WasmiInstance {
             runtime,
         };
 
-        let pointer = externals.send_value(args).map_err(InvokeError::Error)?;
+        let pointer = externals.send_value(args)?;
         let result = self
             .module_ref
             .clone()
@@ -173,14 +196,8 @@ impl WasmInstance for WasmiInstance {
 
         let rtn = result
             .map_err(|e| {
-                let e_str = format!("{:?}", e);
-                match e.into_host_error() {
-                    // Pass-through invoke errors
-                    Some(host_error) => *host_error
-                        .downcast::<InvokeError<WasmError>>()
-                        .expect("Failed to downcast error into WasmInvokeError"),
-                    None => InvokeError::Error(WasmError::WasmError(e_str)),
-                }
+                let err: InvokeError<WasmError> = e.into();
+                err
             })?
             .ok_or(InvokeError::Error(WasmError::MissingReturnData))?;
         match rtn {

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -1,0 +1,138 @@
+use radix_engine::constants::{
+    DEFAULT_COST_UNIT_LIMIT, DEFAULT_COST_UNIT_PRICE, DEFAULT_MAX_CALL_DEPTH, DEFAULT_SYSTEM_LOAN,
+};
+use radix_engine::ledger::TypedInMemorySubstateStore;
+use radix_engine::state_manager::StagedSubstateStoreManager;
+use radix_engine::transaction::{ExecutionConfig, FeeReserveConfig, TransactionExecutor};
+use radix_engine::types::*;
+use radix_engine::wasm::{DefaultWasmEngine, WasmInstrumenter};
+use rand::Rng;
+use rand_chacha;
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rayon::prelude::*;
+use transaction::builder::{ManifestBuilder, TransactionBuilder};
+use transaction::model::{NotarizedTransaction, TransactionHeader};
+use transaction::signing::EcdsaPrivateKey;
+use transaction::validation::{TestIntentHashManager, TransactionValidator, ValidationConfig};
+
+fn execute_single_transaction(transaction: NotarizedTransaction) {
+    let transaction = TransactionValidator::validate(
+        transaction,
+        &TestIntentHashManager::new(),
+        &ValidationConfig {
+            network: &NetworkDefinition::local_simulator(),
+            current_epoch: 1,
+            max_cost_unit_limit: DEFAULT_COST_UNIT_LIMIT,
+            min_tip_percentage: 0,
+        },
+    )
+    .unwrap();
+
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut wasm_engine = DefaultWasmEngine::new();
+    let mut wasm_instrumenter = WasmInstrumenter::new();
+    let execution_config = ExecutionConfig {
+        max_call_depth: DEFAULT_MAX_CALL_DEPTH,
+        is_system: false,
+        trace: false,
+    };
+    let fee_reserve_config = FeeReserveConfig {
+        cost_unit_price: DEFAULT_COST_UNIT_PRICE.parse().unwrap(),
+        system_loan: DEFAULT_SYSTEM_LOAN,
+    };
+
+    let mut staged_store_manager = StagedSubstateStoreManager::new(&mut store);
+    let staged_node = staged_store_manager.new_child_node(0);
+
+    let mut staged_store = staged_store_manager.get_output_store(staged_node);
+    let mut transaction_executor =
+        TransactionExecutor::new(&mut staged_store, &mut wasm_engine, &mut wasm_instrumenter);
+    transaction_executor.execute_and_commit(&transaction, &fee_reserve_config, &execution_config);
+}
+
+struct TransactionFuzzer {
+    rng: ChaCha8Rng,
+}
+
+impl TransactionFuzzer {
+    fn new() -> Self {
+        let rng = ChaCha8Rng::seed_from_u64(1234);
+        Self { rng }
+    }
+
+    fn next_transaction(&mut self) -> NotarizedTransaction {
+        let mut builder = ManifestBuilder::new(&NetworkDefinition::local_simulator());
+        let instruction_count = self.rng.gen_range(0u32..20u32);
+        for _ in 0..instruction_count {
+            let next = self.rng.gen_range(0u32..4u32);
+            match next {
+                0 => {
+                    builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
+                        builder.call_function(
+                            ACCOUNT_PACKAGE,
+                            "Account",
+                            "new_with_resource",
+                            args!(AccessRule::AllowAll, scrypto::resource::Bucket(bucket_id)),
+                        )
+                    });
+                }
+                1 => {
+                    builder.call_function(
+                        ACCOUNT_PACKAGE,
+                        "Account",
+                        "new",
+                        args!(AccessRule::AllowAll),
+                    );
+                }
+                2 => {
+                    builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
+                        builder.call_function(
+                            ACCOUNT_PACKAGE,
+                            "Account",
+                            "new_with_resource",
+                            args!(AccessRule::AllowAll, scrypto::resource::Bucket(bucket_id)),
+                        )
+                    });
+                }
+                3 => {
+                    builder.call_method(SYS_FAUCET_COMPONENT, "lock_fee", args!(dec!("100")));
+                }
+                _ => panic!("Unexpected"),
+            }
+        }
+
+        let manifest = builder.build();
+        let private_key = EcdsaPrivateKey::from_u64(1).unwrap();
+        let header = TransactionHeader {
+            version: 1,
+            network_id: NetworkDefinition::local_simulator().id,
+            start_epoch_inclusive: 0,
+            end_epoch_exclusive: 100,
+            nonce: 5,
+            notary_public_key: private_key.public_key().into(),
+            notary_as_signatory: false,
+            cost_unit_limit: 10_000_000,
+            tip_percentage: 0,
+        };
+
+        TransactionBuilder::new()
+            .header(header)
+            .manifest(manifest)
+            .sign(&private_key)
+            .notarize(&private_key)
+            .build()
+    }
+}
+
+#[test]
+fn simple_transaction_fuzz_test() {
+    let mut fuzzer = TransactionFuzzer::new();
+    let transactions: Vec<NotarizedTransaction> = (0..200)
+        .into_iter()
+        .map(|_| fuzzer.next_transaction())
+        .collect();
+    transactions.into_par_iter().for_each(|transaction| {
+        execute_single_transaction(transaction);
+    });
+}


### PR DESCRIPTION
* Fix a downcast panic which occurs if `send_value` errors
* Update `send_value` error to use invoke error if the error is an actual downstream error
* Implemented a simple fuzz transaction tester