### PR TITLE
Fix/max formatting for large Integer and Unsigned types

### DIFF
--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -399,18 +399,18 @@ where
                 if num_part == 0 {
                     acc
                 } else if acc == "" && minus == "-" {
-                    format!("{}", num_part + 1) // avoid overflow of T::MIN
+                    (num_part + 1).to_string() // avoid overflow of T::MIN
                 } else {
-                    format!("{}{}", num_part, acc)
+                    num_part.to_string() + &acc
                 }
             } else {
                 let padding: String = vec!["0"; 38 - num_part.to_string().len()]
                     .into_iter()
                     .collect();
                 if acc == "" && minus == "-" {
-                    format!("{}{}", padding, num_part + 1)
+                    padding + &(num_part + 1).to_string()
                 } else {
-                    format!("{}{}{}", padding, num_part, acc)
+                    padding +  &num_part.to_string() + &acc
                 }
             }
         });

--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -381,7 +381,7 @@ fn fmt<
 ) -> fmt::Result
 where
     <T as TryInto<i128>>::Error: fmt::Debug,
-    i128: sbor::rust::convert::TryFrom<T>
+    i128: sbor::rust::convert::TryFrom<T>,
 {
     let mut minus = "";
     let mut a = to_fmt;
@@ -389,7 +389,7 @@ where
     if a < T::zero() {
         minus = "-";
         ls_digit = (a % T::from(10u32)).to_i128().unwrap().neg().to_string();
-        a = T::zero() - a / T::from(10u32);  // avoid overflow of T::MIN
+        a = T::zero() - a / T::from(10u32); // avoid overflow of T::MIN
     }
     let num;
     let divisor = T::from(10u32).pow(38u32);
@@ -409,7 +409,7 @@ where
                 let padding: String = vec!["0"; 38 - num_part.to_string().len()]
                     .into_iter()
                     .collect();
-                padding +  &num_part.to_string() + &acc
+                padding + &num_part.to_string() + &acc
             }
         });
     }

--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -365,6 +365,7 @@ fn fmt<
         + Pow<u32, Output = T>
         + Zero
         + One
+        + ToPrimitive
         + TryInto<i128>
         + Add<Output = T>
         + Div<Output = T>
@@ -380,12 +381,15 @@ fn fmt<
 ) -> fmt::Result
 where
     <T as TryInto<i128>>::Error: fmt::Debug,
+    i128: sbor::rust::convert::TryFrom<T>
 {
     let mut minus = "";
     let mut a = to_fmt;
+    let mut ls_digit: String = "".to_owned();
     if a < T::zero() {
         minus = "-";
-        a = T::one() - a ;  // avoid overflow of T::MIN
+        ls_digit = (a % T::from(10u32)).to_i128().unwrap().neg().to_string();
+        a = T::zero() - a / T::from(10u32);  // avoid overflow of T::MIN
     }
     let num;
     let divisor = T::from(10u32).pow(38u32);
@@ -398,8 +402,6 @@ where
             if a == T::zero() {
                 if num_part == 0 {
                     acc
-                } else if acc == "" && minus == "-" {
-                    (num_part + 1).to_string() // avoid overflow of T::MIN
                 } else {
                     num_part.to_string() + &acc
                 }
@@ -407,15 +409,16 @@ where
                 let padding: String = vec!["0"; 38 - num_part.to_string().len()]
                     .into_iter()
                     .collect();
-                if acc == "" && minus == "-" {
-                    padding + &(num_part + 1).to_string()
-                } else {
-                    padding +  &num_part.to_string() + &acc
-                }
+                padding +  &num_part.to_string() + &acc
             }
         });
     }
-    write!(f, "{}{}", minus, num)
+
+    if minus == "-" && num == "0" {
+        write!(f, "{}{}", minus, ls_digit)
+    } else {
+        write!(f, "{}{}{}", minus, num, ls_digit)
+    }
 }
 
 macro_rules! forward_ref_unop {

--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -354,19 +354,25 @@ sbor_codec!(U32, SborTypeId::U32, U32);
 sbor_codec!(U64, SborTypeId::U64, U64);
 sbor_codec!(U128, SborTypeId::U128, U128);
 
+pub trait Min {
+    const MIN: Self;
+}
+
 fn fmt<
     T: fmt::Display
         + Copy
         + From<u32>
         + Pow<u32, Output = T>
         + Zero
+        + One
         + TryInto<i128>
         + Add<Output = T>
         + Div<Output = T>
         + Rem<Output = T>
         + Sub<Output = T>
         + Eq
-        + Ord,
+        + Ord
+        + Min,
 >(
     to_fmt: T,
     f: &mut fmt::Formatter<'_>,
@@ -379,7 +385,7 @@ where
     let mut a = to_fmt;
     if a < T::zero() {
         minus = "-";
-        a = T::zero() - a;
+        a = T::one() - a ;  // avoid overflow of T::MIN
     }
     let num;
     let divisor = T::from(10u32).pow(38u32);
@@ -392,14 +398,20 @@ where
             if a == T::zero() {
                 if num_part == 0 {
                     acc
+                } else if acc == "" && minus == "-" {
+                    format!("{}", num_part + 1) // avoid overflow of T::MIN
                 } else {
-                    num_part.to_string() + &acc
+                    format!("{}{}", num_part, acc)
                 }
             } else {
                 let padding: String = vec!["0"; 38 - num_part.to_string().len()]
                     .into_iter()
                     .collect();
-                padding + &num_part.to_string() + &acc
+                if acc == "" && minus == "-" {
+                    format!("{}{}", padding, num_part + 1)
+                } else {
+                    format!("{}{}{}", padding, num_part, acc)
+                }
             }
         });
     }

--- a/radix-engine-interface/src/math/integer.rs
+++ b/radix-engine-interface/src/math/integer.rs
@@ -385,7 +385,7 @@ where
 {
     let mut minus = "";
     let mut a = to_fmt;
-    let mut ls_digit: String = "".to_owned();
+    let mut ls_digit = String::from("");
     if a < T::zero() {
         minus = "-";
         ls_digit = (a % T::from(10u32)).to_i128().unwrap().neg().to_string();

--- a/radix-engine-interface/src/math/integer/basic.rs
+++ b/radix-engine-interface/src/math/integer/basic.rs
@@ -3,10 +3,13 @@ use super::*;
 macro_rules! checked_int_impl_large {
     (type_id: $t:ident, bytes_len: $bytes_len:literal, MIN: $min: expr, MAX: $max: expr) => {
         paste! {
-            impl $t {
+            impl Min for $t {
                 /// Returns the smallest value that can be represented by this integer type.
                 ///
-                pub const MIN: Self = $min;
+                const MIN: Self = $min;
+            }
+
+            impl $t {
 
                 /// Returns the largest value that can be represented by this integer type.
                 ///

--- a/radix-engine-interface/src/math/integer/test.rs
+++ b/radix-engine-interface/src/math/integer/test.rs
@@ -115,18 +115,18 @@ macro_rules! test_impl {
                     let _ = <$i>::MAX.pow(2u32);             // panics because of overflow
                 }
 
-                #[test] 
+                #[test]
                 fn  [<test_max_to_string_$i:lower>]() {
                     let a = <$i>::MAX;
                     let b = BigInt::from(a);
-                    assert_eq!(a.to_string(), b.to_string()); 
+                    assert_eq!(a.to_string(), b.to_string());
                 }
 
-                #[test] 
+                #[test]
                 fn  [<test_min_to_string_$i:lower>]() {
                     let a = <$i>::MIN;
                     let b = BigInt::from(a);
-                    assert_eq!(a.to_string(), b.to_string()); 
+                    assert_eq!(a.to_string(), b.to_string());
                 }
 
 //                #[test]

--- a/radix-engine-interface/src/math/integer/test.rs
+++ b/radix-engine-interface/src/math/integer/test.rs
@@ -115,6 +115,20 @@ macro_rules! test_impl {
                     let _ = <$i>::MAX.pow(2u32);             // panics because of overflow
                 }
 
+                #[test] 
+                fn  [<test_max_to_string_$i:lower>]() {
+                    let a = <$i>::MAX;
+                    let b = BigInt::from(a);
+                    assert_eq!(a.to_string(), b.to_string()); 
+                }
+
+                #[test] 
+                fn  [<test_min_to_string_$i:lower>]() {
+                    let a = <$i>::MIN;
+                    let b = BigInt::from(a);
+                    assert_eq!(a.to_string(), b.to_string()); 
+                }
+
 //                #[test]
 //                fn [<test_binary_$i:lower>]() {
 //                    let bin = <$i>::try_from(0x0b).unwrap();

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -17,7 +17,7 @@ pub use radix_engine_interface::constants::*;
 pub use radix_engine_interface::crypto::*;
 pub use radix_engine_interface::data::*;
 pub use radix_engine_interface::math::integer::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedPow, CheckedRem, CheckedSub,
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedPow, CheckedRem, CheckedSub, Min
 };
 pub use radix_engine_interface::math::*;
 pub use radix_engine_interface::model::*;

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -17,7 +17,7 @@ pub use radix_engine_interface::constants::*;
 pub use radix_engine_interface::crypto::*;
 pub use radix_engine_interface::data::*;
 pub use radix_engine_interface::math::integer::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedPow, CheckedRem, CheckedSub, Min
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedPow, CheckedRem, CheckedSub, Min,
 };
 pub use radix_engine_interface::math::*;
 pub use radix_engine_interface::model::*;


### PR DESCRIPTION
Things like I256::MAX.to_string() panicked for all large safe types. Now it is fixed.
