### PR TITLE
tweak: Resim bucket syntax for NFIds doesn't require a starting #

### DIFF
--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -24,9 +24,9 @@ non_fungible_create_receipt=`$resim new-simple-badge --name 'TestNonFungible'`
 non_fungible=`echo "$non_fungible_create_receipt" | awk '/NFAddress:/ {print $NF}'`
 non_fungible_resource=`echo "$non_fungible_create_receipt" | awk '/Resource:/ {print $NF}'`
 non_fungible_id=`echo "$non_fungible_create_receipt" | awk '/NFID:/ {print $NF}'`
-# The below line looks like this: #U32#1,resource_address
-# You can put multiple ids into a bucket like so: #String#Id1,#String#num2,#String#num3,resource_address
-$resim call-method $account2 deposit "#$non_fungible_id,$non_fungible_resource"
+# The below line looks like this: U32#1,resource_address
+# You can put multiple ids into a bucket like so: String#Id1,String#num2,String#num3,resource_address
+$resim call-method $account2 deposit "$non_fungible_id,$non_fungible_resource"
 
 # Test - mint and transfer
 $resim mint 777 $token_address --proofs 1,$minter_badge

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -1189,16 +1189,17 @@ fn parse_resource_specifier(
         })?;
 
     // parse non-fungible ids or amount
-    if tokens[0].starts_with('#') {
+    if tokens[0].contains('#') {
         let mut ids = BTreeSet::<NonFungibleId>::new();
-        for id in &tokens[..tokens.len() - 1] {
-            if !id.starts_with('#') {
-                return Err(ParseResourceSpecifierError::InvalidNonFungibleId(
-                    id.to_string(),
-                ));
+        for id in tokens[..tokens.len() - 1].iter() {
+            let mut id = *id;
+            if id.starts_with('#') {
+                // Support the ids optionally starting with a # (which was an old encoding)
+                // EG: #String#123,resource_address
+                id = &id[1..];
             }
             ids.insert(
-                NonFungibleId::try_from_combined_simple_string(&id[1..]).map_err(|_| {
+                NonFungibleId::try_from_combined_simple_string(id).map_err(|_| {
                     ParseResourceSpecifierError::InvalidNonFungibleId(id.to_string())
                 })?,
             );


### PR DESCRIPTION
Resim bucket syntax for NFIds doesn't require a starting # - both are now supported, but the suggested format is now:

```
resim call-method $account deposit "U32#54,U32#55,U32#103,resource_address"
```