### PR TITLE
Fix `NonFungibleId` decompilation

### DIFF
--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -148,9 +148,9 @@ pub fn decompile_instruction<F: fmt::Write>(
             context.bucket_names.insert(bucket_id, name.clone());
             write!(
                 f,
-                "TAKE_FROM_WORKTOP_BY_IDS Set<NonFungibleId>({}) ResourceAddress(\"{}\") Bucket(\"{}\");",
+                "TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleId>({}) ResourceAddress(\"{}\") Bucket(\"{}\");",
                 ids.iter()
-                    .map(|k| format!("NonFungibleId({})", k))
+                    .map(|k| format!("NonFungibleId(\"{}\")", hex::encode(&k.to_vec())))
                     .collect::<Vec<String>>()
                     .join(", "),
                 resource_address.display(context.bech32_encoder),
@@ -192,9 +192,9 @@ pub fn decompile_instruction<F: fmt::Write>(
         } => {
             write!(
                 f,
-                "ASSERT_WORKTOP_CONTAINS_BY_IDS Set<NonFungibleId>({}) ResourceAddress(\"{}\");",
+                "ASSERT_WORKTOP_CONTAINS_BY_IDS Array<NonFungibleId>({}) ResourceAddress(\"{}\");",
                 ids.iter()
-                    .map(|k| format!("NonFungibleId({})", k))
+                    .map(|k| format!("NonFungibleId(\"{}\")", hex::encode(&k.to_vec())))
                     .collect::<Vec<String>>()
                     .join(", "),
                 resource_address.display(context.bech32_encoder)
@@ -267,8 +267,8 @@ pub fn decompile_instruction<F: fmt::Write>(
             context.proof_names.insert(proof_id, name.clone());
             write!(
                 f,
-                "CREATE_PROOF_FROM_AUTH_ZONE_BY_IDS Set<NonFungibleId>({}) ResourceAddress(\"{}\") Proof(\"{}\");",ids.iter()
-                .map(|k| format!("NonFungibleId({})", k))
+                "CREATE_PROOF_FROM_AUTH_ZONE_BY_IDS Array<NonFungibleId>({}) ResourceAddress(\"{}\") Proof(\"{}\");",ids.iter()
+                .map(|k| format!("NonFungibleId(\"{}\")", hex::encode(&k.to_vec())))
                 .collect::<Vec<String>>()
                 .join(", "),
                 resource_address.display(context.bech32_encoder),
@@ -703,5 +703,33 @@ CREATE_PROOF_FROM_AUTH_ZONE ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqq
 CALL_METHOD ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum") "with_all_types" PackageAddress("package_sim1qyqzcexvnyg60z7lnlwauh66nhzg3m8tch2j8wc0e70qkydk8r") ComponentAddress("account_sim1q0u9gxewjxj8nhxuaschth2mgencma2hpkgwz30s9wlslthace") ResourceAddress("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v") SystemAddress("system_sim1qne8qu4seyvzfgd94p3z8rjcdl3v0nfhv84judpum2lq7x4635") Component("000000000000000000000000000000000000000000000000000000000000000005000000") KeyValueStore("000000000000000000000000000000000000000000000000000000000000000005000000") Bucket("bucket1") Proof("proof1") Vault("000000000000000000000000000000000000000000000000000000000000000005000000") Expression("ALL_WORKTOP_RESOURCES") Blob("36dae540b7889956f1f1d8d46ba23e5e44bf5723aef2a8e6b698686c02583618") NonFungibleAddress("00ed9100551d7fae91eaf413e50a3c5a59f8b96af9f1297890a8f45c200721031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f") Hash("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824") EcdsaSecp256k1PublicKey("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798") EcdsaSecp256k1Signature("0079224ea514206706298d8d620f660828f7987068d6d02757e6f3cbbf4a51ab133395db69db1bc9b2726dd99e34efc252d8258dcb003ebaba42be349f50f7765e") EddsaEd25519PublicKey("4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29") EddsaEd25519Signature("ce993adc51111309a041faa65cbcf1154d21ed0ecdc2d54070bc90b9deb744aa8605b3f686fa178fba21070b4a4678e54eee3486a881e0e328251cd37966de09") Decimal("1.2") PreciseDecimal("1.2") NonFungibleId(Bytes("031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"));
 "#
         )
+    }
+
+    #[test]
+    fn decompiled_non_fungible_ids_are_equal_to_their_pre_compilation_representation() {
+        // Arrange
+        let non_fungible_ids = vec![
+            NonFungibleId::U32(12),
+            NonFungibleId::U64(19),
+            NonFungibleId::String("HelloWorld!".to_string()),
+            NonFungibleId::Decimal("1234".parse().unwrap()),
+            NonFungibleId::Bytes(vec![0x12, 0x19, 0x22, 0xff, 0x3]),
+            NonFungibleId::UUID(1922931322)
+        ];
+
+        let manifest = non_fungible_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| format!("TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleId>(NonFungibleId(\"{}\")) ResourceAddress(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\") Bucket(\"bucket{}\");\n", hex::encode(&id.to_vec()), i + 1))
+            .collect::<Vec<String>>()
+            .join("");
+
+        let compiled = compile(&manifest, &NetworkDefinition::simulator(), Vec::new()).unwrap();
+
+        // Act
+        let decompiled = decompile(&compiled.instructions, &NetworkDefinition::simulator()).unwrap();
+
+        // Assert
+        assert_eq!(manifest, decompiled)
     }
 }

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -714,7 +714,7 @@ CALL_METHOD ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9
             NonFungibleId::String("HelloWorld!".to_string()),
             NonFungibleId::Decimal("1234".parse().unwrap()),
             NonFungibleId::Bytes(vec![0x12, 0x19, 0x22, 0xff, 0x3]),
-            NonFungibleId::UUID(1922931322)
+            NonFungibleId::UUID(1922931322),
         ];
 
         let manifest = non_fungible_ids
@@ -727,7 +727,8 @@ CALL_METHOD ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9
         let compiled = compile(&manifest, &NetworkDefinition::simulator(), Vec::new()).unwrap();
 
         // Act
-        let decompiled = decompile(&compiled.instructions, &NetworkDefinition::simulator()).unwrap();
+        let decompiled =
+            decompile(&compiled.instructions, &NetworkDefinition::simulator()).unwrap();
 
         // Assert
         assert_eq!(manifest, decompiled)

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -623,7 +623,7 @@ CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pn
 POP_FROM_AUTH_ZONE Proof("proof3");
 DROP_PROOF Proof("proof3");
 RETURN_TO_WORKTOP Bucket("bucket2");
-TAKE_FROM_WORKTOP_BY_IDS Set<NonFungibleId>(NonFungibleId(Bytes("031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"))) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("bucket3");
+TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleId>(NonFungibleId("5c200721031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f")) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("bucket3");
 CREATE_RESOURCE Enum("Fungible", 0u8) Array<Tuple>() Array<Tuple>() Enum("Some", Enum("Fungible", Decimal("1")));
 CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");
 DROP_ALL_PROOFS;


### PR DESCRIPTION
This PR fixes two issues with the decompilation of `NonFungibleId`s to their manifest representation:

1. Decompilation of `NonFungibleId`s used `Set` instead of `Array`.
2. `NonFungibleId`s decompilation was done by converting them to a string. This creates syntactically incorrect manifests.  