### PR TITLE
Feature/non fungible id validation

### DIFF
--- a/radix-engine-interface/src/model/resource/non_fungible_address.rs
+++ b/radix-engine-interface/src/model/resource/non_fungible_address.rs
@@ -81,8 +81,8 @@ impl NonFungibleAddress {
     }
 
     /// Returns the non-fungible id.
-    pub fn non_fungible_id(&self) -> NonFungibleId {
-        self.non_fungible_id.clone()
+    pub fn non_fungible_id(&self) -> &NonFungibleId {
+        &self.non_fungible_id
     }
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/radix-engine-interface/src/model/resource/non_fungible_id.rs
+++ b/radix-engine-interface/src/model/resource/non_fungible_id.rs
@@ -293,7 +293,8 @@ mod tests {
     #[test]
     fn test_non_fungible_string_validation() {
         let valid_id_string = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWZYZ_0123456789";
-        let validation_result = NonFungibleId::String(valid_id_string.to_owned()).validate_contents();
+        let validation_result =
+            NonFungibleId::String(valid_id_string.to_owned()).validate_contents();
         assert!(matches!(validation_result, Ok(_)));
 
         test_invalid_char('.');
@@ -347,7 +348,7 @@ mod tests {
         assert_eq!(n.id_type(), val.id_type());
         assert!(matches!(val, NonFungibleId::UUID(v) if v == u128::MAX));
 
-        const TEST_STR: &str = "test string 0123";
+        const TEST_STR: &str = "test_string_0123";
         let n = NonFungibleId::String(TEST_STR.to_string());
         let buf = n.to_vec();
         let val = NonFungibleId::try_from(buf.as_slice()).unwrap();

--- a/radix-engine-interface/src/model/resource/non_fungible_id.rs
+++ b/radix-engine-interface/src/model/resource/non_fungible_id.rs
@@ -86,7 +86,7 @@ fn validate_non_fungible_id_string(string: &str) -> Result<(), ParseNonFungibleI
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseNonFungibleIdError {
     InvalidHex(String),
-    InvalidSborPrefix,
+    InvalidSbor,
     UnexpectedTypeId,
     TooLong,
     InvalidCharacter(char),
@@ -121,31 +121,31 @@ impl TryFrom<&[u8]> for NonFungibleId {
             Ok(type_id) => match type_id {
                 ScryptoSborTypeId::Array => NonFungibleId::Bytes(
                     scrypto_decode::<Vec<u8>>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 ScryptoSborTypeId::String => NonFungibleId::String(
                     scrypto_decode::<String>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 ScryptoSborTypeId::U32 => NonFungibleId::U32(
                     scrypto_decode::<u32>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 ScryptoSborTypeId::U64 => NonFungibleId::U64(
                     scrypto_decode::<u64>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 ScryptoSborTypeId::U128 => NonFungibleId::UUID(
                     scrypto_decode::<u128>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 ScryptoSborTypeId::Custom(ScryptoCustomTypeId::Decimal) => NonFungibleId::Decimal(
                     scrypto_decode::<Decimal>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSbor)?,
                 ),
                 _ => return Err(ParseNonFungibleIdError::UnexpectedTypeId),
             },
-            Err(_) => return Err(ParseNonFungibleIdError::InvalidSborPrefix),
+            Err(_) => return Err(ParseNonFungibleIdError::InvalidSbor),
         };
 
         non_fungible_id.validate_contents()?;

--- a/radix-engine-interface/src/model/resource/non_fungible_id.rs
+++ b/radix-engine-interface/src/model/resource/non_fungible_id.rs
@@ -35,6 +35,8 @@ pub enum NonFungibleIdType {
     UUID,
 }
 
+pub const NON_FUNGIBLE_ID_MAX_LENGTH: usize = 64;
+
 impl NonFungibleId {
     /// Returns non-fungible ID type.
     pub fn id_type(&self) -> NonFungibleIdType {
@@ -47,6 +49,33 @@ impl NonFungibleId {
             NonFungibleId::UUID(..) => NonFungibleIdType::UUID,
         }
     }
+
+    pub fn validate_contents(&self) -> Result<(), ParseNonFungibleIdError> {
+        match self {
+            NonFungibleId::String(value) => {
+                if value.len() > NON_FUNGIBLE_ID_MAX_LENGTH {
+                    return Err(ParseNonFungibleIdError::TooLong);
+                }
+                validate_non_fungible_id_string(value)?;
+            }
+            NonFungibleId::Bytes(value) => {
+                if value.len() > NON_FUNGIBLE_ID_MAX_LENGTH {
+                    return Err(ParseNonFungibleIdError::TooLong);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+fn validate_non_fungible_id_string(string: &str) -> Result<(), ParseNonFungibleIdError> {
+    for char in string.chars() {
+        if !matches!(char, '0'..='9' | 'A'..='Z' | 'a'..='z' | '_') {
+            return Err(ParseNonFungibleIdError::InvalidCharacter(char));
+        }
+    }
+    Ok(())
 }
 
 //========
@@ -57,8 +86,10 @@ impl NonFungibleId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseNonFungibleIdError {
     InvalidHex(String),
-    InvalidValue,
+    InvalidSborPrefix,
     UnexpectedTypeId,
+    TooLong,
+    InvalidCharacter(char),
 }
 
 #[cfg(not(feature = "alloc"))]
@@ -86,38 +117,40 @@ impl TryFrom<&[u8]> for NonFungibleId {
     type Error = ParseNonFungibleIdError;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        match validate_id(slice) {
+        let non_fungible_id = match validate_id(slice) {
             Ok(type_id) => match type_id {
-                ScryptoSborTypeId::Array => Ok(NonFungibleId::Bytes(
+                ScryptoSborTypeId::Array => NonFungibleId::Bytes(
                     scrypto_decode::<Vec<u8>>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                )),
-                ScryptoSborTypeId::String => Ok(NonFungibleId::String(
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                ScryptoSborTypeId::String => NonFungibleId::String(
                     scrypto_decode::<String>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                )),
-                ScryptoSborTypeId::U32 => Ok(NonFungibleId::U32(
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                ScryptoSborTypeId::U32 => NonFungibleId::U32(
                     scrypto_decode::<u32>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                )),
-                ScryptoSborTypeId::U64 => Ok(NonFungibleId::U64(
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                ScryptoSborTypeId::U64 => NonFungibleId::U64(
                     scrypto_decode::<u64>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                )),
-                ScryptoSborTypeId::U128 => Ok(NonFungibleId::UUID(
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                ScryptoSborTypeId::U128 => NonFungibleId::UUID(
                     scrypto_decode::<u128>(slice)
-                        .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                )),
-                ScryptoSborTypeId::Custom(ScryptoCustomTypeId::Decimal) => {
-                    Ok(NonFungibleId::Decimal(
-                        scrypto_decode::<Decimal>(slice)
-                            .map_err(|_| ParseNonFungibleIdError::InvalidValue)?,
-                    ))
-                }
-                _ => Err(ParseNonFungibleIdError::UnexpectedTypeId),
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                ScryptoSborTypeId::Custom(ScryptoCustomTypeId::Decimal) => NonFungibleId::Decimal(
+                    scrypto_decode::<Decimal>(slice)
+                        .map_err(|_| ParseNonFungibleIdError::InvalidSborPrefix)?,
+                ),
+                _ => return Err(ParseNonFungibleIdError::UnexpectedTypeId),
             },
-            Err(_) => Err(ParseNonFungibleIdError::InvalidValue),
-        }
+            Err(_) => return Err(ParseNonFungibleIdError::InvalidSborPrefix),
+        };
+
+        non_fungible_id.validate_contents()?;
+
+        Ok(non_fungible_id)
     }
 }
 
@@ -224,12 +257,78 @@ mod tests {
     }
 
     #[test]
+    fn test_non_fungible_length_validation() {
+        // Bytes length
+        let validation_result =
+            NonFungibleId::Bytes([0; NON_FUNGIBLE_ID_MAX_LENGTH].to_vec()).validate_contents();
+        assert!(matches!(validation_result, Ok(_)));
+        let validation_result =
+            NonFungibleId::Bytes([0; 1 + NON_FUNGIBLE_ID_MAX_LENGTH].to_vec()).validate_contents();
+        assert!(matches!(
+            validation_result,
+            Err(ParseNonFungibleIdError::TooLong)
+        ));
+
+        // String length
+        let validation_result =
+            NonFungibleId::String(string_of_length(NON_FUNGIBLE_ID_MAX_LENGTH)).validate_contents();
+        assert!(matches!(validation_result, Ok(_)));
+        let validation_result =
+            NonFungibleId::String(string_of_length(1 + NON_FUNGIBLE_ID_MAX_LENGTH))
+                .validate_contents();
+        assert!(matches!(
+            validation_result,
+            Err(ParseNonFungibleIdError::TooLong)
+        ));
+    }
+
+    fn string_of_length(size: usize) -> String {
+        let mut str_buf = String::new();
+        for _ in 0..size {
+            str_buf.push('a');
+        }
+        str_buf
+    }
+
+    #[test]
+    fn test_non_fungible_string_validation() {
+        let valid_id_string = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWZYZ_0123456789";
+        let validation_result = NonFungibleId::String(valid_id_string.to_owned()).validate_contents();
+        assert!(matches!(validation_result, Ok(_)));
+
+        test_invalid_char('.');
+        test_invalid_char('`');
+        test_invalid_char('\\');
+        test_invalid_char('"');
+        test_invalid_char(' ');
+        test_invalid_char('\r');
+        test_invalid_char('\n');
+        test_invalid_char('\t');
+        test_invalid_char('\u{0000}'); // Null
+        test_invalid_char('\u{0301}'); // Combining acute accent
+        test_invalid_char('\u{2764}'); // ❤
+        test_invalid_char('\u{000C}'); // Form feed
+        test_invalid_char('\u{202D}'); // LTR override
+        test_invalid_char('\u{202E}'); // RTL override
+        test_invalid_char('\u{1F600}'); // :-) emoji
+    }
+
+    fn test_invalid_char(char: char) {
+        let validation_result =
+            NonFungibleId::String(format!("valid_{}", char)).validate_contents();
+        assert_eq!(
+            validation_result,
+            Err(ParseNonFungibleIdError::InvalidCharacter(char))
+        );
+    }
+
+    #[test]
     fn test_non_fungible_id_type_default() {
         assert_eq!(NonFungibleIdType::default(), NonFungibleIdType::UUID);
     }
 
     #[test]
-    fn test_non_fungible_id_enocde_decode() {
+    fn test_non_fungible_id_encode_decode() {
         let n = NonFungibleId::U32(1);
         let buf = n.to_vec();
         let val = NonFungibleId::try_from(buf.as_slice()).unwrap();

--- a/radix-engine/src/model/auth/auth_zone/substates.rs
+++ b/radix-engine/src/model/auth/auth_zone/substates.rs
@@ -16,7 +16,7 @@ impl AuthVerification {
                 let proof_resource_address = proof.resource_address();
                 proof_resource_address == non_fungible_address.resource_address()
                     && match proof.total_ids() {
-                        Ok(ids) => ids.contains(&non_fungible_address.non_fungible_id()),
+                        Ok(ids) => ids.contains(non_fungible_address.non_fungible_id()),
                         Err(_) => false,
                     }
             }

--- a/scrypto/src/resource/non_fungible.rs
+++ b/scrypto/src/resource/non_fungible.rs
@@ -38,24 +38,24 @@ impl<T: NonFungibleData> NonFungible<T> {
         self.address.resource_address()
     }
 
-    /// Returns the non-fungible address.
-    pub fn address(&self) -> NonFungibleAddress {
-        self.address.clone()
+    /// Returns a reference to the non-fungible address.
+    pub fn address(&self) -> &NonFungibleAddress {
+        &self.address
     }
 
-    /// Returns the non-fungible ID.
-    pub fn id(&self) -> NonFungibleId {
+    /// Returns a reference to the the non-fungible ID.
+    pub fn id(&self) -> &NonFungibleId {
         self.address.non_fungible_id()
     }
 
     /// Returns the associated data of this unit.
     pub fn data(&self) -> T {
-        borrow_resource_manager!(self.resource_address()).get_non_fungible_data(&self.id())
+        borrow_resource_manager!(self.resource_address()).get_non_fungible_data(self.id())
     }
 
     /// Updates the associated data of this unit.
     pub fn update_data(&self, new_data: T) {
         borrow_resource_manager!(self.resource_address())
-            .update_non_fungible_data(&self.id(), new_data);
+            .update_non_fungible_data(self.id(), new_data);
     }
 }

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -65,7 +65,7 @@ pub trait ScryptoProof: Sized {
     ) -> Result<(), ProofValidationError>;
     fn validate_contains_non_fungible_id(
         &self,
-        non_fungible_id: NonFungibleId,
+        non_fungible_id: &NonFungibleId,
     ) -> Result<(), ProofValidationError>;
     fn validate_contains_non_fungible_ids(
         &self,
@@ -204,9 +204,9 @@ impl ScryptoProof for Proof {
 
     fn validate_contains_non_fungible_id(
         &self,
-        non_fungible_id: NonFungibleId,
+        non_fungible_id: &NonFungibleId,
     ) -> Result<(), ProofValidationError> {
-        if self.non_fungible_ids().get(&non_fungible_id).is_some() {
+        if self.non_fungible_ids().get(non_fungible_id).is_some() {
             Ok(())
         } else {
             Err(ProofValidationError::NonFungibleIdNotFound)

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -709,7 +709,7 @@ impl ManifestBuilder {
 
     pub fn burn_non_fungible(&mut self, non_fungible_address: NonFungibleAddress) -> &mut Self {
         let mut ids = BTreeSet::new();
-        ids.insert(non_fungible_address.non_fungible_id());
+        ids.insert(non_fungible_address.non_fungible_id().clone());
         self.take_from_worktop_by_ids(
             &ids,
             non_fungible_address.resource_address(),

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -711,7 +711,7 @@ CALL_METHOD ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9
         let non_fungible_ids = vec![
             NonFungibleId::U32(12),
             NonFungibleId::U64(19),
-            NonFungibleId::String("HelloWorld!".to_string()),
+            NonFungibleId::String("HelloWorld".to_string()),
             NonFungibleId::Decimal("1234".parse().unwrap()),
             NonFungibleId::Bytes(vec![0x12, 0x19, 0x22, 0xff, 0x3]),
             NonFungibleId::UUID(1922931322),

--- a/transaction/src/signing/ecdsa_secp256k1.rs
+++ b/transaction/src/signing/ecdsa_secp256k1.rs
@@ -83,7 +83,7 @@ mod tests {
         assert_eq!(s1, expected_address);
         assert_eq!(s2, expected_address);
 
-        let nfid = auth_address2.non_fungible_id();
+        let nfid = auth_address2.non_fungible_id().clone();
         assert_eq!(nfid.id_type(), NonFungibleIdType::Bytes);
         assert_eq!(nfid.to_string(), expected_id_with_type_designator);
         assert!(matches!(nfid, NonFungibleId::Bytes(b) if b == hex::decode(expected_id).unwrap()));


### PR DESCRIPTION
**Breaking changes:**
* NonFungibleId validation: String and Byte NonFungibleIds have a max length of 64, and String NFIDs (for now) can only be composed of the characters `a-z`, `A-Z`, `0-9` or `_`