### PR TITLE
lint: fix `clippy::redundant_clone`

### DIFF
--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -56,7 +56,7 @@ fn bench_transfer(c: &mut Criterion) {
     let account2 = executor
         .execute_and_commit(
             &TestTransaction::new(
-                manifest.clone(),
+                manifest,
                 2,
                 vec![NonFungibleAddress::from_public_key(&public_key)],
             ),

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -306,7 +306,7 @@ where
         self.call_frames.push(frame);
 
         let actor = Self::current_frame(&self.call_frames).actor.clone();
-        let output = match actor.clone() {
+        let output = match actor {
             REActor::Function(ResolvedFunction::Native(native_fn)) => self
                 .execute_in_mode(ExecutionMode::Application, |system_api| {
                     NativeInterpreter::run_function(native_fn, input, system_api)
@@ -1136,7 +1136,7 @@ where
         {
             node_pointer
                 .release_lock(
-                    offset.clone(),
+                    offset,
                     flags.contains(LockFlags::UNMODIFIED_BASE),
                     self.track,
                 )

--- a/radix-engine/src/model/nodes/resource_manager.rs
+++ b/radix-engine/src/model/nodes/resource_manager.rs
@@ -424,7 +424,7 @@ impl ResourceManager {
                         if non_fungible_mut.0.is_some() {
                             return Err(InvokeError::Error(
                                 ResourceManagerError::NonFungibleAlreadyExists(
-                                    NonFungibleAddress::new(resource_address, id.clone()),
+                                    NonFungibleAddress::new(resource_address, id),
                                 ),
                             ));
                         }
@@ -496,7 +496,7 @@ impl ResourceManager {
                     let non_fungible_address =
                         NonFungibleAddress::new(resource_address.clone(), input.id);
                     return Err(InvokeError::Error(
-                        ResourceManagerError::NonFungibleNotFound(non_fungible_address.clone()),
+                        ResourceManagerError::NonFungibleNotFound(non_fungible_address),
                     ));
                 }
                 substate_mut.flush()?;

--- a/radix-engine/src/model/nodes/transaction_processor.rs
+++ b/radix-engine/src/model/nodes/transaction_processor.rs
@@ -225,7 +225,7 @@ impl TransactionProcessor {
                     .expect("AuthZone does not exist");
                 let auth_zone_ref = Receiver::Ref(auth_zone_node_id);
 
-                for inst in &input.instructions.clone() {
+                for inst in &input.instructions {
                     let result = match inst {
                         Instruction::TakeFromWorktop { resource_address } => id_allocator
                             .new_bucket_id()

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -73,7 +73,7 @@ fn can_withdraw_from_my_1_of_3_account_with_either_key_sign() {
         ])),
         rule!(require(auth0.clone()) || require(auth1.clone()) || require(auth2.clone())),
         rule!((require(auth0.clone()) || require(auth1.clone())) || require(auth2.clone())),
-        rule!(require(auth0.clone()) || (require(auth1.clone()) || require(auth2.clone()))),
+        rule!(require(auth0) || (require(auth1) || require(auth2))),
     ];
 
     for auth in auths {
@@ -135,7 +135,7 @@ fn can_withdraw_from_my_complex_account() {
         rule!((require(auth0.clone()) && require(auth1.clone())) || require(auth2.clone())),
         rule!((require(auth0.clone()) && (require(auth1.clone()))) || require(auth2.clone())),
         rule!(require(auth2.clone()) || require(auth0.clone()) && require(auth1.clone())),
-        rule!(require(auth2.clone()) || (require(auth0.clone()) && require(auth1.clone()))),
+        rule!(require(auth2) || (require(auth0) && require(auth1))),
     ];
     let signer_public_keys_list = [
         vec![pk2.into()],
@@ -162,7 +162,7 @@ fn cannot_withdraw_from_my_complex_account() {
         rule!((require(auth0.clone()) && require(auth1.clone())) || require(auth2.clone())),
         rule!((require(auth0.clone()) && (require(auth1.clone()))) || require(auth2.clone())),
         rule!(require(auth2.clone()) || require(auth0.clone()) && require(auth1.clone())),
-        rule!(require(auth2.clone()) || (require(auth0.clone()) && require(auth1.clone()))),
+        rule!(require(auth2) || (require(auth0) && require(auth1))),
     ];
     let signer_public_keys_list = [vec![pk0.into()], vec![pk1.into()]];
 
@@ -186,10 +186,7 @@ fn can_withdraw_from_my_complex_account_2() {
             require(auth0.clone()) && require(auth1.clone()) && require(auth2.clone())
                 || require(auth3.clone())
         ),
-        rule!(
-            (require(auth0.clone()) && require(auth1.clone()) && require(auth2.clone()))
-                || require(auth3.clone())
-        ),
+        rule!((require(auth0) && require(auth1) && require(auth2)) || require(auth3)),
     ];
     let signer_public_keys_list = [vec![pk0.into(), pk1.into(), pk2.into()], vec![pk3.into()]];
 
@@ -213,10 +210,7 @@ fn cannot_withdraw_from_my_complex_account_2() {
             require(auth0.clone()) && require(auth1.clone()) && require(auth2.clone())
                 || require(auth3.clone())
         ),
-        rule!(
-            (require(auth0.clone()) && require(auth1.clone()) && require(auth2.clone()))
-                || require(auth3.clone())
-        ),
+        rule!((require(auth0) && require(auth1) && require(auth2)) || require(auth3)),
     ];
     let signer_public_keys_list = [
         vec![pk0.into()],

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -13,7 +13,7 @@ fn cannot_make_cross_component_call_without_authorization() {
     let auth_id = NonFungibleId::from_u32(1);
     let auth_address = NonFungibleAddress::new(auth, auth_id);
     let authorization =
-        AccessRules::new().method("get_component_state", rule!(require(auth_address.clone())));
+        AccessRules::new().method("get_component_state", rule!(require(auth_address)));
 
     let package_address = test_runner.compile_and_publish("./tests/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -73,7 +73,7 @@ fn can_make_cross_component_call_with_authorization() {
     let auth_id = NonFungibleId::from_u32(1);
     let auth_address = NonFungibleAddress::new(auth, auth_id.clone());
     let authorization =
-        AccessRules::new().method("get_component_state", rule!(require(auth_address.clone())));
+        AccessRules::new().method("get_component_state", rule!(require(auth_address)));
 
     let package_address = test_runner.compile_and_publish("./tests/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -110,7 +110,7 @@ fn can_make_cross_component_call_with_authorization() {
 
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(10.into(), SYS_FAUCET_COMPONENT)
-        .withdraw_from_account_by_ids(&BTreeSet::from([auth_id.clone()]), auth, account)
+        .withdraw_from_account_by_ids(&BTreeSet::from([auth_id]), auth, account)
         .call_method(
             my_component,
             "put_auth",
@@ -146,9 +146,9 @@ fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     let (public_key, _, account) = test_runner.new_account();
     let auth = test_runner.create_non_fungible_resource(account.clone());
     let auth_id = NonFungibleId::from_u32(1);
-    let auth_address = NonFungibleAddress::new(auth, auth_id.clone());
+    let auth_address = NonFungibleAddress::new(auth, auth_id);
     let authorization =
-        AccessRules::new().method("get_component_state", rule!(require(auth_address.clone())));
+        AccessRules::new().method("get_component_state", rule!(require(auth_address)));
 
     let package_address = test_runner.compile_and_publish("./tests/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -112,7 +112,7 @@ fn local_component_with_access_rules_should_be_callable() {
         .call_method(
             account,
             "create_proof_by_ids",
-            args!(BTreeSet::from([auth_id.clone()]), auth_resource_address),
+            args!(BTreeSet::from([auth_id]), auth_resource_address),
         )
         .call_scrypto_function(
             package_address,

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -122,7 +122,7 @@ fn prepare_test_tx_and_preview_intent(
         .unwrap();
 
     let preview_intent = PreviewIntent {
-        intent: notarized_transaction.signed_intent.intent.clone(),
+        intent: notarized_transaction.signed_intent.intent,
         signer_public_keys: vec![tx_signer_priv_key.public_key().into()],
         flags: flags.clone(),
     };

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -67,7 +67,7 @@ impl TransactionValidator<NotarizedTransaction> for NotarizedTransactionValidato
 
         let cost_unit_limit = transaction.signed_intent.intent.header.cost_unit_limit;
         let tip_percentage = transaction.signed_intent.intent.header.tip_percentage;
-        let blobs = transaction.signed_intent.intent.manifest.blobs.clone();
+        let blobs = transaction.signed_intent.intent.manifest.blobs;
 
         let auth_zone_params = AuthZoneParams {
             initial_proofs: AuthModule::pk_non_fungibles(&keys),


### PR DESCRIPTION
This commit is the result of running
```
cargo clippy --fix -- --allow clippy::all --warn clippy::redundant-clone
```

> What it does
> Checks for a redundant clone() (and its relatives) which clones an owned value that is going to be dropped without further use.
>
> Why is this bad?
> It is not always possible for the compiler to eliminate useless allocations and deallocations generated by redundant clone()s.
>
> Known problems
> False-negatives: analysis performed by this lint is conservative and limited.