### PR TITLE
Add set_current_time & get_current_time to TestRunner (develop)

### DIFF
--- a/radix-engine/tests/time.rs
+++ b/radix-engine/tests/time.rs
@@ -48,6 +48,11 @@ fn setting_multiple_time_succeed() {
         test_runner.set_current_time(time_in_ms);
 
         // Assert
-        assert_eq!(test_runner.get_current_time(TimePrecision::Minute).seconds_since_unix_epoch, time_rounded_to_minutes);
+        assert_eq!(
+            test_runner
+                .get_current_time(TimePrecision::Minute)
+                .seconds_since_unix_epoch,
+            time_rounded_to_minutes
+        );
     }
 }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -23,8 +23,8 @@ use radix_engine_interface::constants::EPOCH_MANAGER;
 use radix_engine_interface::data::*;
 use radix_engine_interface::math::Decimal;
 use radix_engine_interface::model::{
-    AccessRule, AccessRules, EpochManagerInvocation, FromPublicKey, NativeInvocation,
-    NonFungibleAddress, NonFungibleIdType, ClockInvocation,
+    AccessRule, AccessRules, ClockInvocation, EpochManagerInvocation, FromPublicKey,
+    NativeInvocation, NonFungibleAddress, NonFungibleIdType,
 };
 use radix_engine_interface::modules::auth::AuthAddresses;
 use radix_engine_interface::node::NetworkDefinition;
@@ -889,10 +889,10 @@ impl TestRunner {
 
     pub fn set_current_time(&mut self, current_time_ms: i64) {
         let instructions = vec![Instruction::System(NativeInvocation::Clock(
-                ClockInvocation::SetCurrentTime(ClockSetCurrentTimeInvocation {
-                    current_time_ms,
-                    receiver: CLOCK,
-                }),
+            ClockInvocation::SetCurrentTime(ClockSetCurrentTimeInvocation {
+                current_time_ms,
+                receiver: CLOCK,
+            }),
         ))];
         let blobs = vec![];
         let nonce = self.next_transaction_nonce();
@@ -910,10 +910,10 @@ impl TestRunner {
 
     pub fn get_current_time(&mut self, precision: TimePrecision) -> Instant {
         let instructions = vec![Instruction::System(NativeInvocation::Clock(
-                ClockInvocation::GetCurrentTime(ClockGetCurrentTimeInvocation {
-                    precision,
-                    receiver: CLOCK,
-                }),
+            ClockInvocation::GetCurrentTime(ClockGetCurrentTimeInvocation {
+                precision,
+                receiver: CLOCK,
+            }),
         ))];
         let blobs = vec![];
         let nonce = self.next_transaction_nonce();


### PR DESCRIPTION
This adds `set_current_time` and `get_current_time` to the latest changes to `TestRunner` 