### PR TITLE
feature: Can serialize a scrypto value

### DIFF
--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -19,14 +19,17 @@ paste = { version = "1.0.7"}
 serde = { version = "1.0.144", default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 
+[dev-dependencies]
+serde_json = { version = "1.0.81", default-features = false }
+
 [features]
 # You should enable either `std` or `alloc`
 default = ["std"]
-std = ["hex/std", "sbor/std", "scrypto-abi/std", "radix-engine-derive/std", "strum/std", "utils/std"]
-alloc = ["hex/alloc", "sbor/alloc", "scrypto-abi/alloc", "radix-engine-derive/alloc", "utils/alloc"]
+std = ["hex/std", "sbor/std", "scrypto-abi/std", "radix-engine-derive/std", "strum/std", "utils/std", "serde_json/std"]
+alloc = ["hex/alloc", "sbor/alloc", "scrypto-abi/alloc", "radix-engine-derive/alloc", "utils/alloc", "serde_json/alloc"]
 
 # Turn on this feature to enable tracing.
 trace = ["radix-engine-derive/trace"]
 
 # Enable serde derives
-serde = ["sbor/serde", "scrypto-abi/serde", "serde/derive"]
+serde = ["utils/serde", "sbor/serde", "scrypto-abi/serde", "serde/derive"]

--- a/radix-engine-interface/src/address/display.rs
+++ b/radix-engine-interface/src/address/display.rs
@@ -15,14 +15,14 @@ impl<'a> AddressDisplayContext<'a> {
 
 pub static NO_NETWORK: AddressDisplayContext = AddressDisplayContext { encoder: None };
 
-impl<'a> Into<AddressDisplayContext<'a>> for &'a Bech32Encoder {
-    fn into(self) -> AddressDisplayContext<'a> {
-        AddressDisplayContext::with_encoder(self)
+impl<'a> From<&'a Bech32Encoder> for AddressDisplayContext<'a> {
+    fn from(encoder: &'a Bech32Encoder) -> Self {
+        Self::with_encoder(encoder)
     }
 }
 
-impl<'a> Into<AddressDisplayContext<'a>> for Option<&'a Bech32Encoder> {
-    fn into(self) -> AddressDisplayContext<'a> {
-        AddressDisplayContext { encoder: self }
+impl<'a> From<Option<&'a Bech32Encoder>> for AddressDisplayContext<'a> {
+    fn from(encoder: Option<&'a Bech32Encoder>) -> Self {
+        Self { encoder }
     }
 }

--- a/radix-engine-interface/src/data/custom_type_id.rs
+++ b/radix-engine-interface/src/data/custom_type_id.rs
@@ -57,6 +57,12 @@ pub enum ScryptoCustomTypeId {
     NonFungibleId,
 }
 
+impl From<ScryptoCustomTypeId> for SborTypeId<ScryptoCustomTypeId> {
+    fn from(custom_type_id: ScryptoCustomTypeId) -> Self {
+        SborTypeId::Custom(custom_type_id)
+    }
+}
+
 impl CustomTypeId for ScryptoCustomTypeId {
     fn as_u8(&self) -> u8 {
         match self {

--- a/radix-engine-interface/src/data/mod.rs
+++ b/radix-engine-interface/src/data/mod.rs
@@ -10,6 +10,9 @@ mod schema_matcher;
 mod schema_path;
 /// Format any Scrypto value using the Manifest syntax.
 mod value_formatter;
+#[cfg(feature = "serde")]
+/// One-way serialize any Scrypto value.
+mod value_serializer;
 
 pub use crate::args;
 pub use custom_type_id::*;
@@ -23,6 +26,8 @@ use sbor::{
 pub use schema_matcher::*;
 pub use schema_path::*;
 pub use value_formatter::*;
+#[cfg(feature = "serde")]
+pub use value_serializer::*;
 
 pub const MAX_SCRYPTO_SBOR_DEPTH: u8 = 64;
 

--- a/radix-engine-interface/src/data/value_formatter.rs
+++ b/radix-engine-interface/src/data/value_formatter.rs
@@ -7,9 +7,9 @@ use utils::ContextualDisplay;
 
 #[derive(Clone, Copy, Debug)]
 pub struct ValueFormattingContext<'a> {
-    bech32_encoder: Option<&'a Bech32Encoder>,
-    bucket_names: Option<&'a HashMap<BucketId, String>>,
-    proof_names: Option<&'a HashMap<ProofId, String>>,
+    pub bech32_encoder: Option<&'a Bech32Encoder>,
+    pub bucket_names: Option<&'a HashMap<BucketId, String>>,
+    pub proof_names: Option<&'a HashMap<ProofId, String>>,
 }
 
 impl<'a> ValueFormattingContext<'a> {
@@ -160,6 +160,18 @@ pub fn format_type_id<F: fmt::Write>(f: &mut F, type_id: &ScryptoSborTypeId) -> 
             ScryptoCustomTypeId::PreciseDecimal => f.write_str("PreciseDecimal"),
             ScryptoCustomTypeId::NonFungibleId => f.write_str("NonFungibleId"),
         },
+    }
+}
+
+pub fn display_type_id(type_id: &ScryptoSborTypeId) -> DisplayableScryptoSborTypeId {
+    DisplayableScryptoSborTypeId(type_id)
+}
+
+pub struct DisplayableScryptoSborTypeId<'a>(&'a ScryptoSborTypeId);
+
+impl<'a> fmt::Display for DisplayableScryptoSborTypeId<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        format_type_id(f, &self.0)
     }
 }
 

--- a/radix-engine-interface/src/data/value_serializer.rs
+++ b/radix-engine-interface/src/data/value_serializer.rs
@@ -5,6 +5,8 @@ use serde::ser::*;
 use serde::*;
 use utils::{ContextSerializable, ContextualDisplay, ContextualSerialize};
 
+// TODO - Add a deserializer for invertible JSON, and tests that the process is invertible
+// TODO - Rewrite value formatter as a serializer/deserializer variant?
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ScryptoValueSerializationType {
     /// This "simple" encoding is intended to be "nice to read" for a human.

--- a/radix-engine-interface/src/data/value_serializer.rs
+++ b/radix-engine-interface/src/data/value_serializer.rs
@@ -1,0 +1,667 @@
+use crate::api::types::*;
+use crate::data::*;
+use sbor::rust::format;
+use serde::ser::*;
+use serde::*;
+use utils::{ContextSerializable, ContextualDisplay, ContextualSerialize};
+
+#[derive(Clone, Copy, Debug)]
+pub enum ScryptoValueSerializationType {
+    /// This "simple" encoding is intended to be "nice to read" for a human.
+    /// It is intended to be one option (likely the default option) for representing
+    /// schemaless scrypto values in a JSON API.
+    ///
+    /// In particular:
+    /// * It is not intended to be invertible - ie the output cannot be mapped back into a ScryptoValue
+    /// * It should favour simplicity for human comprehension, in particular:
+    ///   * If the concept which is being represented (eg number/amount or address) is clear
+    ///     to a human, the type information can be dropped
+    ///   * If the concept which is being represented (eg number/amount or address) is clear
+    ///     to a human, the type information can be dropped
+    ///
+    /// We will eventually support simple_with_schema encoding, which will likely be
+    /// similar to this, except replace Struct/Enum encodings.
+    Simple,
+    /// This "invertible" encoding is intended to fully capture the scrypto value's type along with its value
+    Invertible,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ScryptoValueFormattingContext<'a> {
+    pub serialization_type: ScryptoValueSerializationType,
+    pub display_context: ValueFormattingContext<'a>,
+}
+
+impl<'a> ScryptoValueFormattingContext<'a> {
+    pub fn simple(display_context: ValueFormattingContext<'a>) -> Self {
+        Self {
+            serialization_type: ScryptoValueSerializationType::Simple,
+            display_context,
+        }
+    }
+
+    pub fn invertible(display_context: ValueFormattingContext<'a>) -> Self {
+        Self {
+            serialization_type: ScryptoValueSerializationType::Invertible,
+            display_context,
+        }
+    }
+}
+
+trait SerializableScryptoValue: for<'a> ContextualSerialize<ScryptoValueFormattingContext<'a>> {
+    fn simple_serializable<'a, 'b, TContext: Into<ValueFormattingContext<'b>>>(
+        &'a self,
+        context: TContext,
+    ) -> ContextSerializable<'a, Self, ScryptoValueFormattingContext<'b>> {
+        self.serializable(ScryptoValueFormattingContext::simple(context.into()))
+    }
+
+    fn invertible_serializable<'a, 'b, TContext: Into<ValueFormattingContext<'b>>>(
+        &'a self,
+        context: TContext,
+    ) -> ContextSerializable<'a, Self, ScryptoValueFormattingContext<'b>> {
+        self.serializable(ScryptoValueFormattingContext::invertible(context.into()))
+    }
+}
+
+impl<'a> ContextualSerialize<ScryptoValueFormattingContext<'a>> for ScryptoValue {
+    fn contextual_serialize<S: Serializer>(
+        &self,
+        serializer: S,
+        context: &ScryptoValueFormattingContext<'a>,
+    ) -> Result<S::Ok, S::Error> {
+        serialize_schemaless_scrypto_value(serializer, self, context)
+    }
+}
+
+impl SerializableScryptoValue for ScryptoValue {}
+
+pub fn serialize_schemaless_scrypto_value<S: Serializer>(
+    serializer: S,
+    value: &ScryptoValue,
+    context: &ScryptoValueFormattingContext,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        // primitive types
+        SborValue::Unit => {
+            serialize_potentially_transparent_value(serializer, context, "Unit", &())
+        }
+        SborValue::Bool { value } => {
+            serialize_potentially_transparent_value(serializer, context, "Bool", value)
+        }
+        SborValue::I8 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "I8", value)
+        }
+        SborValue::I16 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "I16", value)
+        }
+        SborValue::I32 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "I32", value)
+        }
+        SborValue::I64 { value } => {
+            // Javascript only safely decodes JSON integers up to 2^53
+            // So to be safe, we encode I64s as strings
+            serialize_potentially_transparent_value(serializer, context, "I64", &value.to_string())
+        }
+        SborValue::I128 { value } => {
+            // Javascript only safely decodes JSON integers up to 2^53
+            // So to be safe, we encode I128 as strings
+            // Moreover, I128 isn't supported by the JSON serializer
+            serialize_potentially_transparent_value(serializer, context, "I128", &value.to_string())
+        }
+        SborValue::U8 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "U8", value)
+        }
+        SborValue::U16 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "U16", value)
+        }
+        SborValue::U32 { value } => {
+            serialize_potentially_transparent_value(serializer, context, "U32", value)
+        }
+        SborValue::U64 { value } => {
+            // Javascript only safely decodes JSON integers up to 2^53
+            // So to be safe, we encode U64s as strings
+            serialize_potentially_transparent_value(serializer, context, "U64", &value.to_string())
+        }
+        SborValue::U128 { value } => {
+            // Javascript only safely decodes JSON integers up to 2^53
+            // So to be safe, we encode U128 as strings
+            // Moreover, U128 isn't supported by the JSON serializer
+            serialize_potentially_transparent_value(serializer, context, "U128", &value.to_string())
+        }
+        SborValue::String { value } => {
+            serialize_potentially_transparent_value(serializer, context, "String", value)
+        }
+        SborValue::Tuple { fields } => serialize_potentially_transparent_value(
+            serializer,
+            context,
+            "Tuple",
+            &fields.serializable(*context),
+        ),
+        SborValue::Enum {
+            discriminator,
+            fields,
+        } => serialize_potentially_transparent_value(
+            serializer,
+            context,
+            "Enum",
+            &EnumVariant {
+                discriminator,
+                fields,
+            }
+            .serializable(*context),
+        ),
+        SborValue::Array {
+            element_type_id,
+            elements,
+        } => {
+            let value = ArrayValue {
+                element_type_id,
+                elements,
+            };
+            let serializable_value = value.serializable(*context);
+            match context.serialization_type {
+                ScryptoValueSerializationType::Simple => serializable_value.serialize(serializer),
+                ScryptoValueSerializationType::Invertible => {
+                    let mut map = serializer.serialize_map(Some(2))?;
+                    map.serialize_entry("type", "Array")?;
+                    map.serialize_entry(
+                        "element_type",
+                        &display_type_id(element_type_id).to_string(),
+                    )?;
+                    map.serialize_entry("value", &serializable_value)?;
+                    map.end()
+                }
+            }
+        }
+        SborValue::Custom { value } => serialize_custom_value(serializer, value, context),
+    }
+}
+
+pub struct ArrayValue<'a> {
+    element_type_id: &'a ScryptoSborTypeId,
+    elements: &'a [ScryptoValue],
+}
+
+impl<'a, 'b> ContextualSerialize<ScryptoValueFormattingContext<'a>> for ArrayValue<'b> {
+    fn contextual_serialize<S: Serializer>(
+        &self,
+        serializer: S,
+        context: &ScryptoValueFormattingContext<'a>,
+    ) -> Result<S::Ok, S::Error> {
+        if *self.element_type_id == SborTypeId::U8 {
+            let length = self.elements.len();
+            let mut bytes_vec = Vec::with_capacity(if length <= 1024 { length } else { 1024 });
+            for element in self.elements {
+                let SborValue::U8 { value: byte } = element else {
+                    return Err(ser::Error::custom("An SBOR array of U8 contained a non-U8 value"));
+                };
+                bytes_vec.push(*byte);
+            }
+            let mut map = serializer.serialize_map(Some(1))?;
+            map.serialize_entry("hex", &hex::encode(&bytes_vec))?;
+            map.end()
+        } else {
+            serialize_schemaless_scrypto_value_slice(serializer, self.elements, context)
+        }
+    }
+}
+
+pub struct EnumVariant<'a> {
+    discriminator: &'a str,
+    fields: &'a [ScryptoValue],
+}
+
+impl<'a, 'b> ContextualSerialize<ScryptoValueFormattingContext<'a>> for EnumVariant<'b> {
+    fn contextual_serialize<S: Serializer>(
+        &self,
+        serializer: S,
+        context: &ScryptoValueFormattingContext<'a>,
+    ) -> Result<S::Ok, S::Error> {
+        let mut discriminator_value_pair = serializer.serialize_tuple(2)?;
+        discriminator_value_pair.serialize_element(self.discriminator)?;
+
+        match self.fields.len() {
+            0 => {
+                discriminator_value_pair.serialize_element(&())?;
+            }
+            1 => {
+                discriminator_value_pair
+                    .serialize_element(&self.fields.get(0).unwrap().serializable(*context))?;
+            }
+            _ => {
+                discriminator_value_pair.serialize_element(&self.fields.serializable(*context))?;
+            }
+        }
+        discriminator_value_pair.end()
+    }
+}
+
+impl<'a> ContextualSerialize<ScryptoValueFormattingContext<'a>> for [ScryptoValue] {
+    fn contextual_serialize<S: Serializer>(
+        &self,
+        serializer: S,
+        context: &ScryptoValueFormattingContext<'a>,
+    ) -> Result<S::Ok, S::Error> {
+        serialize_schemaless_scrypto_value_slice(serializer, self, context)
+    }
+}
+
+impl SerializableScryptoValue for [ScryptoValue] {}
+
+pub fn serialize_schemaless_scrypto_value_slice<S: Serializer>(
+    serializer: S,
+    elements: &[ScryptoValue],
+    context: &ScryptoValueFormattingContext,
+) -> Result<S::Ok, S::Error> {
+    // Tuple is the serde type corresponding to a known-length list
+    // See https://serde.rs/data-model.html
+    let mut tuple = serializer.serialize_tuple(elements.len())?;
+    for element in elements {
+        tuple.serialize_element(&element.serializable(*context))?;
+    }
+    tuple.end()
+}
+
+pub fn serialize_custom_value<S: Serializer>(
+    serializer: S,
+    value: &ScryptoCustomValue,
+    context: &ScryptoValueFormattingContext,
+) -> Result<S::Ok, S::Error> {
+    // We encode custom types in one of two ways:
+    // - As a tagged object { "type": "TypeName", "value": X }
+    // - As a transparent value (ie without a wrapper)
+    //
+    // This serialization approach is to favour simple, readable JSON - so:
+    // - If the interpretation of the value is obvious (eg addresses or decimals), we use the transparent value.
+    // - Otherwise, if the type of value is more important, we use the tagged object representation
+    match value {
+        // Global address types
+        ScryptoCustomValue::PackageAddress(value) => {
+            let string_address =
+                format!("{}", value.display(context.display_context.bech32_encoder));
+            // The fact it's an address is obvious, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "PackageAddress",
+                &string_address,
+            )
+        }
+        ScryptoCustomValue::ComponentAddress(value) => {
+            let string_address =
+                format!("{}", value.display(context.display_context.bech32_encoder));
+            // The fact it's an address is obvious, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "ComponentAddress",
+                &string_address,
+            )
+        }
+        ScryptoCustomValue::ResourceAddress(value) => {
+            let string_address =
+                format!("{}", value.display(context.display_context.bech32_encoder));
+            // The fact it's an address is obvious, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "ResourceAddress",
+                &string_address,
+            )
+        }
+        ScryptoCustomValue::SystemAddress(value) => {
+            let string_address =
+                format!("{}", value.display(context.display_context.bech32_encoder));
+            // The fact it's an address is obvious, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "SystemAddress",
+                &string_address,
+            )
+        }
+        // RE node types
+        ScryptoCustomValue::Component(value) => {
+            serialize_type_name_tagged_value(serializer, context, "Component", &hex::encode(value))
+        }
+        ScryptoCustomValue::KeyValueStore(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "KeyValueStore",
+            &hex::encode(value),
+        ),
+        ScryptoCustomValue::Bucket(value) => {
+            if let Some(name) = context.display_context.get_bucket_name(&value) {
+                serialize_type_name_tagged_value(serializer, context, "Bucket", name)
+            } else {
+                serialize_type_name_tagged_value(serializer, context, "Bucket", value)
+            }
+        }
+        ScryptoCustomValue::Proof(value) => {
+            if let Some(name) = context.display_context.get_proof_name(&value) {
+                serialize_type_name_tagged_value(serializer, context, "Proof", name)
+            } else {
+                serialize_type_name_tagged_value(serializer, context, "Proof", value)
+            }
+        }
+        ScryptoCustomValue::Vault(value) => {
+            serialize_type_name_tagged_value(serializer, context, "Vault", &hex::encode(value))
+        }
+        // Other interpreted types
+        ScryptoCustomValue::Expression(value) => {
+            // The fact it's an expression isn't so relevant, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "Expression",
+                &format!("{}", value),
+            )
+        }
+        ScryptoCustomValue::Blob(value) => {
+            serialize_type_name_tagged_value(serializer, context, "Blob", &format!("{}", value))
+        }
+        ScryptoCustomValue::NonFungibleAddress(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "NonFungibleAddress",
+            &format!("{}", value),
+        ),
+        // Uninterpreted
+        ScryptoCustomValue::Hash(value) => {
+            serialize_type_name_tagged_value(serializer, context, "Hash", &format!("{}", value))
+        }
+        ScryptoCustomValue::EcdsaSecp256k1PublicKey(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "EcdsaSecp256k1PublicKey",
+            &format!("{}", value),
+        ),
+        ScryptoCustomValue::EcdsaSecp256k1Signature(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "EcdsaSecp256k1Signature",
+            &format!("{}", value),
+        ),
+        ScryptoCustomValue::EddsaEd25519PublicKey(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "EddsaEd25519PublicKey",
+            &format!("{}", value),
+        ),
+        ScryptoCustomValue::EddsaEd25519Signature(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "EddsaEd25519Signature",
+            &format!("{}", value),
+        ),
+        ScryptoCustomValue::Decimal(value) => {
+            // The fact it's a decimal number will be obvious from context, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "Decimal",
+                &format!("{}", value),
+            )
+        }
+        ScryptoCustomValue::PreciseDecimal(value) => {
+            // The fact it's a decimal number will be obvious from context, so favour simplicity over verbosity
+            serialize_potentially_transparent_value(
+                serializer,
+                context,
+                "PreciseDecimal",
+                &format!("{}", value),
+            )
+        }
+        ScryptoCustomValue::NonFungibleId(value) => serialize_type_name_tagged_value(
+            serializer,
+            context,
+            "NonFungibleId",
+            &format!("{}", value),
+        ),
+    }
+}
+
+pub fn serialize_potentially_transparent_value<S: Serializer, T: Serialize>(
+    serializer: S,
+    context: &ScryptoValueFormattingContext,
+    type_name: &'static str,
+    value: &T,
+) -> Result<S::Ok, S::Error> {
+    match context.serialization_type {
+        ScryptoValueSerializationType::Simple => value.serialize(serializer),
+        ScryptoValueSerializationType::Invertible => {
+            // In the invertible case, we have to add the tag anyway
+            serialize_type_name_tagged_value(serializer, context, type_name, value)
+        }
+    }
+}
+
+pub fn serialize_type_name_tagged_value<S: Serializer, T: Serialize + ?Sized>(
+    serializer: S,
+    _context: &ScryptoValueFormattingContext,
+    type_name: &'static str,
+    value: &T,
+) -> Result<S::Ok, S::Error> {
+    let mut map = serializer.serialize_map(Some(2))?;
+    map.serialize_entry("type", type_name)?;
+    map.serialize_entry("value", value)?;
+    map.end()
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")] // Ensures that VS Code runs this module with the features serde tag!
+mod tests {
+    use super::*;
+    use crate::address::Bech32Encoder;
+    use radix_engine_derive::scrypto;
+    use sbor::rust::collections::HashMap;
+    use sbor::rust::vec;
+    use serde::Serialize;
+    use serde_json::{json, to_string, to_value, Value};
+
+    use crate::{
+        address::NO_NETWORK,
+        api::types::ResourceAddress,
+        constants::RADIX_TOKEN,
+        data::{scrypto_decode, scrypto_encode, ScryptoValue},
+    };
+
+    #[scrypto(TypeId, Encode, Decode)]
+    pub struct Sample {
+        pub a: ResourceAddress,
+    }
+
+    pub fn assert_json_eq<T: Serialize>(actual: T, expected: Value) {
+        let actual = to_value(&actual).unwrap();
+        if actual != expected {
+            panic!(
+                "Mismatching JSON:\nActual:\n{}\nExpected:\n{}\n",
+                to_string(&actual).unwrap(),
+                to_string(&expected).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")] // Workaround for VS Code "Run Test" feature
+    fn test_address_encoding_no_network() {
+        let value = RADIX_TOKEN;
+
+        let no_network_radix_token_address = RADIX_TOKEN.display(NO_NETWORK).to_string();
+
+        let expected = json!(no_network_radix_token_address);
+        let expected_invertible =
+            json!({ "type": "ResourceAddress", "value": no_network_radix_token_address });
+
+        assert_simple_json_matches(&value, ValueFormattingContext::no_context(), expected);
+        assert_invertible_json_matches(
+            &value,
+            ValueFormattingContext::no_context(),
+            expected_invertible,
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "serde")] // Workaround for VS Code "Run Test" feature
+    fn test_address_encoding_with_network() {
+        let value = RADIX_TOKEN;
+        let encoder = Bech32Encoder::for_simulator();
+
+        let radix_token_address = RADIX_TOKEN.display(&encoder).to_string();
+
+        let expected_simple = json!(radix_token_address);
+        let expected_invertible =
+            json!({ "type": "ResourceAddress", "value": radix_token_address });
+
+        assert_simple_json_matches(&value, &encoder, expected_simple);
+        assert_invertible_json_matches(&value, &encoder, expected_invertible);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")] // Workaround for VS Code "Run Test" feature
+    fn test_complex_encoding_with_network() {
+        use crate::{
+            core::Expression,
+            math::{Decimal, PreciseDecimal},
+        };
+
+        let encoder = Bech32Encoder::for_simulator();
+        let radix_token_address = RADIX_TOKEN.display(&encoder).to_string();
+
+        let value = ScryptoValue::Tuple {
+            fields: vec![
+                SborValue::U8 { value: 5 },
+                SborValue::I32 { value: -5 },
+                SborValue::U64 { value: u64::MAX },
+                SborValue::U128 {
+                    value: 9912313323213,
+                },
+                SborValue::Array {
+                    element_type_id: SborTypeId::U8,
+                    elements: vec![SborValue::U8 { value: 0x3a }, SborValue::U8 { value: 0x92 }],
+                },
+                SborValue::Array {
+                    element_type_id: SborTypeId::U32,
+                    elements: vec![SborValue::U32 { value: 153 }, SborValue::U32 { value: 62 }],
+                },
+                SborValue::Tuple {
+                    fields: vec![
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::ResourceAddress(RADIX_TOKEN),
+                        },
+                        SborValue::U32 { value: 62 },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::Expression(Expression::entire_worktop()),
+                        },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::Decimal(Decimal::ONE),
+                        },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::PreciseDecimal(PreciseDecimal::ZERO),
+                        },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::Decimal(Decimal::ONE / 100),
+                        },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::Bucket(1), // Will be mapped by context to "Hello"
+                        },
+                        SborValue::Custom {
+                            value: ScryptoCustomValue::Bucket(10),
+                        },
+                    ],
+                },
+            ],
+        };
+
+        let expected_simple = json!([
+            5,
+            -5,
+            "18446744073709551615",
+            "9912313323213",
+            { "hex": "3a92" },
+            [153, 62],
+            [
+                radix_token_address,
+                62,
+                "ENTIRE_WORKTOP",
+                "1",
+                "0",
+                "0.01",
+                { "type": "Bucket", "value": "Hello" },
+                { "type": "Bucket", "value": 10 },
+            ]
+        ]);
+
+        let expected_invertible = json!({
+            "type": "Tuple",
+            "value": [
+                { "type": "U8", "value": 5 },
+                { "type": "I32", "value": -5 },
+                { "type": "U64", "value": "18446744073709551615" },
+                { "type": "U128", "value": "9912313323213" },
+                { "type": "Array", "element_type": "U8", "value": { "hex": "3a92" } },
+                {
+                    "type": "Array",
+                    "element_type": "U32",
+                    "value": [
+                        { "type": "U32", "value": 153 },
+                        { "type": "U32", "value": 62 },
+                    ]
+                },
+                {
+                    "type": "Tuple",
+                    "value": [
+                        { "type": "ResourceAddress", "value": radix_token_address },
+                        { "type": "U32", "value": 62 },
+                        { "type": "Expression", "value": "ENTIRE_WORKTOP" },
+                        { "type": "Decimal", "value": "1" },
+                        { "type": "PreciseDecimal", "value": "0" },
+                        { "type": "Decimal", "value": "0.01" },
+                        { "type": "Bucket", "value": "Hello" },
+                        { "type": "Bucket", "value": 10 },
+                    ]
+                }
+            ]
+        });
+
+        let mut bucket_names = HashMap::new();
+        bucket_names.insert(1, "Hello".to_owned());
+        let proof_names = HashMap::new();
+
+        let context = ValueFormattingContext::with_manifest_context(
+            Some(&encoder),
+            &bucket_names,
+            &proof_names,
+        );
+
+        assert_simple_json_matches(&value, context, expected_simple);
+        assert_invertible_json_matches(&value, context, expected_invertible);
+    }
+
+    fn assert_simple_json_matches<'a, T: ScryptoEncode, C: Into<ValueFormattingContext<'a>>>(
+        value: &T,
+        context: C,
+        expected: Value,
+    ) {
+        let bytes = scrypto_encode(&value).unwrap();
+        let scrypto_value = scrypto_decode::<ScryptoValue>(&bytes).unwrap();
+
+        let serializable = scrypto_value.simple_serializable(context);
+
+        assert_json_eq(serializable, expected);
+    }
+
+    fn assert_invertible_json_matches<'a, T: ScryptoEncode, C: Into<ValueFormattingContext<'a>>>(
+        value: &T,
+        context: C,
+        expected: Value,
+    ) {
+        let bytes = scrypto_encode(&value).unwrap();
+        let scrypto_value = scrypto_decode::<ScryptoValue>(&bytes).unwrap();
+
+        let serializable = scrypto_value.invertible_serializable(context);
+
+        assert_json_eq(serializable, expected);
+    }
+}

--- a/radix-engine-interface/src/data/value_serializer.rs
+++ b/radix-engine-interface/src/data/value_serializer.rs
@@ -48,7 +48,7 @@ impl<'a> ScryptoValueFormattingContext<'a> {
     }
 }
 
-trait SerializableScryptoValue: for<'a> ContextualSerialize<ScryptoValueFormattingContext<'a>> {
+pub trait SerializableScryptoValue: for<'a> ContextualSerialize<ScryptoValueFormattingContext<'a>> {
     fn simple_serializable<'a, 'b, TContext: Into<ValueFormattingContext<'b>>>(
         &'a self,
         context: TContext,

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -1679,6 +1679,7 @@ name = "utils"
 version = "0.7.0"
 dependencies = [
  "sbor",
+ "serde",
 ]
 
 [[package]]

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ echo "Testing crates..."
 (cd scrypto-derive; cargo test)
 (cd scrypto-tests; cargo test)
 (cd radix-engine-derive; cargo test)
-(cd radix-engine-interface; cargo test)
+(cd radix-engine-interface; cargo test --features serde)
 (cd radix-engine; cargo test)
 (cd transaction; cargo test)
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 
 [dependencies]
 sbor = { path = "../sbor", default-features = false }
+serde = { version = "1.0.144", default-features = false, optional = true }
 
 [features]
 default = ["std"]
 std = ["sbor/std"]
 alloc = ["sbor/alloc"]
+serde = ["sbor/serde", "serde/derive"]

--- a/utils/src/contextual_display.rs
+++ b/utils/src/contextual_display.rs
@@ -11,7 +11,7 @@ use sbor::rust::fmt;
 /// It is therefore recommended that the `Context` implement `Copy`,
 /// to make it very easy to pass around and re-use.
 ///
-pub trait ContextualDisplay<Context>: Sized {
+pub trait ContextualDisplay<Context> {
     type Error;
 
     /// Formats the value to the given `fmt::Write` buffer, making use of the provided context.
@@ -72,7 +72,7 @@ pub trait ContextualDisplay<Context>: Sized {
 
 pub struct ContextDisplayable<'a, TValue, TContext>
 where
-    TValue: ContextualDisplay<TContext> + Sized,
+    TValue: ContextualDisplay<TContext> + ?Sized,
 {
     value: &'a TValue,
     context: TContext,
@@ -80,7 +80,7 @@ where
 
 impl<'a, 'b, TValue, TContext> fmt::Display for ContextDisplayable<'a, TValue, TContext>
 where
-    TValue: ContextualDisplay<TContext> + Sized,
+    TValue: ContextualDisplay<TContext> + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.value

--- a/utils/src/contextual_serialize.rs
+++ b/utils/src/contextual_serialize.rs
@@ -1,0 +1,70 @@
+use serde::{Serialize, Serializer};
+
+/// This trait is used where context is required to correctly serialize a value.
+///
+/// Typically, this is due to needing to know the current network to display addresses.
+/// Other forms of Context are also possible.
+///
+/// The `Context` used should typically just be a wrapper type around references, and so
+/// be a small, cheap, ephemeral value on the stack (if it's not just optimized away entirely).
+/// It is therefore recommended that the `Context` implement `Copy`,
+/// to make it very easy to pass around and re-use.
+///
+pub trait ContextualSerialize<Context> {
+    /// Serializes the value to the given `serde::Serializer`, making use of the provided context.
+    /// See also [`serialize`], which is typically easier to use, as it takes an `Into<Context>`
+    /// instead of a `&Context`.
+    ///
+    /// Any custom errors during serialization will need mapping into a custom serde error,
+    /// which basically wraps a String, via: `serde::ser::Error::custom(error: Displayable)`.
+    ///
+    /// [`serialize`]: #method.serialize
+    fn contextual_serialize<S: Serializer>(
+        &self,
+        serializer: S,
+        context: &Context,
+    ) -> Result<S::Ok, S::Error>;
+
+    /// Serializes the value to the given `serde::Serializer`, making use of the provided context.
+    /// See also [`contextual_serialize`], which takes a `&Context` instead of an `Into<Context>`.
+    ///
+    /// Alternatively, the [`serializable`] method can be used to create an object that
+    /// directly implements `serde::Serialize`, for passing to `serde` functions.
+    ///
+    /// [`contextual_serialize`]: #method.contextual_serialize
+    /// [`serializable`]: #method.serializable
+    fn serialize<S: Serializer, TContext: Into<Context>>(
+        &self,
+        serializer: S,
+        context: TContext,
+    ) -> Result<S::Ok, S::Error> {
+        self.contextual_serialize(serializer, &context.into())
+    }
+
+    /// Returns an object implementing `serde::Serialize`, which can be passed to `serde` functions.
+    fn serializable<'a, 'b, TContext: Into<Context>>(
+        &'a self,
+        context: TContext,
+    ) -> ContextSerializable<'a, Self, Context> {
+        ContextSerializable {
+            value: self,
+            context: context.into(),
+        }
+    }
+}
+
+pub struct ContextSerializable<'a, TValue, TContext>
+where
+    TValue: ContextualSerialize<TContext> + ?Sized,
+{
+    value: &'a TValue,
+    context: TContext,
+}
+
+impl<'a, TValue: ContextualSerialize<TContext> + ?Sized, TContext> Serialize
+    for ContextSerializable<'a, TValue, TContext>
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.contextual_serialize(serializer, &self.context)
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -6,7 +6,11 @@ compile_error!("Either feature `std` or `alloc` must be enabled for this crate."
 compile_error!("Feature `std` and `alloc` can't be enabled at the same time.");
 
 mod contextual_display;
+#[cfg(feature = "serde")]
+mod contextual_serialize;
 mod slice;
 
 pub use contextual_display::*;
+#[cfg(feature = "serde")]
+pub use contextual_serialize::*;
 pub use slice::*;


### PR DESCRIPTION
Both simple and invertible modes are supported - I'll opt for "simple" for now in the Core API sbor responses and see how it goes down.

Eventually, I'd like to support a choice in the Core and Gateway APIs between what kind of SBOR response you want (raw_hex / simple / invertible / simple_from_schema).

I decided to implement this in scrypto instead of import the toolkit's values for a couple of reasons:
* I don't want to require updating the toolkit in order to pull an updated scrypto into the node - adding an extra layer into the update cycle would cause real pain
* I don't want to have to remap the scrypto value to encode it / I wanted an implementation consistent with the other code in the repo (ie ContextDisplayable)

**Breaking changes**: None