### PR TITLE
add Send + Sync for NativeOutput

### DIFF
--- a/radix-engine/src/model/transaction_processor/executables.rs
+++ b/radix-engine/src/model/transaction_processor/executables.rs
@@ -46,8 +46,8 @@ pub enum TransactionProcessorError {
     ResolveError(ResolveError),
 }
 
-pub trait NativeOutput: ScryptoEncode + Debug {}
-impl<T: ScryptoEncode + Debug> NativeOutput for T {}
+pub trait NativeOutput: ScryptoEncode + Debug + Send + Sync {}
+impl<T: ScryptoEncode + Debug + Send + Sync> NativeOutput for T {}
 
 #[derive(Debug)]
 pub enum InstructionOutput {


### PR DESCRIPTION
Adds Send + Sync for NativeOutput. Needed in order to share state_manager reference between threads inside `babylon-node`.