### PR TITLE
Remove default_alloc_error_handler

### DIFF
--- a/examples/no-std/src/lib.rs
+++ b/examples/no-std/src/lib.rs
@@ -1,5 +1,5 @@
 // Disable std and enable language features.
-#![cfg_attr(target_arch = "wasm32", no_std, feature(default_alloc_error_handler))]
+#![cfg_attr(target_arch = "wasm32", no_std)]
 
 // Abort when panicking.
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Remove feature `default_alloc_error_handler`, which has been stabilised in `nightly` channel.

Hopefully, we will be able to use `stable` channel soon.