### PR TITLE
Add fee payments to ExecutionTrace resource changes receipt

### DIFF
--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -185,8 +185,7 @@ where
         };
 
         // Produce the final transaction receipt
-        let execution_trace_receipt = execution_trace.to_receipt();
-        let track_receipt = track.finalize(invoke_result, execution_trace_receipt.resource_changes);
+        let track_receipt = track.finalize(invoke_result, execution_trace);
 
         let receipt = TransactionReceipt {
             contents: TransactionContents { instructions },

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -17,7 +17,7 @@ fn can_withdraw_from_my_account() {
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
-        .lock_fee(10.into(), account)
+        .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
         .withdraw_from_account(RADIX_TOKEN, account)
         .call_method(
             other_account,
@@ -134,7 +134,7 @@ fn account_to_bucket_to_account() {
 
     // Assert
     receipt.expect_commit_success();
-    assert!(receipt.expect_commit().resource_changes.is_empty());
+    assert_eq!(1, receipt.expect_commit().resource_changes.len()); // Just the fee payment
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn test_account_balance() {
     let outputs = receipt.expect_commit_success();
 
     // Assert
-    assert!(receipt.expect_commit().resource_changes.is_empty());
+    assert_eq!(1, receipt.expect_commit().resource_changes.len()); // Just the fee payment
     assert_eq!(
         outputs[1],
         ScryptoValue::from_typed(&Decimal::from(1000)).raw
@@ -171,7 +171,7 @@ fn assert_resource_changes_for_transfer(
     target_account: ComponentId,
     transfer_amount: Decimal,
 ) {
-    assert_eq!(2, resource_changes.len());
+    assert_eq!(3, resource_changes.len()); // Two transfers (withdrawal, deposit) + fee payment
     assert!(resource_changes
         .iter()
         .any(|r| r.resource_address == resource_address

--- a/radix-engine/tests/execution_trace.rs
+++ b/radix-engine/tests/execution_trace.rs
@@ -1,6 +1,7 @@
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use scrypto_unit::*;
+use std::ops::Add;
 use transaction::builder::ManifestBuilder;
 
 #[test]
@@ -35,7 +36,8 @@ fn test_trace_resource_transfers() {
         ComponentAddress,
     ) = scrypto_decode(&output.get(1).unwrap()[..]).unwrap();
 
-    let component_id: ComponentId = test_runner
+    let account_component_id: ComponentId = test_runner.deref_component(account).unwrap().into();
+    let source_component_id: ComponentId = test_runner
         .deref_component(source_component)
         .unwrap()
         .into();
@@ -44,15 +46,26 @@ fn test_trace_resource_transfers() {
         .unwrap()
         .into();
 
-    /* There should be two resource changes, one for source component and one for target */
-    assert_eq!(2, receipt.expect_commit().resource_changes.len());
+    /* There should be three resource changes: withdrawal from the source vault,
+    deposit to the target vault and withdrawal for the fee */
+    assert_eq!(3, receipt.expect_commit().resource_changes.len());
+
+    let fee_summary = &receipt.execution.fee_summary;
+
+    let fee_resource_address = fee_summary.payments.first().unwrap().1.resource_address();
+
+    let total_fee_paid = fee_summary.burned.add(fee_summary.tipped);
+
+    // Source vault withdrawal
     assert!(receipt
         .expect_commit()
         .resource_changes
         .iter()
         .any(|r| r.resource_address == resource_address
-            && r.component_id == component_id
+            && r.component_id == source_component_id
             && r.amount == -Decimal::from(transfer_amount)));
+
+    // Target vault deposit
     assert!(receipt
         .expect_commit()
         .resource_changes
@@ -60,4 +73,72 @@ fn test_trace_resource_transfers() {
         .any(|r| r.resource_address == resource_address
             && r.component_id == target_component_id
             && r.amount == Decimal::from(transfer_amount)));
+
+    // Fee withdrawal
+    assert!(receipt
+        .expect_commit()
+        .resource_changes
+        .iter()
+        .any(|r| r.resource_address == fee_resource_address
+            && r.component_id == account_component_id
+            && r.amount == -Decimal::from(total_fee_paid)));
+}
+
+#[test]
+fn test_trace_fee_payments() {
+    // Arrange
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(true, &mut store);
+    let package_address = test_runner.compile_and_publish("./tests/execution_trace");
+
+    // Prepare the component that will pay the fee
+    let manifest_prepare = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
+        .call_method(SYS_FAUCET_COMPONENT, "free", args!())
+        .call_scrypto_function(
+            package_address,
+            "ExecutionTraceTest",
+            "create_and_fund_a_component",
+            args!(Expression::entire_worktop()),
+        )
+        .clear_auth_zone()
+        .build();
+
+    let funded_component = test_runner
+        .execute_manifest(manifest_prepare, vec![])
+        .new_component_addresses()
+        .into_iter()
+        .nth(0)
+        .unwrap()
+        .clone();
+
+    let funded_component_id: ComponentId = test_runner
+        .deref_component(funded_component)
+        .unwrap()
+        .into();
+
+    // Act
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
+        .call_method(
+            funded_component.clone(),
+            "test_lock_contingent_fee",
+            args!(),
+        )
+        .clear_auth_zone()
+        .build();
+
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    let _ = receipt.expect_commit_success();
+    let resource_changes = &receipt.expect_commit().resource_changes;
+    let fee_summary = &receipt.execution.fee_summary;
+    let total_fee_paid = fee_summary.burned.add(fee_summary.tipped);
+
+    assert_eq!(1, resource_changes.len());
+
+    assert!(resource_changes
+        .iter()
+        .any(|r| r.component_id == funded_component_id && r.amount == -total_fee_paid));
 }

--- a/radix-engine/tests/execution_trace/src/execution_trace.rs
+++ b/radix-engine/tests/execution_trace/src/execution_trace.rs
@@ -41,5 +41,14 @@ blueprint! {
         pub fn put(&mut self, b: Bucket) {
             self.vault.put(b)
         }
+
+        pub fn create_and_fund_a_component(xrd: Vec<Bucket>) {
+            let vault = Vault::with_bucket(xrd.into_iter().nth(0).unwrap());
+            let _ = ExecutionTraceTest { vault }.instantiate().globalize();
+        }
+
+        pub fn test_lock_contingent_fee(&mut self) {
+            self.vault.lock_contingent_fee(dec!("10"));
+        }
     }
 }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -751,7 +751,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
 
         // Commit
         self.next_transaction_nonce += 1;
-        let receipt = track.finalize(Ok(Vec::new()), Vec::new());
+        let receipt = track.finalize(Ok(Vec::new()), ExecutionTrace::new());
         if let TransactionResult::Commit(c) = receipt.result {
             c.state_updates.commit(substate_store);
         }

--- a/simulator/src/resim/cmd_set_current_epoch.rs
+++ b/simulator/src/resim/cmd_set_current_epoch.rs
@@ -64,7 +64,7 @@ impl SetCurrentEpoch {
             .map_err(Error::TransactionExecutionError)?;
 
         // Commit
-        let receipt = track.finalize(Ok(Vec::new()), Vec::new());
+        let receipt = track.finalize(Ok(Vec::new()), ExecutionTrace::new());
         if let TransactionResult::Commit(c) = receipt.result {
             c.state_updates.commit(&mut substate_store);
         }


### PR DESCRIPTION
Current situation:
Fee payments are not being recorded in execution trace resource changes.

Desired situation:
Resource changes should include fee payments.

Proposed solution:
Nearly all needed information to keep track of the changes is already in FeeSummary. What's missing is vault's component addresses. Execution trace stores those addresses and later combines them with fee summary to create corresponding ResourceChange entries.