### PR TITLE
refactor: WasmEngine trait changes, ScryptoInterpreter is Sync

### DIFF
--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -21,7 +21,6 @@ fn bench_transfer(c: &mut Criterion) {
             InstructionCostRules::tiered(1, 5, 10, 5000),
             512,
         ),
-        phantom: PhantomData,
     };
 
     // Create a key pair

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -26,11 +26,9 @@ pub struct Kernel<
     'g, // Lifetime of values outliving all frames
     's, // Substate store lifetime
     W,  // WASM engine type
-    I,  // WASM instance type
     R,  // Fee reserve type
 > where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     /// Current execution mode, specifies permissions into state/invocations
@@ -55,7 +53,7 @@ pub struct Kernel<
     track: &'g mut Track<'s, R>,
 
     /// Interpreter capable of running scrypto programs
-    scrypto_interpreter: &'g ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &'g ScryptoInterpreter<W>,
 
     /// Kernel modules
     modules: Vec<Box<dyn Module<R>>>,
@@ -63,10 +61,9 @@ pub struct Kernel<
     max_depth: usize,
 }
 
-impl<'g, 's, W, I, R> Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R> Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     pub fn new(
@@ -75,7 +72,7 @@ where
         blobs: &'g HashMap<Hash, &'g [u8]>,
         max_depth: usize,
         track: &'g mut Track<'s, R>,
-        scrypto_interpreter: &'g ScryptoInterpreter<I, W>,
+        scrypto_interpreter: &'g ScryptoInterpreter<W>,
         modules: Vec<Box<dyn Module<R>>>,
     ) -> Self {
         let mut kernel = Self {
@@ -723,10 +720,9 @@ pub trait MethodDeref {
     fn deref(&mut self, node_id: RENodeId) -> Result<Option<RENodeId>, RuntimeError>;
 }
 
-impl<'g, 's, W, I, R> MethodDeref for Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R> MethodDeref for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     fn deref(&mut self, node_id: RENodeId) -> Result<Option<RENodeId>, RuntimeError> {
@@ -757,18 +753,16 @@ pub trait Executor {
         Y: SystemApi + Invokable<ScryptoInvocation> + InvokableNative<'a>;
 }
 
-impl<'g, 's, 'a, W, I, R> InvokableNative<'a> for Kernel<'g, 's, W, I, R>
+impl<'g, 's, 'a, W, R> InvokableNative<'a> for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
 }
 
-impl<'g, 's, W, I, R, N> Invokable<N> for Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R, N> Invokable<N> for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
     N: NativeInvocation,
 {
@@ -816,10 +810,9 @@ where
 }
 
 // TODO: remove redundant code and move this method to the interpreter
-impl<'g, 's, W, I, R> Invokable<ScryptoInvocation> for Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R> Invokable<ScryptoInvocation> for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     fn invoke(&mut self, invocation: ScryptoInvocation) -> Result<ScryptoValue, RuntimeError> {
@@ -864,10 +857,9 @@ where
     }
 }
 
-impl<'g, 's, W, I, R> SystemApi for Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R> SystemApi for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     fn execute_in_mode<X, RTN, E>(
@@ -1380,17 +1372,16 @@ pub trait InvocationResolver<V, X: Executor> {
     fn resolve(&mut self, invocation: V) -> Result<(X, REActor, CallFrameUpdate), RuntimeError>;
 }
 
-impl<'g, 's, W, I, R> InvocationResolver<ScryptoInvocation, ScryptoExecutor<I>>
-    for Kernel<'g, 's, W, I, R>
+impl<'g, 's, W, R> InvocationResolver<ScryptoInvocation, ScryptoExecutor<W::WasmInstance>>
+    for Kernel<'g, 's, W, R>
 where
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
     R: FeeReserve,
 {
     fn resolve(
         &mut self,
         invocation: ScryptoInvocation,
-    ) -> Result<(ScryptoExecutor<I>, REActor, CallFrameUpdate), RuntimeError> {
+    ) -> Result<(ScryptoExecutor<W::WasmInstance>, REActor, CallFrameUpdate), RuntimeError> {
         let mut node_refs_to_copy = HashSet::new();
 
         let (executor, actor) = match &invocation {

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -241,7 +241,6 @@ where
                 InstructionCostRules::tiered(1, 5, 10, 5000),
                 512,
             ),
-            phantom: PhantomData,
         };
 
         let genesis_transaction = create_genesis();
@@ -282,7 +281,6 @@ mod tests {
             wasm_engine,
             wasm_instrumenter,
             wasm_metering_config,
-            phantom: PhantomData,
         };
         let substate_store = TypedInMemorySubstateStore::new();
         let genesis_transaction = create_genesis();

--- a/radix-engine/src/transaction/preview_executor.rs
+++ b/radix-engine/src/transaction/preview_executor.rs
@@ -11,7 +11,7 @@ use crate::fee::SystemLoanFeeReserve;
 use crate::ledger::*;
 use crate::transaction::TransactionReceipt;
 use crate::transaction::*;
-use crate::wasm::{WasmEngine, WasmInstance};
+use crate::wasm::WasmEngine;
 
 #[derive(Debug)]
 pub struct PreviewResult {
@@ -24,14 +24,9 @@ pub enum PreviewError {
     TransactionValidationError(TransactionValidationError),
 }
 
-pub fn execute_preview<
-    S: ReadableSubstateStore,
-    I: WasmInstance,
-    W: WasmEngine<I>,
-    IHM: IntentHashManager,
->(
+pub fn execute_preview<S: ReadableSubstateStore, W: WasmEngine, IHM: IntentHashManager>(
     substate_store: &S,
-    scrypto_interpreter: &ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
     intent_hash_manager: &IHM,
     network: &NetworkDefinition,
     preview_intent: PreviewIntent,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -56,23 +56,21 @@ impl ExecutionConfig {
 /// An executor that runs transactions.
 /// This is no longer public -- it can be removed / merged into the exposed functions in a future small PR
 /// But I'm not doing it in this PR to avoid merge conflicts in the body of execute_with_fee_reserve
-struct TransactionExecutor<'s, 'w, S, W, I>
+struct TransactionExecutor<'s, 'w, S, W>
 where
     S: ReadableSubstateStore,
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
 {
     substate_store: &'s S,
-    scrypto_interpreter: &'w ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &'w ScryptoInterpreter<W>,
 }
 
-impl<'s, 'w, S, W, I> TransactionExecutor<'s, 'w, S, W, I>
+impl<'s, 'w, S, W> TransactionExecutor<'s, 'w, S, W>
 where
     S: ReadableSubstateStore,
-    W: WasmEngine<I>,
-    I: WasmInstance,
+    W: WasmEngine,
 {
-    pub fn new(substate_store: &'s S, scrypto_interpreter: &'w ScryptoInterpreter<I, W>) -> Self {
+    pub fn new(substate_store: &'s S, scrypto_interpreter: &'w ScryptoInterpreter<W>) -> Self {
         Self {
             substate_store,
             scrypto_interpreter,
@@ -205,11 +203,10 @@ where
 
 pub fn execute_and_commit_transaction<
     S: ReadableSubstateStore + WriteableSubstateStore,
-    I: WasmInstance,
-    W: WasmEngine<I>,
+    W: WasmEngine,
 >(
     substate_store: &mut S,
-    scrypto_interpreter: &ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
     fee_reserve_config: &FeeReserveConfig,
     execution_config: &ExecutionConfig,
     transaction: &Executable,
@@ -227,9 +224,9 @@ pub fn execute_and_commit_transaction<
     receipt
 }
 
-pub fn execute_transaction<S: ReadableSubstateStore, I: WasmInstance, W: WasmEngine<I>>(
+pub fn execute_transaction<S: ReadableSubstateStore, W: WasmEngine>(
     substate_store: &S,
-    scrypto_interpreter: &ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
     fee_reserve_config: &FeeReserveConfig,
     execution_config: &ExecutionConfig,
     transaction: &Executable,
@@ -241,13 +238,9 @@ pub fn execute_transaction<S: ReadableSubstateStore, I: WasmInstance, W: WasmEng
     )
 }
 
-pub fn execute_transaction_with_fee_reserve<
-    S: ReadableSubstateStore,
-    I: WasmInstance,
-    W: WasmEngine<I>,
->(
+pub fn execute_transaction_with_fee_reserve<S: ReadableSubstateStore, W: WasmEngine>(
     substate_store: &S,
-    scrypto_interpreter: &ScryptoInterpreter<I, W>,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
     fee_reserve: impl FeeReserve,
     execution_config: &ExecutionConfig,
     transaction: &Executable,

--- a/radix-engine/src/wasm/traits.rs
+++ b/radix-engine/src/wasm/traits.rs
@@ -31,7 +31,9 @@ pub trait WasmInstance {
 }
 
 /// A Scrypto WASM engine validates, instruments and runs Scrypto modules.
-pub trait WasmEngine<I: WasmInstance> {
+pub trait WasmEngine {
+    type WasmInstance: WasmInstance;
+
     /// Instantiate a Scrypto module.
-    fn instantiate(&self, instrumented_code: &InstrumentedCode) -> I;
+    fn instantiate(&self, instrumented_code: &InstrumentedCode) -> Self::WasmInstance;
 }

--- a/radix-engine/src/wasm/wasmer.rs
+++ b/radix-engine/src/wasm/wasmer.rs
@@ -253,7 +253,9 @@ impl WasmerEngine {
     }
 }
 
-impl WasmEngine<WasmerInstance> for WasmerEngine {
+impl WasmEngine for WasmerEngine {
+    type WasmInstance = WasmerInstance;
+
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmerInstance {
         let code_hash = &instrumented_code.code_hash;
         if let Some(cached_module) = self.modules_cache.get(code_hash) {

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -242,7 +242,9 @@ impl WasmiEngine {
     }
 }
 
-impl WasmEngine<WasmiInstance> for WasmiEngine {
+impl WasmEngine for WasmiEngine {
+    type WasmInstance = WasmiInstance;
+
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmiInstance {
         let code_hash = &instrumented_code.code_hash;
         if let Some(cached_module) = self.modules_cache.get(code_hash) {

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -38,7 +38,6 @@ fn execute_single_transaction(transaction: NotarizedTransaction) {
             InstructionCostRules::tiered(1, 5, 10, 5000),
             512,
         ),
-        phantom: PhantomData,
     };
     let execution_config = ExecutionConfig {
         max_call_depth: DEFAULT_MAX_CALL_DEPTH,

--- a/radix-engine/tests/transaction_executor.rs
+++ b/radix-engine/tests/transaction_executor.rs
@@ -130,7 +130,6 @@ fn test_normal_transaction_flow() {
             InstructionCostRules::tiered(1, 5, 10, 5000),
             512,
         ),
-        phantom: PhantomData,
     };
 
     let intent_hash_manager = TestIntentHashManager::new();

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -16,8 +16,7 @@ use radix_engine::transaction::{
 };
 use radix_engine::types::*;
 use radix_engine::wasm::{
-    DefaultWasmEngine, DefaultWasmInstance, InstructionCostRules, WasmInstrumenter,
-    WasmMeteringConfig,
+    DefaultWasmEngine, InstructionCostRules, WasmInstrumenter, WasmMeteringConfig,
 };
 use sbor::describe::*;
 use scrypto::dec;
@@ -30,7 +29,7 @@ use transaction::validation::TestIntentHashManager;
 
 pub struct TestRunner<'s, S: ReadableSubstateStore + WriteableSubstateStore> {
     execution_stores: StagedSubstateStoreManager<'s, S>,
-    scrypto_interpreter: ScryptoInterpreter<DefaultWasmInstance, DefaultWasmEngine>,
+    scrypto_interpreter: ScryptoInterpreter<DefaultWasmEngine>,
     intent_hash_manager: TestIntentHashManager,
     next_private_key: u64,
     next_transaction_nonce: u64,
@@ -46,7 +45,6 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
             ),
             wasm_engine: DefaultWasmEngine::default(),
             wasm_instrumenter: WasmInstrumenter::default(),
-            phantom: PhantomData,
         };
         Self {
             execution_stores: StagedSubstateStoreManager::new(substate_store),
@@ -751,7 +749,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore> TestRunner<'s, S> {
     /// Performs a kernel call through a kernel with `is_system = true`.
     fn kernel_call<F, O>(&mut self, initial_proofs: Vec<NonFungibleAddress>, fun: F) -> O
     where
-        F: FnOnce(&mut Kernel<DefaultWasmEngine, DefaultWasmInstance, SystemLoanFeeReserve>) -> O,
+        F: FnOnce(&mut Kernel<DefaultWasmEngine, SystemLoanFeeReserve>) -> O,
     {
         let tx_hash = hash(self.next_transaction_nonce.to_string());
         let blobs = HashMap::new();

--- a/simulator/src/resim/cmd_set_current_epoch.rs
+++ b/simulator/src/resim/cmd_set_current_epoch.rs
@@ -30,7 +30,6 @@ impl SetCurrentEpoch {
                 InstructionCostRules::tiered(1, 5, 10, 5000),
                 512,
             ),
-            phantom: PhantomData,
         };
         let mut track = Track::new(
             &substate_store,

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -177,7 +177,6 @@ pub fn handle_manifest<O: std::io::Write>(
                     InstructionCostRules::tiered(1, 5, 10, 5000),
                     512,
                 ),
-                phantom: PhantomData,
             };
 
             let sks = get_signing_keys(signing_keys)?;


### PR DESCRIPTION
Trying to merge the changes into the node, I realised that ScryptoInterpreter still wasn't `Sync`... And it transpires that's because of the `PhantomData<I>` which captures the WasmEngine's `WasmModule` type. I realised that this could become an Associated Type - which is much nicer for all our type signatures, and also fixes the Sync problem.

[PhantomData<T>](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) is intended to be used to pretend to the compiler that the type contains a type that behaves like `T` - and is intended for use on FFI, to eg capture lifetimes, or the fact something isn't Sync/Send. In contrast, I think our use of PhantomData is due to us not previously finding the associated type solution. And so does not relate to any want for ScryptoInterpreter to act as if it's carrying round a non-`Sync` WasmModule all the time... but please shout if I've missed something! :)

This PR also adds a test that `ScryptoInterpreter<DefaultWasmEngine>` is indeed `Sync` (and `Send`, although I don't care about that one particularly)

**Breaking Changes:**
* **Transaction Executor** - Anyone making their own can drop the WasmInstance from the generic type signature.