### PR TITLE
Root functions for integers, decimals and precise decimals

### DIFF
--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -882,6 +882,52 @@ macro_rules! checked_int_impl_unsigned_small {
 checked_int_impl_unsigned_large! { U256, U384, U512 }
 checked_int_impl_unsigned_small! { U8, U16, U32, U64, U128 }
 
+pub trait Sqrt {
+    fn sqrt(self) -> Self;
+}
+
+pub trait Cbrt {
+    fn cbrt(self) -> Self;
+}
+
+pub trait NthRoot {
+    fn nth_root(self, n:u32) -> Self;
+}
+
+macro_rules! roots_op_impl
+{
+    ($($t:ty),*) => {
+            paste! {
+                $(
+                    impl Sqrt for $t
+                    {
+                        fn sqrt(self) -> Self
+                        {
+                            BigInt::from(self).sqrt().try_into().unwrap()
+                        }
+                    }
+
+                    impl Cbrt for $t
+                    {
+                        fn cbrt(self) -> Self {
+                            BigInt::from(self).cbrt().try_into().unwrap()
+                        }
+                    }
+
+                    impl NthRoot for $t
+                    {
+                        fn nth_root(self, n: u32) -> Self
+                        {
+                            BigInt::from(self).nth_root(n).try_into().unwrap()
+                        }
+                    }
+                )*
+            }
+        };
+}
+
+roots_op_impl! {U8, U16, U32, U64, U128, U256, U384, U512, I8, I16, I32, I64, I128, I256, I384, I512}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/radix-engine-interface/src/math/precise_decimal.rs
+++ b/radix-engine-interface/src/math/precise_decimal.rs
@@ -1,4 +1,5 @@
 use core::ops::*;
+use num_bigint::BigInt;
 use num_traits::{One, Pow, ToPrimitive, Zero};
 use sbor::rust::convert::{TryFrom, TryInto};
 use sbor::rust::fmt;
@@ -200,6 +201,65 @@ impl PreciseDecimal {
                         .0
                     / &one,
             );
+        }
+    }
+
+    /// Square root of a Decimal
+    pub fn sqrt(&self) -> Option<Self> {
+        if self.is_negative() {
+            return None;
+        }
+        if self.is_zero() {
+            return Some(Self::ZERO);
+        }
+
+        // The I512 i associated to a Decimal d is : i = d*10^64.
+        // Therefore, taking sqrt yields sqrt(i) = sqrt(d)*10^32 => We lost precision
+        // To get the right precision, we compute : sqrt(i*10^64) = sqrt(d)*10^64
+        let self_bigint = BigInt::from(self.0);
+        let correct_nb = self_bigint * BigInt::from(PreciseDecimal::one().0);
+        let sqrt = I512::try_from(correct_nb.sqrt()).unwrap();
+        Some(PreciseDecimal(sqrt))
+    }
+
+    /// Cubic root of a Decimal
+    pub fn cbrt(&self) -> Self
+    {
+        if self.is_zero() {
+            return Self::ZERO
+        }
+
+        // By reasoning in the same way as before, we realise that we need to multiply by 10^36
+        let self_bigint = BigInt::from(self.0);
+        let correct_nb: BigInt = self_bigint * BigInt::from(PreciseDecimal::one().0).pow(2 as u32);
+        let cbrt = I512::try_from(correct_nb.cbrt()).unwrap();
+        PreciseDecimal(cbrt)
+    }
+
+    /// Nth root of a Decimal
+    pub fn nth_root(&self, n: u32) -> Option<Self>
+    {
+
+        if (self.is_negative() && n%2==0) || n==0
+        {
+            None
+        }
+        else if n==1
+        {
+            Some(self.clone())
+        }
+        else
+        {
+            if self.is_zero() {
+                return Some(Self::ZERO)
+            }
+
+            // By induction, we need to multiply by the (n-1)th power of 10^64.
+            // To not overflow, we use BigInts
+            let self_bigint = BigInt::from(self.0);
+            let correct_nb = self_bigint * BigInt::from(PreciseDecimal::one().0).pow(n-1);
+            let root = I512::try_from(correct_nb.nth_root(n)).unwrap();
+            Some(PreciseDecimal(root))
         }
     }
 }
@@ -1120,5 +1180,42 @@ mod tests {
     fn test_from_str_failure_precise_decimal() {
         let pdec = PreciseDecimal::from_str("non_decimal_value");
         assert_eq!(pdec, Err(ParsePreciseDecimalError::InvalidChar('n')));
+    }
+
+
+    #[test]
+    fn test_sqrt() {
+        let sqrt_of_42 = pdec!(42).sqrt();
+        let sqrt_of_0 = pdec!(0).sqrt();
+        let sqrt_of_negative = pdec!("-1").sqrt();
+        assert_eq!(sqrt_of_42.unwrap(), pdec!("6.4807406984078602309659674360879966577052043070583465497113543978"));
+        assert_eq!(sqrt_of_0.unwrap(), pdec!(0));
+        assert_eq!(sqrt_of_negative, None);
+    }
+
+    #[test]
+    fn test_cbrt() {
+        let cbrt_of_42 = pdec!(42).cbrt();
+        let cbrt_of_0 = pdec!(0).cbrt();
+        let cbrt_of_negative_42 = pdec!("-42").cbrt();
+        assert_eq!(cbrt_of_42, pdec!("3.4760266448864497867398652190045374340048385387869674214742239567"));
+        assert_eq!(cbrt_of_0, pdec!("0"));
+        assert_eq!(cbrt_of_negative_42, pdec!("-3.4760266448864497867398652190045374340048385387869674214742239567"));
+    }
+
+    #[test]
+    fn test_nth_root() {
+        let root_4_42 = pdec!(42).nth_root(4);
+        let root_5_42 = pdec!(42).nth_root(5);
+        let root_42_42 = pdec!(42).nth_root(42);
+        let root_neg_4_42 = pdec!("-42").nth_root(4);
+        let root_neg_5_42 = pdec!("-42").nth_root(5);
+        let root_0 = pdec!(42).nth_root(0);
+        assert_eq!(root_4_42.unwrap(), pdec!("2.5457298950218305182697889605762886851969608313019270894320607936"));
+        assert_eq!(root_5_42.unwrap(), pdec!("2.1117857649667539127325673305502334863032026536306378208090387860"));
+        assert_eq!(root_42_42.unwrap(),pdec!("1.0930720579348236186827847318556257862429004287369365621359139742"));
+        assert_eq!(root_neg_4_42, None);
+        assert_eq!(root_neg_5_42.unwrap(), pdec!("-2.1117857649667539127325673305502334863032026536306378208090387860"));
+        assert_eq!(root_0, None);
     }
 }


### PR DESCRIPTION
Implements `sqrt`, `cbrt` and `nth root` functions for integers, decimals and precise decimals using implementations from `BigInt`, the type behind integers.