### PR TITLE
Added --document-private-items to doc generation

### DIFF
--- a/doc.sh
+++ b/doc.sh
@@ -5,7 +5,12 @@ set -e
 
 cd "$(dirname "$0")"
 
-cd radix-engine;
-cargo doc --no-deps --package scrypto --package sbor --package radix-engine;
+cargo doc \
+    --no-deps \
+    --document-private-items \
+    --package sbor \
+    --package radix-engine \
+    --package scrypto;
+
 doc_index="./target/doc/scrypto/index.html";
 (xdg-open $doc_index || open $doc_index || start $doc_index);


### PR DESCRIPTION
I just added the `--document-private-items` flag so that more things are displayed in the documentation like `FungibleResourceBuilder` and `NonFungibleResourceBuilder`