### PR TITLE
Refactor test scripts to reduce execution time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDU
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/radixdlt/radixdlt-scrypto/issues).
 * If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/radixdlt/radixdlt-scrypto/issues/new). Be sure to include:
   * a **title**,
-  * a **clear description**, 
+  * a **clear description**,
   * as much **relevant information** as possible,
   * a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
@@ -21,7 +21,7 @@ This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDU
 
 Development flow:
 1. Create feature branches using develop as a starting point to start new work;
-1. Submit a new pull request to the `develop` branch 
+1. Submit a new pull request to the `develop` branch
    * please ensure the PR description clearly describes the problem and solution and include the relevant issue number if applicable.
 
 Release workflow:
@@ -58,12 +58,25 @@ Release workflow:
    * [Markdown Preview Enhanced](https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced)
    * [Radix Transaction Manifest Support](https://marketplace.visualstudio.com/items?itemName=RadixPublishing.radix-transaction-manifest-support)
    * [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+6. (Optional) Install `cargo nextest` to speedup test execution time
+    Installation method
+    ```
+    cargo install cargo-nextest
+    ```
+    more details: [cargo-nextest](https://nexte.st/index.html)
+7. (Optional) Install `sccache` to speedup compilation times.
+    Recommended installation method
+    ```
+    cargo install sccache
+    ```
+    more details: [sccache - Shared Compilation Cache](https://github.com/mozilla/sccache)
 
 
 Bash scripts that might be of help:
 * `format.sh` - Formats the entire repo
 * `build.sh` - Builds main packages
-* `test.sh` - Runs all the tests
+* `test.sh` - Runs the essential tests
+* `test_extra.sh` - Runs the additional tests
 * `assets/update-assets.sh` - Updates `Account`/`Faucet` scrypto packages (needed when your change would affect the output WASM)
 
 ## Branching strategy
@@ -95,7 +108,7 @@ When QA gives the green light, a new release branch is created
 
 These branches will stay alive forever, or at least while we support the release, thereby allowing us to release security hotfixes for older versions.
 
-If QA discovers a bug with any of the features before a release happens, it is fixed in the feature branch taken from the release branch and then merged into the release again. 
+If QA discovers a bug with any of the features before a release happens, it is fixed in the feature branch taken from the release branch and then merged into the release again.
 
 These changes should immediately be propagated to the current release candidate branch.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation: https://docs.radixdlt.com/main/scrypto/introduction.html
     *  macOS:
         * Make sure you have the xcode command line tools: `xcode-select --install`.
         * Install cmake: `brew install cmake`
-        * Install the Rust compiler: 
+        * Install the Rust compiler:
         ```bash
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
         ```
@@ -47,6 +47,18 @@ Documentation: https://docs.radixdlt.com/main/scrypto/introduction.html
     ```
     ./doc.sh
     ```
+6. (Optional) Install `cargo nextest` to speedup test execution time
+    Installation method
+    ```
+    cargo install cargo-nextest
+    ```
+    more details: [cargo-nextest](https://nexte.st/index.html)
+7. (Optional) Install `sccache` to speedup compilation times.
+    Recommended installation method
+    ```
+    cargo install sccache
+    ```
+    more details: [sccache - Shared Compilation Cache](https://github.com/mozilla/sccache)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@ Documentation: https://docs.radixdlt.com/main/scrypto/introduction.html
     ```
     ./doc.sh
     ```
-6. (Optional) Install `cargo nextest` to speedup test execution time
-    Installation method
-    ```
-    cargo install cargo-nextest
-    ```
-    more details: [cargo-nextest](https://nexte.st/index.html)
-7. (Optional) Install `sccache` to speedup compilation times.
-    Recommended installation method
-    ```
-    cargo install sccache
-    ```
-    more details: [sccache - Shared Compilation Cache](https://github.com/mozilla/sccache)
 
 ## Getting Started
 

--- a/clean.sh
+++ b/clean.sh
@@ -16,7 +16,7 @@ cd "$(dirname "$0")"
 (cd transaction; cargo clean)
 (cd simulator; cargo clean)
 
-(cd assets/account; cargo clean)
-(cd assets/faucet; cargo clean)
+(cd assets/blueprints/account; cargo clean)
+(cd assets/blueprints/faucet; cargo clean)
 (cd examples/hello-world; cargo clean)
 (cd examples/no-std; cargo clean)

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@ set -e
 cd "$(dirname "$0")"
 source test_utils.sh
 
+setup_test_runner
+
 echo "Testing crates..."
 test_crates_features \
     "sbor \

--- a/test.sh
+++ b/test.sh
@@ -4,32 +4,36 @@ set -x
 set -e
 
 cd "$(dirname "$0")"
+source test_utils.sh
 
 echo "Testing crates..."
-(cd sbor; cargo test)
-(cd sbor-derive; cargo test)
-(cd sbor-tests; cargo test)
-(cd scrypto; cargo test)
-(cd scrypto-derive; cargo test)
-(cd scrypto-tests; cargo test)
-(cd radix-engine-derive; cargo test)
-(cd radix-engine-interface; cargo test --features serde)
-(cd radix-engine; cargo test)
-(cd transaction; cargo test)
+test_crates_features \
+    "sbor \
+    sbor-derive \
+    sbor-tests \
+    scrypto \
+    scrypto-derive \
+    scrypto-tests \
+    radix-engine-derive \
+    radix-engine-interface \
+    radix-engine transaction"
 
 echo "Testing scrypto packages..."
-(cd assets/blueprints/account; scrypto test)
-(cd assets/blueprints/faucet; scrypto test)
-(cd examples/hello-world; scrypto test)
-(cd examples/no-std; scrypto test)
+test_packages \
+    "assets/blueprints/account \
+    assets/blueprints/faucet \
+    examples/hello-world \
+    examples/no-std"
 
 echo "Testing CLIs..."
-(cd simulator; bash ./tests/resim.sh)
-(cd simulator; bash ./tests/scrypto.sh)
-(cd simulator; bash ./tests/manifest.sh)
+test_cli \
+    "./tests/resim.sh \
+    ./tests/scrypto.sh \
+    ./tests/manifest.sh"
 
-echo "Testing benchmark..."
-(cd sbor-tests; cargo bench)
-(cd radix-engine; cargo bench)
+echo "Running benchmark..."
+test_benchmark  \
+    "sbor-tests \
+    radix-engine"
 
 echo "Congrats! All tests passed."

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+#set -x
 set -e
 
 cd "$(dirname "$0")"

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,8 @@ test_crates_features \
     scrypto-tests \
     radix-engine-derive \
     radix-engine-interface \
-    radix-engine transaction"
+    radix-engine \
+    transaction"
 
 echo "Testing scrypto packages..."
 test_packages \

--- a/test_extra.sh
+++ b/test_extra.sh
@@ -4,19 +4,29 @@ set -x
 set -e
 
 cd "$(dirname "$0")"
+source test_utils.sh
 
 echo "Testing scrypto with release profile..."
-(cd sbor; cargo test --release)
+test_crates_features \
+    "sbor" \
+    "--release"
 
 echo "Testing raidx engine with wasmer..."
-(cd radix-engine; cargo test --features wasmer)
+test_crates_features \
+    "radix-engine" \
+    "--features wasmer"
 
 echo "Testing crates with no_std..."
-(cd sbor; cargo test --no-default-features --features alloc)
-(cd sbor-tests; cargo test --no-default-features --features alloc)
-(cd scrypto; cargo test --no-default-features --features alloc,prelude)
-(cd scrypto-abi; cargo test --no-default-features --features alloc)
-(cd scrypto-tests; cargo test --no-default-features --features alloc)
-(cd radix-engine; cargo test --no-default-features --features alloc)
+test_crates_features \
+    "sbor \
+    sbor-tests \
+    scrypto-abi \
+    scrypto-tests \
+    radix-engine" \
+    "--no-default-features --features alloc"
+
+test_crates_features \
+    "scrypto" \
+    "--no-default-features --features alloc,prelude"
 
 echo "Congrats! All extra tests passed."

--- a/test_extra.sh
+++ b/test_extra.sh
@@ -6,6 +6,8 @@ set -e
 cd "$(dirname "$0")"
 source test_utils.sh
 
+setup_test_runner
+
 echo "Testing scrypto with release profile..."
 test_crates_features \
     "sbor" \

--- a/test_extra.sh
+++ b/test_extra.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+#set -x
 set -e
 
 cd "$(dirname "$0")"

--- a/test_utils.sh
+++ b/test_utils.sh
@@ -45,10 +45,6 @@ test_packages() {
     do
         (cd $p; scrypto test)
     done
-    (cd assets/blueprints/account; scrypto test)
-    (cd assets/blueprints/faucet; scrypto test)
-    (cd examples/hello-world; scrypto test)
-    (cd examples/no-std; scrypto test)
 }
 
 test_cli() {

--- a/test_utils.sh
+++ b/test_utils.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+test_runner="test"
+doc_test_separately=0
+
+setup_test_runner() {
+    if cargo help nextest 2>/dev/null >&2 ; then
+        test_runner="nextest run"
+
+        # workaround for lack of doctests support for nextest
+        # need to keep it until issue resolved https://github.com/nextest-rs/nextest/issues/16
+        doc_test_separately=1
+    fi
+}
+
 # Add '-p' refix to each create in list.
 # This is for cargo command.
 to_cargo_crates() {
@@ -17,7 +30,11 @@ test_crates_features() {
     local crates=$(to_cargo_crates "$1")
     local args="${2:-}"
 
-    cargo test $crates $args
+    cargo $test_runner $crates $args
+
+    if [ $doc_test_separately -eq 1 ] ; then
+        cargo test $crates --doc $args
+    fi
 }
 
 test_packages() {

--- a/test_utils.sh
+++ b/test_utils.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Add '-p' refix to each create in list.
+# This is for cargo command.
+to_cargo_crates() {
+    # input must be space-separated list of crates
+    local crates="$1"
+    local out=
+    for c in $crates
+    do
+        out+="-p $c "
+    done
+    echo "$out"
+}
+
+test_crates_features() {
+    local crates=$(to_cargo_crates "$1")
+    local args="${2:-}"
+
+    cargo test $crates $args
+}
+
+test_packages() {
+    # input must be space-separated list of packages
+    local packages="${1:-}"
+
+    for p in $packages
+    do
+        (cd $p; scrypto test)
+    done
+    (cd assets/blueprints/account; scrypto test)
+    (cd assets/blueprints/faucet; scrypto test)
+    (cd examples/hello-world; scrypto test)
+    (cd examples/no-std; scrypto test)
+}
+
+test_cli() {
+    # input must be space-separated list of bash scripts
+    local clis="${1:-}"
+    for c in $clis
+    do
+        (cd simulator; bash $c)
+    done
+}
+
+test_benchmark() {
+    local crates=$(to_cargo_crates "$1")
+    local args="${2:-}"
+    cargo bench $crates $args
+}
+


### PR DESCRIPTION
Changes:
- use cargo workspaces to build crates
  building crates within a workspace allows to share build artifacts in one target folder, which helps to avoid unnecessary compilation
- use `cargo nextest` (if available on the host) instead of `cargo test` built-in test runner 
  `cargo nextest` is much faster - it runs tests in parallel. Additionally it presents results in more consistent way.
  It is also capable of detecting slow tests.
  Installation: `cargo install cargo-nextest`
  More details: https://nexte.st/

Additionally it is recommended to use `sccache` (shared cache compiler) as a wrapper for Rust compiler.
Installation:
`cargo install sccache`
Usage:
add below entry to `$HOME/.cargo/config.toml`
```
[build]
rustc-wrapper = "/path/to/sccache"
```
More details on sccache: https://github.com/mozilla/sccache

Implementing above allows to reduce test execution time by ~20%.