### PR TITLE
Fix/contextual display neatenings

### DIFF
--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -255,11 +255,7 @@ impl<'a> ContextualDisplay<AddressDisplayContext<'a>> for TransactionReceipt {
                         prefix!(i, outputs),
                         ScryptoValue::from_slice(output)
                             .expect("Failed to parse return data")
-                            .displayable(
-                                bech32_encoder,
-                                &decompilation_context.bucket_names,
-                                &decompilation_context.proof_names
-                            )
+                            .display(decompilation_context.for_value_display())
                     )?;
                 }
             }

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -2,6 +2,7 @@ use radix_engine::engine::*;
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::{BucketError, ResourceContainerError};
 use radix_engine::types::*;
+use scrypto::misc::ContextualDisplay;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
@@ -204,7 +205,7 @@ fn create_empty_bucket() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();

--- a/radix-engine/tests/math.rs
+++ b/radix-engine/tests/math.rs
@@ -1,5 +1,6 @@
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
+use scrypto::misc::ContextualDisplay;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
@@ -25,7 +26,7 @@ fn test_integer_basic_ops() {
         .unwrap()
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -49,7 +50,7 @@ fn test_native_and_safe_integer_interop() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -1,6 +1,6 @@
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
-use scrypto::address::ContextualDisplay;
+use scrypto::misc::ContextualDisplay;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -1,7 +1,7 @@
 use radix_engine::engine::{KernelError, RuntimeError};
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
-use scrypto::address::ContextualDisplay;
+use scrypto::misc::ContextualDisplay;
 use scrypto::resource::{Bucket, Proof, DIVISIBILITY_MAXIMUM};
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
@@ -40,7 +40,7 @@ fn can_create_clone_and_drop_bucket_proof() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -76,7 +76,7 @@ fn can_create_clone_and_drop_vault_proof() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -116,7 +116,7 @@ fn can_create_clone_and_drop_vault_proof_by_amount() {
         .unwrap()
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -3,6 +3,7 @@ use radix_engine::engine::RuntimeError;
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use scrypto::core::Blob;
+use scrypto::misc::ContextualDisplay;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 use transaction::model::Instruction;
@@ -44,7 +45,7 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -66,7 +67,7 @@ fn test_transaction_can_end_with_proofs_remaining_in_auth_zone() {
         .create_proof_from_account_by_amount(dec!("1"), RADIX_TOKEN, account)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -89,7 +90,7 @@ fn test_non_existent_blob_hash() {
         .0
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -117,7 +118,7 @@ fn test_entire_auth_zone() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_success();
@@ -142,7 +143,7 @@ fn test_faucet_drain_attempt_should_fail() {
         )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![public_key.into()]);
-    println!("{}", receipt.displayable(&Bech32Encoder::for_simulator()));
+    println!("{}", receipt.display(&Bech32Encoder::for_simulator()));
 
     // Assert
     receipt.expect_commit_failure();

--- a/scrypto/src/address/display.rs
+++ b/scrypto/src/address/display.rs
@@ -1,8 +1,5 @@
 use super::*;
 
-// Re-export so it's easy to pick up
-pub use crate::misc::ContextualDisplay;
-
 #[derive(Clone, Copy)]
 pub struct AddressDisplayContext<'a> {
     pub encoder: Option<&'a Bech32Encoder>,

--- a/scrypto/src/address/encoder.rs
+++ b/scrypto/src/address/encoder.rs
@@ -12,6 +12,7 @@ use crate::misc::combine;
 use crate::resource::ResourceAddress;
 
 /// Represents an encoder which understands how to encode Scrypto addresses in Bech32.
+#[derive(Debug)]
 pub struct Bech32Encoder {
     pub hrp_set: HrpSet,
 }

--- a/scrypto/src/misc/contextual_display.rs
+++ b/scrypto/src/misc/contextual_display.rs
@@ -9,6 +9,14 @@ pub trait ContextualDisplay<Context>: Sized {
         context: &Context,
     ) -> Result<(), Self::Error>;
 
+    fn format<F: fmt::Write, TContext: Into<Context>>(
+        &self,
+        f: &mut F,
+        context: TContext,
+    ) -> Result<(), Self::Error> {
+        self.contextual_format(f, &context.into())
+    }
+
     fn display<'a, 'b, TContext: Into<Context>>(
         &'a self,
         context: TContext,

--- a/scrypto/src/misc/contextual_display.rs
+++ b/scrypto/src/misc/contextual_display.rs
@@ -5,12 +5,12 @@ use sbor::rust::fmt;
 /// Typically, this is due to needing to know the current network to display addresses.
 /// Other forms of Context are also possible. See [`ComponentAddress`][ComponentAddress]
 /// or `TransactionReceipt` in the `radix-engine` crate for example implementations.
-/// 
+///
 /// The `Context` used should typically just be a wrapper type around references, and so
 /// be a small, cheap, ephemeral value on the stack (if it's not just optimized away entirely).
 /// It is therefore recommended that the `Context` implement `Copy`,
 /// to make it very easy to pass around and re-use.
-/// 
+///
 /// [ComponentAddress]: crate::component::component::ComponentAddress
 pub trait ContextualDisplay<Context>: Sized {
     type Error;
@@ -18,7 +18,7 @@ pub trait ContextualDisplay<Context>: Sized {
     /// Formats the value to the given `fmt::Write` buffer, making use of the provided context.
     /// See also [`format`], which is typically easier to use, as it takes an `Into<Context>`
     /// instead of a `&Context`.
-    /// 
+    ///
     /// [`format`]: #method.format
     fn contextual_format<F: fmt::Write>(
         &self,
@@ -28,10 +28,10 @@ pub trait ContextualDisplay<Context>: Sized {
 
     /// Formats the value to the given `fmt::Write` buffer, making use of the provided context.
     /// See also [`contextual_format`], which takes a `&Context` instead of an `Into<Context>`.
-    /// 
+    ///
     /// Alternatively, the [`display`] method can be used to create an object that can be used
     /// directly in a `format!` style macro.
-    /// 
+    ///
     /// [`contextual_format`]: #method.contextual_format
     /// [`display`]: #method.display
     fn format<F: fmt::Write, TContext: Into<Context>>(
@@ -48,17 +48,17 @@ pub trait ContextualDisplay<Context>: Sized {
     /// formatting, replacing them with `fmt::Error`.
     /// If you'd like to preserve errors, use the [`format`] method instead. This may require manually
     /// splitting up your `format!` style macro. For example:
-    /// 
+    ///
     /// ```rust,ignore
     /// // Syntactically nice, but the AddressError is swallowed into fmt::Error
     /// write!(f, "ComponentAddress(\"{}\")", address.display(context))?;
-    /// 
+    ///
     /// // Less nice, but the AddressError is correctly returned
     /// f.write_str("ComponentAddress(\"")?;
     /// address.format(f, context)?;
     /// f.write_str("\")")?;
     /// ```
-    /// 
+    ///
     /// [`format`]: #method.format
     fn display<'a, 'b, TContext: Into<Context>>(
         &'a self,

--- a/scrypto/src/misc/contextual_display.rs
+++ b/scrypto/src/misc/contextual_display.rs
@@ -1,14 +1,39 @@
 use sbor::rust::fmt;
 
+/// This trait is used where context is required to correctly display a value.
+///
+/// Typically, this is due to needing to know the current network to display addresses.
+/// Other forms of Context are also possible. See [`ComponentAddress`][ComponentAddress]
+/// or `TransactionReceipt` in the `radix-engine` crate for example implementations.
+/// 
+/// The `Context` used should typically just be a wrapper type around references, and so
+/// be a small, cheap, ephemeral value on the stack (if it's not just optimized away entirely).
+/// It is therefore recommended that the `Context` implement `Copy`,
+/// to make it very easy to pass around and re-use.
+/// 
+/// [ComponentAddress]: crate::component::component::ComponentAddress
 pub trait ContextualDisplay<Context>: Sized {
     type Error;
 
+    /// Formats the value to the given `fmt::Write` buffer, making use of the provided context.
+    /// See also [`format`], which is typically easier to use, as it takes an `Into<Context>`
+    /// instead of a `&Context`.
+    /// 
+    /// [`format`]: #method.format
     fn contextual_format<F: fmt::Write>(
         &self,
         f: &mut F,
         context: &Context,
     ) -> Result<(), Self::Error>;
 
+    /// Formats the value to the given `fmt::Write` buffer, making use of the provided context.
+    /// See also [`contextual_format`], which takes a `&Context` instead of an `Into<Context>`.
+    /// 
+    /// Alternatively, the [`display`] method can be used to create an object that can be used
+    /// directly in a `format!` style macro.
+    /// 
+    /// [`contextual_format`]: #method.contextual_format
+    /// [`display`]: #method.display
     fn format<F: fmt::Write, TContext: Into<Context>>(
         &self,
         f: &mut F,
@@ -17,6 +42,24 @@ pub trait ContextualDisplay<Context>: Sized {
         self.contextual_format(f, &context.into())
     }
 
+    /// Returns an object implementing `fmt::Display`, which can be used in a `format!` style macro.
+    ///
+    /// Whilst this is syntactically nicer, beware that the use of `format!` absorbs any errors during
+    /// formatting, replacing them with `fmt::Error`.
+    /// If you'd like to preserve errors, use the [`format`] method instead. This may require manually
+    /// splitting up your `format!` style macro. For example:
+    /// 
+    /// ```rust,ignore
+    /// // Syntactically nice, but the AddressError is swallowed into fmt::Error
+    /// write!(f, "ComponentAddress(\"{}\")", address.display(context))?;
+    /// 
+    /// // Less nice, but the AddressError is correctly returned
+    /// f.write_str("ComponentAddress(\"")?;
+    /// address.format(f, context)?;
+    /// f.write_str("\")")?;
+    /// ```
+    /// 
+    /// [`format`]: #method.format
     fn display<'a, 'b, TContext: Into<Context>>(
         &'a self,
         context: TContext,

--- a/scrypto/src/values.rs
+++ b/scrypto/src/values.rs
@@ -561,7 +561,9 @@ impl ScryptoValueFormatter {
                 Self::format_elements(elements, context)?
             ),
             // custom types
-            Value::Custom { type_id, bytes } => Self::format_custom_value(*type_id, bytes, context)?,
+            Value::Custom { type_id, bytes } => {
+                Self::format_custom_value(*type_id, bytes, context)?
+            }
         })
     }
 

--- a/scrypto/src/values.rs
+++ b/scrypto/src/values.rs
@@ -561,7 +561,7 @@ impl ScryptoValueFormatter {
                 Self::format_elements(elements, context)?
             ),
             // custom types
-            Value::Custom { type_id, bytes } => Self::from_custom_value(*type_id, bytes, context)?,
+            Value::Custom { type_id, bytes } => Self::format_custom_value(*type_id, bytes, context)?,
         })
     }
 
@@ -617,7 +617,7 @@ impl ScryptoValueFormatter {
         Ok(buf)
     }
 
-    pub fn from_custom_value(
+    pub fn format_custom_value(
         type_id: u8,
         data: &[u8],
         context: &ScryptoValueFormatterContext,

--- a/scrypto/src/values.rs
+++ b/scrypto/src/values.rs
@@ -4,7 +4,6 @@ use sbor::rust::collections::HashMap;
 use sbor::rust::collections::HashSet;
 use sbor::rust::fmt;
 use sbor::rust::format;
-use sbor::rust::string::String;
 use sbor::rust::string::*;
 use sbor::rust::vec::Vec;
 use sbor::type_id::*;
@@ -400,6 +399,7 @@ impl CustomValueVisitor for ScryptoCustomValueChecker {
 /// Utility that formats any Scrypto value.
 pub struct ScryptoValueFormatter {}
 
+#[derive(Clone, Copy, Debug)]
 pub struct ScryptoValueFormatterContext<'a> {
     bech32_encoder: Option<&'a Bech32Encoder>,
     bucket_names: Option<&'a HashMap<BucketId, String>>,
@@ -415,7 +415,7 @@ impl<'a> ScryptoValueFormatterContext<'a> {
         }
     }
 
-    pub fn new_with_no_manifest_context(bech32_encoder: Option<&'a Bech32Encoder>) -> Self {
+    pub fn no_manifest_context(bech32_encoder: Option<&'a Bech32Encoder>) -> Self {
         Self {
             bech32_encoder,
             bucket_names: None,
@@ -448,13 +448,13 @@ impl<'a> ScryptoValueFormatterContext<'a> {
 
 impl<'a> Into<ScryptoValueFormatterContext<'a>> for &'a Bech32Encoder {
     fn into(self) -> ScryptoValueFormatterContext<'a> {
-        ScryptoValueFormatterContext::new_with_no_manifest_context(Some(self))
+        ScryptoValueFormatterContext::no_manifest_context(Some(self))
     }
 }
 
 impl<'a> Into<ScryptoValueFormatterContext<'a>> for Option<&'a Bech32Encoder> {
     fn into(self) -> ScryptoValueFormatterContext<'a> {
-        ScryptoValueFormatterContext::new_with_no_manifest_context(self)
+        ScryptoValueFormatterContext::no_manifest_context(self)
     }
 }
 
@@ -485,250 +485,327 @@ impl<'a> ContextualDisplay<ScryptoValueFormatterContext<'a>> for ScryptoValue {
         f: &mut F,
         context: &ScryptoValueFormatterContext<'a>,
     ) -> Result<(), Self::Error> {
-        write!(
-            f,
-            "{}",
-            ScryptoValueFormatter::format_value(&self.dom, context)?
-        )?;
-        Ok(())
+        ScryptoValueFormatter::format_value(f, &self.dom, context)
+    }
+}
+
+impl<'a> ContextualDisplay<ScryptoValueFormatterContext<'a>> for Value {
+    type Error = ScryptoValueFormatterError;
+
+    fn contextual_format<F: fmt::Write>(
+        &self,
+        f: &mut F,
+        context: &ScryptoValueFormatterContext<'a>,
+    ) -> Result<(), Self::Error> {
+        ScryptoValueFormatter::format_value(f, &self, context)
     }
 }
 
 impl ScryptoValueFormatter {
-    pub fn format_value(
+    pub fn format_value<F: fmt::Write>(
+        f: &mut F,
         value: &Value,
         context: &ScryptoValueFormatterContext,
-    ) -> Result<String, ScryptoValueFormatterError> {
-        Ok(match value {
+    ) -> Result<(), ScryptoValueFormatterError> {
+        match value {
             // primitive types
-            Value::Unit => "()".to_string(),
-            Value::Bool { value } => value.to_string(),
-            Value::I8 { value } => format!("{}i8", value),
-            Value::I16 { value } => format!("{}i16", value),
-            Value::I32 { value } => format!("{}i32", value),
-            Value::I64 { value } => format!("{}i64", value),
-            Value::I128 { value } => format!("{}i128", value),
-            Value::U8 { value } => format!("{}u8", value),
-            Value::U16 { value } => format!("{}u16", value),
-            Value::U32 { value } => format!("{}u32", value),
-            Value::U64 { value } => format!("{}u64", value),
-            Value::U128 { value } => format!("{}u128", value),
-            Value::String { value } => format!("\"{}\"", value),
+            Value::Unit => write!(f, "()")?,
+            Value::Bool { value } => write!(f, "{}", value)?,
+            Value::I8 { value } => write!(f, "{}i8", value)?,
+            Value::I16 { value } => write!(f, "{}i16", value)?,
+            Value::I32 { value } => write!(f, "{}i32", value)?,
+            Value::I64 { value } => write!(f, "{}i64", value)?,
+            Value::I128 { value } => write!(f, "{}i128", value)?,
+            Value::U8 { value } => write!(f, "{}u8", value)?,
+            Value::U16 { value } => write!(f, "{}u16", value)?,
+            Value::U32 { value } => write!(f, "{}u32", value)?,
+            Value::U64 { value } => write!(f, "{}u64", value)?,
+            Value::U128 { value } => write!(f, "{}u128", value)?,
+            Value::String { value } => write!(f, "\"{}\"", value)?,
             // struct & enum
             Value::Struct { fields } => {
-                format!("Struct({})", Self::format_elements(fields, context)?)
+                f.write_str("Struct(")?;
+                Self::format_elements(f, fields, context)?;
+                f.write_str(")")?;
             }
             Value::Enum { name, fields } => {
-                format!(
-                    "Enum(\"{}\"{}{})",
-                    name,
-                    if fields.is_empty() { "" } else { ", " },
-                    Self::format_elements(fields, context)?
-                )
+                f.write_str("Enum(\"")?;
+                f.write_str(name)?;
+                f.write_str("\"")?;
+                if !fields.is_empty() {
+                    f.write_str(", ")?;
+                    Self::format_elements(f, fields, context)?;
+                }
+                f.write_str(")")?;
             }
             // rust types
             Value::Option { value } => match value.borrow() {
-                Some(x) => format!("Some({})", Self::format_value(x, context)?),
-                None => "None".to_string(),
+                Some(x) => {
+                    f.write_str("Some(")?;
+                    Self::format_value(f, x, context)?;
+                    f.write_str(")")?;
+                }
+                None => write!(f, "None")?,
             },
             Value::Array {
                 element_type_id,
                 elements,
-            } => format!(
-                "Array<{}>({})",
-                Self::format_type_id(*element_type_id)?,
-                Self::format_elements(elements, context)?
-            ),
+            } => {
+                f.write_str("Array<")?;
+                Self::format_type_id(f, *element_type_id)?;
+                f.write_str(">(")?;
+                Self::format_elements(f, elements, context)?;
+                f.write_str(")")?;
+            }
             Value::Tuple { elements } => {
-                format!("Tuple({})", Self::format_elements(elements, context)?)
+                f.write_str("Tuple(")?;
+                Self::format_elements(f, elements, context)?;
+                f.write_str(")")?;
             }
             Value::Result { value } => match value.borrow() {
-                Ok(x) => format!("Ok({})", Self::format_value(x, context)?),
-                Err(x) => format!("Err({})", Self::format_value(x, context)?),
+                Ok(x) => {
+                    f.write_str("Ok(")?;
+                    Self::format_value(f, x, context)?;
+                    f.write_str(")")?
+                }
+                Err(x) => {
+                    f.write_str("Err(")?;
+                    Self::format_value(f, x, context)?;
+                    f.write_str(")")?;
+                }
             },
             // collections
             Value::List {
                 element_type_id,
                 elements,
             } => {
-                format!(
-                    "Vec<{}>({})",
-                    Self::format_type_id(*element_type_id)?,
-                    Self::format_elements(elements, context)?
-                )
+                f.write_str("Vec<")?;
+                Self::format_type_id(f, *element_type_id)?;
+                f.write_str(">(")?;
+                Self::format_elements(f, elements, context)?;
+                f.write_str(")")?;
             }
             Value::Set {
                 element_type_id,
                 elements,
-            } => format!(
-                "Set<{}>({})",
-                Self::format_type_id(*element_type_id)?,
-                Self::format_elements(elements, context)?
-            ),
+            } => {
+                f.write_str("Set<")?;
+                Self::format_type_id(f, *element_type_id)?;
+                f.write_str(">(")?;
+                Self::format_elements(f, elements, context)?;
+                f.write_str(")")?;
+            }
             Value::Map {
                 key_type_id,
                 value_type_id,
                 elements,
-            } => format!(
-                "Map<{}, {}>({})",
-                Self::format_type_id(*key_type_id)?,
-                Self::format_type_id(*value_type_id)?,
-                Self::format_elements(elements, context)?
-            ),
+            } => {
+                f.write_str("Map<")?;
+                Self::format_type_id(f, *key_type_id)?;
+                f.write_str(", ")?;
+                Self::format_type_id(f, *value_type_id)?;
+                f.write_str(">(")?;
+                Self::format_elements(f, elements, context)?;
+                f.write_str(")")?;
+            }
             // custom types
             Value::Custom { type_id, bytes } => {
-                Self::format_custom_value(*type_id, bytes, context)?
+                Self::format_custom_value(f, *type_id, bytes, context)?;
             }
-        })
+        };
+        Ok(())
     }
 
-    pub fn format_type_id(type_id: u8) -> Result<String, ScryptoValueFormatterError> {
+    pub fn format_type_id<F: fmt::Write>(
+        f: &mut F,
+        type_id: u8,
+    ) -> Result<(), ScryptoValueFormatterError> {
         if let Some(ty) = ScryptoType::from_id(type_id) {
-            return Ok(ty.name());
+            write!(f, "{}", ty.name())?;
+            return Ok(());
         }
 
-        Ok(match type_id {
+        match type_id {
             // primitive types
-            TYPE_UNIT => "Unit",
-            TYPE_BOOL => "Bool",
-            TYPE_I8 => "I8",
-            TYPE_I16 => "I16",
-            TYPE_I32 => "I32",
-            TYPE_I64 => "I64",
-            TYPE_I128 => "I128",
-            TYPE_U8 => "U8",
-            TYPE_U16 => "U16",
-            TYPE_U32 => "U32",
-            TYPE_U64 => "U64",
-            TYPE_U128 => "U128",
-            TYPE_STRING => "String",
+            TYPE_UNIT => f.write_str("Unit")?,
+            TYPE_BOOL => f.write_str("Bool")?,
+            TYPE_I8 => f.write_str("I8")?,
+            TYPE_I16 => f.write_str("I16")?,
+            TYPE_I32 => f.write_str("I32")?,
+            TYPE_I64 => f.write_str("I64")?,
+            TYPE_I128 => f.write_str("I128")?,
+            TYPE_U8 => f.write_str("U8")?,
+            TYPE_U16 => f.write_str("U16")?,
+            TYPE_U32 => f.write_str("U32")?,
+            TYPE_U64 => f.write_str("U64")?,
+            TYPE_U128 => f.write_str("U128")?,
+            TYPE_STRING => f.write_str("String")?,
             // struct & enum
-            TYPE_STRUCT => "Struct",
-            TYPE_ENUM => "Enum",
-            TYPE_OPTION => "Option",
-            TYPE_RESULT => "Result",
+            TYPE_STRUCT => f.write_str("Struct")?,
+            TYPE_ENUM => f.write_str("Enum")?,
+            TYPE_OPTION => f.write_str("Option")?,
+            TYPE_RESULT => f.write_str("Result")?,
             // composite
-            TYPE_ARRAY => "Array",
-            TYPE_TUPLE => "Tuple",
+            TYPE_ARRAY => f.write_str("Array")?,
+            TYPE_TUPLE => f.write_str("Tuple")?,
             // collections
-            TYPE_LIST => "List",
-            TYPE_SET => "Set",
-            TYPE_MAP => "Map",
+            TYPE_LIST => f.write_str("List")?,
+            TYPE_SET => f.write_str("Set")?,
+            TYPE_MAP => f.write_str("Map")?,
             //
             _ => Err(ScryptoValueFormatterError::InvalidTypeId(type_id))?,
-        }
-        .to_string())
+        };
+
+        Ok(())
     }
 
-    pub fn format_elements(
+    pub fn format_elements<F: fmt::Write>(
+        f: &mut F,
         values: &[Value],
         context: &ScryptoValueFormatterContext,
-    ) -> Result<String, ScryptoValueFormatterError> {
-        let mut buf = String::new();
+    ) -> Result<(), ScryptoValueFormatterError> {
         for (i, x) in values.iter().enumerate() {
             if i != 0 {
-                buf.push_str(", ");
+                f.write_str(", ")?;
             }
-            buf.push_str(Self::format_value(x, context)?.as_str());
+            Self::format_value(f, x, context)?;
         }
-        Ok(buf)
+        Ok(())
     }
 
-    pub fn format_custom_value(
+    pub fn format_custom_value<F: fmt::Write>(
+        f: &mut F,
         type_id: u8,
         data: &[u8],
         context: &ScryptoValueFormatterContext,
-    ) -> Result<String, ScryptoValueFormatterError> {
+    ) -> Result<(), ScryptoValueFormatterError> {
         let scrypto_type = ScryptoType::from_id(type_id);
         if scrypto_type.is_none() {
             Err(ScryptoCustomValueCheckError::UnknownTypeId(type_id))?;
         }
-        Ok(match scrypto_type.unwrap() {
-            ScryptoType::Decimal => Decimal::try_from(data)
-                .map(|d| format!("Decimal(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidDecimal)?,
-            ScryptoType::PreciseDecimal => PreciseDecimal::try_from(data)
-                .map(|d| format!("PreciseDecimal(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidPreciseDecimal)?,
-            ScryptoType::PackageAddress => PackageAddress::try_from(data)
-                .map(|address| {
-                    format!(
-                        "PackageAddress(\"{}\")",
-                        address.display(context.bech32_encoder)
-                    )
-                })
-                .map_err(ScryptoCustomValueCheckError::InvalidPackageAddress)?,
-            ScryptoType::ComponentAddress => ComponentAddress::try_from(data)
-                .map(|address| {
-                    format!(
-                        "ComponentAddress(\"{}\")",
-                        address.display(context.bech32_encoder)
-                    )
-                })
-                .map_err(ScryptoCustomValueCheckError::InvalidComponentAddress)?,
-            ScryptoType::Component => Component::try_from(data)
-                .map(|d| format!("Component(\"{}\")", d.0.display(context.bech32_encoder)))
-                .map_err(ScryptoCustomValueCheckError::InvalidComponent)?,
-            ScryptoType::KeyValueStore => KeyValueStore::<(), ()>::try_from(data)
-                .map(|d| format!("KeyValueStore(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidKeyValueStore)?,
-            ScryptoType::Hash => Hash::try_from(data)
-                .map(|d| format!("Hash(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidHash)?,
-            ScryptoType::EcdsaSecp256k1PublicKey => EcdsaSecp256k1PublicKey::try_from(data)
-                .map(|d| format!("EcdsaSecp256k1PublicKey(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidEcdsaSecp256k1PublicKey)?,
-            ScryptoType::EcdsaSecp256k1Signature => EcdsaSecp256k1Signature::try_from(data)
-                .map(|d| format!("EcdsaSecp256k1Signature(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidEcdsaSecp256k1Signature)?,
-            ScryptoType::EddsaEd25519PublicKey => EddsaEd25519PublicKey::try_from(data)
-                .map(|d| format!("EddsaEd25519PublicKey(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidEddsaEd25519PublicKey)?,
-            ScryptoType::EddsaEd25519Signature => EddsaEd25519Signature::try_from(data)
-                .map(|d| format!("EddsaEd25519Signature(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidEddsaEd25519Signature)?,
-            ScryptoType::Bucket => Bucket::try_from(data)
-                .map(|bucket| {
-                    if let Some(name) = context.get_bucket_name(&bucket.0) {
-                        format!("Bucket(\"{}\")", name)
-                    } else {
-                        format!("Bucket({}u32)", bucket.0)
-                    }
-                })
-                .map_err(ScryptoCustomValueCheckError::InvalidBucket)?,
-            ScryptoType::Proof => Proof::try_from(data)
-                .map(|proof| {
-                    if let Some(name) = context.get_proof_name(&proof.0) {
-                        format!("Proof(\"{}\")", name)
-                    } else {
-                        format!("Proof({}u32)", proof.0)
-                    }
-                })
-                .map_err(ScryptoCustomValueCheckError::InvalidProof)?,
-            ScryptoType::Vault => Vault::try_from(data)
-                .map(|d| format!("Vault(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidVault)?,
-            ScryptoType::NonFungibleId => NonFungibleId::try_from(data)
-                .map(|d| format!("NonFungibleId(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidNonFungibleId)?,
-            ScryptoType::NonFungibleAddress => NonFungibleAddress::try_from(data)
-                .map(|d| format!("NonFungibleAddress(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidNonFungibleAddress)?,
-            ScryptoType::ResourceAddress => ResourceAddress::try_from(data)
-                .map(|address| {
-                    format!(
-                        "ResourceAddress(\"{}\")",
-                        address.display(context.bech32_encoder)
-                    )
-                })
-                .map_err(ScryptoCustomValueCheckError::InvalidResourceAddress)?,
-            ScryptoType::Expression => Expression::try_from(data)
-                .map(|d| format!("Expression(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidExpression)?,
-            ScryptoType::Blob => Blob::try_from(data)
-                .map(|d| format!("Blob(\"{}\")", d))
-                .map_err(ScryptoCustomValueCheckError::InvalidBlob)?,
-        })
+        match scrypto_type.unwrap() {
+            ScryptoType::Decimal => {
+                let value = Decimal::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidDecimal)?;
+                write!(f, "Decimal(\"{}\")", value)?;
+            }
+            ScryptoType::PreciseDecimal => {
+                let value = PreciseDecimal::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidPreciseDecimal)?;
+                write!(f, "PreciseDecimal(\"{}\")", value)?;
+            }
+            ScryptoType::PackageAddress => {
+                let value = PackageAddress::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidPackageAddress)?;
+                f.write_str("PackageAddress(\"")?;
+                value
+                    .format(f, context.bech32_encoder)
+                    .map_err(ScryptoCustomValueCheckError::InvalidPackageAddress)?;
+                f.write_str("\")")?;
+            }
+            ScryptoType::ComponentAddress => {
+                let value = ComponentAddress::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidComponentAddress)?;
+                f.write_str("ComponentAddress(\"")?;
+                value
+                    .format(f, context.bech32_encoder)
+                    .map_err(ScryptoCustomValueCheckError::InvalidComponentAddress)?;
+                f.write_str("\")")?;
+            }
+            ScryptoType::Component => {
+                let value = Component::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidComponent)?;
+                f.write_str("Component(\"")?;
+                value
+                    .0
+                    .format(f, context.bech32_encoder)
+                    .map_err(ScryptoCustomValueCheckError::InvalidComponent)?;
+                f.write_str("\")")?;
+            }
+            ScryptoType::KeyValueStore => {
+                let value = KeyValueStore::<(), ()>::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidKeyValueStore)?;
+                write!(f, "KeyValueStore(\"{}\")", value)?;
+            }
+            ScryptoType::Hash => {
+                let value =
+                    Hash::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidHash)?;
+                write!(f, "Hash(\"{}\")", value)?;
+            }
+            ScryptoType::EcdsaSecp256k1PublicKey => {
+                let value = EcdsaSecp256k1PublicKey::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidEcdsaSecp256k1PublicKey)?;
+                write!(f, "EcdsaSecp256k1PublicKey(\"{}\")", value)?;
+            }
+            ScryptoType::EcdsaSecp256k1Signature => {
+                let value = EcdsaSecp256k1Signature::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidEcdsaSecp256k1Signature)?;
+                write!(f, "EcdsaSecp256k1Signature(\"{}\")", value)?;
+            }
+            ScryptoType::EddsaEd25519PublicKey => {
+                let value = EddsaEd25519PublicKey::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidEddsaEd25519PublicKey)?;
+                write!(f, "EddsaEd25519PublicKey(\"{}\")", value)?;
+            }
+            ScryptoType::EddsaEd25519Signature => {
+                let value = EddsaEd25519Signature::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidEddsaEd25519Signature)?;
+                write!(f, "EddsaEd25519Signature(\"{}\")", value)?;
+            }
+            ScryptoType::Bucket => {
+                let value =
+                    Bucket::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidBucket)?;
+                if let Some(name) = context.get_bucket_name(&value.0) {
+                    write!(f, "Bucket(\"{}\")", name)?;
+                } else {
+                    write!(f, "Bucket({}u32)", value.0)?;
+                }
+            }
+            ScryptoType::Proof => {
+                let value =
+                    Proof::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidProof)?;
+                if let Some(name) = context.get_proof_name(&value.0) {
+                    write!(f, "Proof(\"{}\")", name)?;
+                } else {
+                    write!(f, "Proof({}u32)", value.0)?;
+                }
+            }
+            ScryptoType::Vault => {
+                let value =
+                    Vault::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidVault)?;
+                write!(f, "Vault(\"{}\")", value)?;
+            }
+            ScryptoType::NonFungibleId => {
+                let value = NonFungibleId::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidNonFungibleId)?;
+                write!(f, "NonFungibleId(\"{}\")", value)?;
+            }
+            ScryptoType::NonFungibleAddress => {
+                let value = NonFungibleAddress::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidNonFungibleAddress)?;
+                write!(f, "NonFungibleAddress(\"{}\")", value)?;
+            }
+            ScryptoType::ResourceAddress => {
+                let value = ResourceAddress::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidResourceAddress)?;
+                f.write_str("ResourceAddress(\"")?;
+                value
+                    .format(f, context.bech32_encoder)
+                    .map_err(ScryptoCustomValueCheckError::InvalidResourceAddress)?;
+                f.write_str("\")")?;
+            }
+            ScryptoType::Expression => {
+                let value = Expression::try_from(data)
+                    .map_err(ScryptoCustomValueCheckError::InvalidExpression)?;
+                write!(f, "Expression(\"{}\")", value)?;
+            }
+            ScryptoType::Blob => {
+                let value =
+                    Blob::try_from(data).map_err(ScryptoCustomValueCheckError::InvalidBlob)?;
+                write!(f, "Blob(\"{}\")", value)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -3,7 +3,7 @@ use colored::*;
 use radix_engine::ledger::*;
 use radix_engine::model::*;
 use radix_engine::types::*;
-use scrypto::address::ContextualDisplay;
+use scrypto::misc::ContextualDisplay;
 use std::collections::VecDeque;
 
 use crate::utils::*;

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -4,6 +4,7 @@ use radix_engine::ledger::*;
 use radix_engine::model::*;
 use radix_engine::types::*;
 use scrypto::misc::ContextualDisplay;
+use scrypto::values::ScryptoValueFormatterContext;
 use std::collections::VecDeque;
 
 use crate::utils::*;
@@ -92,11 +93,13 @@ pub fn dump_component<T: ReadableSubstateStore + QueryableSubstateStore, O: std:
                 .unwrap();
 
             let state_data = ScryptoValue::from_slice(state.state()).unwrap();
+            let value_display_context =
+                ScryptoValueFormatterContext::no_manifest_context(Some(&bech32_encoder));
             writeln!(
                 output,
                 "{}: {}",
                 "State".green().bold(),
-                state_data.displayable(&bech32_encoder, None, None)
+                state_data.display(value_display_context)
             );
 
             // Find all vaults owned by the component, assuming a tree structure.
@@ -139,12 +142,14 @@ fn dump_kv_store<T: ReadableSubstateStore + QueryableSubstateStore, O: std::io::
         let key = ScryptoValue::from_slice(k).unwrap();
         if let Some(v) = &v.kv_entry().0 {
             let value = ScryptoValue::from_slice(&v).unwrap();
+            let value_display_context =
+                ScryptoValueFormatterContext::no_manifest_context(Some(&bech32_encoder));
             writeln!(
                 output,
                 "{} {} => {}",
                 list_item_prefix(last),
-                key.displayable(&bech32_encoder, None, None),
-                value.displayable(&bech32_encoder, None, None)
+                key.display(value_display_context),
+                value.display(value_display_context)
             );
             referenced_maps.extend(value.kv_store_ids);
             referenced_vaults.extend(value.vault_ids);
@@ -205,14 +210,16 @@ fn dump_resources<T: ReadableSubstateStore, O: std::io::Write>(
                         ScryptoValue::from_slice(&non_fungible.immutable_data()).unwrap();
                     let mutable_data =
                         ScryptoValue::from_slice(&non_fungible.mutable_data()).unwrap();
+                    let value_display_context =
+                        ScryptoValueFormatterContext::no_manifest_context(Some(&bech32_encoder));
                     writeln!(
                         output,
                         "{}  {} NonFungible {{ id: {}, immutable_data: {}, mutable_data: {} }}",
                         if last { " " } else { "│" },
                         list_item_prefix(inner_last),
-                        id.displayable(&bech32_encoder, None, None),
-                        immutable_data.displayable(&bech32_encoder, None, None),
-                        mutable_data.displayable(&bech32_encoder, None, None)
+                        id.display(value_display_context),
+                        immutable_data.display(value_display_context),
+                        mutable_data.display(value_display_context)
                     );
                 }
             }

--- a/simulator/src/resim/addressing.rs
+++ b/simulator/src/resim/addressing.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use radix_engine::types::{
     AddressError, Bech32Decoder, Bech32Encoder, ComponentAddress, PackageAddress, ResourceAddress,
 };
-use scrypto::address::ContextualDisplay;
+use scrypto::misc::ContextualDisplay;
 
 #[derive(Clone)]
 pub struct SimulatorPackageAddress(pub PackageAddress);

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use colored::*;
 use radix_engine_stores::rocks_db::RadixEngineDB;
-use scrypto::address::{Bech32Encoder, ContextualDisplay};
+use scrypto::address::Bech32Encoder;
+use scrypto::misc::ContextualDisplay;
 
 use crate::resim::*;
 use crate::utils::*;

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -60,6 +60,7 @@ use radix_engine::types::*;
 use radix_engine::wasm::*;
 use radix_engine_stores::rocks_db::RadixEngineDB;
 use scrypto::abi;
+use scrypto::misc::ContextualDisplay;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -196,12 +197,8 @@ pub fn handle_manifest<O: std::io::Write>(
             );
 
             if output_receipt {
-                writeln!(
-                    out,
-                    "{}",
-                    receipt.displayable(&Bech32Encoder::new(&network))
-                )
-                .map_err(Error::IOError)?;
+                writeln!(out, "{}", receipt.display(&Bech32Encoder::new(&network)))
+                    .map_err(Error::IOError)?;
             }
 
             if receipt.is_commit() {

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -66,6 +66,14 @@ impl<'a> DecompilationContext<'a> {
             proof_names: HashMap::<ProofId, String>::new(),
         }
     }
+
+    pub fn for_value_display(&'a self) -> ScryptoValueFormatterContext<'a> {
+        ScryptoValueFormatterContext::with_manifest_context(
+            self.bech32_encoder,
+            &self.bucket_names,
+            &self.proof_names,
+        )
+    }
 }
 
 /// Contract: if the instructions are from a validated notarized transaction, no error
@@ -356,11 +364,7 @@ pub fn decompile_instruction<F: fmt::Write>(
                             .map_err(DecompileError::IdValidationError)?;
 
                         f.write_char(' ')?;
-                        f.write_str(&validated_arg.to_string_with_fixed_context(
-                            context.bech32_encoder,
-                            &context.bucket_names,
-                            &context.proof_names,
-                        )?)?;
+                        write!(f, "{}", validated_arg.display(context.for_value_display()))?;
                     }
                 } else {
                     return Err(DecompileError::InvalidArguments);
@@ -376,29 +380,13 @@ pub fn decompile_instruction<F: fmt::Write>(
                             f.write_str(&format!(
                                 "CREATE_RESOURCE {} {} {} {};",
                                 ScryptoValue::from_typed(&input.resource_type)
-                                    .to_string_with_fixed_context(
-                                        context.bech32_encoder,
-                                        &context.bucket_names,
-                                        &context.proof_names,
-                                    )?,
+                                    .display(context.for_value_display()),
                                 ScryptoValue::from_typed(&input.metadata)
-                                    .to_string_with_fixed_context(
-                                        context.bech32_encoder,
-                                        &context.bucket_names,
-                                        &context.proof_names,
-                                    )?,
+                                    .display(context.for_value_display()),
                                 ScryptoValue::from_typed(&input.access_rules)
-                                    .to_string_with_fixed_context(
-                                        context.bech32_encoder,
-                                        &context.bucket_names,
-                                        &context.proof_names,
-                                    )?,
+                                    .display(context.for_value_display()),
                                 ScryptoValue::from_typed(&input.mint_params)
-                                    .to_string_with_fixed_context(
-                                        context.bech32_encoder,
-                                        &context.bucket_names,
-                                        &context.proof_names,
-                                    )?,
+                                    .display(context.for_value_display()),
                             ))?;
                         }
                     }
@@ -438,11 +426,7 @@ pub fn decompile_instruction<F: fmt::Write>(
                             .map_err(DecompileError::IdValidationError)?;
 
                         f.write_char(' ')?;
-                        f.write_str(&validated_arg.to_string_with_fixed_context(
-                            context.bech32_encoder,
-                            &context.bucket_names,
-                            &context.proof_names,
-                        )?)?;
+                        write!(f, "{}", &validated_arg.display(context.for_value_display()))?;
                     }
                 } else {
                     return Err(DecompileError::InvalidArguments);

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -1,13 +1,14 @@
 use sbor::rust::collections::*;
 use sbor::rust::fmt;
 use sbor::{encode_any, DecodeError, Value};
-use scrypto::address::{AddressError, Bech32Encoder, ContextualDisplay};
+use scrypto::address::{AddressError, Bech32Encoder};
 use scrypto::buffer::scrypto_decode;
 use scrypto::core::{
     BucketFnIdentifier, FnIdentifier, NativeFnIdentifier, NetworkDefinition, Receiver,
     ResourceManagerFnIdentifier,
 };
 use scrypto::engine::types::*;
+use scrypto::misc::ContextualDisplay;
 use scrypto::resource::{
     ConsumingBucketBurnInput, MintParams, ResourceManagerCreateInput, ResourceManagerMintInput,
 };


### PR DESCRIPTION
A follow-up PR to https://github.com/radixdlt/radixdlt-scrypto/pull/528

Includes:
* Allowing ScryptoValue / Value / TransactionReceipt to be formatted using ContextualDisplay
* ScryptoValue is formatted without large string allocations
* Added rust docs to ContextualDisplay trait to aid with its usage