### PR TITLE
feat: Improved Encode/Decode derive to work with generics

### DIFF
--- a/sbor-derive/src/encode.rs
+++ b/sbor-derive/src/encode.rs
@@ -36,7 +36,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                     impl #impl_generics ::sbor::Encode <#custom_type_id_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                            encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                            encoder.write_type_id(::sbor::SborTypeId::Tuple)
                         }
 
                         #[inline]
@@ -61,7 +61,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                     impl #impl_generics ::sbor::Encode <#custom_type_id_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                            encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                            encoder.write_type_id(::sbor::SborTypeId::Tuple)
                         }
 
                         #[inline]
@@ -79,7 +79,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                     impl #impl_generics ::sbor::Encode <#custom_type_id_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                            encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                            encoder.write_type_id(::sbor::SborTypeId::Tuple)
                         }
 
                         #[inline]
@@ -144,7 +144,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                     impl #impl_generics ::sbor::Encode <#custom_type_id_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                            encoder.write_type_id(::sbor::type_id::SborTypeId::Enum)
+                            encoder.write_type_id(::sbor::SborTypeId::Enum)
                         }
 
                         #[inline]
@@ -158,7 +158,7 @@ pub fn handle_encode(input: TokenStream) -> Result<TokenStream> {
                     impl #impl_generics ::sbor::Encode <#custom_type_id_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                         #[inline]
                         fn encode_type_id(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                            encoder.write_type_id(::sbor::type_id::SborTypeId::Enum)
+                            encoder.write_type_id(::sbor::SborTypeId::Enum)
                         }
 
                         #[inline]
@@ -205,14 +205,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <CTI: ::sbor::type_id::CustomTypeId, ENC: ::sbor::encoder::Encoder<CTI> > ::sbor::Encode<CTI, ENC> for Test {
+                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomTypeId > ::sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_type_id(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
                         use ::sbor::{self, Encode};
                         encoder.write_size(1)?;
                         encoder.encode(&self.a)?;
@@ -231,14 +231,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <CTI: ::sbor::type_id::CustomTypeId, ENC: ::sbor::encoder::Encoder<CTI> > ::sbor::Encode<CTI, ENC> for Test {
+                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomTypeId > ::sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_type_id(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_type_id(::sbor::type_id::SborTypeId::Enum)
+                    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Enum)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
                         use ::sbor::{self, Encode};
                         match self {
                             Self::A => {
@@ -271,16 +271,43 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <CTI: ::sbor::type_id::CustomTypeId, ENC: ::sbor::encoder::Encoder<CTI> > ::sbor::Encode<CTI, ENC> for Test {
+                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomTypeId > ::sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_type_id(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
                         use ::sbor::{self, Encode};
                         encoder.write_size(0)?;
+                        Ok(())
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn test_encode_generic() {
+        let input = TokenStream::from_str("struct Test<T, E: Clashing> { a: T, b: E, }").unwrap();
+        let output = handle_encode(input).unwrap();
+
+        assert_code_eq(
+            output,
+            quote! {
+                impl <T: ::sbor::Encode<X, E0>, E: Clashing + ::sbor::Encode<X, E0>, E0: ::sbor::Encoder<X>, X: ::sbor::CustomTypeId > ::sbor::Encode<X, E0> for Test<T, E > {
+                    #[inline]
+                    fn encode_type_id(&self, encoder: &mut E0) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Tuple)
+                    }
+
+                    #[inline]
+                    fn encode_body(&self, encoder: &mut E0) -> Result<(), ::sbor::EncodeError> {
+                        use ::sbor::{self, Encode};
+                        encoder.write_size(2)?;
+                        encoder.encode(&self.a)?;
+                        encoder.encode(&self.b)?;
                         Ok(())
                     }
                 }
@@ -299,14 +326,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <ENC: ::sbor::encoder::Encoder<NoCustomTypeId> > ::sbor::Encode<NoCustomTypeId, ENC> for Test {
+                impl <E: ::sbor::Encoder<NoCustomTypeId> > ::sbor::Encode<NoCustomTypeId, E> for Test {
                     #[inline]
-                    fn encode_type_id(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
                         use ::sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
@@ -327,14 +354,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <ENC: ::sbor::encoder::Encoder<::sbor::basic::NoCustomTypeId> > ::sbor::Encode<::sbor::basic::NoCustomTypeId, ENC> for Test {
+                impl <E: ::sbor::Encoder<::sbor::basic::NoCustomTypeId> > ::sbor::Encode<::sbor::basic::NoCustomTypeId, E> for Test {
                     #[inline]
-                    fn encode_type_id(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
+                    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
+                        encoder.write_type_id(::sbor::SborTypeId::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut ENC) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
                         use ::sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())

--- a/sbor-derive/src/type_id.rs
+++ b/sbor-derive/src/type_id.rs
@@ -23,22 +23,22 @@ pub fn handle_type_id(input: TokenStream) -> Result<TokenStream> {
     } = parse2(input)?;
     let custom_type_id = custom_type_id(&attrs);
     let (impl_generics, ty_generics, where_clause, sbor_cti) =
-        build_generics(&generics, custom_type_id)?;
+        build_custom_type_id_generic(&generics, custom_type_id)?;
 
     let output = match data {
         Data::Struct(_) => quote! {
             impl #impl_generics ::sbor::TypeId <#sbor_cti> for #ident #ty_generics #where_clause {
                 #[inline]
-                fn type_id() -> ::sbor::type_id::SborTypeId <#sbor_cti> {
-                    ::sbor::type_id::SborTypeId::Tuple
+                fn type_id() -> ::sbor::SborTypeId <#sbor_cti> {
+                    ::sbor::SborTypeId::Tuple
                 }
             }
         },
         Data::Enum(_) => quote! {
             impl #impl_generics ::sbor::TypeId <#sbor_cti> for #ident #ty_generics #where_clause {
                 #[inline]
-                fn type_id() -> ::sbor::type_id::SborTypeId <#sbor_cti> {
-                    ::sbor::type_id::SborTypeId::Enum
+                fn type_id() -> ::sbor::SborTypeId <#sbor_cti> {
+                    ::sbor::SborTypeId::Enum
                 }
             }
         },
@@ -73,10 +73,10 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <CTI: ::sbor::type_id::CustomTypeId> ::sbor::TypeId<CTI> for Test {
+                impl <X: ::sbor::CustomTypeId> ::sbor::TypeId<X> for Test {
                     #[inline]
-                    fn type_id() -> ::sbor::type_id::SborTypeId<CTI> {
-                        ::sbor::type_id::SborTypeId::Tuple
+                    fn type_id() -> ::sbor::SborTypeId<X> {
+                        ::sbor::SborTypeId::Tuple
                     }
                 }
             },
@@ -91,10 +91,10 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <A, CTI: ::sbor::type_id::CustomTypeId> ::sbor::TypeId<CTI> for Test<A> {
+                impl <A, X: ::sbor::CustomTypeId> ::sbor::TypeId<X> for Test<A> {
                     #[inline]
-                    fn type_id() -> ::sbor::type_id::SborTypeId<CTI> {
-                        ::sbor::type_id::SborTypeId::Tuple
+                    fn type_id() -> ::sbor::SborTypeId<X> {
+                        ::sbor::SborTypeId::Tuple
                     }
                 }
             },
@@ -109,10 +109,10 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <CTI: ::sbor::type_id::CustomTypeId> ::sbor::TypeId<CTI> for Test {
+                impl <X: ::sbor::CustomTypeId> ::sbor::TypeId<X> for Test {
                     #[inline]
-                    fn type_id() -> ::sbor::type_id::SborTypeId<CTI> {
-                        ::sbor::type_id::SborTypeId::Enum
+                    fn type_id() -> ::sbor::SborTypeId<X> {
+                        ::sbor::SborTypeId::Enum
                     }
                 }
             },


### PR DESCRIPTION
Small, independent change that may as well be merged in separately from the type schema work.

Basically it enables you to do this now - with a generic type parameter like `T`:

```
#[derive(Debug, Clone, PartialEq, Eq, Default, TypeId, Encode, Decode)]
pub struct NumericValidation<T> {
    pub min: Option<T>,
    pub max: Option<T>,
}
```

And the macro now expands to the following - which includes the bound `T: ::sbor::Encode<X, E>`
```
impl<T: ::sbor::Encode<X, E>, E: ::sbor::encoder::Encoder<X>, X: ::sbor::type_id::CustomTypeId>
    ::sbor::Encode<X, E> for NumericValidation<T>
{
    #[inline]
    fn encode_type_id(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
        encoder.write_type_id(::sbor::type_id::SborTypeId::Tuple)
    }
    #[inline]
    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
        use ::sbor::{self, Encode};
        encoder.write_size(2)?;
        encoder.encode(&self.min)?;
        encoder.encode(&self.max)?;
        Ok(())
    }
}
```

I've also neatened up the default generic parameter idents to be X/D/E instead of CTI/DEC/ENC... and implemented automatic clash-avoidance so that they automatically get numbers to avoid clashes with other generic parameters if required - see test cases :)