### PR TITLE
Fix/remove unneeded typeid bounds in sbor

### DIFF
--- a/radix-engine-interface/src/data/custom_type_id.rs
+++ b/radix-engine-interface/src/data/custom_type_id.rs
@@ -21,6 +21,11 @@ pub const TYPE_DECIMAL: u8 = 0xb5;
 pub const TYPE_PRECISE_DECIMAL: u8 = 0xb6;
 pub const TYPE_NON_FUNGIBLE_ID: u8 = 0xb7;
 
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(tag = "type")
+)]
 #[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum ScryptoCustomTypeId {
     // Global address types

--- a/sbor/src/codec/misc.rs
+++ b/sbor/src/codec/misc.rs
@@ -100,7 +100,7 @@ impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D>> Decode<X, D> for Rc<T> {
     }
 }
 
-impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D> + TypeId<X>> Decode<X, D> for RefCell<T> {
+impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D>> Decode<X, D> for RefCell<T> {
     #[inline]
     fn decode_body_with_type_id(
         decoder: &mut D,

--- a/sbor/src/codec/option.rs
+++ b/sbor/src/codec/option.rs
@@ -2,7 +2,7 @@ use crate::constants::*;
 use crate::type_id::*;
 use crate::*;
 
-impl<X: CustomTypeId, E: Encoder<X>, T: Encode<X, E> + TypeId<X>> Encode<X, E> for Option<T> {
+impl<X: CustomTypeId, E: Encoder<X>, T: Encode<X, E>> Encode<X, E> for Option<T> {
     #[inline]
     fn encode_type_id(&self, encoder: &mut E) -> Result<(), EncodeError> {
         encoder.write_type_id(Self::type_id())

--- a/sbor/src/codec/result.rs
+++ b/sbor/src/codec/result.rs
@@ -28,7 +28,7 @@ impl<X: CustomTypeId, Enc: Encoder<X>, T: Encode<X, Enc>, E: Encode<X, Enc>> Enc
     }
 }
 
-impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D> + TypeId<X>, E: Decode<X, D> + TypeId<X>>
+impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D>, E: Decode<X, D>>
     Decode<X, D> for Result<T, E>
 {
     #[inline]

--- a/sbor/src/codec/result.rs
+++ b/sbor/src/codec/result.rs
@@ -28,8 +28,8 @@ impl<X: CustomTypeId, Enc: Encoder<X>, T: Encode<X, Enc>, E: Encode<X, Enc>> Enc
     }
 }
 
-impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D>, E: Decode<X, D>>
-    Decode<X, D> for Result<T, E>
+impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D>, E: Decode<X, D>> Decode<X, D>
+    for Result<T, E>
 {
     #[inline]
     fn decode_body_with_type_id(


### PR DESCRIPTION
Very small PR - I noticed a couple of these as I was updating the node to be compatible with SBOR