### PR TITLE
feature: Executable specifies if it needs fees

### DIFF
--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -48,7 +48,7 @@ fn bench_transfer(c: &mut Criterion) {
     let account1 = execute_and_commit_transaction(
         &mut substate_store,
         &mut scrypto_interpreter,
-        &FeeReserveConfig::standard(),
+        &FeeReserveConfig::default(),
         &ExecutionConfig::default(),
         &TestTransaction::new(manifest.clone(), 1, DEFAULT_COST_UNIT_LIMIT)
             .get_executable(vec![NonFungibleAddress::from_public_key(&public_key)]),
@@ -60,7 +60,7 @@ fn bench_transfer(c: &mut Criterion) {
     let account2 = execute_and_commit_transaction(
         &mut substate_store,
         &mut scrypto_interpreter,
-        &FeeReserveConfig::standard(),
+        &FeeReserveConfig::default(),
         &ExecutionConfig::default(),
         &TestTransaction::new(manifest, 2, DEFAULT_COST_UNIT_LIMIT)
             .get_executable(vec![NonFungibleAddress::from_public_key(&public_key)]),
@@ -83,7 +83,7 @@ fn bench_transfer(c: &mut Criterion) {
         execute_and_commit_transaction(
             &mut substate_store,
             &mut scrypto_interpreter,
-            &FeeReserveConfig::standard(),
+            &FeeReserveConfig::default(),
             &ExecutionConfig::default(),
             &TestTransaction::new(manifest.clone(), nonce, DEFAULT_COST_UNIT_LIMIT)
                 .get_executable(vec![NonFungibleAddress::from_public_key(&public_key)]),
@@ -109,7 +109,7 @@ fn bench_transfer(c: &mut Criterion) {
             let receipt = execute_and_commit_transaction(
                 &mut substate_store,
                 &mut scrypto_interpreter,
-                &FeeReserveConfig::standard(),
+                &FeeReserveConfig::default(),
                 &ExecutionConfig::default(),
                 &TestTransaction::new(manifest.clone(), nonce, DEFAULT_COST_UNIT_LIMIT)
                     .get_executable(vec![NonFungibleAddress::from_public_key(&public_key)]),

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -1,8 +1,7 @@
 use crate::engine::ScryptoInterpreter;
-use crate::fee::SystemLoanFeeReserve;
 use crate::ledger::{ReadableSubstateStore, WriteableSubstateStore};
 use crate::transaction::{
-    execute_transaction_with_fee_reserve, ExecutionConfig, TransactionReceipt,
+    execute_transaction, ExecutionConfig, FeeReserveConfig, TransactionReceipt,
 };
 use crate::types::*;
 use crate::wasm::{DefaultWasmEngine, InstructionCostRules, WasmInstrumenter, WasmMeteringConfig};
@@ -291,13 +290,12 @@ where
         };
 
         let genesis_transaction = create_genesis();
-        let fee_reserve = SystemLoanFeeReserve::no_fee();
 
-        let transaction_receipt = execute_transaction_with_fee_reserve(
+        let transaction_receipt = execute_transaction(
             substate_store,
             &scrypto_interpreter,
-            fee_reserve,
-            &ExecutionConfig::standard(),
+            &FeeReserveConfig::default(),
+            &ExecutionConfig::default(),
             &genesis_transaction.get_executable(),
         );
 
@@ -330,13 +328,12 @@ mod tests {
         };
         let substate_store = TypedInMemorySubstateStore::new();
         let genesis_transaction = create_genesis();
-        let fee_reserve = SystemLoanFeeReserve::no_fee();
 
-        let transaction_receipt = execute_transaction_with_fee_reserve(
+        let transaction_receipt = execute_transaction(
             &substate_store,
             &scrypto_interpreter,
-            fee_reserve,
-            &ExecutionConfig::standard(),
+            &FeeReserveConfig::default(),
+            &ExecutionConfig::default(),
             &genesis_transaction.get_executable(),
         );
 

--- a/radix-engine/src/transaction/preview_executor.rs
+++ b/radix-engine/src/transaction/preview_executor.rs
@@ -6,7 +6,6 @@ use transaction::validation::NotarizedTransactionValidator;
 use transaction::validation::ValidationConfig;
 
 use crate::engine::ScryptoInterpreter;
-use crate::fee::SystemLoanFeeReserve;
 use crate::ledger::*;
 use crate::transaction::TransactionReceipt;
 use crate::transaction::*;
@@ -39,16 +38,10 @@ pub fn execute_preview<S: ReadableSubstateStore, W: WasmEngine, IHM: IntentHashM
             .validate_preview_intent(&preview_intent, intent_hash_manager)
             .map_err(PreviewError::TransactionValidationError)?;
 
-        let fee_reserve = if preview_intent.flags.unlimited_loan {
-            SystemLoanFeeReserve::no_fee()
-        } else {
-            SystemLoanFeeReserve::default()
-        };
-
-        execute_transaction_with_fee_reserve(
+        execute_transaction(
             substate_store,
             scrypto_interpreter,
-            fee_reserve,
+            &FeeReserveConfig::default(),
             &ExecutionConfig::default(),
             &executable,
         )

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -38,8 +38,8 @@ fn execute_single_transaction(transaction: NotarizedTransaction) {
             1024,
         ),
     };
-    let execution_config = ExecutionConfig::standard();
-    let fee_reserve_config = FeeReserveConfig::standard();
+    let execution_config = ExecutionConfig::default();
+    let fee_reserve_config = FeeReserveConfig::default();
 
     let mut staged_store_manager = StagedSubstateStoreManager::new(&mut store);
     let staged_node = staged_store_manager.new_child_node(0);

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -43,8 +43,8 @@ fn test_transaction_preview_cost_estimate() {
 
     let receipt = test_runner.execute_transaction_with_config(
         &make_executable(&network, &notarized_transaction),
-        &FeeReserveConfig::standard(),
-        &ExecutionConfig::standard(),
+        &FeeReserveConfig::default(),
+        &ExecutionConfig::default(),
     );
     receipt.expect_commit_success();
 

--- a/radix-engine/tests/transaction_executor.rs
+++ b/radix-engine/tests/transaction_executor.rs
@@ -128,7 +128,7 @@ fn test_normal_transaction_flow() {
     };
 
     let intent_hash_manager = TestIntentHashManager::new();
-    let fee_reserve_config = FeeReserveConfig::standard();
+    let fee_reserve_config = FeeReserveConfig::default();
     let execution_config = ExecutionConfig::debug();
     let raw_transaction = create_notarized_transaction(TransactionParams {
         cost_unit_limit: 1_000_000,

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -476,8 +476,8 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     pub fn execute_transaction(&mut self, transaction: &Executable) -> TransactionReceipt {
         self.execute_transaction_with_config(
             transaction,
-            &FeeReserveConfig::standard(),
-            &ExecutionConfig::standard(),
+            &FeeReserveConfig::default(),
+            &ExecutionConfig::default(),
         )
     }
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -202,10 +202,7 @@ pub fn handle_manifest<O: std::io::Write>(
             let receipt = execute_and_commit_transaction(
                 &mut substate_store,
                 &mut scrypto_interpreter,
-                &FeeReserveConfig {
-                    cost_unit_price: DEFAULT_COST_UNIT_PRICE,
-                    system_loan: DEFAULT_SYSTEM_LOAN,
-                },
+                &FeeReserveConfig::default(),
                 &ExecutionConfig {
                     max_call_depth: DEFAULT_MAX_CALL_DEPTH,
                     trace,

--- a/transaction/src/model/executable.rs
+++ b/transaction/src/model/executable.rs
@@ -24,9 +24,12 @@ pub struct ExecutionContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TypeId, Encode, Decode)]
-pub struct FeePayment {
-    pub cost_unit_limit: u32,
-    pub tip_percentage: u8,
+pub enum FeePayment {
+    User {
+        cost_unit_limit: u32,
+        tip_percentage: u8,
+    },
+    NoFee,
 }
 
 /// Represents a validated transaction
@@ -93,12 +96,8 @@ impl<'a> Executable<'a> {
         &self.context.transaction_hash
     }
 
-    pub fn cost_unit_limit(&self) -> u32 {
-        self.context.fee_payment.cost_unit_limit
-    }
-
-    pub fn tip_percentage(&self) -> u8 {
-        self.context.fee_payment.tip_percentage
+    pub fn fee_payment(&self) -> &FeePayment {
+        &self.context.fee_payment
     }
 
     pub fn instructions(&self) -> &[Instruction] {

--- a/transaction/src/model/system_transaction.rs
+++ b/transaction/src/model/system_transaction.rs
@@ -1,5 +1,4 @@
 use crate::model::{AuthModule, AuthZoneParams, Executable, TransactionManifest};
-use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::crypto::Hash;
 
 use radix_engine_interface::scrypto;
@@ -28,10 +27,7 @@ impl SystemTransaction {
             ExecutionContext {
                 transaction_hash,
                 auth_zone_params,
-                fee_payment: FeePayment {
-                    cost_unit_limit: DEFAULT_COST_UNIT_LIMIT,
-                    tip_percentage: 0,
-                },
+                fee_payment: FeePayment::NoFee,
                 runtime_validations: vec![],
             },
         )

--- a/transaction/src/model/test_transaction.rs
+++ b/transaction/src/model/test_transaction.rs
@@ -47,7 +47,7 @@ impl TestTransaction {
                     initial_proofs,
                     virtualizable_proofs_resource_addresses: BTreeSet::new(),
                 },
-                fee_payment: FeePayment {
+                fee_payment: FeePayment::User {
                     cost_unit_limit: intent.header.cost_unit_limit,
                     tip_percentage: intent.header.tip_percentage,
                 },

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -93,7 +93,7 @@ impl TransactionValidator<NotarizedTransaction> for NotarizedTransactionValidato
                     virtualizable_proofs_resource_addresses: BTreeSet::new(),
                 },
                 transaction_hash,
-                fee_payment: FeePayment {
+                fee_payment: FeePayment::User {
                     cost_unit_limit: header.cost_unit_limit,
                     tip_percentage: header.tip_percentage,
                 },
@@ -137,6 +137,15 @@ impl NotarizedTransactionValidator {
         let header = &intent.header;
         let manifest = &intent.manifest;
 
+        let fee_payment = if flags.unlimited_loan {
+            FeePayment::NoFee
+        } else {
+            FeePayment::User {
+                cost_unit_limit: header.cost_unit_limit,
+                tip_percentage: header.tip_percentage,
+            }
+        };
+
         Ok(Executable::new(
             &manifest.instructions,
             &manifest.blobs,
@@ -146,10 +155,7 @@ impl NotarizedTransactionValidator {
                     initial_proofs,
                     virtualizable_proofs_resource_addresses,
                 },
-                fee_payment: FeePayment {
-                    cost_unit_limit: header.cost_unit_limit,
-                    tip_percentage: header.tip_percentage,
-                },
+                fee_payment,
                 runtime_validations: vec![
                     RuntimeValidation::IntentHashUniqueness { intent_hash }
                         .with_skipped_assertion_if(flags.permit_duplicate_intent_hash),


### PR DESCRIPTION
This change comes from wanting a nice/easy way to remove the need to lock fee for validator transactions on betanet, which will speed the network up a little :)

**Breaking changes:**
* Removed `execute_tranasction_with_fee_reserve` methods, replaced with FeeConfig being an enum on each transaction executable, which can be used to disable fee payment