### PR TITLE
Fix handling of `NonFungibleAddress`es for some Resim subcommands

### DIFF
--- a/radix-engine/tests/common_transactions.rs
+++ b/radix-engine/tests/common_transactions.rs
@@ -1,8 +1,8 @@
 use radix_engine::ledger::TypedInMemorySubstateStore;
 use radix_engine::types::{
-    hash, require, Bech32Encoder, Blob, ComponentAddress, Decimal, FromPublicKey, HashMap,
+    require, Bech32Encoder, Blob, ComponentAddress, Decimal, FromPublicKey, HashMap,
     NonFungibleAddress, NonFungibleId, ResourceAddress, ResourceMethodAuthKey, ResourceType,
-    ACCOUNT_PACKAGE, FAUCET_COMPONENT, RADIX_TOKEN,
+    FAUCET_COMPONENT, RADIX_TOKEN,
 };
 use radix_engine_interface::core::NetworkDefinition;
 use radix_engine_interface::rule;
@@ -69,13 +69,11 @@ fn multi_account_fund_transfer_succeeds() {
 /// An example manifest for creating a new fungible resource with no initial supply
 #[test]
 fn creating_a_fungible_resource_with_no_initial_supply_succeeds() {
-    test_manifest(|account_component_address, bech32_encoder| {
-        let manifest = format!(
-            include_str!(
-                "../../transaction/examples/resources/creation/fungible/no_initial_supply.rtm"
-            ),
-            account_component_address = account_component_address.display(bech32_encoder)
-        );
+    test_manifest(|_, _| {
+        let manifest = include_str!(
+            "../../transaction/examples/resources/creation/fungible/no_initial_supply.rtm"
+        )
+        .to_string();
         (manifest, Vec::new())
     });
 }
@@ -100,13 +98,11 @@ fn creating_a_fungible_resource_with_initial_supply_succeeds() {
 /// An example manifest for creating a new non-fungible resource with no supply
 #[test]
 fn creating_a_non_fungible_resource_with_no_initial_supply_succeeds() {
-    test_manifest(|account_component_address, bech32_encoder| {
-        let manifest = format!(
-            include_str!(
-                "../../transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm"
-            ),
-            account_component_address = account_component_address.display(bech32_encoder)
-        );
+    test_manifest(|_, _| {
+        let manifest = include_str!(
+            "../../transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm"
+        )
+        .to_string();
         (manifest, Vec::new())
     });
 }
@@ -127,34 +123,31 @@ fn creating_a_non_fungible_resource_with_initial_supply_succeeds() {
 /// A sample manifest that publishes a package.
 #[test]
 fn publish_package_with_owner_succeeds() {
-    test_manifest_with_owner_badge(
-        |account_component_address, owner_badge_non_fungible_address, bech32_encoder| {
-            let owner_badge_resource_address = owner_badge_non_fungible_address.resource_address();
-            let owner_badge_non_fungible_id = if let NonFungibleId::U32(non_fungible_id) =
-                owner_badge_non_fungible_address.non_fungible_id()
-            {
-                *non_fungible_id
-            } else {
-                panic!("expected a u32 non-fungible-id");
-            };
+    test_manifest_with_owner_badge(|_, owner_badge_non_fungible_address, bech32_encoder| {
+        let owner_badge_resource_address = owner_badge_non_fungible_address.resource_address();
+        let owner_badge_non_fungible_id = if let NonFungibleId::U32(non_fungible_id) =
+            owner_badge_non_fungible_address.non_fungible_id()
+        {
+            *non_fungible_id
+        } else {
+            panic!("expected a u32 non-fungible-id");
+        };
 
-            // TODO: Update the complex.abi and complex.code files that are used for testing.
-            // Using the WASM and ABI from the account blueprint here as they are up to date. The
-            // complex.code and complex.abi files from the transaction crate are not.
-            let code_blob = include_bytes!("../../assets/account.wasm").to_vec();
-            let abi_blob = include_bytes!("../../assets/account.abi").to_vec();
+        // TODO: Update the complex.abi and complex.code files that are used for testing.
+        // Using the WASM and ABI from the account blueprint here as they are up to date. The
+        // complex.code and complex.abi files from the transaction crate are not.
+        let code_blob = include_bytes!("../../assets/account.wasm").to_vec();
+        let abi_blob = include_bytes!("../../assets/account.abi").to_vec();
 
-            let manifest = format!(
-                include_str!("../../transaction/examples/package/publish_with_owner.rtm"),
-                owner_badge_resource_address = owner_badge_resource_address.display(bech32_encoder),
-                owner_badge_non_fungible_id = owner_badge_non_fungible_id,
-                code_blob_hash = Blob::new(&code_blob),
-                abi_blob_hash = Blob::new(&abi_blob),
-                account_component_address = account_component_address.display(bech32_encoder)
-            );
-            (manifest, vec![code_blob, abi_blob])
-        },
-    );
+        let manifest = format!(
+            include_str!("../../transaction/examples/package/publish_with_owner.rtm"),
+            owner_badge_resource_address = owner_badge_resource_address.display(bech32_encoder),
+            owner_badge_non_fungible_id = owner_badge_non_fungible_id,
+            code_blob_hash = Blob::new(&code_blob),
+            abi_blob_hash = Blob::new(&abi_blob),
+        );
+        (manifest, vec![code_blob, abi_blob])
+    });
 }
 
 /// A sample manifest for minting of a fungible resource
@@ -227,7 +220,7 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -292,7 +285,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -324,7 +317,7 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -359,6 +352,6 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }

--- a/radix-engine/tests/common_transactions.rs
+++ b/radix-engine/tests/common_transactions.rs
@@ -69,11 +69,13 @@ fn multi_account_fund_transfer_succeeds() {
 /// An example manifest for creating a new fungible resource with no initial supply
 #[test]
 fn creating_a_fungible_resource_with_no_initial_supply_succeeds() {
-    test_manifest(|_, _| {
-        let manifest = include_str!(
-            "../../transaction/examples/resources/creation/fungible/no_initial_supply.rtm"
-        )
-        .to_string();
+    test_manifest(|account_component_address, bech32_encoder| {
+        let manifest = format!(
+            include_str!(
+                "../../transaction/examples/resources/creation/fungible/no_initial_supply.rtm"
+            ),
+            account_component_address = account_component_address.display(bech32_encoder)
+        );
         (manifest, Vec::new())
     });
 }
@@ -98,11 +100,13 @@ fn creating_a_fungible_resource_with_initial_supply_succeeds() {
 /// An example manifest for creating a new non-fungible resource with no supply
 #[test]
 fn creating_a_non_fungible_resource_with_no_initial_supply_succeeds() {
-    test_manifest(|_, _| {
-        let manifest = include_str!(
-            "../../transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm"
-        )
-        .to_string();
+    test_manifest(|account_component_address, bech32_encoder| {
+        let manifest = format!(
+            include_str!(
+                "../../transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm"
+            ),
+            account_component_address = account_component_address.display(bech32_encoder)
+        );
         (manifest, Vec::new())
     });
 }
@@ -123,31 +127,34 @@ fn creating_a_non_fungible_resource_with_initial_supply_succeeds() {
 /// A sample manifest that publishes a package.
 #[test]
 fn publish_package_with_owner_succeeds() {
-    test_manifest_with_owner_badge(|_, owner_badge_non_fungible_address, bech32_encoder| {
-        let owner_badge_resource_address = owner_badge_non_fungible_address.resource_address();
-        let owner_badge_non_fungible_id = if let NonFungibleId::U32(non_fungible_id) =
-            owner_badge_non_fungible_address.non_fungible_id()
-        {
-            *non_fungible_id
-        } else {
-            panic!("expected a u32 non-fungible-id");
-        };
+    test_manifest_with_owner_badge(
+        |account_component_address, owner_badge_non_fungible_address, bech32_encoder| {
+            let owner_badge_resource_address = owner_badge_non_fungible_address.resource_address();
+            let owner_badge_non_fungible_id = if let NonFungibleId::U32(non_fungible_id) =
+                owner_badge_non_fungible_address.non_fungible_id()
+            {
+                *non_fungible_id
+            } else {
+                panic!("expected a u32 non-fungible-id");
+            };
 
-        // TODO: Update the complex.abi and complex.code files that are used for testing.
-        // Using the WASM and ABI from the account blueprint here as they are up to date. The
-        // complex.code and complex.abi files from the transaction crate are not.
-        let code_blob = include_bytes!("../../assets/account.wasm").to_vec();
-        let abi_blob = include_bytes!("../../assets/account.abi").to_vec();
+            // TODO: Update the complex.abi and complex.code files that are used for testing.
+            // Using the WASM and ABI from the account blueprint here as they are up to date. The
+            // complex.code and complex.abi files from the transaction crate are not.
+            let code_blob = include_bytes!("../../assets/account.wasm").to_vec();
+            let abi_blob = include_bytes!("../../assets/account.abi").to_vec();
 
-        let manifest = format!(
-            include_str!("../../transaction/examples/package/publish_with_owner.rtm"),
-            owner_badge_resource_address = owner_badge_resource_address.display(bech32_encoder),
-            owner_badge_non_fungible_id = owner_badge_non_fungible_id,
-            code_blob_hash = Blob::new(&code_blob),
-            abi_blob_hash = Blob::new(&abi_blob),
-        );
-        (manifest, vec![code_blob, abi_blob])
-    });
+            let manifest = format!(
+                include_str!("../../transaction/examples/package/publish_with_owner.rtm"),
+                owner_badge_resource_address = owner_badge_resource_address.display(bech32_encoder),
+                owner_badge_non_fungible_id = owner_badge_non_fungible_id,
+                code_blob_hash = Blob::new(&code_blob),
+                abi_blob_hash = Blob::new(&abi_blob),
+                account_component_address = account_component_address.display(bech32_encoder)
+            );
+            (manifest, vec![code_blob, abi_blob])
+        },
+    );
 }
 
 /// A sample manifest for minting of a fungible resource
@@ -220,7 +227,7 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -285,7 +292,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -317,7 +324,7 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }
 
@@ -352,6 +359,6 @@ where
         .expect("Failed to compile manifest from manifest string");
 
     test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![virtual_badge_non_fungible_address])
+        .execute_manifest(manifest, vec![virtual_badge_non_fungible_address])
         .expect_commit_success();
 }

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -6,7 +6,7 @@ use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
 
-/// Create a badge with fixed supply
+/// Create a fungible badge with fixed supply
 #[derive(Parser, Debug)]
 pub struct NewBadgeFixed {
     /// The total supply

--- a/simulator/src/resim/cmd_new_badge_mutable.rs
+++ b/simulator/src/resim/cmd_new_badge_mutable.rs
@@ -9,7 +9,7 @@ use crate::resim::*;
 #[derive(Parser, Debug)]
 pub struct NewBadgeMutable {
     /// The minter resource address
-    minter_resource_address: SimulatorResourceAddress,
+    minter_badge: SimulatorResourceOrNonFungibleAddress,
 
     /// The symbol
     #[clap(long)]
@@ -69,7 +69,7 @@ impl NewBadgeMutable {
 
         let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
             .lock_fee(FAUCET_COMPONENT, 100.into())
-            .new_badge_mutable(metadata, self.minter_resource_address.0)
+            .new_badge_mutable(metadata, self.minter_badge.clone().into())
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_badge_mutable.rs
+++ b/simulator/src/resim/cmd_new_badge_mutable.rs
@@ -5,7 +5,7 @@ use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
 
-/// Create a badge with mutable supply
+/// Create a fungible badge with mutable supply
 #[derive(Parser, Debug)]
 pub struct NewBadgeMutable {
     /// The minter resource address

--- a/simulator/src/resim/cmd_new_simple_badge.rs
+++ b/simulator/src/resim/cmd_new_simple_badge.rs
@@ -122,36 +122,38 @@ impl NewSimpleBadge {
             false,
             out,
         )
-        .unwrap()
         .unwrap();
 
-        let resource_address = receipt
-            .expect_commit()
-            .entity_changes
-            .new_resource_addresses[0];
+        if let Some(receipt) = receipt {
+            let resource_address = receipt
+                .expect_commit()
+                .entity_changes
+                .new_resource_addresses[0];
 
-        let bech32_encoder = Bech32Encoder::new(&network_definition);
-        writeln!(
-            out,
-            "NFAddress: {}",
-            NonFungibleAddress::new(resource_address, NonFungibleId::U32(1))
-                // This should be the opposite of parse_args in the manifest builder
-                .to_canonical_combined_string(&bech32_encoder)
-                .green()
-        )
-        .map_err(Error::IOError)?;
-        writeln!(
-            out,
-            "Resource: {}",
-            resource_address.to_string(&bech32_encoder).green()
-        )
-        .map_err(Error::IOError)?;
-        writeln!(
-            out,
-            "NFID: {}",
-            NonFungibleId::U32(1).to_combined_simple_string()
-        )
-        .map_err(Error::IOError)?;
+            let bech32_encoder = Bech32Encoder::new(&network_definition);
+            writeln!(
+                out,
+                "NFAddress: {}",
+                NonFungibleAddress::new(resource_address, NonFungibleId::U32(1))
+                    // This should be the opposite of parse_args in the manifest builder
+                    .to_canonical_combined_string(&bech32_encoder)
+                    .green()
+            )
+            .map_err(Error::IOError)?;
+            writeln!(
+                out,
+                "Resource: {}",
+                resource_address.to_string(&bech32_encoder).green()
+            )
+            .map_err(Error::IOError)?;
+            writeln!(
+                out,
+                "NFID: {}",
+                NonFungibleId::U32(1).to_combined_simple_string()
+            )
+            .map_err(Error::IOError)?;
+        };
+
         Ok(())
     }
 }

--- a/simulator/src/resim/cmd_new_simple_badge.rs
+++ b/simulator/src/resim/cmd_new_simple_badge.rs
@@ -13,7 +13,7 @@ use crate::resim::*;
 #[scrypto(TypeId, Encode, Decode)]
 struct EmptyStruct;
 
-/// Create a badge with fixed supply
+/// Create a non-fungible badge with fixed supply
 #[derive(Parser, Debug)]
 pub struct NewSimpleBadge {
     /// The symbol

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -6,7 +6,7 @@ use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
 
-/// Create a token with fixed supply
+/// Create a fungible token with fixed supply
 #[derive(Parser, Debug)]
 pub struct NewTokenFixed {
     /// The total supply

--- a/simulator/src/resim/cmd_new_token_mutable.rs
+++ b/simulator/src/resim/cmd_new_token_mutable.rs
@@ -9,7 +9,7 @@ use crate::resim::*;
 #[derive(Parser, Debug)]
 pub struct NewTokenMutable {
     /// The minter resource address
-    mint_badge: SimulatorResourceOrNonFungibleAddress,
+    minter_badge: SimulatorResourceOrNonFungibleAddress,
 
     /// The symbol
     #[clap(long)]
@@ -69,7 +69,7 @@ impl NewTokenMutable {
 
         let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
             .lock_fee(FAUCET_COMPONENT, 100.into())
-            .new_token_mutable(metadata, self.mint_badge.clone().into())
+            .new_token_mutable(metadata, self.minter_badge.clone().into())
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_token_mutable.rs
+++ b/simulator/src/resim/cmd_new_token_mutable.rs
@@ -5,7 +5,7 @@ use transaction::builder::ManifestBuilder;
 
 use crate::resim::*;
 
-/// Create a token with mutable supply
+/// Create a fungible token with mutable supply
 #[derive(Parser, Debug)]
 pub struct NewTokenMutable {
     /// The minter resource address

--- a/simulator/src/resim/cmd_new_token_mutable.rs
+++ b/simulator/src/resim/cmd_new_token_mutable.rs
@@ -9,7 +9,7 @@ use crate::resim::*;
 #[derive(Parser, Debug)]
 pub struct NewTokenMutable {
     /// The minter resource address
-    minter_resource_address: SimulatorResourceAddress,
+    mint_badge: SimulatorResourceOrNonFungibleAddress,
 
     /// The symbol
     #[clap(long)]
@@ -69,7 +69,7 @@ impl NewTokenMutable {
 
         let manifest = ManifestBuilder::new(&NetworkDefinition::simulator())
             .lock_fee(FAUCET_COMPONENT, 100.into())
-            .new_token_mutable(metadata, self.minter_resource_address.0)
+            .new_token_mutable(metadata, self.mint_badge.clone().into())
             .build();
         handle_manifest(
             manifest,

--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -99,4 +99,3 @@ token_address=`$resim new-token-mutable $non_fungible | awk '/Resource:/ {print 
 
 # Test - mint and transfer (Mintable that requires a `NonFungibleAddress`)
 $resim mint 777 $token_address --proofs "$non_fungible_id,$non_fungible_resource"
-resim show $token_address

--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -16,7 +16,7 @@ account2=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 # Test - create fixed supply badge
 minter_badge=`$resim new-badge-fixed 1 --name 'MinterBadge' | awk '/Resource:/ {print $NF}'`
 
-# Test - create mutable supply token
+# Test - create mutable supply token (requires a `ResourceAddress`)
 token_address=`$resim new-token-mutable $minter_badge | awk '/Resource:/ {print $NF}'`
 
 # Test - transfer non fungible
@@ -28,7 +28,7 @@ non_fungible_id=`echo "$non_fungible_create_receipt" | awk '/NFID:/ {print $NF}'
 # You can put multiple ids into a bucket like so: String#Id1,String#num2,String#num3,resource_address
 $resim call-method $account2 deposit "$non_fungible_id,$non_fungible_resource"
 
-# Test - mint and transfer
+# Test - mint and transfer (Mintable that requires a `ResourceAddress`)
 $resim mint 777 $token_address --proofs 1,$minter_badge
 $resim transfer 111 $token_address $account2
 
@@ -88,3 +88,15 @@ $resim publish ./tests/large_package.wasm --owner-badge $owner_badge
 
 # Test - math types and numbers
 $resim call-function $package "Numbers" test_input 1 2
+
+# Test - create mutable supply token (requires a `NonFungibleAddress`)
+non_fungible_create_receipt=`$resim new-simple-badge --name 'TestNonFungible'`
+non_fungible=`echo "$non_fungible_create_receipt" | awk '/NFAddress:/ {print $NF}'`
+non_fungible_resource=`echo "$non_fungible_create_receipt" | awk '/Resource:/ {print $NF}'`
+non_fungible_id=`echo "$non_fungible_create_receipt" | awk '/NFID:/ {print $NF}'`
+
+token_address=`$resim new-token-mutable $non_fungible | awk '/Resource:/ {print $NF}'`
+
+# Test - mint and transfer (Mintable that requires a `NonFungibleAddress`)
+$resim mint 777 $token_address --proofs "$non_fungible_id,$non_fungible_resource"
+resim show $token_address

--- a/transaction/examples/account/multi_account_resource_transfer.rtm
+++ b/transaction/examples/account/multi_account_resource_transfer.rtm
@@ -6,13 +6,15 @@
 # Account C: 50 XRD
 # Which is a total of 330 XRD. 
 
-# The account component withdraw methods which have been optimized to also lock a fee in a single 
-# call. In this call, we lock a fee of 10 XRD and also withdraw 330 XRD from the account.
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
+
+# Withdrawing 330 XRD from the account component and into the worktop
 CALL_METHOD 
     ComponentAddress("{this_account_component_address}") 
-    "lock_fee_and_withdraw_by_amount"
-    Decimal("10")                                   # Amount of XRD to lock for fees
-    Decimal("330")                                  # Amount of XRD to withdraw
+    "withdraw_by_amount"
+    Decimal("330")
     ResourceAddress("{xrd_resource_address}");
 
 # Taking 150 XRD from the worktop and depositing them into Account A

--- a/transaction/examples/account/multi_account_resource_transfer.rtm
+++ b/transaction/examples/account/multi_account_resource_transfer.rtm
@@ -6,11 +6,17 @@
 # Account C: 50 XRD
 # Which is a total of 330 XRD. 
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+CALL_METHOD 
+    ComponentAddress("{this_account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
-# Withdrawing 330 XRD from the account component and into the worktop
+# Withdrawing 330 XRD from the account component
 CALL_METHOD 
     ComponentAddress("{this_account_component_address}") 
     "withdraw_by_amount"

--- a/transaction/examples/account/resource_transfer.rtm
+++ b/transaction/examples/account/resource_transfer.rtm
@@ -2,12 +2,17 @@
 # transaction. We will be withdrawing 100 XRD from our account component and depositing them in 
 # another account component. 
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+CALL_METHOD 
+    ComponentAddress("{this_account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
-# The account component withdraw methods which have been optimized to also lock a fee in a single 
-# call. In this call, we lock a fee of 10 XRD and also withdraw 100 XRD from the account.
+# Withdrawing 100 XRD from the account component
 CALL_METHOD 
     ComponentAddress("{this_account_component_address}") 
     "withdraw_by_amount"

--- a/transaction/examples/account/resource_transfer.rtm
+++ b/transaction/examples/account/resource_transfer.rtm
@@ -2,13 +2,16 @@
 # transaction. We will be withdrawing 100 XRD from our account component and depositing them in 
 # another account component. 
 
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
+
 # The account component withdraw methods which have been optimized to also lock a fee in a single 
 # call. In this call, we lock a fee of 10 XRD and also withdraw 100 XRD from the account.
 CALL_METHOD 
     ComponentAddress("{this_account_component_address}") 
-    "lock_fee_and_withdraw_by_amount"
-    Decimal("10")                                   # Amount of XRD to lock for fees
-    Decimal("100")                                  # Amount of XRD to withdraw
+    "withdraw_by_amount"
+    Decimal("100")
     ResourceAddress("{xrd_resource_address}");
 
 # Depositing all of the XRD withdrawn from the account into the other account

--- a/transaction/examples/faucet/free_funds.rtm
+++ b/transaction/examples/faucet/free_funds.rtm
@@ -1,8 +1,18 @@
 # This transaction manifest shows how you can call into the testnet's faucet to get XRD.
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the faucet component. Alternatively, we may also lock a fee from our 
+# account component. However, since this example hows how to get free funds from the faucet, then 
+# we can assume that our account component probably has no funds in the first place. 
+CALL_METHOD 
+    ComponentAddress("{faucet_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Calling the "free" method on the faucet component which is the method responsible for dispensing 
 # XRD from the faucet.

--- a/transaction/examples/faucet/free_funds.rtm
+++ b/transaction/examples/faucet/free_funds.rtm
@@ -1,12 +1,8 @@
 # This transaction manifest shows how you can call into the testnet's faucet to get XRD.
 
-# Locking 10 XRD in fees from the faucet component. Alternatively, we may also lock a fee from our 
-# account component. However, since this example hows how to get free funds from the faucet, then 
-# we can assume that our account component probably has no funds in the first place. 
-CALL_METHOD 
-    ComponentAddress("{faucet_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Calling the "free" method on the faucet component which is the method responsible for dispensing 
 # XRD from the faucet.

--- a/transaction/examples/package/publish_with_owner.rtm
+++ b/transaction/examples/package/publish_with_owner.rtm
@@ -1,10 +1,8 @@
 # This transaction manifest shows how a package that has an owner badge can be published. 
 
-# Locking 10 XRD in fees from the account component. 
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Publishing a new package with an owner badge
 PUBLISH_PACKAGE_WITH_OWNER 

--- a/transaction/examples/package/publish_with_owner.rtm
+++ b/transaction/examples/package/publish_with_owner.rtm
@@ -1,8 +1,16 @@
 # This transaction manifest shows how a package that has an owner badge can be published. 
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component. 
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Publishing a new package with an owner badge
 PUBLISH_PACKAGE_WITH_OWNER 

--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -1,11 +1,9 @@
 # This transaction manifest creates a new fungible resource with no initial supply and with the 
 # default auth.
 
-# Locking 10 XRD in fees from the account component. 
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Creating a new resource with a divisibility of 18 and a name of `MyResource`. The resource has 
 # default resource behavior where it can be withdrawn and deposited by anybody.

--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -1,9 +1,17 @@
 # This transaction manifest creates a new fungible resource with no initial supply and with the 
 # default auth.
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component. 
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Creating a new resource with a divisibility of 18 and a name of `MyResource`. The resource has 
 # default resource behavior where it can be withdrawn and deposited by anybody.

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -1,11 +1,9 @@
 # This transaction manifest creates a new fungible resource with initial supply and with the default
 # auth.
 
-# Locking 10 XRD in fees from the account component. 
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Creating a new resource with a divisibility of 18 and a name of `MyResource`. The resource has 
 # default resource behavior where it can be withdrawn and deposited by anybody.

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -1,9 +1,17 @@
 # This transaction manifest creates a new fungible resource with initial supply and with the default
 # auth.
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component. 
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Creating a new resource with a divisibility of 18 and a name of `MyResource`. The resource has 
 # default resource behavior where it can be withdrawn and deposited by anybody.

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -21,7 +21,6 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
-        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -15,7 +15,6 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
-        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -1,11 +1,9 @@
 # This transaction manifest creates a new non-fungible resource with no initial supply and with the 
 # default auth.
 
-# Locking 10 XRD in fees from the account component. 
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Creating a new resource 
 CREATE_RESOURCE 

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -1,9 +1,17 @@
 # This transaction manifest creates a new non-fungible resource with no initial supply and with the 
 # default auth.
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component. 
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Creating a new resource 
 CREATE_RESOURCE 
@@ -13,6 +21,7 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
+        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -21,7 +21,6 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
-        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -1,11 +1,9 @@
 # This transaction manifest creates a new non-fungible resource with initial supply and with the 
 # default auth.
 
-# Locking 10 XRD in fees from the account component. 
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # Creating a new resource 
 CREATE_RESOURCE 

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -15,7 +15,6 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
-        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -1,9 +1,17 @@
 # This transaction manifest creates a new non-fungible resource with initial supply and with the 
 # default auth.
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component. 
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # Creating a new resource 
 CREATE_RESOURCE 
@@ -13,6 +21,7 @@ CREATE_RESOURCE
     ) 
     Array<Tuple>(
         Tuple("name", "MyResource"), 
+        Tuple("symbol", "RSRC"),
         Tuple("description", "A very innovative and important resource"), 
     ) 
     Array<Tuple>(

--- a/transaction/examples/resources/mint/fungible/mint.rtm
+++ b/transaction/examples/resources/mint/fungible/mint.rtm
@@ -3,13 +3,9 @@
 # being allowed to mint a resource. This example is no different. In this example, there is a minter
 # badge which we have in our account which allows us to mint this resource
 
-# Locking 10 XRD in fees from the account component - Currently, the account component does not have
-# a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
-# its own method call and creating a proof will be its own method call.
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource

--- a/transaction/examples/resources/mint/fungible/mint.rtm
+++ b/transaction/examples/resources/mint/fungible/mint.rtm
@@ -3,9 +3,19 @@
 # being allowed to mint a resource. This example is no different. In this example, there is a minter
 # badge which we have in our account which allows us to mint this resource
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component - Currently, the account component does not have
+# a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
+# its own method call and creating a proof will be its own method call.
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource

--- a/transaction/examples/resources/mint/non_fungible/mint.rtm
+++ b/transaction/examples/resources/mint/non_fungible/mint.rtm
@@ -3,13 +3,9 @@
 # being allowed to mint a resource. This example is no different. In this example, there is a minter
 # badge which we have in our account which allows us to mint this resource
 
-# Locking 10 XRD in fees from the account component - Currently, the account component does not have
-# a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
-# its own method call and creating a proof will be its own method call.
-CALL_METHOD 
-    ComponentAddress("{account_component_address}") 
-    "lock_fee"
-    Decimal("10");
+# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
+# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
+# add this instruction.
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource

--- a/transaction/examples/resources/mint/non_fungible/mint.rtm
+++ b/transaction/examples/resources/mint/non_fungible/mint.rtm
@@ -3,9 +3,19 @@
 # being allowed to mint a resource. This example is no different. In this example, there is a minter
 # badge which we have in our account which allows us to mint this resource
 
-# Note: This manifest does not have a "lock_fee" instruction as this instruction will be added
-# automatically by the wallet. If all you intend to do is run this manifest in resim then you can
-# add this instruction.
+# ==================================================================================================
+# WARNING: If you will be submitting this transaction through the Babylon wallet then you MUST
+# remove the "lock_fee" instruction that you see below. Otherwise your transaction will fail. If all 
+# that you are using is resim then you can safely ignore this warning.
+# ==================================================================================================
+
+# Locking 10 XRD in fees from the account component - Currently, the account component does not have
+# a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
+# its own method call and creating a proof will be its own method call.
+CALL_METHOD 
+    ComponentAddress("{account_component_address}") 
+    "lock_fee"
+    Decimal("10");
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -560,27 +560,15 @@ impl ManifestBuilder {
     pub fn new_token_mutable(
         &mut self,
         metadata: HashMap<String, String>,
-        minter_resource_address: ResourceAddress,
+        minter_rule: AccessRule,
     ) -> &mut Self {
         let mut resource_auth = HashMap::new();
         resource_auth.insert(
             ResourceMethodAuthKey::Withdraw,
             (rule!(allow_all), rule!(deny_all)),
         );
-        resource_auth.insert(
-            Mint,
-            (
-                rule!(require(minter_resource_address.clone())),
-                rule!(deny_all),
-            ),
-        );
-        resource_auth.insert(
-            Burn,
-            (
-                rule!(require(minter_resource_address.clone())),
-                rule!(deny_all),
-            ),
-        );
+        resource_auth.insert(Mint, (minter_rule.clone(), rule!(deny_all)));
+        resource_auth.insert(Burn, (minter_rule.clone(), rule!(deny_all)));
 
         let mint_params: Option<MintParams> = Option::None;
         self.add_instruction(Instruction::CallNativeFunction {
@@ -633,27 +621,15 @@ impl ManifestBuilder {
     pub fn new_badge_mutable(
         &mut self,
         metadata: HashMap<String, String>,
-        minter_resource_address: ResourceAddress,
+        minter_rule: AccessRule,
     ) -> &mut Self {
         let mut resource_auth = HashMap::new();
         resource_auth.insert(
             ResourceMethodAuthKey::Withdraw,
             (rule!(allow_all), rule!(deny_all)),
         );
-        resource_auth.insert(
-            Mint,
-            (
-                rule!(require(minter_resource_address.clone())),
-                rule!(deny_all),
-            ),
-        );
-        resource_auth.insert(
-            Burn,
-            (
-                rule!(require(minter_resource_address.clone())),
-                rule!(deny_all),
-            ),
-        );
+        resource_auth.insert(Mint, (minter_rule.clone(), rule!(deny_all)));
+        resource_auth.insert(Burn, (minter_rule.clone(), rule!(deny_all)));
 
         let mint_params: Option<MintParams> = Option::None;
 


### PR DESCRIPTION
* This PR allows for either a `NonFungibleAddress` or `ResourceAddress` to be the minting authority of mutable resources and badges.
* Added some comments to the common manifests and made some minor changes to them. 