### PR TITLE
Make the `generate_value` function public

### DIFF
--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -989,7 +989,7 @@ fn generate_non_fungible_ids(
     }
 }
 
-fn generate_value(
+pub fn generate_value(
     value: &ast::Value,
     expected: Option<ast::Type>,
     resolver: &mut NameResolver,


### PR DESCRIPTION
This PR makes the `generate_value` function public. This is needed for the RET testing. 