### PR TITLE
SBOR generics, refs and Cow support

### DIFF
--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -919,7 +919,7 @@ where
             let maybe_txn: Result<TransactionProcessorRunInput, DecodeError> =
                 scrypto_decode(&invocation.args().raw);
             if let Ok(input) = maybe_txn {
-                for instruction in &input.instructions {
+                for instruction in input.instructions.as_ref() {
                     match instruction {
                         Instruction::CallFunction { args, .. }
                         | Instruction::CallMethod { args, .. }

--- a/radix-engine/src/model/nodes/transaction_processor.rs
+++ b/radix-engine/src/model/nodes/transaction_processor.rs
@@ -1,3 +1,4 @@
+use sbor::rust::borrow::Cow;
 use scrypto::resource::AuthZoneDrainInput;
 use transaction::errors::IdAllocationError;
 use transaction::model::*;
@@ -16,8 +17,8 @@ use crate::model::{
 use crate::types::*;
 
 #[derive(Debug, TypeId, Encode, Decode)]
-pub struct TransactionProcessorRunInput {
-    pub instructions: Vec<Instruction>,
+pub struct TransactionProcessorRunInput<'a> {
+    pub instructions: Cow<'a, Vec<Instruction>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TypeId, Encode, Decode)]
@@ -199,7 +200,7 @@ impl TransactionProcessor {
                     .expect("AuthZone does not exist");
                 let auth_zone_ref = auth_zone_node_id;
 
-                for inst in &input.instructions {
+                for inst in input.instructions.as_ref() {
                     let result = match inst {
                         Instruction::TakeFromWorktop { resource_address } => id_allocator
                             .new_bucket_id()

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -167,7 +167,7 @@ where
                 .invoke_native(NativeInvocation::Function(
                     NativeFunction::TransactionProcessor(TransactionProcessorFunction::Run),
                     ScryptoValue::from_typed(&TransactionProcessorRunInput {
-                        instructions: instructions.clone(),
+                        instructions: sbor::rust::borrow::Cow::Borrowed(&instructions),
                     }),
                 ))
                 .map(|o| {

--- a/sbor-derive/src/describe.rs
+++ b/sbor-derive/src/describe.rs
@@ -14,7 +14,19 @@ macro_rules! trace {
 pub fn handle_describe(input: TokenStream) -> Result<TokenStream> {
     trace!("handle_describe() starts");
 
-    let DeriveInput { ident, data, .. } = parse2(input)?;
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = parse2(input)?;
+    if !generics.params.is_empty() {
+        return Err(Error::new(
+            Span::call_site(),
+            "Generics are not presently supported with Describe",
+        ));
+    }
+
     let ident_str = ident.to_string();
     trace!("Describing: {}", ident);
 

--- a/sbor-derive/src/encode.rs
+++ b/sbor-derive/src/encode.rs
@@ -14,7 +14,13 @@ macro_rules! trace {
 pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
     trace!("handle_encode() starts");
 
-    let DeriveInput { ident, data, .. } = parse2(input)?;
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = parse2(input)?;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     trace!("Encoding: {}", ident);
 
     let output = match data {
@@ -25,7 +31,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                 let ns_ids = ns.iter().map(|f| &f.ident);
                 let ns_len = Index::from(ns_ids.len());
                 quote! {
-                    impl ::sbor::Encode for #ident {
+                    impl #impl_generics ::sbor::Encode for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(encoder: &mut ::sbor::Encoder) {
                             encoder.write_type_id(::sbor::type_id::TYPE_STRUCT);
@@ -48,7 +54,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                 }
                 let ns_len = Index::from(ns_indices.len());
                 quote! {
-                    impl ::sbor::Encode for #ident {
+                    impl #impl_generics ::sbor::Encode for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(encoder: &mut ::sbor::Encoder) {
                             encoder.write_type_id(::sbor::type_id::TYPE_STRUCT);
@@ -64,7 +70,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
             }
             syn::Fields::Unit => {
                 quote! {
-                    impl ::sbor::Encode for #ident {
+                    impl #impl_generics ::sbor::Encode for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(encoder: &mut ::sbor::Encoder) {
                             encoder.write_type_id(::sbor::type_id::TYPE_STRUCT);
@@ -127,7 +133,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
 
             if match_arms.len() == 0 {
                 quote! {
-                    impl ::sbor::Encode for #ident {
+                    impl #impl_generics ::sbor::Encode for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(encoder: &mut ::sbor::Encoder) {
                             encoder.write_type_id(::sbor::type_id::TYPE_ENUM);
@@ -139,7 +145,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                 }
             } else {
                 quote! {
-                    impl ::sbor::Encode for #ident {
+                    impl #impl_generics ::sbor::Encode for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(encoder: &mut ::sbor::Encoder) {
                             encoder.write_type_id(::sbor::type_id::TYPE_ENUM);

--- a/sbor-derive/src/type_id.rs
+++ b/sbor-derive/src/type_id.rs
@@ -12,12 +12,18 @@ macro_rules! trace {
 pub fn handle_type_id(input: TokenStream) -> Result<TokenStream> {
     trace!("handle_type_id() starts");
 
-    let DeriveInput { ident, data, .. } = parse2(input).expect("Unable to parse input");
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = parse2(input).expect("Unable to parse input");
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     trace!("Encoding: {}", ident);
 
     let output = match data {
         Data::Struct(_) => quote! {
-            impl ::sbor::TypeId for #ident {
+            impl #impl_generics ::sbor::TypeId for #ident #ty_generics #where_clause {
                 #[inline]
                 fn type_id() -> u8 {
                     ::sbor::type_id::TYPE_STRUCT
@@ -25,7 +31,7 @@ pub fn handle_type_id(input: TokenStream) -> Result<TokenStream> {
             }
         },
         Data::Enum(_) => quote! {
-            impl ::sbor::TypeId for #ident {
+            impl #impl_generics ::sbor::TypeId for #ident #ty_generics #where_clause {
                 #[inline]
                 fn type_id() -> u8 {
                     ::sbor::type_id::TYPE_ENUM

--- a/sbor/src/decode.rs
+++ b/sbor/src/decode.rs
@@ -292,6 +292,19 @@ impl<T: Decode> Decode for Option<T> {
     }
 }
 
+impl<'a, B: ?Sized + 'a + ToOwned<Owned = O>, O: Decode + TypeId> Decode
+    for crate::rust::borrow::Cow<'a, B>
+{
+    #[inline]
+    fn check_type_id(decoder: &mut Decoder) -> Result<(), DecodeError> {
+        decoder.check_type_id(O::type_id())
+    }
+    fn decode_value(decoder: &mut Decoder) -> Result<Self, DecodeError> {
+        let v = O::decode_value(decoder)?;
+        Ok(crate::rust::borrow::Cow::Owned(v))
+    }
+}
+
 impl<T: Decode + TypeId> Decode for Box<T> {
     #[inline]
     fn check_type_id(decoder: &mut Decoder) -> Result<(), DecodeError> {

--- a/sbor/src/decode.rs
+++ b/sbor/src/decode.rs
@@ -1,3 +1,5 @@
+use crate::rust::borrow::Cow;
+use crate::rust::borrow::ToOwned;
 use crate::rust::boxed::Box;
 use crate::rust::cell::RefCell;
 use crate::rust::collections::*;
@@ -8,8 +10,6 @@ use crate::rust::rc::Rc;
 use crate::rust::string::String;
 use crate::rust::string::ToString;
 use crate::rust::vec::Vec;
-use crate::rust::borrow::Cow;
-use crate::rust::borrow::ToOwned;
 use crate::type_id::*;
 use sbor::*;
 

--- a/sbor/src/decode.rs
+++ b/sbor/src/decode.rs
@@ -8,6 +8,8 @@ use crate::rust::rc::Rc;
 use crate::rust::string::String;
 use crate::rust::string::ToString;
 use crate::rust::vec::Vec;
+use crate::rust::borrow::Cow;
+use crate::rust::borrow::ToOwned;
 use crate::type_id::*;
 use sbor::*;
 

--- a/sbor/src/encode.rs
+++ b/sbor/src/encode.rs
@@ -5,6 +5,8 @@ use crate::rust::hash::Hash;
 use crate::rust::ptr::copy;
 use crate::rust::string::String;
 use crate::rust::vec::Vec;
+use crate::rust::borrow::Cow;
+use crate::rust::borrow::ToOwned;
 use crate::type_id::*;
 
 /// A data structure that can be serialized into a byte array using SBOR.
@@ -225,7 +227,7 @@ impl<T: Encode + TypeId> Encode for Option<T> {
     }
 }
 
-impl<'a, B: ?Sized + 'a + ToOwned + Encode> Encode for crate::rust::borrow::Cow<'a, B> {
+impl<'a, B: ?Sized + 'a + ToOwned + Encode> Encode for Cow<'a, B> {
     #[inline]
     fn encode_type_id(encoder: &mut Encoder) {
         B::encode_type_id(encoder)

--- a/sbor/src/encode.rs
+++ b/sbor/src/encode.rs
@@ -225,6 +225,17 @@ impl<T: Encode + TypeId> Encode for Option<T> {
     }
 }
 
+impl<'a, B: ?Sized + 'a + ToOwned + Encode> Encode for crate::rust::borrow::Cow<'a, B> {
+    #[inline]
+    fn encode_type_id(encoder: &mut Encoder) {
+        B::encode_type_id(encoder)
+    }
+    #[inline]
+    fn encode_value(&self, encoder: &mut Encoder) {
+        self.as_ref().encode_value(encoder);
+    }
+}
+
 impl<T: Encode> Encode for Box<T> {
     #[inline]
     fn encode_type_id(encoder: &mut Encoder) {

--- a/sbor/src/encode.rs
+++ b/sbor/src/encode.rs
@@ -1,3 +1,5 @@
+use crate::rust::borrow::Cow;
+use crate::rust::borrow::ToOwned;
 use crate::rust::boxed::Box;
 use crate::rust::cell::RefCell;
 use crate::rust::collections::*;
@@ -5,8 +7,6 @@ use crate::rust::hash::Hash;
 use crate::rust::ptr::copy;
 use crate::rust::string::String;
 use crate::rust::vec::Vec;
-use crate::rust::borrow::Cow;
-use crate::rust::borrow::ToOwned;
 use crate::type_id::*;
 
 /// A data structure that can be serialized into a byte array using SBOR.

--- a/sbor/src/type_id.rs
+++ b/sbor/src/type_id.rs
@@ -1,3 +1,5 @@
+use crate::rust::borrow::Cow;
+use crate::rust::borrow::ToOwned;
 use crate::rust::boxed::Box;
 use crate::rust::cell::RefCell;
 use crate::rust::collections::*;
@@ -135,6 +137,13 @@ impl<T> TypeId for Option<T> {
     #[inline]
     fn type_id() -> u8 {
         TYPE_OPTION
+    }
+}
+
+impl<'a, B: ?Sized + 'a + ToOwned + TypeId> TypeId for Cow<'a, B> {
+    #[inline]
+    fn type_id() -> u8 {
+        B::type_id()
     }
 }
 


### PR DESCRIPTION
This PR can give us increased performance with SBOR encoding 👍

By using the "Cow" (copy-on-write) smart pointer: https://doc.rust-lang.org/std/borrow/enum.Cow.html we can now have a typed struct which can _encode_ a reference or owned, and output an owned value ✨. I've then shown an example of how it can be used to reduce the cloning in the transaction processor.

To complete this magic, I had to extend the Encode/Decode/TypeId macros to work with generics.

I have also added a nicer error message for Describe when used with a type with generics. The SBOR schema doesn't currently support generics (for eg recreation of the code), and I didn't fancy adding that! But at least we get a clearer error message that generics aren't supported.