### PR TITLE
No more hashing in wasm cache

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -8,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_hello() {
     // Setup the environment
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Create an account
     let (public_key, _private_key, account_component) = test_runner.new_allocated_account();

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -8,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_hello() {
     // Setup the environment
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Create an account
     let (public_key, _private_key, account_component) = test_runner.new_allocated_account();

--- a/radix-engine-stores/src/memory_db.rs
+++ b/radix-engine-stores/src/memory_db.rs
@@ -1,8 +1,10 @@
+use radix_engine::engine::ScryptoInterpreter;
 use radix_engine::ledger::{
     bootstrap, OutputValue, QueryableSubstateStore, ReadableSubstateStore, WriteableSubstateStore,
 };
 use radix_engine::model::PersistedSubstate;
 use radix_engine::types::*;
+use radix_engine::wasm::WasmEngine;
 use radix_engine_interface::api::types::RENodeId;
 
 /// A substate store that stores all typed substates in host memory.
@@ -18,9 +20,9 @@ impl SerializedInMemorySubstateStore {
         }
     }
 
-    pub fn with_bootstrap() -> Self {
+    pub fn with_bootstrap<W: WasmEngine>(scrypto_interpreter: &ScryptoInterpreter<W>) -> Self {
         let mut substate_store = Self::new();
-        bootstrap(&mut substate_store);
+        bootstrap(&mut substate_store, scrypto_interpreter);
         substate_store
     }
 }

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use radix_engine::ledger::*;
+use radix_engine::engine::ScryptoInterpreter;
 use radix_engine::model::PersistedSubstate;
 use radix_engine::types::*;
+use radix_engine::{ledger::*, wasm::WasmEngine};
 use radix_engine_interface::{api::types::RENodeId, data::ScryptoDecode};
 use rocksdb::{DBWithThreadMode, Direction, IteratorMode, SingleThreaded, DB};
 
@@ -17,9 +18,12 @@ impl RadixEngineDB {
         Self { db }
     }
 
-    pub fn with_bootstrap(root: PathBuf) -> Self {
+    pub fn with_bootstrap<W: WasmEngine>(
+        root: PathBuf,
+        scrypto_interpreter: &ScryptoInterpreter<W>,
+    ) -> Self {
         let mut substate_store = Self::new(root);
-        bootstrap(&mut substate_store);
+        bootstrap(&mut substate_store, scrypto_interpreter);
         substate_store
     }
 

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -18,13 +18,12 @@ use transaction::signing::EcdsaSecp256k1PrivateKey;
 
 fn bench_transfer(c: &mut Criterion) {
     // Set up environment.
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
         wasm_metering_config: WasmMeteringConfig::V0,
     };
+    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
 
     // Create a key pair
     let private_key = EcdsaSecp256k1PrivateKey::from_u64(1).unwrap();

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -5,7 +5,7 @@ use radix_engine::transaction::execute_and_commit_transaction;
 use radix_engine::transaction::{ExecutionConfig, FeeReserveConfig};
 use radix_engine::types::*;
 use radix_engine::wasm::WasmInstrumenter;
-use radix_engine::wasm::{DefaultWasmEngine, InstructionCostRules, WasmMeteringConfig};
+use radix_engine::wasm::{DefaultWasmEngine, WasmMeteringConfig};
 use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -23,10 +23,7 @@ fn bench_transfer(c: &mut Criterion) {
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
-        wasm_metering_config: WasmMeteringConfig::new(
-            InstructionCostRules::tiered(1, 5, 10, 5000),
-            1024,
-        ),
+        wasm_metering_config: WasmMeteringConfig::V0,
     };
 
     // Create a key pair

--- a/radix-engine/benches/wasm.rs
+++ b/radix-engine/benches/wasm.rs
@@ -1,10 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use radix_engine::model::extract_abi;
+use radix_engine::types::PackageAddress;
 use radix_engine::wasm::DefaultWasmEngine;
 use radix_engine::wasm::InstrumentedCode;
 use radix_engine::wasm::WasmEngine;
+use radix_engine::wasm::WasmMeteringConfig;
 use radix_engine::wasm::WasmValidator;
-use radix_engine_interface::crypto::hash;
 use sbor::rust::sync::Arc;
 
 fn bench_wasm_validation(c: &mut Criterion) {
@@ -17,11 +18,11 @@ fn bench_wasm_validation(c: &mut Criterion) {
 }
 
 fn bench_wasm_instantiation(c: &mut Criterion) {
+    let package_address = PackageAddress::Normal([0u8; 26]);
     let code = include_bytes!("../../assets/account.wasm").to_vec();
-    let code_hash = hash(&code);
     let pretend_instrumented_code = InstrumentedCode {
+        metered_code_key: (package_address, WasmMeteringConfig::V0),
         code: Arc::new(code),
-        code_hash,
     };
     c.bench_function("WASM instantiation", |b| {
         b.iter(|| {
@@ -32,11 +33,11 @@ fn bench_wasm_instantiation(c: &mut Criterion) {
 }
 
 fn bench_wasm_instantiation_pre_loaded(c: &mut Criterion) {
+    let package_address = PackageAddress::Normal([0u8; 26]);
     let code = include_bytes!("../../assets/account.wasm").to_vec();
-    let code_hash = hash(&code);
     let pretend_instrumented_code = InstrumentedCode {
+        metered_code_key: (package_address, WasmMeteringConfig::V0),
         code: Arc::new(code),
-        code_hash,
     };
     let engine = DefaultWasmEngine::default();
     engine.instantiate(&pretend_instrumented_code);

--- a/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
+++ b/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
@@ -109,12 +109,13 @@ pub struct ScryptoInterpreter<W: WasmEngine> {
 impl<W: WasmEngine> ScryptoInterpreter<W> {
     pub fn create_executor(
         &self,
+        package_address: PackageAddress,
         code: &[u8],
         args: IndexedScryptoValue,
     ) -> ScryptoExecutor<W::WasmInstance> {
-        let instrumented_code = self
-            .wasm_instrumenter
-            .instrument(code, self.wasm_metering_config);
+        let instrumented_code =
+            self.wasm_instrumenter
+                .instrument(package_address, code, self.wasm_metering_config);
         let instance = self.wasm_engine.instantiate(&instrumented_code);
         ScryptoExecutor {
             instance,
@@ -124,12 +125,13 @@ impl<W: WasmEngine> ScryptoInterpreter<W> {
 
     pub fn create_executor_to_parsed(
         &self,
+        package_address: PackageAddress,
         code: &[u8],
         args: IndexedScryptoValue,
     ) -> ScryptoExecutorToParsed<W::WasmInstance> {
-        let instrumented_code = self
-            .wasm_instrumenter
-            .instrument(code, self.wasm_metering_config);
+        let instrumented_code =
+            self.wasm_instrumenter
+                .instrument(package_address, code, self.wasm_metering_config);
         let instance = self.wasm_engine.instantiate(&instrumented_code);
         ScryptoExecutorToParsed {
             instance,

--- a/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
+++ b/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
@@ -106,6 +106,16 @@ pub struct ScryptoInterpreter<W: WasmEngine> {
     pub wasm_metering_config: WasmMeteringConfig,
 }
 
+impl<W: WasmEngine + Default> Default for ScryptoInterpreter<W> {
+    fn default() -> Self {
+        Self {
+            wasm_engine: W::default(),
+            wasm_instrumenter: WasmInstrumenter::default(),
+            wasm_metering_config: WasmMeteringConfig::default(),
+        }
+    }
+}
+
 impl<W: WasmEngine> ScryptoInterpreter<W> {
     pub fn create_executor(
         &self,

--- a/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
+++ b/radix-engine/src/engine/interpreters/scrypto_interpreter.rs
@@ -114,7 +114,7 @@ impl<W: WasmEngine> ScryptoInterpreter<W> {
     ) -> ScryptoExecutor<W::WasmInstance> {
         let instrumented_code = self
             .wasm_instrumenter
-            .instrument(code, &self.wasm_metering_config);
+            .instrument(code, self.wasm_metering_config);
         let instance = self.wasm_engine.instantiate(&instrumented_code);
         ScryptoExecutor {
             instance,
@@ -129,7 +129,7 @@ impl<W: WasmEngine> ScryptoInterpreter<W> {
     ) -> ScryptoExecutorToParsed<W::WasmInstance> {
         let instrumented_code = self
             .wasm_instrumenter
-            .instrument(code, &self.wasm_metering_config);
+            .instrument(code, self.wasm_metering_config);
         let instance = self.wasm_engine.instantiate(&instrumented_code);
         ScryptoExecutorToParsed {
             instance,

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -4,7 +4,7 @@ use crate::transaction::{
     execute_transaction, ExecutionConfig, FeeReserveConfig, TransactionReceipt,
 };
 use crate::types::*;
-use crate::wasm::{DefaultWasmEngine, InstructionCostRules, WasmInstrumenter, WasmMeteringConfig};
+use crate::wasm::{DefaultWasmEngine, WasmInstrumenter, WasmMeteringConfig};
 use radix_engine_interface::api::types::{
     EpochManagerFunction, GlobalAddress, NativeFunctionIdent, RENodeId, ResourceManagerFunction,
     ResourceManagerOffset, ScryptoFunctionIdent, ScryptoPackage, SubstateId, SubstateOffset,
@@ -294,10 +294,7 @@ where
         let scrypto_interpreter = ScryptoInterpreter {
             wasm_engine: DefaultWasmEngine::default(),
             wasm_instrumenter: WasmInstrumenter::default(),
-            wasm_metering_config: WasmMeteringConfig::new(
-                InstructionCostRules::tiered(1, 5, 10, 5000),
-                1024,
-            ),
+            wasm_metering_config: WasmMeteringConfig::V0,
         };
 
         let genesis_transaction = create_genesis();
@@ -330,8 +327,7 @@ mod tests {
     fn bootstrap_receipt_should_match_constants() {
         let wasm_engine = DefaultWasmEngine::default();
         let wasm_instrumenter = WasmInstrumenter::default();
-        let wasm_metering_config =
-            WasmMeteringConfig::new(InstructionCostRules::tiered(1, 5, 10, 5000), 1024);
+        let wasm_metering_config = WasmMeteringConfig::V0;
         let scrypto_interpreter = ScryptoInterpreter {
             wasm_engine,
             wasm_instrumenter,

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -4,7 +4,7 @@ use crate::transaction::{
     execute_transaction, ExecutionConfig, FeeReserveConfig, TransactionReceipt,
 };
 use crate::types::*;
-use crate::wasm::{DefaultWasmEngine, WasmInstrumenter, WasmMeteringConfig};
+use crate::wasm::WasmEngine;
 use radix_engine_interface::api::types::{
     EpochManagerFunction, GlobalAddress, NativeFunctionIdent, RENodeId, ResourceManagerFunction,
     ResourceManagerOffset, ScryptoFunctionIdent, ScryptoPackage, SubstateId, SubstateOffset,
@@ -280,9 +280,13 @@ pub fn genesis_result(invoke_result: &Vec<Vec<u8>>) -> GenesisReceipt {
     }
 }
 
-pub fn bootstrap<S>(substate_store: &mut S) -> Option<TransactionReceipt>
+pub fn bootstrap<S, W>(
+    substate_store: &mut S,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
+) -> Option<TransactionReceipt>
 where
     S: ReadableSubstateStore + WriteableSubstateStore,
+    W: WasmEngine,
 {
     if substate_store
         .get_substate(&SubstateId(
@@ -291,17 +295,11 @@ where
         ))
         .is_none()
     {
-        let scrypto_interpreter = ScryptoInterpreter {
-            wasm_engine: DefaultWasmEngine::default(),
-            wasm_instrumenter: WasmInstrumenter::default(),
-            wasm_metering_config: WasmMeteringConfig::V0,
-        };
-
         let genesis_transaction = create_genesis();
 
         let transaction_receipt = execute_transaction(
             substate_store,
-            &scrypto_interpreter,
+            scrypto_interpreter,
             &FeeReserveConfig::default(),
             &ExecutionConfig::default(),
             &genesis_transaction.get_executable(),
@@ -319,20 +317,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::ledger::TypedInMemorySubstateStore;
+    use crate::{ledger::TypedInMemorySubstateStore, wasm::DefaultWasmEngine};
 
     use super::*;
 
     #[test]
     fn bootstrap_receipt_should_match_constants() {
-        let wasm_engine = DefaultWasmEngine::default();
-        let wasm_instrumenter = WasmInstrumenter::default();
-        let wasm_metering_config = WasmMeteringConfig::V0;
-        let scrypto_interpreter = ScryptoInterpreter {
-            wasm_engine,
-            wasm_instrumenter,
-            wasm_metering_config,
-        };
+        let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
         let substate_store = TypedInMemorySubstateStore::new();
         let genesis_transaction = create_genesis();
 

--- a/radix-engine/src/ledger/memory.rs
+++ b/radix-engine/src/ledger/memory.rs
@@ -1,7 +1,9 @@
+use crate::engine::ScryptoInterpreter;
 use crate::ledger::*;
 use crate::ledger::{OutputValue, WriteableSubstateStore};
 use crate::model::PersistedSubstate;
 use crate::types::*;
+use crate::wasm::WasmEngine;
 use radix_engine_interface::api::types::{
     KeyValueStoreId, KeyValueStoreOffset, RENodeId, SubstateId, SubstateOffset,
 };
@@ -19,9 +21,9 @@ impl TypedInMemorySubstateStore {
         }
     }
 
-    pub fn with_bootstrap() -> Self {
+    pub fn with_bootstrap<W: WasmEngine>(scrypto_interpreter: &ScryptoInterpreter<W>) -> Self {
         let mut substate_store = Self::new();
-        bootstrap(&mut substate_store);
+        bootstrap(&mut substate_store, scrypto_interpreter);
         substate_store
     }
 }

--- a/radix-engine/src/model/package_extractor.rs
+++ b/radix-engine/src/model/package_extractor.rs
@@ -24,9 +24,7 @@ pub fn extract_abi(code: &[u8]) -> Result<HashMap<String, BlueprintAbi>, Extract
     let wasm_engine = DefaultWasmEngine::default();
     let wasm_instrumenter = WasmInstrumenter::default();
 
-    let metering_params =
-        WasmMeteringConfig::new(InstructionCostRules::tiered(1, 5, 10, 5000), 1024);
-    let instrumented_code = wasm_instrumenter.instrument(code, &metering_params);
+    let instrumented_code = wasm_instrumenter.instrument(code, WasmMeteringConfig::V0);
     let fee_reserve = SystemLoanFeeReserve::no_fee();
     let mut runtime: Box<dyn WasmRuntime> = Box::new(NopWasmRuntime::new(fee_reserve));
     let mut instance = wasm_engine.instantiate(&instrumented_code);

--- a/radix-engine/src/model/package_extractor.rs
+++ b/radix-engine/src/model/package_extractor.rs
@@ -23,8 +23,11 @@ pub fn extract_abi(code: &[u8]) -> Result<HashMap<String, BlueprintAbi>, Extract
 
     let wasm_engine = DefaultWasmEngine::default();
     let wasm_instrumenter = WasmInstrumenter::default();
-
-    let instrumented_code = wasm_instrumenter.instrument(code, WasmMeteringConfig::V0);
+    let instrumented_code = wasm_instrumenter.instrument(
+        PackageAddress::Normal([0u8; 26]),
+        code,
+        WasmMeteringConfig::V0,
+    );
     let fee_reserve = SystemLoanFeeReserve::no_fee();
     let mut runtime: Box<dyn WasmRuntime> = Box::new(NopWasmRuntime::new(fee_reserve));
     let mut instance = wasm_engine.instantiate(&instrumented_code);

--- a/radix-engine/src/model/scrypto/executables.rs
+++ b/radix-engine/src/model/scrypto/executables.rs
@@ -89,7 +89,8 @@ impl<W: WasmEngine> ExecutableInvocation<W> for ScryptoInvocation {
                 api.on_wasm_instantiation(package.code())?;
 
                 (
-                    api.vm().create_executor(&package.code, args),
+                    api.vm()
+                        .create_executor(package_address, &package.code, args),
                     REActor::Function(ResolvedFunction::Scrypto {
                         package_address,
                         blueprint_name: function_ident.blueprint_name.clone(),
@@ -200,7 +201,8 @@ impl<W: WasmEngine> ExecutableInvocation<W> for ScryptoInvocation {
                 api.on_wasm_instantiation(package.code())?;
 
                 (
-                    api.vm().create_executor(&package.code, args),
+                    api.vm()
+                        .create_executor(component_info.package_address, &package.code, args),
                     REActor::Method(
                         ResolvedMethod::Scrypto {
                             package_address: component_info.package_address,
@@ -320,7 +322,8 @@ impl<W: WasmEngine> ExecutableInvocation<W> for ParsedScryptoInvocation {
                 api.on_wasm_instantiation(package.code())?;
 
                 (
-                    api.vm().create_executor_to_parsed(&package.code, args),
+                    api.vm()
+                        .create_executor_to_parsed(package_address, &package.code, args),
                     REActor::Function(ResolvedFunction::Scrypto {
                         package_address,
                         blueprint_name: function_ident.blueprint_name.clone(),
@@ -431,7 +434,11 @@ impl<W: WasmEngine> ExecutableInvocation<W> for ParsedScryptoInvocation {
                 api.on_wasm_instantiation(package.code())?;
 
                 (
-                    api.vm().create_executor_to_parsed(&package.code, args),
+                    api.vm().create_executor_to_parsed(
+                        component_info.package_address,
+                        &package.code,
+                        args,
+                    ),
                     REActor::Method(
                         ResolvedMethod::Scrypto {
                             package_address: component_info.package_address,

--- a/radix-engine/src/state_manager/staging.rs
+++ b/radix-engine/src/state_manager/staging.rs
@@ -152,13 +152,16 @@ impl<'t, 's, S: ReadableSubstateStore> WriteableSubstateStore for StagedSubstate
 
 #[cfg(test)]
 mod tests {
+    use crate::engine::ScryptoInterpreter;
     use crate::ledger::TypedInMemorySubstateStore;
     use crate::state_manager::StagedSubstateStoreManager;
+    use crate::wasm::DefaultWasmEngine;
 
     #[test]
     fn test_complicated_merge() {
         // Arrange
-        let mut store = TypedInMemorySubstateStore::with_bootstrap();
+        let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+        let mut store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
         let mut stores = StagedSubstateStoreManager::new(&mut store);
         let child_node1 = stores.new_child_node(0);
         let child_node2 = stores.new_child_node(child_node1);

--- a/radix-engine/src/wasm/mod.rs
+++ b/radix-engine/src/wasm/mod.rs
@@ -31,3 +31,8 @@ pub type DefaultWasmInstance = WasmerInstance;
 pub type DefaultWasmEngine = WasmiEngine;
 #[cfg(not(feature = "wasmer"))]
 pub type DefaultWasmInstance = WasmiInstance;
+
+// TODO: expand if package is upgradable.
+use radix_engine_interface::model::PackageAddress;
+pub type CodeKey = PackageAddress;
+pub type MeteredCodeKey = (CodeKey, WasmMeteringConfig);

--- a/radix-engine/src/wasm/wasm_metering_config.rs
+++ b/radix-engine/src/wasm/wasm_metering_config.rs
@@ -7,6 +7,12 @@ pub enum WasmMeteringConfig {
     V0,
 }
 
+impl Default for WasmMeteringConfig {
+    fn default() -> Self {
+        Self::V0
+    }
+}
+
 impl WasmMeteringConfig {
     pub fn parameters(&self) -> WasmMeteringParams {
         match self {

--- a/radix-engine/src/wasm/wasm_validator.rs
+++ b/radix-engine/src/wasm/wasm_validator.rs
@@ -30,8 +30,7 @@ impl WasmValidator {
         // Not all "valid" wasm modules are instrumentable, with the instrumentation library
         // we are using. To deal with this, we attempt to instrument the input module with
         // some mocked parameters and reject it if fails to do so.
-        let mocked_wasm_metering_config =
-            WasmMeteringConfig::new(InstructionCostRules::constant(1, 100), 1024);
+        let parameters = WasmMeteringConfig::V0.parameters();
 
         WasmModule::init(code)?
             .enforce_no_floating_point()?
@@ -43,8 +42,8 @@ impl WasmValidator {
             .enforce_function_limit(self.max_number_of_functions)?
             .enforce_global_limit(self.max_number_of_globals)?
             .enforce_export_constraints(blueprints)?
-            .inject_instruction_metering(mocked_wasm_metering_config.instruction_cost_rules())?
-            .inject_stack_metering(mocked_wasm_metering_config.max_stack_size())?
+            .inject_instruction_metering(parameters.instruction_cost_rules())?
+            .inject_stack_metering(parameters.max_stack_size())?
             .ensure_instantiatable()?
             .ensure_compilable()?
             .to_bytes()?;

--- a/radix-engine/src/wasm/wasmer.rs
+++ b/radix-engine/src/wasm/wasmer.rs
@@ -13,6 +13,7 @@ use crate::wasm::errors::*;
 use crate::wasm::traits::*;
 
 use super::InstrumentedCode;
+use super::MeteredCodeKey;
 
 // IMPORTANT:
 // The below integration of Wasmer is not yet checked rigorously enough for production use
@@ -79,9 +80,9 @@ pub struct WasmerInstanceEnv {
 pub struct WasmerEngine {
     store: Store,
     #[cfg(not(feature = "moka"))]
-    modules_cache: RefCell<lru::LruCache<Hash, Arc<WasmerModule>>>,
+    modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmerModule>>>,
     #[cfg(feature = "moka")]
-    modules_cache: moka::sync::Cache<Hash, Arc<WasmerModule>>,
+    modules_cache: moka::sync::Cache<MeteredCodeKey, Arc<WasmerModule>>,
 }
 
 pub fn send_value(instance: &Instance, value: &[u8]) -> Result<usize, InvokeError<WasmError>> {
@@ -286,10 +287,12 @@ impl WasmerEngine {
         ));
         #[cfg(feature = "moka")]
         let modules_cache = moka::sync::Cache::builder()
-            .weigher(|_key: &Hash, value: &Arc<WasmerModule>| -> u32 {
-                // Approximate the module entry size by the code size
-                value.code_size_bytes.try_into().unwrap_or(u32::MAX)
-            })
+            .weigher(
+                |_metered_code_key: &MeteredCodeKey, value: &Arc<WasmerModule>| -> u32 {
+                    // Approximate the module entry size by the code size
+                    value.code_size_bytes.try_into().unwrap_or(u32::MAX)
+                },
+            )
             .max_capacity(options.max_cache_size_bytes as u64)
             .build();
         Self {
@@ -303,15 +306,15 @@ impl WasmEngine for WasmerEngine {
     type WasmInstance = WasmerInstance;
 
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmerInstance {
-        let code_hash = &instrumented_code.code_hash;
+        let metered_code_key = &instrumented_code.metered_code_key;
         #[cfg(not(feature = "moka"))]
         {
-            if let Some(cached_module) = self.modules_cache.borrow_mut().get(code_hash) {
+            if let Some(cached_module) = self.modules_cache.borrow_mut().get(key) {
                 return cached_module.instantiate();
             }
         }
         #[cfg(feature = "moka")]
-        if let Some(cached_module) = self.modules_cache.get(code_hash) {
+        if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
             return cached_module.instantiate();
         }
 
@@ -325,9 +328,10 @@ impl WasmEngine for WasmerEngine {
         #[cfg(not(feature = "moka"))]
         self.modules_cache
             .borrow_mut()
-            .put(*code_hash, new_module.clone());
+            .put(*metered_code_key, new_module.clone());
         #[cfg(feature = "moka")]
-        self.modules_cache.insert(*code_hash, new_module.clone());
+        self.modules_cache
+            .insert(*metered_code_key, new_module.clone());
 
         new_module.instantiate()
     }

--- a/radix-engine/src/wasm/wasmi.rs
+++ b/radix-engine/src/wasm/wasmi.rs
@@ -1,15 +1,14 @@
-use radix_engine_interface::crypto::Hash;
 use radix_engine_interface::data::IndexedScryptoValue;
 use sbor::rust::sync::Arc;
 use wasmi::*;
 
+use super::InstrumentedCode;
+use super::MeteredCodeKey;
 use crate::model::InvokeError;
 use crate::types::*;
 use crate::wasm::constants::*;
 use crate::wasm::errors::*;
 use crate::wasm::traits::*;
-
-use super::InstrumentedCode;
 
 pub struct WasmiModule {
     module: Module,
@@ -220,9 +219,9 @@ pub struct EngineOptions {
 
 pub struct WasmiEngine {
     #[cfg(not(feature = "moka"))]
-    modules_cache: RefCell<lru::LruCache<Hash, Arc<WasmiModule>>>,
+    modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmiModule>>>,
     #[cfg(feature = "moka")]
-    modules_cache: moka::sync::Cache<Hash, Arc<WasmiModule>>,
+    modules_cache: moka::sync::Cache<MeteredCodeKey, Arc<WasmiModule>>,
 }
 
 impl Default for WasmiEngine {
@@ -241,7 +240,7 @@ impl WasmiEngine {
         ));
         #[cfg(feature = "moka")]
         let modules_cache = moka::sync::Cache::builder()
-            .weigher(|_key: &Hash, value: &Arc<WasmiModule>| -> u32 {
+            .weigher(|_key: &MeteredCodeKey, value: &Arc<WasmiModule>| -> u32 {
                 // Approximate the module entry size by the code size
                 value.code_size_bytes.try_into().unwrap_or(u32::MAX)
             })
@@ -255,16 +254,16 @@ impl WasmEngine for WasmiEngine {
     type WasmInstance = WasmiInstance;
 
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmiInstance {
-        let code_hash = &instrumented_code.code_hash;
+        let metered_code_key = &instrumented_code.metered_code_key;
 
         #[cfg(not(feature = "moka"))]
         {
-            if let Some(cached_module) = self.modules_cache.borrow_mut().get(code_hash) {
+            if let Some(cached_module) = self.modules_cache.borrow_mut().get(metered_code_key) {
                 return cached_module.instantiate();
             }
         }
         #[cfg(feature = "moka")]
-        if let Some(cached_module) = self.modules_cache.get(code_hash) {
+        if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
             return cached_module.instantiate();
         }
 
@@ -278,9 +277,10 @@ impl WasmEngine for WasmiEngine {
         #[cfg(not(feature = "moka"))]
         self.modules_cache
             .borrow_mut()
-            .put(*code_hash, new_module.clone());
+            .put(*metered_code_key, new_module.clone());
         #[cfg(feature = "moka")]
-        self.modules_cache.insert(*code_hash, new_module.clone());
+        self.modules_cache
+            .insert(*metered_code_key, new_module.clone());
 
         new_module.instantiate()
     }

--- a/radix-engine/tests/abi.rs
+++ b/radix-engine/tests/abi.rs
@@ -2,7 +2,6 @@ use crate::ExpectedResult::{InvalidInput, InvalidOutput, Success};
 use radix_engine::engine::{
     ApplicationError, InterpreterError, KernelError, RuntimeError, ScryptoFnResolvingError,
 };
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::AccessRulesChainError;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
@@ -13,8 +12,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_invalid_access_rule_methods() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/abi");
 
     // Act
@@ -48,8 +46,7 @@ enum ExpectedResult {
 
 fn test_arg(method_name: &str, args: Vec<u8>, expected_result: ExpectedResult) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/abi");
 
     // Act

--- a/radix-engine/tests/account.rs
+++ b/radix-engine/tests/account.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::ResourceChange;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::ScryptoMethodIdent;
 use radix_engine_interface::core::NetworkDefinition;
@@ -12,8 +11,7 @@ use transaction::model::*;
 
 fn can_withdraw_from_my_account_internal(use_virtual: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_account(use_virtual);
     let (_, _, other_account) = test_runner.new_account(use_virtual);
 
@@ -58,8 +56,7 @@ fn can_withdraw_from_my_virtual_account() {
 
 fn can_withdraw_non_fungible_from_my_account_internal(use_virtual: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_account(use_virtual);
     let (_, _, other_account) = test_runner.new_account(use_virtual);
     let resource_address = test_runner.create_non_fungible_resource(account);
@@ -94,8 +91,7 @@ fn can_withdraw_non_fungible_from_my_virtual_account() {
 
 fn cannot_withdraw_from_other_account_internal(is_virtual: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_account(is_virtual);
     let (_, _, other_account) = test_runner.new_account(is_virtual);
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -130,8 +126,7 @@ fn cannot_withdraw_from_other_virtual_account() {
 
 fn account_to_bucket_to_account_internal(use_virtual: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_account(use_virtual);
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee_and_withdraw(account, 10u32.into(), RADIX_TOKEN)
@@ -171,8 +166,7 @@ fn account_to_bucket_to_virtual_account() {
 
 fn test_account_balance_internal(use_virtual: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account1) = test_runner.new_account(use_virtual);
     let (_, _, account2) = test_runner.new_account(use_virtual);
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/arguments.rs
+++ b/radix-engine/tests/arguments.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -8,8 +7,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn vector_of_buckets_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act
@@ -35,8 +33,7 @@ fn vector_of_buckets_argument_should_succeed() {
 #[test]
 fn tuple_of_buckets_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act
@@ -62,8 +59,7 @@ fn tuple_of_buckets_argument_should_succeed() {
 #[test]
 fn treemap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act
@@ -88,8 +84,7 @@ fn treemap_of_strings_and_buckets_argument_should_succeed() {
 #[test]
 fn hashmap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act
@@ -114,8 +109,7 @@ fn hashmap_of_strings_and_buckets_argument_should_succeed() {
 #[test]
 fn some_optional_bucket_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act
@@ -139,8 +133,7 @@ fn some_optional_bucket_argument_should_succeed() {
 #[test]
 fn none_optional_bucket_argument_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
 
     // Act

--- a/radix-engine/tests/authorization_account.rs
+++ b/radix-engine/tests/authorization_account.rs
@@ -1,9 +1,3 @@
-extern crate core;
-
-use radix_engine::ledger::{
-    QueryableSubstateStore, ReadableSubstateStore, TypedInMemorySubstateStore,
-    WriteableSubstateStore,
-};
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -12,11 +6,8 @@ use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 use transaction::model::AuthModule;
 
-fn test_auth_rule<
-    's,
-    S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateStore,
->(
-    test_runner: &mut TestRunner<'s, S>,
+fn test_auth_rule(
+    test_runner: &mut TestRunner,
     auth_rule: &AccessRule,
     signer_public_keys: &[PublicKey],
     should_succeed: bool,
@@ -48,8 +39,7 @@ fn test_auth_rule<
 
 #[test]
 fn can_withdraw_from_my_1_of_2_account_with_either_key_sign() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
 
@@ -67,8 +57,7 @@ fn can_withdraw_from_my_1_of_2_account_with_either_key_sign() {
 
 #[test]
 fn can_withdraw_from_my_1_of_3_account_with_either_key_sign() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (pk2, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -92,8 +81,7 @@ fn can_withdraw_from_my_1_of_3_account_with_either_key_sign() {
 
 #[test]
 fn can_withdraw_from_my_2_of_2_resource_auth_account_with_both_signatures() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
 
@@ -105,8 +93,7 @@ fn can_withdraw_from_my_2_of_2_resource_auth_account_with_both_signatures() {
 #[test]
 fn cannot_withdraw_from_my_2_of_2_account_with_single_signature() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (_, _, auth1) = test_runner.new_key_pair_with_auth_address();
 
@@ -116,8 +103,7 @@ fn cannot_withdraw_from_my_2_of_2_account_with_single_signature() {
 
 #[test]
 fn can_withdraw_from_my_2_of_3_account_with_2_signatures() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (pk2, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -132,8 +118,7 @@ fn can_withdraw_from_my_2_of_3_account_with_2_signatures() {
 
 #[test]
 fn can_withdraw_from_my_complex_account() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (pk2, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -159,8 +144,7 @@ fn can_withdraw_from_my_complex_account() {
 
 #[test]
 fn cannot_withdraw_from_my_complex_account() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (_, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -182,8 +166,7 @@ fn cannot_withdraw_from_my_complex_account() {
 
 #[test]
 fn can_withdraw_from_my_complex_account_2() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (pk2, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -206,8 +189,7 @@ fn can_withdraw_from_my_complex_account_2() {
 
 #[test]
 fn cannot_withdraw_from_my_complex_account_2() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk0, _, auth0) = test_runner.new_key_pair_with_auth_address();
     let (pk1, _, auth1) = test_runner.new_key_pair_with_auth_address();
     let (pk2, _, auth2) = test_runner.new_key_pair_with_auth_address();
@@ -237,8 +219,7 @@ fn cannot_withdraw_from_my_complex_account_2() {
 #[test]
 fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let xrd_auth = rule!(require(RADIX_TOKEN));
     let account = test_runner.new_account_with_auth_rule(&xrd_auth);
     let (_, _, other_account) = test_runner.new_allocated_account();
@@ -272,8 +253,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
 #[test]
 fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let xrd_auth = rule!(require_amount(Decimal(I256::from(1)), RADIX_TOKEN));
     let account = test_runner.new_account_with_auth_rule(&xrd_auth);
     let (_, _, other_account) = test_runner.new_allocated_account();
@@ -307,8 +287,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
 #[test]
 fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let xrd_auth = rule!(require_amount(Decimal::from(1), RADIX_TOKEN));
     let account = test_runner.new_account_with_auth_rule(&xrd_auth);
     let (_, _, other_account) = test_runner.new_allocated_account();

--- a/radix-engine/tests/authorization_component.rs
+++ b/radix-engine/tests/authorization_component.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn cannot_make_cross_component_call_without_authorization() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
     let auth = test_runner.create_non_fungible_resource(account);
     let auth_id = NonFungibleId::U32(1);
@@ -73,8 +71,7 @@ fn cannot_make_cross_component_call_without_authorization() {
 #[test]
 fn can_make_cross_component_call_with_authorization() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let auth = test_runner.create_non_fungible_resource(account.clone());
     let auth_id = NonFungibleId::U32(1);
@@ -151,8 +148,7 @@ fn can_make_cross_component_call_with_authorization() {
 #[test]
 fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let auth = test_runner.create_non_fungible_resource(account.clone());
     let auth_id = NonFungibleId::U32(1);

--- a/radix-engine/tests/authorization_dynamic.rs
+++ b/radix-engine/tests/authorization_dynamic.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -16,8 +15,7 @@ fn test_dynamic_auth(
     should_succeed: bool,
 ) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let key_and_addresses: Vec<(
         EcdsaSecp256k1PublicKey,
         EcdsaSecp256k1PrivateKey,
@@ -86,8 +84,7 @@ fn test_dynamic_authlist(
     signer_public_keys: &[usize],
     should_succeed: bool,
 ) {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let key_and_addresses: Vec<(
         EcdsaSecp256k1PublicKey,
         EcdsaSecp256k1PrivateKey,
@@ -225,8 +222,7 @@ fn dynamic_any_of_should_fail_if_path_does_not_exist() {
 #[test]
 fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (pk, _, _) = test_runner.new_allocated_account();
     let (other_public_key, _, _) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/component");
@@ -262,8 +258,7 @@ fn chess_should_not_allow_second_player_to_move_if_first_player_didnt_move() {
 #[test]
 fn chess_should_allow_second_player_to_move_after_first_player() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, _) = test_runner.new_allocated_account();
     let (other_public_key, _, _) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/component");

--- a/radix-engine/tests/authorization_mutability.rs
+++ b/radix-engine/tests/authorization_mutability.rs
@@ -1,7 +1,6 @@
 extern crate core;
 
 use radix_engine::engine::{ApplicationError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::{AccessRulesChainError, AuthZoneError};
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
@@ -21,8 +20,7 @@ enum ResourceAuth {
 
 fn lock_resource_auth_and_try_update(action: ResourceAuth, lock: bool) -> TransactionReceipt {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (token_address, _, _, _, _, admin_auth) = test_runner.create_restricted_token(account);
     let (_, updated_auth) = test_runner.create_restricted_burn_token(account);

--- a/radix-engine/tests/authorization_resource.rs
+++ b/radix-engine/tests/authorization_resource.rs
@@ -1,6 +1,5 @@
 extern crate core;
 
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -20,8 +19,7 @@ enum Action {
 
 fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, expect_err: bool) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (token_address, mint_auth, burn_auth, withdraw_auth, recall_auth, admin_auth) =
         test_runner.create_restricted_token(account);

--- a/radix-engine/tests/authorization_vault.rs
+++ b/radix-engine/tests/authorization_vault.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (_, _, other_account) = test_runner.new_allocated_account();
     let (_, token_resource_address) = test_runner.create_restricted_transfer_token(account);
@@ -36,8 +34,7 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
 #[test]
 fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (_, _, other_account) = test_runner.new_allocated_account();
     let (auth_resource_address, token_resource_address) =

--- a/radix-engine/tests/bucket.rs
+++ b/radix-engine/tests/bucket.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::*;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::{BucketError, ResourceOperationError};
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
@@ -11,8 +10,7 @@ use utils::ContextualDisplay;
 
 fn test_bucket_internal(method_name: &str) {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
 
@@ -82,8 +80,7 @@ fn test_bucket_empty_non_fungible() {
 
 #[test]
 fn test_bucket_of_badges() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
 
@@ -109,8 +106,7 @@ fn test_bucket_of_badges() {
 #[test]
 fn test_take_with_invalid_granularity() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
     let resource_address_str =
@@ -154,8 +150,7 @@ fn test_take_with_invalid_granularity() {
 #[test]
 fn test_take_with_negative_amount() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
     let resource_address_str =
@@ -199,8 +194,7 @@ fn test_take_with_negative_amount() {
 #[test]
 fn create_empty_bucket() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 

--- a/radix-engine/tests/clock.rs
+++ b/radix-engine/tests/clock.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{ModuleError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use transaction::model::AuthModule;
 #[test]
 fn a_new_clock_instance_can_be_created_by_the_system() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -30,8 +28,7 @@ fn a_new_clock_instance_can_be_created_by_the_system() {
 #[test]
 fn a_new_clock_instance_cannot_be_created_by_a_validator() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -52,8 +49,7 @@ fn a_new_clock_instance_cannot_be_created_by_a_validator() {
 #[test]
 fn set_current_time_should_fail_without_validator_auth() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
 
     // Act
@@ -77,8 +73,7 @@ fn set_current_time_should_fail_without_validator_auth() {
 #[test]
 fn validator_can_set_current_time() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
 
     let time_to_set_ms: u64 = 1669663688996;
@@ -117,8 +112,7 @@ fn validator_can_set_current_time() {
 #[test]
 fn no_auth_required_to_get_current_time_rounded_to_minutes() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
 
     // Act
@@ -142,8 +136,7 @@ fn no_auth_required_to_get_current_time_rounded_to_minutes() {
 #[test]
 fn test_clock_comparison_methods_against_the_current_time() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
 
     // Act

--- a/radix-engine/tests/component.rs
+++ b/radix-engine/tests/component.rs
@@ -2,7 +2,6 @@ use radix_engine::engine::{
     ApplicationError, AuthError, InterpreterError, KernelError, LockState, ModuleError,
     RuntimeError, ScryptoFnResolvingError, TrackError,
 };
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::AccessRulesChainError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
@@ -18,8 +17,7 @@ use transaction::signing::EcdsaSecp256k1PrivateKey;
 
 #[test]
 fn test_component() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/component");
 
@@ -64,8 +62,7 @@ fn test_component() {
 #[test]
 fn invalid_blueprint_name_should_cause_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_addr = test_runner.compile_and_publish("./tests/blueprints/component");
 
     // Act
@@ -101,8 +98,7 @@ fn invalid_blueprint_name_should_cause_error() {
 #[test]
 fn mut_reentrancy_should_not_be_possible() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -140,8 +136,7 @@ fn mut_reentrancy_should_not_be_possible() {
 #[test]
 fn read_reentrancy_should_be_possible() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -168,8 +163,7 @@ fn read_reentrancy_should_be_possible() {
 #[test]
 fn read_then_mut_reentrancy_should_not_be_possible() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -207,8 +201,7 @@ fn read_then_mut_reentrancy_should_not_be_possible() {
 #[test]
 fn missing_component_address_in_manifest_should_cause_rejection() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let _ = test_runner.compile_and_publish("./tests/blueprints/component");
     let component_address = Bech32Decoder::new(&NetworkDefinition::simulator())
         .validate_and_decode_component_address(
@@ -585,7 +578,7 @@ fn user_can_not_mutate_auth_on_methods_that_control_auth() {
 }
 
 struct MutableAccessRulesTestRunner {
-    substate_store: TypedInMemorySubstateStore,
+    test_runner: TestRunner,
     package_address: PackageAddress,
     component_address: ComponentAddress,
     initial_proofs: Vec<NonFungibleAddress>,
@@ -595,8 +588,7 @@ impl MutableAccessRulesTestRunner {
     const BLUEPRINT_NAME: &'static str = "MutableAccessRulesComponent";
 
     pub fn new(access_rules: Vec<AccessRules>) -> Self {
-        let mut store = TypedInMemorySubstateStore::with_bootstrap();
-        let mut test_runner = TestRunner::new(true, &mut store);
+        let mut test_runner = TestRunner::new(true);
         let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
 
         let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -611,7 +603,7 @@ impl MutableAccessRulesTestRunner {
         let component_address = receipt.new_component_addresses()[0];
 
         Self {
-            substate_store: store,
+            test_runner,
             package_address,
             component_address,
             initial_proofs: Vec::new(),
@@ -700,7 +692,7 @@ impl MutableAccessRulesTestRunner {
     }
 
     pub fn execute_manifest(&mut self, manifest: TransactionManifest) -> TransactionReceipt {
-        TestRunner::new(true, &mut self.substate_store)
+        self.test_runner
             .execute_manifest_ignoring_fee(manifest, self.initial_proofs.clone())
     }
 }

--- a/radix-engine/tests/core.rs
+++ b/radix-engine/tests/core.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -8,8 +7,7 @@ use transaction::builder::ManifestBuilder;
 
 #[test]
 fn test_process_and_transaction() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/core");
 
     let manifest1 = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -22,8 +20,7 @@ fn test_process_and_transaction() {
 
 #[test]
 fn test_call() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/core");
 

--- a/radix-engine/tests/data_access.rs
+++ b/radix-engine/tests/data_access.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn should_not_be_able_to_read_component_state_after_creation() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/data_access");
 
     // Act
@@ -37,8 +35,7 @@ fn should_not_be_able_to_read_component_state_after_creation() {
 #[test]
 fn should_not_be_able_to_write_component_state_after_creation() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/data_access");
 
     // Act
@@ -65,8 +62,7 @@ fn should_not_be_able_to_write_component_state_after_creation() {
 #[test]
 fn should_be_able_to_read_component_info() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/data_access");
 
     // Act
@@ -88,8 +84,7 @@ fn should_be_able_to_read_component_info() {
 #[test]
 fn should_not_be_able_to_write_component_info() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/data_access");
 
     // Act

--- a/radix-engine/tests/deep_sbor.rs
+++ b/radix-engine/tests/deep_sbor.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine::wasm::WasmError;
@@ -11,8 +10,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn deep_auth_rules_on_component_create_creation_fails() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
 
     // Act 1 - Small Depth
@@ -54,8 +52,7 @@ fn deep_auth_rules_on_component_create_creation_fails() {
 #[test]
 fn setting_struct_with_deep_recursive_data_panics_inside_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
 
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -115,8 +112,7 @@ fn malicious_component_replying_with_large_payload_is_handled_well_by_engine() {
 
 fn publish_wasm_with_deep_sbor_response_and_execute_it(depth: u8) -> TransactionReceipt {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     let code = wat2wasm(
         &include_str!("wasm/deep_sbor_response.wat").replace("${depth}", &depth.to_string()),

--- a/radix-engine/tests/deref.rs
+++ b/radix-engine/tests/deref.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{CallFrameError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::{RENodeId, ScryptoMethodIdent};
 use radix_engine_interface::core::NetworkDefinition;
@@ -12,8 +11,7 @@ use transaction::model::*;
 #[test]
 fn manifest_cannot_refer_to_persisted_component_by_id() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (victim_public_key, _, victim_account) = test_runner.new_allocated_account();
     let (_, _, attacker_account) = test_runner.new_allocated_account();
 
@@ -55,8 +53,7 @@ fn manifest_cannot_refer_to_persisted_component_by_id() {
 #[test]
 fn no_visible_component_nodes_on_deref_lock() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/deref");
 
@@ -79,8 +76,7 @@ fn no_visible_component_nodes_on_deref_lock() {
 #[test]
 fn no_visible_component_nodes_after_deref_lock_drop() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/deref");
 

--- a/radix-engine/tests/epoch.rs
+++ b/radix-engine/tests/epoch.rs
@@ -1,11 +1,9 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use scrypto_unit::*;
 
 #[test]
 fn setting_single_epoch_succeeds() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let epoch = 12u64;
 
     // Act
@@ -18,8 +16,7 @@ fn setting_single_epoch_succeeds() {
 #[test]
 fn setting_multiple_epochs_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let epochs = vec![0u64, 100u64, 12u64, 19u64, 128u64, 4u64];
 
     for epoch in epochs.into_iter() {

--- a/radix-engine/tests/epoch_manager.rs
+++ b/radix-engine/tests/epoch_manager.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{ModuleError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use transaction::model::AuthModule;
 #[test]
 fn get_epoch_should_succeed() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/epoch_manager");
 
     // Act
@@ -30,8 +28,7 @@ fn get_epoch_should_succeed() {
 #[test]
 fn set_epoch_without_supervisor_auth_fails() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/epoch_manager");
 
     // Act
@@ -57,8 +54,7 @@ fn set_epoch_without_supervisor_auth_fails() {
 #[test]
 fn epoch_manager_create_should_fail_with_supervisor_privilege() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -83,8 +79,7 @@ fn epoch_manager_create_should_fail_with_supervisor_privilege() {
 #[test]
 fn epoch_manager_create_should_succeed_with_system_privilege() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/execution_trace.rs
+++ b/radix-engine/tests/execution_trace.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{NativeEvent, SysCallTrace, SysCallTraceOrigin, TrackedEvent};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::LockedAmountOrIds;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::NativeMethod;
@@ -12,8 +11,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_trace_resource_transfers() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
     let transfer_amount = 10u8;
@@ -91,8 +89,7 @@ fn test_trace_resource_transfers() {
 #[test]
 fn test_trace_fee_payments() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
 
     // Prepare the component that will pay the fee
@@ -150,8 +147,7 @@ fn test_trace_fee_payments() {
 #[test]
 fn test_instruction_traces() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
 
     let manfiest = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/external_bridge.rs
+++ b/radix-engine/tests/external_bridge.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_external_bridges() {
     // ARRANGE
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Part 1 - Upload the target and caller packages
     // Note - we put them in separate packages so that we test that the package call is to an external package

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -1,6 +1,5 @@
 use radix_engine::engine::{ApplicationError, KernelError, TrackError};
 use radix_engine::engine::{RejectionError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::WorktopError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
@@ -16,8 +15,7 @@ where
     F: FnOnce(ComponentAddress) -> TransactionManifest,
 {
     // Basic setup
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package and instantiate component
@@ -182,8 +180,7 @@ fn should_succeed_when_lock_fee_and_query_vault() {
 #[test]
 fn test_fee_accounting_success() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account1) = test_runner.new_allocated_account();
     let (_, _, account2) = test_runner.new_allocated_account();
     let account1_balance = test_runner
@@ -238,8 +235,7 @@ fn test_fee_accounting_success() {
 #[test]
 fn test_fee_accounting_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account1) = test_runner.new_allocated_account();
     let (_, _, account2) = test_runner.new_allocated_account();
     let account1_balance = test_runner
@@ -301,8 +297,7 @@ fn test_fee_accounting_failure() {
 #[test]
 fn test_fee_accounting_rejection() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account1) = test_runner.new_allocated_account();
     let account1_balance = test_runner
         .get_component_resources(account1)
@@ -332,8 +327,7 @@ fn test_fee_accounting_rejection() {
 #[test]
 fn test_contingent_fee_accounting_success() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key1, _, account1) = test_runner.new_allocated_account();
     let (public_key2, _, account2) = test_runner.new_allocated_account();
     let account1_balance = test_runner
@@ -386,8 +380,7 @@ fn test_contingent_fee_accounting_success() {
 #[test]
 fn test_contingent_fee_accounting_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key1, _, account1) = test_runner.new_allocated_account();
     let (public_key2, _, account2) = test_runner.new_allocated_account();
     let account1_balance = test_runner

--- a/radix-engine/tests/frame.rs
+++ b/radix-engine/tests/frame.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_constants::DEFAULT_MAX_CALL_DEPTH;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_max_call_depth_success() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/recursion");
 
     // Act
@@ -35,8 +33,7 @@ fn test_max_call_depth_success() {
 #[test]
 fn test_max_call_depth_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/recursion");
 
     // Act

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -5,9 +5,7 @@ use radix_engine::transaction::{
     execute_and_commit_transaction, ExecutionConfig, FeeReserveConfig,
 };
 use radix_engine::types::*;
-use radix_engine::wasm::{
-    DefaultWasmEngine, InstructionCostRules, WasmInstrumenter, WasmMeteringConfig,
-};
+use radix_engine::wasm::{DefaultWasmEngine, WasmInstrumenter, WasmMeteringConfig};
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
 use rand::Rng;

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -27,12 +27,12 @@ fn execute_single_transaction(transaction: NotarizedTransaction) {
         .validate(&transaction, &TestIntentHashManager::new())
         .unwrap();
 
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
         wasm_metering_config: WasmMeteringConfig::V0,
     };
+    let mut store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
     let execution_config = ExecutionConfig::default();
     let fee_reserve_config = FeeReserveConfig::default();
 

--- a/radix-engine/tests/fuzz_transactions.rs
+++ b/radix-engine/tests/fuzz_transactions.rs
@@ -33,10 +33,7 @@ fn execute_single_transaction(transaction: NotarizedTransaction) {
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
-        wasm_metering_config: WasmMeteringConfig::new(
-            InstructionCostRules::tiered(1, 5, 10, 5000),
-            1024,
-        ),
+        wasm_metering_config: WasmMeteringConfig::V0,
     };
     let execution_config = ExecutionConfig::default();
     let fee_reserve_config = FeeReserveConfig::default();

--- a/radix-engine/tests/invalid_stored_values.rs
+++ b/radix-engine/tests/invalid_stored_values.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn stored_bucket_in_committed_component_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/stored_values");
 
     // Act
@@ -41,8 +39,7 @@ fn stored_bucket_in_committed_component_should_fail() {
 #[test]
 fn stored_bucket_in_owned_component_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/stored_values");
 
     // Act

--- a/radix-engine/tests/kernel_node_create.rs
+++ b/radix-engine/tests/kernel_node_create.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, REActor, ResolvedFunction, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn should_not_be_able_to_node_create_with_invalid_blueprint() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kernel");
 
     // Act
@@ -44,8 +42,7 @@ fn should_not_be_able_to_node_create_with_invalid_blueprint() {
 #[test]
 fn should_not_be_able_to_node_create_with_invalid_package() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kernel");
 
     // Act

--- a/radix-engine/tests/kernel_read.rs
+++ b/radix-engine/tests/kernel_read.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, REActor, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn should_not_be_able_to_read_global_substate() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kernel");
 

--- a/radix-engine/tests/kv_store.rs
+++ b/radix-engine/tests/kv_store.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{CallFrameError, KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn can_insert_in_child_nodes() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -28,8 +26,7 @@ fn can_insert_in_child_nodes() {
 #[test]
 fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -51,8 +48,7 @@ fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
 #[test]
 fn cyclic_map_fails_execution() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -74,8 +70,7 @@ fn cyclic_map_fails_execution() {
 #[test]
 fn self_cyclic_map_fails_execution() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -97,8 +92,7 @@ fn self_cyclic_map_fails_execution() {
 #[test]
 fn cannot_remove_kv_stores() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -134,8 +128,7 @@ fn cannot_remove_kv_stores() {
 #[test]
 fn cannot_overwrite_kv_stores() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -171,8 +164,7 @@ fn cannot_overwrite_kv_stores() {
 #[test]
 fn create_kv_store_and_get() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -194,8 +186,7 @@ fn create_kv_store_and_get() {
 #[test]
 fn create_kv_store_and_put() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -217,8 +208,7 @@ fn create_kv_store_and_put() {
 #[test]
 fn can_reference_in_memory_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -240,8 +230,7 @@ fn can_reference_in_memory_vault() {
 #[test]
 fn can_reference_deep_in_memory_value() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -263,8 +252,7 @@ fn can_reference_deep_in_memory_value() {
 #[test]
 fn can_reference_deep_in_memory_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -286,8 +274,7 @@ fn can_reference_deep_in_memory_vault() {
 #[test]
 fn cannot_directly_reference_inserted_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -314,8 +301,7 @@ fn cannot_directly_reference_inserted_vault() {
 #[test]
 fn cannot_directly_reference_vault_after_container_moved() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -342,8 +328,7 @@ fn cannot_directly_reference_vault_after_container_moved() {
 #[test]
 fn cannot_directly_reference_vault_after_container_stored() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act
@@ -370,8 +355,7 @@ fn cannot_directly_reference_vault_after_container_stored() {
 #[test]
 fn multiple_reads_should_work() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
 
     // Act

--- a/radix-engine/tests/leaks.rs
+++ b/radix-engine/tests/leaks.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{ExecutionMode, KernelError, REActor, ResolvedFunction, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn dangling_component_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act
@@ -37,8 +35,7 @@ fn dangling_component_should_fail() {
 #[test]
 fn dangling_bucket_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act
@@ -64,8 +61,7 @@ fn dangling_bucket_should_fail() {
 #[test]
 fn dangling_vault_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act
@@ -91,8 +87,7 @@ fn dangling_vault_should_fail() {
 #[test]
 fn dangling_worktop_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act
@@ -114,8 +109,7 @@ fn dangling_worktop_should_fail() {
 #[test]
 fn dangling_kv_store_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act
@@ -141,8 +135,7 @@ fn dangling_kv_store_should_fail() {
 #[test]
 fn dangling_bucket_with_proof_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
 
     // Act

--- a/radix-engine/tests/local_component.rs
+++ b/radix-engine/tests/local_component.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{KernelError, ModuleError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn local_component_should_return_correct_info() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -33,8 +31,7 @@ fn local_component_should_return_correct_info() {
 #[test]
 fn local_component_should_be_callable_read_only() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -51,8 +48,7 @@ fn local_component_should_be_callable_read_only() {
 #[test]
 fn local_component_should_be_callable_with_write() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -69,8 +65,7 @@ fn local_component_should_be_callable_with_write() {
 #[test]
 fn local_component_with_access_rules_should_not_be_callable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let (public_key, _, account) = test_runner.new_allocated_account();
     let auth_resource_address = test_runner.create_non_fungible_resource(account);
@@ -101,8 +96,7 @@ fn local_component_with_access_rules_should_not_be_callable() {
 #[test]
 fn local_component_with_access_rules_should_be_callable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let (public_key, _, account) = test_runner.new_allocated_account();
     let auth_resource_address = test_runner.create_non_fungible_resource(account);
@@ -136,8 +130,7 @@ fn local_component_with_access_rules_should_be_callable() {
 #[test]
 fn recursion_bomb() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
 
@@ -172,8 +165,7 @@ fn recursion_bomb() {
 #[test]
 fn recursion_bomb_to_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
 
@@ -212,8 +204,7 @@ fn recursion_bomb_to_failure() {
 #[test]
 fn recursion_bomb_2() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
 
@@ -248,8 +239,7 @@ fn recursion_bomb_2() {
 #[test]
 fn recursion_bomb_2_to_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
 

--- a/radix-engine/tests/math.rs
+++ b/radix-engine/tests/math.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use utils::ContextualDisplay;
 #[test]
 fn test_integer_basic_ops() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/math-ops-check");
 
@@ -41,8 +39,7 @@ fn test_integer_basic_ops() {
 #[test]
 fn test_native_and_safe_integer_interop() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/math-ops-check");
 
     // Act

--- a/radix-engine/tests/metadata_component.rs
+++ b/radix-engine/tests/metadata_component.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::args;
 use radix_engine_interface::core::NetworkDefinition;
@@ -8,8 +7,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn can_set_component_metadata() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
 
     // Act

--- a/radix-engine/tests/metadata_package.rs
+++ b/radix-engine/tests/metadata_package.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{AuthError, ModuleError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use scrypto_unit::*;
@@ -8,8 +7,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn cannot_set_package_metadata_with_no_owner() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let code = wat2wasm(include_str!("wasm/basic_package.wat"));
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -54,8 +52,7 @@ fn cannot_set_package_metadata_with_no_owner() {
 #[test]
 fn can_set_package_metadata_with_owner() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let code = wat2wasm(include_str!("wasm/basic_package.wat"));
     let (public_key, _, account) = test_runner.new_account(false);
     let owner_badge_resource = test_runner.create_non_fungible_resource(account);
@@ -97,8 +94,7 @@ fn can_set_package_metadata_with_owner() {
 #[test]
 fn can_lock_package_metadata_with_owner() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let code = wat2wasm(include_str!("wasm/basic_package.wat"));
     let (public_key, _, account) = test_runner.new_account(false);
     let owner_badge_resource = test_runner.create_non_fungible_resource(account);

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_loop() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "100000"));
@@ -36,8 +34,7 @@ fn test_loop() {
 #[test]
 fn test_loop_out_of_cost_unit() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "200000"));
@@ -61,8 +58,7 @@ fn test_loop_out_of_cost_unit() {
 #[test]
 fn test_recursion() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     // In this test case, each call frame costs 4 stack units
@@ -87,8 +83,7 @@ fn test_recursion() {
 #[test]
 fn test_recursion_stack_overflow() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&include_str!("wasm/recursion.wat").replace("${n}", "257"));
@@ -112,8 +107,7 @@ fn test_recursion_stack_overflow() {
 #[test]
 fn test_grow_memory() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", "100"));
@@ -137,8 +131,7 @@ fn test_grow_memory() {
 #[test]
 fn test_grow_memory_out_of_cost_unit() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", "100000"));
@@ -162,8 +155,7 @@ fn test_grow_memory_out_of_cost_unit() {
 #[test]
 fn test_basic_transfer() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key1, _, account1) = test_runner.new_allocated_account();
     let (_, _, account2) = test_runner.new_allocated_account();
 
@@ -213,8 +205,7 @@ fn test_basic_transfer() {
 #[test]
 fn test_publish_large_package() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(&format!(
@@ -251,8 +242,7 @@ fn test_publish_large_package() {
 #[test]
 fn should_be_able_run_large_manifest() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -282,8 +272,7 @@ fn should_be_able_run_large_manifest() {
 #[test]
 fn should_be_able_invoke_account_balance_50_times() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -305,8 +294,7 @@ fn should_be_able_invoke_account_balance_50_times() {
 #[test]
 fn should_be_able_to_generate_5_proofs_and_then_lock_fee() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 0, account);
 

--- a/radix-engine/tests/non_fungible.rs
+++ b/radix-engine/tests/non_fungible.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use utils::ContextualDisplay;
 #[test]
 fn create_non_fungible_mutable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
 
@@ -42,8 +40,7 @@ fn create_non_fungible_mutable() {
 #[test]
 fn can_burn_non_fungible() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -98,8 +95,7 @@ fn can_burn_non_fungible() {
 
 #[test]
 fn test_non_fungible() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
 
@@ -162,8 +158,7 @@ fn test_non_fungible() {
 
 #[test]
 fn test_singleton_non_fungible() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
 
@@ -192,8 +187,7 @@ fn test_singleton_non_fungible() {
 // by a proof in a vault was accidentally committed/persisted, and locked in future transactions
 #[test]
 fn test_mint_update_and_withdraw() {
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
     let network = NetworkDefinition::simulator();
@@ -275,8 +269,7 @@ fn test_mint_update_and_withdraw() {
 #[test]
 fn create_non_fungible_with_id_type_different_than_in_initial_supply() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
 
@@ -307,8 +300,7 @@ fn create_non_fungible_with_id_type_different_than_in_initial_supply() {
 #[test]
 fn create_non_fungible_with_default_id_type() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
 
@@ -339,8 +331,7 @@ fn create_non_fungible_with_default_id_type() {
 #[test]
 fn cant_burn_non_fungible_with_wrong_non_fungible_id_type() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/package.rs
+++ b/radix-engine/tests/package.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{ApplicationError, KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::PackageError;
 use radix_engine::types::*;
 use radix_engine::wasm::*;
@@ -11,8 +10,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn missing_memory_should_cause_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(
@@ -52,8 +50,7 @@ fn missing_memory_should_cause_error() {
 #[test]
 fn large_return_len_should_cause_memory_access_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package = test_runner.compile_and_publish("./tests/blueprints/package");
 
     // Act
@@ -76,8 +73,7 @@ fn large_return_len_should_cause_memory_access_error() {
 #[test]
 fn overflow_return_len_should_cause_memory_access_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package = test_runner.compile_and_publish("./tests/blueprints/package");
 
     // Act
@@ -100,8 +96,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
 #[test]
 fn zero_return_len_should_cause_data_validation_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package = test_runner.compile_and_publish("./tests/blueprints/package");
 
     // Act
@@ -121,8 +116,7 @@ fn zero_return_len_should_cause_data_validation_error() {
 #[test]
 fn test_basic_package() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
 
     // Act
     let code = wat2wasm(include_str!("wasm/basic_package.wat"));
@@ -145,8 +139,7 @@ fn test_basic_package() {
 #[test]
 fn test_basic_package_missing_export() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let mut blueprints = HashMap::new();
     blueprints.insert(
         "some_blueprint".to_string(),

--- a/radix-engine/tests/preview.rs
+++ b/radix-engine/tests/preview.rs
@@ -1,5 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
-use radix_engine::transaction::{ExecutionConfig, FeeReserveConfig};
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -15,8 +13,7 @@ use transaction::validation::{TransactionValidator, ValidationConfig};
 #[test]
 fn test_transaction_preview_cost_estimate() {
     // Arrange
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut substate_store);
+    let mut test_runner = TestRunner::new(true);
     let network = NetworkDefinition::simulator();
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -41,11 +38,8 @@ fn test_transaction_preview_cost_estimate() {
     let preview_receipt = preview_result.unwrap().receipt;
     preview_receipt.expect_commit_success();
 
-    let receipt = test_runner.execute_transaction_with_config(
-        &make_executable(&network, &notarized_transaction),
-        &FeeReserveConfig::default(),
-        &ExecutionConfig::default(),
-    );
+    let receipt =
+        test_runner.execute_transaction(&make_executable(&network, &notarized_transaction));
     receipt.expect_commit_success();
 
     assert_eq!(
@@ -58,8 +52,7 @@ fn test_transaction_preview_cost_estimate() {
 fn test_assume_all_signature_proofs_flag_method_authorization() {
     // Arrange
     // Create an account component that requires a key auth for withdrawal
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut substate_store);
+    let mut test_runner = TestRunner::new(true);
     let network = NetworkDefinition::simulator();
 
     let public_key = EcdsaSecp256k1PrivateKey::from_u64(99).unwrap().public_key();
@@ -100,7 +93,7 @@ fn test_assume_all_signature_proofs_flag_method_authorization() {
 }
 
 fn prepare_matching_test_tx_and_preview_intent(
-    test_runner: &TestRunner<TypedInMemorySubstateStore>,
+    test_runner: &TestRunner,
     network: &NetworkDefinition,
     manifest: TransactionManifest,
     flags: &PreviewFlags,

--- a/radix-engine/tests/proof.rs
+++ b/radix-engine/tests/proof.rs
@@ -1,6 +1,5 @@
 use radix_engine::engine::node_move_module::NodeMoveError;
 use radix_engine::engine::{ModuleError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -14,8 +13,7 @@ use utils::ContextualDisplay;
 #[test]
 fn can_create_clone_and_drop_bucket_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
@@ -57,8 +55,7 @@ fn can_create_clone_and_drop_bucket_proof() {
 #[test]
 fn can_create_clone_and_drop_vault_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
@@ -93,8 +90,7 @@ fn can_create_clone_and_drop_vault_proof() {
 #[test]
 fn can_create_clone_and_drop_vault_proof_by_amount() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
@@ -133,8 +129,7 @@ fn can_create_clone_and_drop_vault_proof_by_amount() {
 #[test]
 fn can_create_clone_and_drop_vault_proof_by_ids() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
@@ -174,8 +169,7 @@ fn can_create_clone_and_drop_vault_proof_by_ids() {
 #[test]
 fn can_use_bucket_for_authorization() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
@@ -220,8 +214,7 @@ fn can_use_bucket_for_authorization() {
 #[test]
 fn can_use_vault_for_authorization() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
@@ -265,8 +258,7 @@ fn can_use_vault_for_authorization() {
 #[test]
 fn can_create_proof_from_account_and_pass_on() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
@@ -303,8 +295,7 @@ fn can_create_proof_from_account_and_pass_on() {
 #[test]
 fn cant_move_restricted_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
@@ -348,8 +339,7 @@ fn cant_move_restricted_proof() {
 #[test]
 fn cant_move_locked_bucket() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
@@ -393,8 +383,7 @@ fn cant_move_locked_bucket() {
 #[test]
 fn can_compose_bucket_and_vault_proof() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
@@ -435,8 +424,7 @@ fn can_compose_bucket_and_vault_proof() {
 #[test]
 fn can_compose_bucket_and_vault_proof_by_amount() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
@@ -477,8 +465,7 @@ fn can_compose_bucket_and_vault_proof_by_amount() {
 #[test]
 fn can_compose_bucket_and_vault_proof_by_ids() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
@@ -529,8 +516,7 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
 #[test]
 fn can_create_vault_proof_by_amount_from_non_fungibles() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
@@ -564,8 +550,7 @@ fn can_create_vault_proof_by_amount_from_non_fungibles() {
 #[test]
 fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");

--- a/radix-engine/tests/recallable.rs
+++ b/radix-engine/tests/recallable.rs
@@ -2,7 +2,6 @@ use radix_engine::engine::{
     AuthError, KernelError, ModuleError, REActor, RejectionError, ResolvedMethod, ResolvedReceiver,
     RuntimeError,
 };
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::MethodAuthorizationError;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::{NativeMethod, RENodeId};
@@ -16,8 +15,7 @@ use transaction::model::Instruction;
 #[test]
 fn non_existing_vault_should_cause_error() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
 
     let non_existing_vault_id = [0; 36];
@@ -58,8 +56,7 @@ fn non_existing_vault_should_cause_error() {
 #[test]
 fn cannot_get_amount_on_direct_vault_access() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
 
     let resource_address = test_runner.create_fungible_resource(10u32.into(), 0u8, account);
@@ -91,8 +88,7 @@ fn cannot_get_amount_on_direct_vault_access() {
 #[test]
 fn cannot_take_on_non_recallable_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
 
     let resource_address = test_runner.create_fungible_resource(10u32.into(), 0u8, account);
@@ -144,8 +140,7 @@ fn cannot_take_on_non_recallable_vault() {
 #[test]
 fn can_take_on_recallable_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (_, _, account) = test_runner.new_allocated_account();
     let (_, _, other_account) = test_runner.new_allocated_account();
 

--- a/radix-engine/tests/resource.rs
+++ b/radix-engine/tests/resource.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{ApplicationError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::model::ResourceManagerError;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
@@ -11,8 +10,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_set_mintable_with_self_resource_address() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, _) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
 
@@ -38,8 +36,7 @@ fn test_set_mintable_with_self_resource_address() {
 #[test]
 fn test_resource_manager() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
 
@@ -73,8 +70,7 @@ fn test_resource_manager() {
 #[test]
 fn mint_with_bad_granularity_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
 
@@ -114,8 +110,7 @@ fn mint_with_bad_granularity_should_fail() {
 #[test]
 fn mint_too_much_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
 

--- a/radix-engine/tests/royalty.rs
+++ b/radix-engine/tests/royalty.rs
@@ -1,5 +1,4 @@
 use radix_engine::fee::u128_to_decimal;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_constants::DEFAULT_COST_UNIT_PRICE;
 use radix_engine_interface::core::NetworkDefinition;
@@ -11,8 +10,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_component_royalty() {
     // Basic setup
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
@@ -51,7 +49,7 @@ fn test_component_royalty() {
 }
 
 fn set_up_package_and_component() -> (
-    TypedInMemorySubstateStore,
+    TestRunner,
     ComponentAddress,
     EcdsaSecp256k1PublicKey,
     PackageAddress,
@@ -59,8 +57,7 @@ fn set_up_package_and_component() -> (
     ResourceAddress,
 ) {
     // Basic setup
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
@@ -102,7 +99,7 @@ fn set_up_package_and_component() -> (
         scrypto_decode(&receipt.expect_commit_success()[1]).unwrap();
 
     (
-        store,
+        test_runner,
         account,
         public_key,
         package_address,
@@ -114,14 +111,13 @@ fn set_up_package_and_component() -> (
 #[test]
 fn test_package_royalty() {
     let (
-        mut store,
+        mut test_runner,
         account,
         public_key,
         _package_address,
         component_address,
         _owner_badge_resource,
     ) = set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -140,9 +136,14 @@ fn test_package_royalty() {
 
 #[test]
 fn test_royalty_accumulation_when_success() {
-    let (mut store, account, public_key, package_address, component_address, _owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        package_address,
+        component_address,
+        _owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -165,9 +166,14 @@ fn test_royalty_accumulation_when_success() {
 
 #[test]
 fn test_royalty_accumulation_when_failure() {
-    let (mut store, account, public_key, package_address, component_address, _owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        package_address,
+        component_address,
+        _owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -190,9 +196,14 @@ fn test_royalty_accumulation_when_failure() {
 
 #[test]
 fn test_claim_royalty() {
-    let (mut store, account, public_key, package_address, component_address, owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        package_address,
+        component_address,
+        owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/royalty_auth.rs
+++ b/radix-engine/tests/royalty_auth.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -7,7 +6,7 @@ use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
 fn set_up_package_and_component() -> (
-    TypedInMemorySubstateStore,
+    TestRunner,
     ComponentAddress,
     EcdsaSecp256k1PublicKey,
     PackageAddress,
@@ -15,8 +14,7 @@ fn set_up_package_and_component() -> (
     ResourceAddress,
 ) {
     // Basic setup
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let owner_badge_resource = test_runner.create_non_fungible_resource(account);
     let owner_badge_addr = NonFungibleAddress::new(owner_badge_resource, NonFungibleId::U32(1));
@@ -82,7 +80,7 @@ fn set_up_package_and_component() -> (
         .new_component_addresses[0];
 
     (
-        store,
+        test_runner,
         account,
         public_key,
         package_address,
@@ -93,9 +91,14 @@ fn set_up_package_and_component() -> (
 
 #[test]
 fn test_only_package_owner_can_set_royalty_config() {
-    let (mut store, account, public_key, package_address, _component_address, owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        package_address,
+        _component_address,
+        owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -140,9 +143,14 @@ fn test_only_package_owner_can_set_royalty_config() {
 
 #[test]
 fn test_only_package_owner_can_claim_royalty() {
-    let (mut store, account, public_key, package_address, _component_address, owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        package_address,
+        _component_address,
+        owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -185,9 +193,14 @@ fn test_only_package_owner_can_claim_royalty() {
 
 #[test]
 fn test_only_component_owner_can_set_royalty_config() {
-    let (mut store, account, public_key, _package_address, component_address, owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        _package_address,
+        component_address,
+        owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())
@@ -226,9 +239,14 @@ fn test_only_component_owner_can_set_royalty_config() {
 
 #[test]
 fn test_only_component_owner_can_claim_royalty() {
-    let (mut store, account, public_key, _package_address, component_address, owner_badge_resource) =
-        set_up_package_and_component();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let (
+        mut test_runner,
+        account,
+        public_key,
+        _package_address,
+        component_address,
+        owner_badge_resource,
+    ) = set_up_package_and_component();
 
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/stored_external_component.rs
+++ b/radix-engine/tests/stored_external_component.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn stored_component_addresses_in_non_globalized_component_are_invokable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package = test_runner.compile_and_publish("./tests/blueprints/stored_external_component");
 
     // Act
@@ -26,8 +24,7 @@ fn stored_component_addresses_in_non_globalized_component_are_invokable() {
 #[test]
 fn stored_component_addresses_are_invokable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, _) = test_runner.new_allocated_account();
     let package = test_runner.compile_and_publish("./tests/blueprints/stored_external_component");
     let manifest1 = ManifestBuilder::new(&NetworkDefinition::simulator())

--- a/radix-engine/tests/stored_local_component.rs
+++ b/radix-engine/tests/stored_local_component.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -9,8 +8,7 @@ use transaction::builder::ManifestBuilder;
 #[ignore = "FIXME: Node root-ness property is not tracked properly"]
 fn should_not_be_able_call_owned_components_directly() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -42,8 +40,7 @@ fn should_not_be_able_call_owned_components_directly() {
 #[test]
 fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -65,8 +62,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component()
 #[test]
 fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -88,8 +84,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component(
 #[test]
 fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -123,8 +118,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
 #[test]
 fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -159,8 +153,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
 #[test]
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -182,8 +175,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_componen
 #[test]
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
 
     // Act
@@ -205,8 +197,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_compone
 #[test]
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -240,8 +231,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
 #[test]
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())

--- a/radix-engine/tests/stored_resource.rs
+++ b/radix-engine/tests/stored_resource.rs
@@ -1,4 +1,3 @@
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -8,8 +7,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn stored_resource_is_invokeable() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package = test_runner.compile_and_publish("./tests/blueprints/stored_resource");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -1,5 +1,11 @@
+use radix_engine::engine::ScryptoInterpreter;
 use radix_engine::ledger::TypedInMemorySubstateStore;
+use radix_engine::state_manager::StagedSubstateStoreManager;
+use radix_engine::transaction::{
+    execute_and_commit_transaction, ExecutionConfig, FeeReserveConfig, TransactionReceipt,
+};
 use radix_engine::types::*;
+use radix_engine::wasm::WasmEngine;
 use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -24,74 +30,123 @@ fn self_transfer_txn(account: ComponentAddress, amount: Decimal) -> TransactionM
 fn batched_executions_should_result_in_the_same_result() {
     // Arrange
     // These runners should mirror each other
-    let mut store0 = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner0 = TestRunner::new(true, &mut store0);
+    let mut test_runner0 = TestRunner::new(true);
     let (public_key, _, account) = test_runner0.new_allocated_account();
-    let mut manifests = Vec::<(TransactionManifest, Vec<NonFungibleAddress>)>::new();
-    for amount in 0u32..10u32 {
-        let manifest = self_transfer_txn(account, Decimal::from(amount));
+    let mut manifests = Vec::<(TransactionManifest, Vec<NonFungibleAddress>, u64)>::new();
+    for i in 0u64..10u64 {
+        let manifest = self_transfer_txn(account, Decimal::from(i));
         manifests.push((
             manifest,
             vec![NonFungibleAddress::from_public_key(&public_key)],
+            i,
         ));
     }
 
-    let mut store1 = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner1 = TestRunner::new(true, &mut store1);
+    let mut test_runner1 = TestRunner::new(true);
     let _ = test_runner1.new_allocated_account();
-    let mut store2 = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner2 = TestRunner::new(true, &mut store2);
+    let mut test_runner2 = TestRunner::new(true);
     let _ = test_runner2.new_allocated_account();
-    let mut store3 = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner3 = TestRunner::new(true, &mut store3);
+    let mut test_runner3 = TestRunner::new(true);
     let _ = test_runner3.new_allocated_account();
-    let mut store4 = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner4 = TestRunner::new(true, &mut store4);
+    let mut test_runner4 = TestRunner::new(true);
     let _ = test_runner4.new_allocated_account();
 
     // Act
 
     // Test Runner 0: One by One
-    for (manifest, signers) in &manifests {
-        let receipt = test_runner0.execute_manifest(manifest.clone(), signers.clone());
-        receipt.expect_commit_success();
+    for each in &manifests {
+        let (mut manager, scrypto_interpreter) = test_runner0.new_staged_substate_store_manager();
+        execute_and_commit_manifests(&mut manager, scrypto_interpreter, 0, vec![each.clone()]);
     }
 
     // Test Runner 1: Batch
-    test_runner1.execute_batch(manifests.clone(), DEFAULT_COST_UNIT_LIMIT);
+    let (mut manager, scrypto_interpreter) = test_runner1.new_staged_substate_store_manager();
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, 0, manifests.clone());
 
     // Test Runner 2: Multi-batch, Single-commit
     let (batch0, batch1) = manifests.split_at(5);
-    let node_id0 = test_runner2.create_child_node(0);
-    test_runner2.execute_batch_on_node(node_id0, batch0.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    let node_id1 = test_runner2.create_child_node(node_id0);
-    test_runner2.execute_batch_on_node(node_id1, batch1.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    test_runner2.merge_node(node_id1);
+    let (mut manager, scrypto_interpreter) = test_runner2.new_staged_substate_store_manager();
+    let node_id0 = manager.new_child_node(0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id0, batch0.to_vec());
+    let node_id1 = manager.new_child_node(node_id0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id1, batch1.to_vec());
+    manager.merge_to_parent(node_id1);
 
     // Test Runner 3: Multi-batch, Multi-commit
     let (batch0, batch1) = manifests.split_at(5);
-    let node_id0 = test_runner3.create_child_node(0);
-    test_runner3.execute_batch_on_node(node_id0, batch0.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    let node_id1 = test_runner3.create_child_node(node_id0);
-    test_runner3.execute_batch_on_node(node_id1, batch1.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    test_runner3.merge_node(node_id0);
-    test_runner3.merge_node(node_id1);
+    let (mut manager, scrypto_interpreter) = test_runner3.new_staged_substate_store_manager();
+    let node_id0 = manager.new_child_node(0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id0, batch0.to_vec());
+    let node_id1 = manager.new_child_node(node_id0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id1, batch1.to_vec());
+    manager.merge_to_parent(node_id0);
+    manager.merge_to_parent(node_id1);
 
     // Test Runner 3: Multi-batch, Fork, Single-commit
     let (batch0, batch1) = manifests.split_at(5);
-    let node_id0 = test_runner4.create_child_node(0);
-    test_runner4.execute_batch_on_node(node_id0, batch0.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    let node_id1 = test_runner4.create_child_node(node_id0);
-    test_runner4.execute_batch_on_node(node_id1, batch1.to_vec(), DEFAULT_COST_UNIT_LIMIT);
-    let fork_id = test_runner4.create_child_node(node_id0);
-    test_runner4.execute_batch_on_node(fork_id, manifests.clone(), DEFAULT_COST_UNIT_LIMIT);
-    let fork_child_id = test_runner4.create_child_node(fork_id);
-    test_runner4.execute_batch_on_node(fork_child_id, manifests.clone(), DEFAULT_COST_UNIT_LIMIT);
-    test_runner4.merge_node(node_id1);
+    let (mut manager, scrypto_interpreter) = test_runner4.new_staged_substate_store_manager();
+    let node_id0 = manager.new_child_node(0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id0, batch0.to_vec());
+    let node_id1 = manager.new_child_node(node_id0);
+    execute_and_commit_manifests(&mut manager, scrypto_interpreter, node_id1, batch1.to_vec());
+    let fork_id = manager.new_child_node(node_id0);
+    execute_and_commit_manifests(
+        &mut manager,
+        scrypto_interpreter,
+        fork_id,
+        manifests.clone(),
+    );
+    let fork_child_id = manager.new_child_node(fork_id);
+    execute_and_commit_manifests(
+        &mut manager,
+        scrypto_interpreter,
+        fork_child_id,
+        manifests.clone(),
+    );
+    manager.merge_to_parent(node_id1);
 
     // Assert
-    assert_eq!(store0, store1);
-    assert_eq!(store1, store2);
-    assert_eq!(store2, store3);
-    assert_eq!(store3, store4);
+    assert_eq!(test_runner0.substate_store(), test_runner1.substate_store());
+    assert_eq!(test_runner1.substate_store(), test_runner2.substate_store());
+    assert_eq!(test_runner2.substate_store(), test_runner3.substate_store());
+    assert_eq!(test_runner3.substate_store(), test_runner4.substate_store());
+}
+
+pub fn execute_and_commit_manifests<W: WasmEngine>(
+    manager: &mut StagedSubstateStoreManager<TypedInMemorySubstateStore>,
+    scrypto_interpreter: &ScryptoInterpreter<W>,
+    node_id: u64,
+    manifests: Vec<(TransactionManifest, Vec<NonFungibleAddress>, u64)>,
+) -> Vec<TransactionReceipt> {
+    if node_id == 0 {
+        let staged = manager.get_root_store();
+        manifests
+            .into_iter()
+            .map(|(manifest, initial_proofs, nonce)| {
+                let transaction = TestTransaction::new(manifest, nonce, DEFAULT_COST_UNIT_LIMIT);
+                execute_and_commit_transaction(
+                    staged,
+                    scrypto_interpreter,
+                    &FeeReserveConfig::default(),
+                    &ExecutionConfig::default(),
+                    &transaction.get_executable(initial_proofs),
+                )
+            })
+            .collect()
+    } else {
+        let mut staged = manager.get_output_store(node_id);
+        manifests
+            .into_iter()
+            .map(|(manifest, initial_proofs, nonce)| {
+                let transaction = TestTransaction::new(manifest, nonce, DEFAULT_COST_UNIT_LIMIT);
+                execute_and_commit_transaction(
+                    &mut staged,
+                    scrypto_interpreter,
+                    &FeeReserveConfig::default(),
+                    &ExecutionConfig::default(),
+                    &transaction.get_executable(initial_proofs),
+                )
+            })
+            .collect()
+    }
 }

--- a/radix-engine/tests/track.rs
+++ b/radix-engine/tests/track.rs
@@ -124,12 +124,13 @@ pub fn execute_and_commit_manifests<W: WasmEngine>(
             .into_iter()
             .map(|(manifest, initial_proofs, nonce)| {
                 let transaction = TestTransaction::new(manifest, nonce, DEFAULT_COST_UNIT_LIMIT);
+                let executable = transaction.get_executable(initial_proofs);
                 execute_and_commit_transaction(
                     staged,
                     scrypto_interpreter,
                     &FeeReserveConfig::default(),
                     &ExecutionConfig::default(),
-                    &transaction.get_executable(initial_proofs),
+                    &executable,
                 )
             })
             .collect()
@@ -139,12 +140,13 @@ pub fn execute_and_commit_manifests<W: WasmEngine>(
             .into_iter()
             .map(|(manifest, initial_proofs, nonce)| {
                 let transaction = TestTransaction::new(manifest, nonce, DEFAULT_COST_UNIT_LIMIT);
+                let executable = transaction.get_executable(initial_proofs);
                 execute_and_commit_transaction(
                     &mut staged,
                     scrypto_interpreter,
                     &FeeReserveConfig::default(),
                     &ExecutionConfig::default(),
-                    &transaction.get_executable(initial_proofs),
+                    &executable,
                 )
             })
             .collect()

--- a/radix-engine/tests/transaction.rs
+++ b/radix-engine/tests/transaction.rs
@@ -1,7 +1,6 @@
 use radix_engine::engine::KernelError;
 use radix_engine::engine::RejectionError;
 use radix_engine::engine::RuntimeError;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -14,8 +13,7 @@ use utils::ContextualDisplay;
 #[test]
 fn test_manifest_with_non_existent_resource() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let non_existent_resource = ResourceAddress::Normal([0u8; 26]);
 
@@ -45,8 +43,7 @@ fn test_manifest_with_non_existent_resource() {
 #[test]
 fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -91,8 +88,7 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
 #[test]
 fn test_transaction_can_end_with_proofs_remaining_in_auth_zone() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -116,8 +112,7 @@ fn test_transaction_can_end_with_proofs_remaining_in_auth_zone() {
 #[test]
 fn test_non_existent_blob_hash() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -155,8 +150,7 @@ fn test_non_existent_blob_hash() {
 #[test]
 fn test_entire_auth_zone() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
 
@@ -184,8 +178,7 @@ fn test_entire_auth_zone() {
 #[test]
 fn test_faucet_drain_attempt_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act

--- a/radix-engine/tests/transaction_commit_rollback.rs
+++ b/radix-engine/tests/transaction_commit_rollback.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::*;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::data::*;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_state_track_success() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (_, _, other_account) = test_runner.new_allocated_account();
 
@@ -42,8 +40,7 @@ fn test_state_track_success() {
 #[test]
 fn test_state_track_failure() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (_, _, other_account) = test_runner.new_allocated_account();
 

--- a/radix-engine/tests/transaction_executor.rs
+++ b/radix-engine/tests/transaction_executor.rs
@@ -42,8 +42,7 @@ fn low_cost_unit_limit_should_result_in_rejection() {
 #[test]
 fn transaction_executed_before_valid_returns_that_rejection_reason() {
     // Arrange
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut substate_store);
+    let mut test_runner = TestRunner::new(true);
 
     const CURRENT_EPOCH: u64 = 150;
     const VALID_FROM_EPOCH: u64 = 151;
@@ -79,8 +78,7 @@ fn transaction_executed_before_valid_returns_that_rejection_reason() {
 #[test]
 fn transaction_executed_after_valid_returns_that_rejection_reason() {
     // Arrange
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut substate_store);
+    let mut test_runner = TestRunner::new(true);
 
     const CURRENT_EPOCH: u64 = 157;
     const VALID_FROM_EPOCH: u64 = 151;
@@ -116,13 +114,12 @@ fn transaction_executed_after_valid_returns_that_rejection_reason() {
 #[test]
 fn test_normal_transaction_flow() {
     // Arrange
-    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap();
-
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
         wasm_metering_config: WasmMeteringConfig::V0,
     };
+    let mut substate_store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
 
     let intent_hash_manager = TestIntentHashManager::new();
     let fee_reserve_config = FeeReserveConfig::default();

--- a/radix-engine/tests/transaction_executor.rs
+++ b/radix-engine/tests/transaction_executor.rs
@@ -5,7 +5,7 @@ use radix_engine::transaction::execute_and_commit_transaction;
 use radix_engine::transaction::{ExecutionConfig, FeeReserveConfig};
 use radix_engine::types::*;
 use radix_engine::wasm::WasmInstrumenter;
-use radix_engine::wasm::{DefaultWasmEngine, InstructionCostRules, WasmMeteringConfig};
+use radix_engine::wasm::{DefaultWasmEngine, WasmMeteringConfig};
 use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::core::NetworkDefinition;
 use scrypto_unit::*;
@@ -121,10 +121,7 @@ fn test_normal_transaction_flow() {
     let mut scrypto_interpreter = ScryptoInterpreter {
         wasm_engine: DefaultWasmEngine::default(),
         wasm_instrumenter: WasmInstrumenter::default(),
-        wasm_metering_config: WasmMeteringConfig::new(
-            InstructionCostRules::tiered(1, 5, 10, 5000),
-            1024,
-        ),
+        wasm_metering_config: WasmMeteringConfig::V0,
     };
 
     let intent_hash_manager = TestIntentHashManager::new();

--- a/radix-engine/tests/vault.rs
+++ b/radix-engine/tests/vault.rs
@@ -1,5 +1,4 @@
 use radix_engine::engine::{CallFrameError, KernelError, RuntimeError};
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -10,8 +9,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn non_existent_vault_in_component_creation_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -38,8 +36,7 @@ fn non_existent_vault_in_component_creation_should_fail() {
 #[test]
 fn non_existent_vault_in_committed_component_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -70,8 +67,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
 #[test]
 fn non_existent_vault_in_kv_store_creation_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -98,8 +94,7 @@ fn non_existent_vault_in_kv_store_creation_should_fail() {
 #[test]
 fn non_existent_vault_in_committed_kv_store_should_fail() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -134,8 +129,7 @@ fn non_existent_vault_in_committed_kv_store_should_fail() {
 #[test]
 fn create_mutable_vault_into_map() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -152,8 +146,7 @@ fn create_mutable_vault_into_map() {
 #[test]
 fn invalid_double_ownership_of_vault() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -180,8 +173,7 @@ fn invalid_double_ownership_of_vault() {
 #[test]
 fn create_mutable_vault_into_map_and_referencing_before_storing() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -203,8 +195,7 @@ fn create_mutable_vault_into_map_and_referencing_before_storing() {
 #[test]
 fn cannot_overwrite_vault_in_map() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -235,8 +226,7 @@ fn cannot_overwrite_vault_in_map() {
 #[test]
 fn create_mutable_vault_into_vector() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -258,8 +248,7 @@ fn create_mutable_vault_into_vector() {
 #[test]
 fn cannot_remove_vaults() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10u32.into())
@@ -295,8 +284,7 @@ fn cannot_remove_vaults() {
 #[test]
 fn can_push_vault_into_vector() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
     let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
         .lock_fee(FAUCET_COMPONENT, 10.into())
@@ -327,8 +315,7 @@ fn can_push_vault_into_vector() {
 #[test]
 fn create_mutable_vault_with_take() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -345,8 +332,7 @@ fn create_mutable_vault_with_take() {
 #[test]
 fn create_mutable_vault_with_take_non_fungible() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -368,8 +354,7 @@ fn create_mutable_vault_with_take_non_fungible() {
 #[test]
 fn create_mutable_vault_with_get_nonfungible_ids() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -391,8 +376,7 @@ fn create_mutable_vault_with_get_nonfungible_ids() {
 #[test]
 fn create_mutable_vault_with_get_nonfungible_id() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -414,8 +398,7 @@ fn create_mutable_vault_with_get_nonfungible_id() {
 #[test]
 fn create_mutable_vault_with_get_amount() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act
@@ -437,8 +420,7 @@ fn create_mutable_vault_with_get_amount() {
 #[test]
 fn create_mutable_vault_with_get_resource_manager() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
 
     // Act

--- a/radix-engine/tests/worktop.rs
+++ b/radix-engine/tests/worktop.rs
@@ -1,6 +1,5 @@
 use radix_engine::engine::KernelError;
 use radix_engine::engine::RuntimeError;
-use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::*;
 use radix_engine_interface::api::types::RENodeId;
 use radix_engine_interface::core::NetworkDefinition;
@@ -11,8 +10,7 @@ use transaction::builder::ManifestBuilder;
 #[test]
 fn test_worktop_resource_leak() {
     // Arrange
-    let mut store = TypedInMemorySubstateStore::with_bootstrap();
-    let mut test_runner = TestRunner::new(true, &mut store);
+    let mut test_runner = TestRunner::new(true);
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -16,9 +16,7 @@ use radix_engine::transaction::{
     FeeReserveConfig, PreviewError, PreviewResult, TransactionReceipt, TransactionResult,
 };
 use radix_engine::types::*;
-use radix_engine::wasm::{
-    DefaultWasmEngine, InstructionCostRules, WasmInstrumenter, WasmMeteringConfig,
-};
+use radix_engine::wasm::{DefaultWasmEngine, WasmInstrumenter, WasmMeteringConfig};
 use radix_engine_constants::*;
 use radix_engine_interface::api::api::Invokable;
 use radix_engine_interface::api::types::{RENodeId, ScryptoMethodIdent};
@@ -52,10 +50,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
 {
     pub fn new(trace: bool, substate_store: &'s mut S) -> Self {
         let scrypto_interpreter = ScryptoInterpreter {
-            wasm_metering_config: WasmMeteringConfig::new(
-                InstructionCostRules::tiered(1, 5, 10, 5000),
-                1024,
-            ),
+            wasm_metering_config: WasmMeteringConfig::V0,
             wasm_engine: DefaultWasmEngine::default(),
             wasm_instrumenter: WasmInstrumenter::default(),
         };

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -36,32 +36,51 @@ use transaction::model::{PreviewIntent, TestTransaction};
 use transaction::signing::EcdsaSecp256k1PrivateKey;
 use transaction::validation::TestIntentHashManager;
 
-pub struct TestRunner<'s, S: ReadableSubstateStore + WriteableSubstateStore> {
-    execution_stores: StagedSubstateStoreManager<'s, S>,
+pub struct TestRunner {
     scrypto_interpreter: ScryptoInterpreter<DefaultWasmEngine>,
+    substate_store: TypedInMemorySubstateStore,
     intent_hash_manager: TestIntentHashManager,
     next_private_key: u64,
     next_transaction_nonce: u64,
     trace: bool,
 }
 
-impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateStore>
-    TestRunner<'s, S>
-{
-    pub fn new(trace: bool, substate_store: &'s mut S) -> Self {
+impl TestRunner {
+    pub fn new(trace: bool) -> Self {
         let scrypto_interpreter = ScryptoInterpreter {
             wasm_metering_config: WasmMeteringConfig::V0,
             wasm_engine: DefaultWasmEngine::default(),
             wasm_instrumenter: WasmInstrumenter::default(),
         };
+        let substate_store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
         Self {
-            execution_stores: StagedSubstateStoreManager::new(substate_store),
             scrypto_interpreter,
+            substate_store,
             intent_hash_manager: TestIntentHashManager::new(),
             next_private_key: 1, // 0 is invalid
             next_transaction_nonce: 0,
             trace,
         }
+    }
+
+    pub fn substate_store(&self) -> &TypedInMemorySubstateStore {
+        &self.substate_store
+    }
+
+    pub fn substate_store_mut(&mut self) -> &mut TypedInMemorySubstateStore {
+        &mut self.substate_store
+    }
+
+    pub fn new_staged_substate_store_manager(
+        &mut self,
+    ) -> (
+        StagedSubstateStoreManager<TypedInMemorySubstateStore>,
+        &ScryptoInterpreter<DefaultWasmEngine>,
+    ) {
+        (
+            StagedSubstateStoreManager::new(&mut self.substate_store),
+            &self.scrypto_interpreter,
+        )
     }
 
     pub fn next_transaction_nonce(&self) -> u64 {
@@ -94,8 +113,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     pub fn get_metadata(&mut self, address: GlobalAddress) -> HashMap<String, String> {
         let node_id = RENodeId::Global(address);
         let global = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 node_id,
                 SubstateOffset::Global(GlobalOffset::Global),
@@ -106,8 +124,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         let underlying_node = global.global().node_deref();
 
         let metadata = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 underlying_node,
                 SubstateOffset::Metadata(MetadataOffset::Metadata),
@@ -122,8 +139,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     pub fn deref_component(&mut self, component_address: ComponentAddress) -> Option<RENodeId> {
         let node_id = RENodeId::Global(GlobalAddress::Component(component_address));
         let global = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 node_id,
                 SubstateOffset::Global(GlobalOffset::Global),
@@ -135,8 +151,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     pub fn deref_package(&mut self, package_address: PackageAddress) -> Option<RENodeId> {
         let node_id = RENodeId::Global(GlobalAddress::Package(package_address));
         let global = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 node_id,
                 SubstateOffset::Global(GlobalOffset::Global),
@@ -151,8 +166,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     ) -> Option<Decimal> {
         let node_id = self.deref_component(component_address)?;
 
-        self.execution_stores
-            .get_root_store()
+        self.substate_store
             .get_substate(&SubstateId(
                 node_id,
                 SubstateOffset::Component(ComponentOffset::RoyaltyAccumulator),
@@ -169,8 +183,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     pub fn inspect_package_royalty(&mut self, package_address: PackageAddress) -> Option<Decimal> {
         let node_id = self.deref_package(package_address)?;
 
-        self.execution_stores
-            .get_root_store()
+        self.substate_store
             .get_substate(&SubstateId(
                 node_id,
                 SubstateOffset::Package(PackageOffset::RoyaltyAccumulator),
@@ -192,11 +205,8 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         let node_id = RENodeId::Global(GlobalAddress::Component(component_address));
         let mut vault_finder = VaultFinder::new(resource_address);
 
-        let mut state_tree_visitor = StateTreeTraverser::new(
-            self.execution_stores.get_root_store(),
-            &mut vault_finder,
-            100,
-        );
+        let mut state_tree_visitor =
+            StateTreeTraverser::new(&self.substate_store, &mut vault_finder, 100);
         state_tree_visitor
             .traverse_all_descendents(None, node_id)
             .unwrap();
@@ -208,7 +218,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         component_address: ComponentAddress,
     ) -> HashMap<ResourceAddress, Decimal> {
         let node_id = RENodeId::Global(GlobalAddress::Component(component_address));
-        let mut accounter = ResourceAccounter::new(self.execution_stores.get_root_store());
+        let mut accounter = ResourceAccounter::new(&self.substate_store);
         accounter.add_resources(node_id).unwrap();
         accounter.into_map()
     }
@@ -261,8 +271,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
 
     pub fn deref_component_address(&mut self, component_address: ComponentAddress) -> RENodeId {
         let substate: GlobalAddressSubstate = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 RENodeId::Global(GlobalAddress::Component(component_address)),
                 SubstateOffset::Global(GlobalOffset::Global),
@@ -275,8 +284,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
 
     pub fn deref_package_address(&mut self, package_address: PackageAddress) -> RENodeId {
         let substate: GlobalAddressSubstate = self
-            .execution_stores
-            .get_root_store()
+            .substate_store
             .get_substate(&SubstateId(
                 RENodeId::Global(GlobalAddress::Package(package_address)),
                 SubstateOffset::Global(GlobalOffset::Global),
@@ -484,10 +492,8 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         fee_reserve_config: &FeeReserveConfig,
         execution_config: &ExecutionConfig,
     ) -> TransactionReceipt {
-        let node_id = self.create_child_node(0);
-
         execute_transaction(
-            &self.execution_stores.get_output_store(node_id),
+            &self.substate_store,
             &self.scrypto_interpreter,
             fee_reserve_config,
             execution_config,
@@ -500,10 +506,8 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         preview_intent: PreviewIntent,
         network: &NetworkDefinition,
     ) -> Result<PreviewResult, PreviewError> {
-        let node_id = self.create_child_node(0);
-
         execute_preview(
-            &self.execution_stores.get_output_store(node_id),
+            &self.substate_store,
             &mut self.scrypto_interpreter,
             &self.intent_hash_manager,
             network,
@@ -516,30 +520,13 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         manifests: Vec<(TransactionManifest, Vec<NonFungibleAddress>)>,
         cost_unit_limit: u32,
     ) -> Vec<TransactionReceipt> {
-        let node_id = self.create_child_node(0);
-        let receipts = self.execute_batch_on_node(node_id, manifests, cost_unit_limit);
-        self.merge_node(node_id);
-        receipts
-    }
-
-    pub fn create_child_node(&mut self, parent_id: u64) -> u64 {
-        self.execution_stores.new_child_node(parent_id)
-    }
-
-    pub fn execute_batch_on_node(
-        &mut self,
-        node_id: u64,
-        manifests: Vec<(TransactionManifest, Vec<NonFungibleAddress>)>,
-        cost_unit_limit: u32,
-    ) -> Vec<TransactionReceipt> {
-        let mut store = self.execution_stores.get_output_store(node_id);
         let mut receipts = Vec::new();
         for (manifest, initial_proofs) in manifests {
             let transaction =
                 TestTransaction::new(manifest, self.next_transaction_nonce, cost_unit_limit);
             self.next_transaction_nonce += 1;
             let receipt = execute_and_commit_transaction(
-                &mut store,
+                &mut self.substate_store,
                 &mut self.scrypto_interpreter,
                 &FeeReserveConfig {
                     cost_unit_price: DEFAULT_COST_UNIT_PRICE,
@@ -558,22 +545,18 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         receipts
     }
 
-    pub fn merge_node(&mut self, node_id: u64) {
-        self.execution_stores.merge_to_parent(node_id);
-    }
-
     pub fn export_abi(
         &mut self,
         package_address: PackageAddress,
         blueprint_name: &str,
     ) -> BlueprintAbi {
-        let output_store = self.execution_stores.get_root_store();
-        export_abi(output_store, package_address, blueprint_name).expect("Failed to export ABI")
+        export_abi(&self.substate_store, package_address, blueprint_name)
+            .expect("Failed to export ABI")
     }
 
     pub fn export_abi_by_component(&mut self, component_address: ComponentAddress) -> BlueprintAbi {
-        let output_store = self.execution_stores.get_root_store();
-        export_abi_by_component(output_store, component_address).expect("Failed to export ABI")
+        export_abi_by_component(&self.substate_store, component_address)
+            .expect("Failed to export ABI")
     }
 
     pub fn lock_resource_auth(
@@ -895,9 +878,8 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
     {
         let tx_hash = hash(self.next_transaction_nonce.to_string());
         let blobs = HashMap::new();
-        let substate_store = self.execution_stores.get_root_store();
         let track = Track::new(
-            substate_store,
+            &self.substate_store,
             SystemLoanFeeReserve::default(),
             FeeTable::new(),
         );
@@ -927,7 +909,7 @@ impl<'s, S: ReadableSubstateStore + WriteableSubstateStore + QueryableSubstateSt
         // Commit
         self.next_transaction_nonce += 1;
         if let TransactionResult::Commit(c) = receipt.result {
-            c.state_updates.commit(substate_store);
+            c.state_updates.commit(&mut self.substate_store);
         }
 
         output

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -60,7 +60,9 @@ impl Publish {
         .map_err(Error::DataError)?;
 
         if let Some(package_address) = self.package_address.clone() {
-            let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?);
+            let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+            let mut substate_store =
+                RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
 
             let global: GlobalAddressSubstate = substate_store
                 .get_substate(&SubstateId(

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -14,7 +14,7 @@ pub struct Show {
 
 impl Show {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-        let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
+        let ledger = RadixEngineDB::new(get_data_dir()?);
 
         let bech32_decoder = Bech32Decoder::new(&NetworkDefinition::simulator());
 

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -14,22 +14,23 @@ pub struct Show {
 
 impl Show {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-        let ledger = RadixEngineDB::new(get_data_dir()?);
-
+        let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+        let substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
         let bech32_decoder = Bech32Decoder::new(&NetworkDefinition::simulator());
 
         if let Ok(package_address) =
             bech32_decoder.validate_and_decode_package_address(&self.address)
         {
-            dump_package(package_address, &ledger, out).map_err(Error::LedgerDumpError)
+            dump_package(package_address, &substate_store, out).map_err(Error::LedgerDumpError)
         } else if let Ok(component_address) =
             bech32_decoder.validate_and_decode_component_address(&self.address)
         {
-            dump_component(component_address, &ledger, out).map_err(Error::LedgerDumpError)
+            dump_component(component_address, &substate_store, out).map_err(Error::LedgerDumpError)
         } else if let Ok(resource_address) =
             bech32_decoder.validate_and_decode_resource_address(&self.address)
         {
-            dump_resource_manager(resource_address, &ledger, out).map_err(Error::LedgerDumpError)
+            dump_resource_manager(resource_address, &substate_store, out)
+                .map_err(Error::LedgerDumpError)
         } else {
             Err(Error::InvalidId(self.address.clone()))
         }

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -13,12 +13,12 @@ pub struct ShowLedger {}
 
 impl ShowLedger {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-        let ledger = RadixEngineDB::new(get_data_dir()?);
-
+        let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+        let substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
         let bech32_encoder = Bech32Encoder::new(&NetworkDefinition::simulator());
 
         writeln!(out, "{}:", "Packages".green().bold()).map_err(Error::IOError)?;
-        for (last, package_address) in ledger.list_packages().iter().identify_last() {
+        for (last, package_address) in substate_store.list_packages().iter().identify_last() {
             writeln!(
                 out,
                 "{} {}",
@@ -29,7 +29,7 @@ impl ShowLedger {
         }
 
         writeln!(out, "{}:", "Components".green().bold()).map_err(Error::IOError)?;
-        for (last, component_address) in ledger.list_components().iter().identify_last() {
+        for (last, component_address) in substate_store.list_components().iter().identify_last() {
             writeln!(
                 out,
                 "{} {}",
@@ -40,7 +40,11 @@ impl ShowLedger {
         }
 
         writeln!(out, "{}:", "Resource Managers".green().bold()).map_err(Error::IOError)?;
-        for (last, resource_address) in ledger.list_resource_managers().iter().identify_last() {
+        for (last, resource_address) in substate_store
+            .list_resource_managers()
+            .iter()
+            .identify_last()
+        {
             writeln!(
                 out,
                 "{} {}",

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -13,7 +13,7 @@ pub struct ShowLedger {}
 
 impl ShowLedger {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
-        let ledger = RadixEngineDB::with_bootstrap(get_data_dir()?);
+        let ledger = RadixEngineDB::new(get_data_dir()?);
 
         let bech32_encoder = Bech32Encoder::new(&NetworkDefinition::simulator());
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -182,10 +182,7 @@ pub fn handle_manifest<O: std::io::Write>(
             let mut scrypto_interpreter = ScryptoInterpreter {
                 wasm_engine: DefaultWasmEngine::default(),
                 wasm_instrumenter: WasmInstrumenter::default(),
-                wasm_metering_config: WasmMeteringConfig::new(
-                    InstructionCostRules::tiered(1, 5, 10, 5000),
-                    1024,
-                ),
+                wasm_metering_config: WasmMeteringConfig::V0,
             };
 
             let sks = get_signing_keys(signing_keys)?;

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -177,13 +177,9 @@ pub fn handle_manifest<O: std::io::Write>(
             Ok(None)
         }
         None => {
-            let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?);
-
-            let mut scrypto_interpreter = ScryptoInterpreter {
-                wasm_engine: DefaultWasmEngine::default(),
-                wasm_instrumenter: WasmInstrumenter::default(),
-                wasm_metering_config: WasmMeteringConfig::V0,
-            };
+            let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+            let mut substate_store =
+                RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
 
             let sks = get_signing_keys(signing_keys)?;
             let mut initial_proofs = sks
@@ -198,7 +194,7 @@ pub fn handle_manifest<O: std::io::Write>(
 
             let receipt = execute_and_commit_transaction(
                 &mut substate_store,
-                &mut scrypto_interpreter,
+                &scrypto_interpreter,
                 &FeeReserveConfig::default(),
                 &ExecutionConfig {
                     max_call_depth: DEFAULT_MAX_CALL_DEPTH,
@@ -264,7 +260,8 @@ pub fn export_abi(
     package_address: PackageAddress,
     blueprint_name: &str,
 ) -> Result<abi::BlueprintAbi, Error> {
-    let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?);
+    let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+    let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
     radix_engine::model::export_abi(&mut substate_store, package_address, blueprint_name)
         .map_err(Error::AbiExportError)
 }
@@ -272,7 +269,8 @@ pub fn export_abi(
 pub fn export_abi_by_component(
     component_address: ComponentAddress,
 ) -> Result<abi::BlueprintAbi, Error> {
-    let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?);
+    let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
+    let mut substate_store = RadixEngineDB::with_bootstrap(get_data_dir()?, &scrypto_interpreter);
     radix_engine::model::export_abi_by_component(&mut substate_store, component_address)
         .map_err(Error::AbiExportError)
 }


### PR DESCRIPTION
- Use `(PackageAddress, WasmMeteringConfig)` as cache key, instead of `hash(code)`;
- Share `ScryptoInterpreter` between bootstrap and subsequent transactions;
- `TestRunner` now owns a substate store.