### PR TITLE
feat: Add indexset to sbor

### DIFF
--- a/sbor/src/encoder.rs
+++ b/sbor/src/encoder.rs
@@ -255,6 +255,37 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "indexmap")]
+    pub fn test_encode_index_map_and_set() {
+        let mut bytes = Vec::with_capacity(512);
+        let mut encoder = BasicEncoder::new(&mut bytes);
+        let mut set = IndexSet::<u8>::new();
+        set.insert(1);
+        set.insert(2);
+        encoder.encode(&set).unwrap();
+        let mut map = IndexMap::<u8, u8>::new();
+        map.insert(1, 2);
+        map.insert(3, 4);
+        encoder.encode(&map).unwrap();
+
+        assert_eq!(
+            vec![
+                32, 7, 2, 1, 2, // set
+                32, 33, 2, 2, 7, 1, 7, 2, 2, 7, 3, 7, 4, // map
+            ],
+            bytes
+        );
+
+        let mut decoder = BasicDecoder::new(&bytes);
+        let set_out = decoder.decode::<IndexSet<u8>>().unwrap();
+        let map_out = decoder.decode::<IndexMap<u8, u8>>().unwrap();
+        decoder.check_end().unwrap();
+
+        assert_eq!(set, set_out);
+        assert_eq!(map, map_out);
+    }
+
+    #[test]
     pub fn test_encode_cow_borrowed() {
         let mut set = BTreeSet::<u8>::new();
         set.insert(1);

--- a/sbor/src/rust.rs
+++ b/sbor/src/rust.rs
@@ -123,4 +123,6 @@ pub mod collections {
 
     #[cfg(feature = "indexmap")]
     pub use indexmap::IndexMap;
+    #[cfg(feature = "indexmap")]
+    pub use indexmap::IndexSet;
 }

--- a/sbor/src/type_id.rs
+++ b/sbor/src/type_id.rs
@@ -302,7 +302,15 @@ impl<X: CustomTypeId, K, V> TypeId<X> for HashMap<K, V> {
 }
 
 #[cfg(feature = "indexmap")]
-impl<X: CustomTypeId, K, V> TypeId<X> for indexmap::IndexMap<K, V> {
+impl<X: CustomTypeId, T> TypeId<X> for IndexSet<T> {
+    #[inline]
+    fn type_id() -> SborTypeId<X> {
+        SborTypeId::Array
+    }
+}
+
+#[cfg(feature = "indexmap")]
+impl<X: CustomTypeId, K, V> TypeId<X> for IndexMap<K, V> {
     #[inline]
     fn type_id() -> SborTypeId<X> {
         SborTypeId::Array


### PR DESCRIPTION
So that we can use indexset and indexmap in the engine (just add the `indexmap` feature to sbor in the Cargo.toml if it's not there already - but I think it is)