### PR TITLE
Fixes for Core API

### DIFF
--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -1025,6 +1025,7 @@ name = "sbor"
 version = "0.7.0"
 dependencies = [
  "hex",
+ "indexmap",
  "sbor-derive",
  "serde",
 ]
@@ -1465,6 +1466,7 @@ name = "utils"
 version = "0.7.0"
 dependencies = [
  "sbor",
+ "serde",
 ]
 
 [[package]]

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -1014,6 +1014,7 @@ name = "sbor"
 version = "0.7.0"
 dependencies = [
  "hex",
+ "indexmap",
  "sbor-derive",
  "serde",
 ]
@@ -1454,6 +1455,7 @@ name = "utils"
 version = "0.7.0"
 dependencies = [
  "sbor",
+ "serde",
 ]
 
 [[package]]

--- a/radix-engine-interface/src/data/value_serializer.rs
+++ b/radix-engine-interface/src/data/value_serializer.rs
@@ -298,22 +298,10 @@ impl<'a, 'b> ContextualSerialize<ScryptoValueFormattingContext<'a>> for EnumVari
         serializer: S,
         context: &ScryptoValueFormattingContext<'a>,
     ) -> Result<S::Ok, S::Error> {
-        let mut discriminator_value_pair = serializer.serialize_tuple(2)?;
-        discriminator_value_pair.serialize_element(self.discriminator)?;
-
-        match self.fields.len() {
-            0 => {
-                discriminator_value_pair.serialize_element(&())?;
-            }
-            1 => {
-                discriminator_value_pair
-                    .serialize_element(&self.fields.get(0).unwrap().serializable(*context))?;
-            }
-            _ => {
-                discriminator_value_pair.serialize_element(&self.fields.serializable(*context))?;
-            }
-        }
-        discriminator_value_pair.end()
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("variant", &self.discriminator)?;
+        map.serialize_entry("fields", &self.fields.serializable(*context))?;
+        map.end()
     }
 }
 
@@ -917,9 +905,9 @@ mod tests {
             "-5",
             { "hex": "3a92" },
             [153, 62],
-            ["VariantUnit", null],
-            ["VariantSingleValue", 153],
-            ["VariantMultiValues", [153, true]],
+            { "variant": "VariantUnit", "fields": [] },
+            { "variant": "VariantSingleValue", "fields": [153] },
+            { "variant": "VariantMultiValues", "fields": [153, true] },
             [
                 account_package_address,
                 faucet_address,
@@ -975,9 +963,9 @@ mod tests {
                         { "type": "U32", "value": 62 },
                     ]
                 },
-                { "type": "Enum", "value": ["VariantUnit", null] },
-                { "type": "Enum", "value": ["VariantSingleValue", { "type": "U32", "value": 153 }] },
-                { "type": "Enum", "value": ["VariantMultiValues", [{ "type": "U32", "value": 153 }, { "type": "Bool", "value": true }]] },
+                { "type": "Enum", "value": { "variant": "VariantUnit", "fields": [] } },
+                { "type": "Enum", "value": { "variant": "VariantSingleValue", "fields": [{ "type": "U32", "value": 153 }] } },
+                { "type": "Enum", "value": { "variant": "VariantMultiValues", "fields": [{ "type": "U32", "value": 153 }, { "type": "Bool", "value": true }] } },
                 {
                     "type": "Tuple",
                     "value": [

--- a/radix-engine-interface/src/model/resource/access_rules.rs
+++ b/radix-engine-interface/src/model/resource/access_rules.rs
@@ -166,4 +166,28 @@ impl AccessRules {
         let l = self.method_auth.iter();
         l
     }
+
+    pub fn get_all_method_auth(&self) -> &HashMap<AccessRuleKey, AccessRuleEntry> {
+        &self.method_auth
+    }
+
+    pub fn get_all_grouped_auth(&self) -> &HashMap<String, AccessRule> {
+        &self.grouped_auth
+    }
+
+    pub fn get_default_auth(&self) -> &AccessRule {
+        &self.default_auth
+    }
+
+    pub fn get_all_method_auth_mutability(&self) -> &HashMap<AccessRuleKey, AccessRule> {
+        &self.method_auth_mutability
+    }
+
+    pub fn get_all_grouped_auth_mutability(&self) -> &HashMap<String, AccessRule> {
+        &self.grouped_auth_mutability
+    }
+
+    pub fn get_default_auth_mutability(&self) -> &AccessRule {
+        &self.default_auth_mutability
+    }
 }

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../sbor", default-features = false }
+sbor = { path = "../sbor", default-features = false, features = ["indexmap"] }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
 native-sdk = { path = "../native-sdk", default-features = false }
@@ -13,7 +13,7 @@ utils = { path = "../utils", default-features = false }
 colored = { version = "2.0.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 bitflags = { version = "1.3" }
-indexmap = { version = "1.8.1" }
+indexmap = { version = "1.9.2" }
 lru = { version = "0.8.1", default-features = false }
 moka = { version = "0.9.4", features = ["sync"], default-features = false, optional = true }
 

--- a/radix-engine/src/engine/modules/execution_trace.rs
+++ b/radix-engine/src/engine/modules/execution_trace.rs
@@ -2,6 +2,7 @@ use crate::engine::*;
 use crate::fee::FeeReserve;
 use crate::model::*;
 use crate::types::*;
+use indexmap::IndexMap;
 use radix_engine_interface::api::types::{
     BucketOffset, ComponentId, NativeMethod, RENodeId, SubstateId, SubstateOffset, VaultId,
     VaultMethod, VaultOffset,
@@ -583,7 +584,7 @@ impl ExecutionTraceReceipt {
 
     pub fn new(
         ops: Vec<(REActor, VaultId, VaultOp)>,
-        actual_fee_payments: HashMap<VaultId, Decimal>,
+        actual_fee_payments: &IndexMap<VaultId, Decimal>,
         to_persist: &mut HashMap<SubstateId, (PersistedSubstate, Option<u32>)>,
         is_commit_success: bool,
     ) -> Self {

--- a/radix-engine/src/fee/fee_summary.rs
+++ b/radix-engine/src/fee/fee_summary.rs
@@ -1,6 +1,7 @@
 use super::RoyaltyReceiver;
 use crate::model::Resource;
 use crate::types::*;
+use indexmap::IndexMap;
 use radix_engine_interface::api::types::VaultId;
 
 #[derive(Debug, Clone)]
@@ -15,21 +16,23 @@ pub struct FeeSummary {
     /// The total number of cost units consumed.
     pub cost_unit_consumed: u32,
     /// The total amount of XRD burned.
-    pub execution: Decimal,
+    pub total_execution_cost_xrd: Decimal,
     /// The total royalty.
-    pub royalty: Decimal,
-    /// The amount of bad debt due to transaction unable to repay loan.
-    pub bad_debt: Decimal,
-    /// The fee payments
-    pub payments: Vec<(VaultId, Resource, bool)>,
+    pub total_royalty_cost_xrd: Decimal,
+    /// The (non-negative) amount of bad debt due to transaction unable to repay loan.
+    pub bad_debt_xrd: Decimal,
+    /// The vaults locked for XRD payment
+    pub vault_locks: Vec<(VaultId, Resource, bool)>,
+    /// The resultant vault charges in XRD (only present on commit)
+    pub vault_payments_xrd: Option<IndexMap<VaultId, Decimal>>,
     /// The execution cost breakdown
-    pub execution_breakdown: HashMap<String, u32>,
+    pub execution_cost_unit_breakdown: HashMap<String, u32>,
     /// The royalty cost breakdown.
-    pub royalty_breakdown: HashMap<RoyaltyReceiver, u32>,
+    pub royalty_cost_unit_breakdown: HashMap<RoyaltyReceiver, u32>,
 }
 
 impl FeeSummary {
     pub fn loan_fully_repaid(&self) -> bool {
-        self.bad_debt <= 0.into()
+        self.bad_debt_xrd == 0.into()
     }
 }

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -190,7 +190,7 @@ where
             let break_down = receipt
                 .execution
                 .fee_summary
-                .execution_breakdown
+                .execution_cost_unit_breakdown
                 .iter()
                 .collect::<BTreeMap<&String, &u32>>();
             for (k, v) in break_down {

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -290,9 +290,9 @@ impl<'a> ContextualDisplay<AddressDisplayContext<'a>> for TransactionReceipt {
             f,
             "\n{} {} XRD used for execution, {} XRD used for royalty, {} XRD in bad debt",
             "Transaction Fee:".bold().green(),
-            execution.fee_summary.execution,
-            execution.fee_summary.royalty,
-            execution.fee_summary.bad_debt,
+            execution.fee_summary.total_execution_cost_xrd,
+            execution.fee_summary.total_royalty_cost_xrd,
+            execution.fee_summary.bad_debt_xrd,
         )?;
 
         write!(

--- a/radix-engine/tests/execution_trace.rs
+++ b/radix-engine/tests/execution_trace.rs
@@ -57,9 +57,8 @@ fn test_trace_resource_transfers() {
 
     let fee_summary = &receipt.execution.fee_summary;
 
-    let fee_resource_address = fee_summary.payments.first().unwrap().1.resource_address();
-
-    let total_fee_paid = fee_summary.execution + fee_summary.royalty - fee_summary.bad_debt;
+    let total_fee_paid = fee_summary.total_execution_cost_xrd + fee_summary.total_royalty_cost_xrd
+        - fee_summary.bad_debt_xrd;
 
     // Source vault withdrawal
     assert!(receipt
@@ -84,7 +83,7 @@ fn test_trace_resource_transfers() {
         .expect_commit()
         .resource_changes
         .iter()
-        .any(|r| r.resource_address == fee_resource_address
+        .any(|r| r.resource_address == RADIX_TOKEN
             && r.component_id == account_component_id
             && r.amount == -Decimal::from(total_fee_paid)));
 }
@@ -139,7 +138,8 @@ fn test_trace_fee_payments() {
     let _ = receipt.expect_commit_success();
     let resource_changes = &receipt.expect_commit().resource_changes;
     let fee_summary = &receipt.execution.fee_summary;
-    let total_fee_paid = fee_summary.execution + fee_summary.royalty - fee_summary.bad_debt;
+    let total_fee_paid = fee_summary.total_execution_cost_xrd + fee_summary.total_royalty_cost_xrd
+        - fee_summary.bad_debt_xrd;
 
     assert_eq!(1, resource_changes.len());
     assert!(resource_changes

--- a/radix-engine/tests/royalty.rs
+++ b/radix-engine/tests/royalty.rs
@@ -45,7 +45,7 @@ fn test_component_royalty() {
 
     receipt.expect_commit_success();
     assert_eq!(
-        receipt.execution.fee_summary.royalty,
+        receipt.execution.fee_summary.total_royalty_cost_xrd,
         dec!("1") * u128_to_decimal(DEFAULT_COST_UNIT_PRICE)
     );
 }
@@ -133,7 +133,7 @@ fn test_package_royalty() {
 
     receipt.expect_commit_success();
     assert_eq!(
-        receipt.execution.fee_summary.royalty,
+        receipt.execution.fee_summary.total_royalty_cost_xrd,
         (dec!("1") + dec!("2")) * u128_to_decimal(DEFAULT_COST_UNIT_PRICE)
     );
 }

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -8,6 +8,7 @@ sbor-derive = { path = "../sbor-derive" }
 hashbrown = { version = "0.12.1", optional = true }
 serde = { version = "1.0.137", default-features = false, optional = true, features=["derive"] }
 hex = { version = "0.4.3", default-features = false, optional = true }
+indexmap = { version = "1.9.2", default-features = false, optional = true }
 
 [features]
 # You should enable either `std` or `alloc`

--- a/sbor/src/codec/collection.rs
+++ b/sbor/src/codec/collection.rs
@@ -93,6 +93,26 @@ impl<X: CustomTypeId, E: Encoder<X>, K: Encode<X, E> + Ord + Hash, V: Encode<X, 
     }
 }
 
+#[cfg(feature = "indexmap")]
+impl<X: CustomTypeId, E: Encoder<X>, K: Encode<X, E> + Ord + Hash, V: Encode<X, E>> Encode<X, E>
+    for indexmap::IndexMap<K, V>
+{
+    #[inline]
+    fn encode_type_id(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        encoder.write_type_id(Self::type_id())
+    }
+
+    #[inline]
+    fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        encoder.write_type_id(<(K, V)>::type_id())?;
+        encoder.write_size(self.len())?;
+        for (key, value) in self {
+            encoder.encode_deeper_body(&(key, value))?;
+        }
+        Ok(())
+    }
+}
+
 impl<X: CustomTypeId, D: Decoder<X>, T: Decode<X, D> + TypeId<X>> Decode<X, D> for Vec<T> {
     #[inline]
     fn decode_body_with_type_id(
@@ -165,6 +185,21 @@ impl<X: CustomTypeId, D: Decoder<X>, K: Decode<X, D> + Ord, V: Decode<X, D>> Dec
 
 impl<X: CustomTypeId, D: Decoder<X>, K: Decode<X, D> + Hash + Eq, V: Decode<X, D>> Decode<X, D>
     for HashMap<K, V>
+{
+    #[inline]
+    fn decode_body_with_type_id(
+        decoder: &mut D,
+        type_id: SborTypeId<X>,
+    ) -> Result<Self, DecodeError> {
+        decoder.check_preloaded_type_id(type_id, Self::type_id())?;
+        let elements: Vec<(K, V)> = Vec::<(K, V)>::decode_body_with_type_id(decoder, type_id)?;
+        Ok(elements.into_iter().collect())
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<X: CustomTypeId, D: Decoder<X>, K: Decode<X, D> + Hash + Eq, V: Decode<X, D>> Decode<X, D>
+    for indexmap::IndexMap<K, V>
 {
     #[inline]
     fn decode_body_with_type_id(

--- a/sbor/src/type_id.rs
+++ b/sbor/src/type_id.rs
@@ -301,6 +301,14 @@ impl<X: CustomTypeId, K, V> TypeId<X> for HashMap<K, V> {
     }
 }
 
+#[cfg(feature = "indexmap")]
+impl<X: CustomTypeId, K, V> TypeId<X> for indexmap::IndexMap<K, V> {
+    #[inline]
+    fn type_id() -> SborTypeId<X> {
+        SborTypeId::Array
+    }
+}
+
 pub trait CustomTypeId: Copy + Debug + Clone + PartialEq + Eq {
     fn as_u8(&self) -> u8;
 

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -1244,6 +1244,7 @@ name = "sbor"
 version = "0.7.0"
 dependencies = [
  "hex",
+ "indexmap",
  "sbor-derive",
  "serde",
 ]


### PR DESCRIPTION
Various fixes / minor changes that I've made as part of integrating the Core API:
* Adds `indexmap` support in SBOR
* Renames fields in Fee Summary to be clearer on units
* Adds `vault_payments_xrd` which tracks the resultant fee payment changes (it's only present on commit, not on rejection)
* Adds getters to read values from AccessRules
* Minor change to how SBOR enums are serialized to JSON

**Breaking changes:**
* Renames of fields in FeeSummary