### PR TITLE
Fix/SCRY-314 transaction size

### DIFF
--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -27,6 +27,9 @@ pub const DEFAULT_MAX_TIP_PERCENTAGE: u16 = u16::MAX;
 /// The max epoch range
 pub const DEFAULT_MAX_EPOCH_RANGE: u64 = 100;
 
+/// The max transaction size
+pub const MAX_TRANSACTION_SIZE: usize = 1 * 1024 * 1024;
+
 //==========================
 // Transaction execution
 //==========================

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -10,14 +10,13 @@ use crate::errors::{SignatureValidationError, *};
 use crate::model::*;
 use crate::validation::*;
 
-pub const MAX_PAYLOAD_SIZE: usize = 4 * 1024 * 1024;
 
 pub trait TransactionValidator<T: ScryptoDecode> {
     fn check_length_and_decode_from_slice(
         &self,
         transaction: &[u8],
     ) -> Result<T, TransactionValidationError> {
-        if transaction.len() > MAX_PAYLOAD_SIZE {
+        if transaction.len() > MAX_TRANSACTION_SIZE {
             return Err(TransactionValidationError::TransactionTooLarge);
         }
 


### PR DESCRIPTION
Changed maximum transaction size from 4MiB to 1MiB.
Moved constant to `radix-engine-constants`.