### PR TITLE
fix: Substate encode errors caught during execution

### DIFF
--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -61,6 +61,13 @@ pub enum TransactionOutcome {
 }
 
 impl TransactionOutcome {
+    pub fn is_success(&self) -> bool {
+        match self {
+            TransactionOutcome::Success(_) => true,
+            TransactionOutcome::Failure(_) => false,
+        }
+    }
+
     pub fn expect_success(&self) -> &Vec<Vec<u8>> {
         match self {
             TransactionOutcome::Success(results) => results,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -75,6 +75,13 @@ impl TransactionOutcome {
         }
     }
 
+    pub fn expect_failure(&self) -> &RuntimeError {
+        match self {
+            TransactionOutcome::Success(_) => panic!("Outcome was a success!"),
+            TransactionOutcome::Failure(error) => error,
+        }
+    }
+
     pub fn success_or_else<E, F: FnOnce(&RuntimeError) -> E>(
         &self,
         f: F,

--- a/radix-engine/tests/blueprints/.cargo/config.toml
+++ b/radix-engine/tests/blueprints/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/radix-engine/tests/blueprints/Cargo.toml
+++ b/radix-engine/tests/blueprints/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "component",
     "core",
     "data_access",
+    "deep_sbor",
     "execution_trace",
     "external_blueprint_caller",
     "fee",

--- a/radix-engine/tests/blueprints/deep_sbor/Cargo.toml
+++ b/radix-engine/tests/blueprints/deep_sbor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "deep_sbor"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sbor = { path = "../../../../sbor" }
+scrypto = { path = "../../../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../../../radix-engine" }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/radix-engine/tests/blueprints/deep_sbor/src/deep_authrules_on_create.rs
+++ b/radix-engine/tests/blueprints/deep_sbor/src/deep_authrules_on_create.rs
@@ -1,0 +1,30 @@
+use scrypto::prelude::*;
+
+blueprint! {
+    struct DeepAuthRulesOnCreate {}
+
+    impl DeepAuthRulesOnCreate {
+        pub fn new(resource_address: ResourceAddress, access_rules_depth: u8) -> ComponentAddress {
+            let mut component = Self {}.instantiate();
+
+            component.add_access_check(generate_deep_access_rules(
+                resource_address,
+                access_rules_depth,
+            ));
+
+            component.globalize()
+        }
+    }
+}
+
+fn generate_deep_access_rules(resource_address: ResourceAddress, exceed_depth: u8) -> AccessRules {
+    let mut access_rule_node = AccessRuleNode::ProofRule(ProofRule::Require(
+        SoftResourceOrNonFungible::StaticResource(resource_address),
+    ));
+    let mut curr_depth = 6; // The inner bit and the outer mapping
+    while curr_depth < exceed_depth {
+        access_rule_node = AccessRuleNode::AllOf(vec![access_rule_node]);
+        curr_depth += 2;
+    }
+    AccessRules::new().default(AccessRule::Protected(access_rule_node))
+}

--- a/radix-engine/tests/blueprints/deep_sbor/src/deep_struct.rs
+++ b/radix-engine/tests/blueprints/deep_sbor/src/deep_struct.rs
@@ -1,0 +1,29 @@
+use scrypto::prelude::*;
+
+blueprint! {
+    struct DeepStruct {
+        deep_object: Option<AccessRules>,
+    }
+
+    impl DeepStruct {
+        pub fn new() -> ComponentAddress {
+            Self { deep_object: None }.instantiate().globalize()
+        }
+
+        pub fn set_depth(&mut self, resource_address: ResourceAddress, exceed_depth: u8) {
+            self.deep_object = Some(generate_deep_access_rules(resource_address, exceed_depth));
+        }
+    }
+}
+
+fn generate_deep_access_rules(resource_address: ResourceAddress, exceed_depth: u8) -> AccessRules {
+    let mut access_rule_node = AccessRuleNode::ProofRule(ProofRule::Require(
+        SoftResourceOrNonFungible::StaticResource(resource_address),
+    ));
+    let mut curr_depth = 6; // The inner bit and the outer mapping
+    while curr_depth < exceed_depth {
+        access_rule_node = AccessRuleNode::AllOf(vec![access_rule_node]);
+        curr_depth += 2;
+    }
+    AccessRules::new().default(AccessRule::Protected(access_rule_node))
+}

--- a/radix-engine/tests/blueprints/deep_sbor/src/lib.rs
+++ b/radix-engine/tests/blueprints/deep_sbor/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod deep_authrules_on_create;
+pub mod deep_struct;

--- a/radix-engine/tests/deep_sbor.rs
+++ b/radix-engine/tests/deep_sbor.rs
@@ -1,0 +1,133 @@
+use radix_engine::engine::{KernelError, RuntimeError};
+use radix_engine::ledger::TypedInMemorySubstateStore;
+use radix_engine::transaction::TransactionReceipt;
+use radix_engine::types::*;
+use radix_engine::wasm::WasmError;
+use radix_engine_interface::core::NetworkDefinition;
+use radix_engine_interface::data::*;
+use scrypto_unit::*;
+use transaction::builder::ManifestBuilder;
+
+#[test]
+fn deep_auth_rules_on_component_create_creation_fails() {
+    // Arrange
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(true, &mut store);
+    let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
+
+    // Act 1 - Small Depth
+    let depth = 10u8;
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_function(
+            package_address,
+            "DeepAuthRulesOnCreate",
+            "new",
+            args!(RADIX_TOKEN, depth),
+        )
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    receipt.expect_commit_success();
+
+    // Act 2 - Very Large Depth - we get a panic at encoding time in the Scrypto WASM
+    let depth = 100u8;
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_function(
+            package_address,
+            "DeepAuthRulesOnCreate",
+            "new",
+            args!(RADIX_TOKEN, depth),
+        )
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    receipt.expect_specific_failure(|f| {
+        matches!(f, RuntimeError::KernelError(KernelError::WasmError(_)))
+    });
+
+    // Act 3 - I'd hoped for a third style of error - where scrypto can encode it but
+    //         It's an error when it's put in the substate
+    //         The change point is at a depth of 40/41, but I can't find this third kind of behaviour - likely because
+    //         scrypto actually encodes the full substate itself
+}
+
+#[test]
+fn setting_struct_with_deep_recursive_data_panics_inside_component() {
+    // Arrange
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(true, &mut store);
+    let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
+
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_function(package_address, "DeepStruct", "new", args!())
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    receipt.expect_commit_success();
+    let component_address = receipt.new_component_addresses().get(0).unwrap();
+
+    // Act 1 - Small Depth - Succeeds
+    let depth = 10u8;
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_method(*component_address, "set_depth", args!(RADIX_TOKEN, depth))
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    receipt.expect_commit_success();
+
+    // Act 2 - Very Large Depth - we get a panic at encoding time in the Scrypto WASM
+    let depth = 100u8;
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_method(*component_address, "set_depth", args!(RADIX_TOKEN, depth))
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    receipt.expect_specific_failure(|f| {
+        matches!(f, RuntimeError::KernelError(KernelError::WasmError(_)))
+    });
+
+    // Act 3 - I'd hoped for a third style of error - where scrypto can encode it but
+    //         It's an error when it's put in the substate
+    //         The change point is at a depth of 42/43, but I can't find this third kind of behaviour.
+}
+
+#[test]
+fn malicious_component_replying_with_large_payload_is_handled_well_by_engine() {
+    // Act 1 - Small Depth
+    let receipt = publish_wasm_with_deep_sbor_response_and_execute_it(10);
+    receipt.expect_commit_success();
+
+    // Act 2 - Depth just under the limit
+    let receipt = publish_wasm_with_deep_sbor_response_and_execute_it(MAX_SCRYPTO_SBOR_DEPTH);
+    receipt.expect_commit_success();
+
+    // Act 2 - Depth just over the limit
+    let receipt = publish_wasm_with_deep_sbor_response_and_execute_it(MAX_SCRYPTO_SBOR_DEPTH + 1);
+    receipt.expect_specific_failure(|f| {
+        matches!(
+            f,
+            RuntimeError::KernelError(KernelError::WasmError(WasmError::InvalidScryptoValue(
+                ScryptoValueDecodeError::DecodeError(DecodeError::MaxDepthExceeded(_))
+            )))
+        )
+    });
+}
+
+fn publish_wasm_with_deep_sbor_response_and_execute_it(depth: u8) -> TransactionReceipt {
+    // Arrange
+    let mut store = TypedInMemorySubstateStore::with_bootstrap();
+    let mut test_runner = TestRunner::new(true, &mut store);
+
+    let n: u32 = (depth - 2).into();
+    let code =
+        wat2wasm(&include_str!("wasm/deep_sbor_response.wat").replace("${n}", &n.to_string()));
+    let package_address =
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Any));
+
+    // Act
+    let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .call_function(package_address, "Test", "f", args!())
+        .build();
+    test_runner.execute_manifest(manifest, vec![])
+}

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -15,7 +15,7 @@ fn test_loop() {
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "2000"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())
@@ -35,7 +35,7 @@ fn test_loop_out_of_cost_unit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "70000000"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 45.into())
         .call_function(package_address, "Test", "f", args!())
@@ -56,7 +56,7 @@ fn test_recursion() {
     // In this test case, each call frame costs 4 stack units
     let code = wat2wasm(&include_str!("wasm/recursion.wat").replace("${n}", "256"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())
@@ -76,7 +76,7 @@ fn test_recursion_stack_overflow() {
     // Act
     let code = wat2wasm(&include_str!("wasm/recursion.wat").replace("${n}", "257"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())
@@ -96,7 +96,7 @@ fn test_grow_memory() {
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", "100"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())
@@ -116,7 +116,7 @@ fn test_grow_memory_out_of_cost_unit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", "100000"));
     let package_address =
-        test_runner.publish_package(code, generate_single_function_abi("Test", "f"));
+        test_runner.publish_package(code, generate_single_function_abi("Test", "f", Type::Unit));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())

--- a/radix-engine/tests/wasm/deep_sbor_response.wat
+++ b/radix-engine/tests/wasm/deep_sbor_response.wat
@@ -1,0 +1,96 @@
+(module
+
+  ;; Simple function that always returns `()`
+  ;; Need to replace ${n} with the depth
+  (func $Test_f (param $0 i32) (result i32)
+    ;; Loop starts!
+    (local $i i32)
+    (local $curr_pointer i32)
+    (local $return_length i32)
+
+    ;; Return length needs 2 + 2 * n
+    ;; It needs 4 initial bytes, plus (n-2) * 2 bytes in the middle, plus 2 bytes for the end
+    (local.set
+      $return_length
+      (i32.add
+        (i32.const 2)
+        (i32.mul
+          (i32.const 2)
+          (i32.const ${n})
+        )
+      )
+    )
+
+    ;; Return stuff
+    (local.set 
+      $0
+      (call $scrypto_alloc
+        (local.get $return_length)
+      )
+    )
+
+    (local.set
+      $curr_pointer
+      (i32.add
+        (local.get $0)
+        (i32.const 4)
+      )
+    )
+  
+    ;; Now start our loop
+    (loop $loop
+      ;; Add one to $i
+      local.get $i
+      i32.const 1
+      i32.add
+      local.set $i
+
+      ;; Write Tuple Type, and push the pointer forward one
+      local.get $curr_pointer
+      i32.const 33
+      i32.store8
+
+      (local.set
+        $curr_pointer
+        (i32.add
+          (local.get $curr_pointer)
+          (i32.const 1)
+        )
+      )
+
+      ;; Write Tuple length of 1, and push the pointer forward one
+      local.get $curr_pointer
+      i32.const 1
+      i32.store8
+
+      (local.set
+        $curr_pointer
+        (i32.add
+          (local.get $curr_pointer)
+          (i32.const 1)
+        )
+      )
+
+      ;; If $i < ${n}, branch to loop
+      local.get $i
+      i32.const ${n}
+      i32.lt_s
+      br_if $loop
+    )
+
+    ;; Write a unit 0x0000 to finish off
+    local.get $curr_pointer
+    (i32.const 0)
+    (i32.store16)
+    (local.get $0)
+  )
+
+  (memory $0 1)
+  (export "memory" (memory $0))
+  (export "scrypto_alloc" (func $scrypto_alloc))
+  (export "scrypto_free" (func $scrypto_free))
+  (export "Test_f" (func $Test_f))
+
+  ${memcpy}
+  ${buffer}
+)

--- a/radix-engine/tests/wasm_validation.rs
+++ b/radix-engine/tests/wasm_validation.rs
@@ -1,10 +1,11 @@
+use radix_engine::types::Type;
 use radix_engine::wasm::{InvalidMemory, PrepareError, WasmValidator};
 use scrypto_unit::*;
 
 #[test]
 fn test_large_data() {
     let code = wat2wasm(&include_str!("wasm/large_data.wat"));
-    let abi = generate_single_function_abi("Test", "f");
+    let abi = generate_single_function_abi("Test", "f", Type::Unit);
     let result = WasmValidator::default().validate(&code, &abi);
 
     assert_eq!(Err(PrepareError::NotInstantiatable), result);
@@ -13,7 +14,7 @@ fn test_large_data() {
 #[test]
 fn test_large_memory() {
     let code = wat2wasm(&include_str!("wasm/large_memory.wat"));
-    let abi = generate_single_function_abi("Test", "f");
+    let abi = generate_single_function_abi("Test", "f", Type::Unit);
     let result = WasmValidator::default().validate(&code, &abi);
 
     assert_eq!(

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -846,6 +846,7 @@ pub fn get_cargo_target_directory(manifest_path: impl AsRef<OsStr>) -> String {
 pub fn generate_single_function_abi(
     blueprint_name: &str,
     function_name: &str,
+    output_type: Type,
 ) -> HashMap<String, BlueprintAbi> {
     let mut blueprint_abis = HashMap::new();
     blueprint_abis.insert(
@@ -859,7 +860,7 @@ pub fn generate_single_function_abi(
                     name: "Any".to_string(),
                     fields: Fields::Named { named: vec![] },
                 },
-                output: Type::Unit,
+                output: output_type,
                 export_name: format!("{}_{}", blueprint_name, function_name),
             }],
         },


### PR DESCRIPTION
Builds on https://github.com/radixdlt/radixdlt-scrypto/pull/600

* Ensures that we can't return unencodable substates in the transaction result. Prior to this change, with an SBOR stack size of 32, I saw exceptions through at commit time(!) from some tests which happened to hit the sweet-spot where returning an ABI value from a component was okay, but when wrapped in a substate, it was too large to encode.
* Adds a number of tests to show the consequences of adding the sbor limit, and ensure that we don't panic in the engine (or outside of the engine!)

No breaking changes.