### PR TITLE
fix: Tweak cost unit multipliers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - docs
       - alphanet
       - betanet
-      - release/*
+      - release\/*
   pull_request:
     branches:
       - main
@@ -16,7 +16,7 @@ on:
       - docs
       - alphanet
       - betanet
-      - release/*
+      - release\/*
 
 env:
   CARGO_TERM_COLOR: always

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -35,7 +35,7 @@ pub const MAX_TRANSACTION_SIZE: usize = 1 * 1024 * 1024;
 //==========================
 
 /// The default system loan amount, used by transaction executor.
-pub const DEFAULT_SYSTEM_LOAN: u32 = 5_000_000;
+pub const DEFAULT_SYSTEM_LOAN: u32 = 10_000_000;
 
 /// The default max call depth, used by transaction executor.
 pub const DEFAULT_MAX_CALL_DEPTH: usize = 12;

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -35,7 +35,7 @@ pub const MAX_TRANSACTION_SIZE: usize = 1 * 1024 * 1024;
 //==========================
 
 /// The default system loan amount, used by transaction executor.
-pub const DEFAULT_SYSTEM_LOAN: u32 = 1_000_000;
+pub const DEFAULT_SYSTEM_LOAN: u32 = 5_000_000;
 
 /// The default max call depth, used by transaction executor.
 pub const DEFAULT_MAX_CALL_DEPTH: usize = 12;

--- a/radix-engine/benches/radix_engine.rs
+++ b/radix-engine/benches/radix_engine.rs
@@ -10,6 +10,7 @@ use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::dec;
 use radix_engine_interface::model::FromPublicKey;
 use radix_engine_interface::rule;
+use scrypto_unit::TestRunner;
 use transaction::builder::ManifestBuilder;
 use transaction::model::TestTransaction;
 use transaction::signing::EcdsaSecp256k1PrivateKey;
@@ -114,5 +115,43 @@ fn bench_transfer(c: &mut Criterion) {
     });
 }
 
-criterion_group!(radix_engine, bench_transfer);
+fn bench_spin_loop(c: &mut Criterion) {
+    // Set up environment.
+    let mut test_runner = TestRunner::builder().without_trace().build();
+
+    let package_address = test_runner.compile_and_publish("./tests/blueprints/fee");
+    let component_address = test_runner
+        .execute_manifest(
+            ManifestBuilder::new()
+                .lock_fee(FAUCET_COMPONENT, 10u32.into())
+                .call_method(FAUCET_COMPONENT, "free", args!())
+                .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
+                    builder.call_function(package_address, "Fee", "new", args!(bucket_id));
+                    builder
+                })
+                .build(),
+            vec![],
+        )
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
+
+    // Create a transfer manifest
+    let manifest = ManifestBuilder::new()
+        // First, lock the fee so that the loan will be repaid
+        .call_method(FAUCET_COMPONENT, "lock_fee", args!(Decimal::from(10)))
+        // Now spin-loop to wait for the fee loan to burn through
+        .call_method(component_address, "spin_loop", args!())
+        .build();
+
+    // Loop
+    c.bench_function("Spin Loop", |b| {
+        b.iter(|| {
+            let receipt = test_runner.execute_manifest(manifest.clone(), vec![]);
+            receipt.expect_commit_failure();
+        })
+    });
+}
+
+criterion_group!(radix_engine, bench_transfer, bench_spin_loop);
 criterion_main!(radix_engine);

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -65,14 +65,14 @@ pub struct FeeTable {
 impl FeeTable {
     pub fn new() -> Self {
         Self {
-            tx_base_fee: 100_000,
-            tx_payload_cost_per_byte: 10,
-            tx_signature_verification_per_sig: 37500,
-            tx_blob_price_per_byte: 10,
-            wasm_instantiation_per_byte: 0, // TODO: Re-enable WASM instantiation cost if it's unavoidable
-            fixed_low: 1000,
-            fixed_medium: 5000,
-            fixed_high: 10000,
+            tx_base_fee: 200_000,
+            tx_payload_cost_per_byte: 20,
+            tx_signature_verification_per_sig: 375000,
+            tx_blob_price_per_byte: 20,
+            wasm_instantiation_per_byte: 1, // TODO: Re-enable WASM instantiation cost if it's unavoidable
+            fixed_low: 2000,
+            fixed_medium: 10000,
+            fixed_high: 20000,
         }
     }
 

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -65,14 +65,14 @@ pub struct FeeTable {
 impl FeeTable {
     pub fn new() -> Self {
         Self {
-            tx_base_fee: 10_000,
-            tx_payload_cost_per_byte: 1,
-            tx_signature_verification_per_sig: 3750,
-            tx_blob_price_per_byte: 1,
+            tx_base_fee: 100_000,
+            tx_payload_cost_per_byte: 10,
+            tx_signature_verification_per_sig: 37500,
+            tx_blob_price_per_byte: 10,
             wasm_instantiation_per_byte: 0, // TODO: Re-enable WASM instantiation cost if it's unavoidable
-            fixed_low: 100,
-            fixed_medium: 500,
-            fixed_high: 1000,
+            fixed_low: 1000,
+            fixed_medium: 5000,
+            fixed_high: 10000,
         }
     }
 

--- a/radix-engine/src/fee/fee_table.rs
+++ b/radix-engine/src/fee/fee_table.rs
@@ -65,14 +65,14 @@ pub struct FeeTable {
 impl FeeTable {
     pub fn new() -> Self {
         Self {
-            tx_base_fee: 200_000,
-            tx_payload_cost_per_byte: 20,
-            tx_signature_verification_per_sig: 375000,
-            tx_blob_price_per_byte: 20,
+            tx_base_fee: 50_000,
+            tx_payload_cost_per_byte: 5,
+            tx_signature_verification_per_sig: 100_000,
+            tx_blob_price_per_byte: 5,
             wasm_instantiation_per_byte: 1, // TODO: Re-enable WASM instantiation cost if it's unavoidable
-            fixed_low: 2000,
-            fixed_medium: 10000,
-            fixed_high: 20000,
+            fixed_low: 500,
+            fixed_medium: 2500,
+            fixed_high: 5000,
         }
     }
 

--- a/radix-engine/src/model/fee/module.rs
+++ b/radix-engine/src/model/fee/module.rs
@@ -167,8 +167,12 @@ impl<R: FeeReserve> BaseModule<R> for CostingModule {
         // We add a little to make up for billing overhead, and then multiply by a large enough factor
         // to ensure spin loops end within a fraction of a second.
         // These values will be tweaked, alongside the whole fee table.
-        let amount_to_consume = units.checked_add(20).and_then(|a| a.checked_mul(20))
-            .ok_or(ModuleError::CostingError(CostingError::FeeReserveError(FeeReserveError::Overflow)))?;
+        let amount_to_consume = units
+            .checked_add(20)
+            .and_then(|a| a.checked_mul(20))
+            .ok_or(ModuleError::CostingError(CostingError::FeeReserveError(
+                FeeReserveError::Overflow,
+            )))?;
         track
             .fee_reserve()
             .consume_execution(amount_to_consume, "run_wasm")

--- a/radix-engine/src/model/fee/module.rs
+++ b/radix-engine/src/model/fee/module.rs
@@ -164,9 +164,14 @@ impl<R: FeeReserve> BaseModule<R> for CostingModule {
         track: &mut Track<R>,
         units: u32,
     ) -> Result<(), ModuleError> {
+        // We add a little to make up for billing overhead, and then multiply by a large enough factor
+        // to ensure spin loops end within a fraction of a second.
+        // These values will be tweaked, alongside the whole fee table.
+        let amount_to_consume = units.checked_add(20).and_then(|a| a.checked_mul(20))
+            .ok_or(ModuleError::CostingError(CostingError::FeeReserveError(FeeReserveError::Overflow)))?;
         track
             .fee_reserve()
-            .consume_execution(units, "run_wasm")
+            .consume_execution(amount_to_consume, "run_wasm")
             .map_err(|e| ModuleError::CostingError(CostingError::FeeReserveError(e)))
     }
 

--- a/radix-engine/src/model/fee/module.rs
+++ b/radix-engine/src/model/fee/module.rs
@@ -164,18 +164,12 @@ impl<R: FeeReserve> BaseModule<R> for CostingModule {
         track: &mut Track<R>,
         units: u32,
     ) -> Result<(), ModuleError> {
-        // We add a little to make up for billing overhead, and then multiply by a large enough factor
-        // to ensure spin loops end within a fraction of a second.
+        // We multiply by a large enough factor to ensure spin loops end within a fraction of a second.
         // These values will be tweaked, alongside the whole fee table.
-        let amount_to_consume = units
-            .checked_add(20)
-            .and_then(|a| a.checked_mul(20))
-            .ok_or(ModuleError::CostingError(CostingError::FeeReserveError(
-                FeeReserveError::Overflow,
-            )))?;
+        let multiplier = 5;
         track
             .fee_reserve()
-            .consume_execution(amount_to_consume, "run_wasm")
+            .consume_multiplied_execution(units, multiplier, "run_wasm")
             .map_err(|e| ModuleError::CostingError(CostingError::FeeReserveError(e)))
     }
 

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -226,8 +226,37 @@ where
                 .iter()
                 .collect::<BTreeMap<&String, &u32>>();
             for (k, v) in break_down {
-                println!("{:<30}: {:>8}", k, v);
+                println!("{:<30}: {:>10}", k, v);
             }
+
+            println!("{:-^80}", "Cost Totals");
+            println!(
+                "{:<30}: {:>10}",
+                "Total Cost Units Consumed", receipt.execution.fee_summary.cost_unit_consumed
+            );
+            println!(
+                "{:<30}: {:>10}",
+                "Cost Unit Limit", receipt.execution.fee_summary.cost_unit_limit
+            );
+            // NB - we use "to_string" to ensure they align correctly
+            println!(
+                "{:<30}: {:>10}",
+                "Execution XRD",
+                receipt
+                    .execution
+                    .fee_summary
+                    .total_execution_cost_xrd
+                    .to_string()
+            );
+            println!(
+                "{:<30}: {:>10}",
+                "Royalty XRD",
+                receipt
+                    .execution
+                    .fee_summary
+                    .total_royalty_cost_xrd
+                    .to_string()
+            );
 
             match &receipt.result {
                 TransactionResult::Commit(commit) => {

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -59,25 +59,12 @@ fn should_be_aborted_when_loan_repaid() {
         .call_method(component_address, "spin_loop", args!())
         .build();
 
-    let test_transaction = TestTransaction::new(
-        manifest,
-        test_runner.next_transaction_nonce(),
-        DEFAULT_COST_UNIT_LIMIT,
-    );
-    let executable = test_transaction.get_executable(vec![]);
-
-    let receipt = test_runner.execute_transaction_with_config(
-        executable,
-        &FeeReserveConfig::default(),
-        &ExecutionConfig::up_to_loan_repayment_with_debug(),
-    );
-
-    let abort_reason = receipt.expect_abortion().clone();
-
-    assert_eq!(
-        abort_reason,
-        AbortReason::ConfiguredAbortTriggeredOnFeeLoanRepayment
-    );
+    let start = std::time::Instant::now();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+    let duration = start.elapsed();
+    println!("Time elapsed is: {:?}", duration);
+    println!("{:?}", receipt);
+    receipt.expect_commit_failure();
 }
 
 #[test]

--- a/radix-engine/tests/fee.rs
+++ b/radix-engine/tests/fee.rs
@@ -1,11 +1,8 @@
 use radix_engine::engine::{ApplicationError, KernelError, TrackError};
 use radix_engine::engine::{RejectionError, RuntimeError};
 use radix_engine::model::WorktopError;
-use radix_engine::transaction::{
-    AbortReason, ExecutionConfig, FeeReserveConfig, TransactionReceipt,
-};
+use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
-use radix_engine_constants::DEFAULT_COST_UNIT_LIMIT;
 use radix_engine_interface::model::FromPublicKey;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -1,9 +1,37 @@
+use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::model::FromPublicKey;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
+use transaction::model::TransactionManifest;
 
 // For WASM-specific metering tests, see `wasm_metering.rs`.
+
+#[cfg(feature = "std")]
+fn execute_with_time_logging(
+    test_runner: &mut TestRunner,
+    manifest: TransactionManifest,
+    proofs: Vec<NonFungibleGlobalId>,
+) -> (TransactionReceipt, u32) {
+    let start = std::time::Instant::now();
+    let receipt = test_runner.execute_manifest(manifest, proofs);
+    let duration = start.elapsed();
+    println!(
+        "Time elapsed is: {:?} - NOTE: this is a very bad measure. Use benchmarks instead.",
+        duration
+    );
+    (receipt, duration.as_millis().try_into().unwrap())
+}
+
+#[cfg(feature = "alloc")]
+fn execute_with_time_logging(
+    test_runner: &mut TestRunner,
+    manifest: TransactionManifest,
+    proofs: Vec<NonFungibleGlobalId>,
+) -> (TransactionReceipt, u32) {
+    let receipt = test_runner.execute_manifest(manifest, proofs);
+    (receipt, 0)
+}
 
 #[test]
 fn test_basic_transfer() {
@@ -22,10 +50,13 @@ fn test_basic_transfer() {
             args!(ManifestExpression::EntireWorktop),
         )
         .build();
-    let receipt = test_runner.execute_manifest(
+
+    let (receipt, _) = execute_with_time_logging(
+        &mut test_runner,
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key1)],
     );
+
     receipt.expect_commit_success();
 
     // Assert
@@ -33,20 +64,20 @@ fn test_basic_transfer() {
     // Or you can run just this test with the below:
     // (cd radix-engine && cargo test --test metering -- test_basic_transfer)
     assert_eq!(
-        60000 /* create_node */
-        + 176000 /* drop_lock */
-        + 40000 /* drop_node */
+        15000 /* create_node */
+        + 44000 /* drop_lock */
+        + 10000 /* drop_node */
         + 902454 /* instantiate_wasm */
-        + 26000 /* invoke */
-        + 238000 /* lock_substate */
-        + 140000 /* read_owned_nodes */
-        + 800000 /* read_substate */
-        + 80000 /* run_native_method */
-        + 7931440 /* run_wasm */
-        + 200000 /* tx_base_fee */
-        + 5480 /* tx_payload_cost */
-        + 375000 /* tx_signature_verification */
-        + 460000, /* write_substate */
+        + 6500 /* invoke */
+        + 59500 /* lock_substate */
+        + 35000 /* read_owned_nodes */
+        + 200000 /* read_substate */
+        + 20000 /* run_native_method */
+        + 929070 /* run_wasm */
+        + 50000 /* tx_base_fee */
+        + 1370 /* tx_payload_cost */
+        + 100000 /* tx_signature_verification */
+        + 115000, /* write_substate */
         receipt.execution.fee_summary.cost_unit_consumed
     );
 }
@@ -78,13 +109,15 @@ fn test_publish_large_package() {
             AccessRules::new(),
         )
         .build();
-    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    let (receipt, _) = execute_with_time_logging(&mut test_runner, manifest, vec![]);
+
     receipt.expect_commit_success();
 
     // Assert
     assert!(
-        receipt.execution.fee_summary.cost_unit_consumed > 4000000
-            && receipt.execution.fee_summary.cost_unit_consumed < 5000000
+        receipt.execution.fee_summary.cost_unit_consumed > 20000000
+            && receipt.execution.fee_summary.cost_unit_consumed < 30000000
     );
 }
 
@@ -109,7 +142,9 @@ fn should_be_able_run_large_manifest() {
         args!(ManifestExpression::EntireWorktop),
     );
     let manifest = builder.build();
-    let receipt = test_runner.execute_manifest(
+
+    let (receipt, _) = execute_with_time_logging(
+        &mut test_runner,
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -119,7 +154,7 @@ fn should_be_able_run_large_manifest() {
 }
 
 #[test]
-fn should_be_able_invoke_account_balance_50_times() {
+fn should_be_able_invoke_account_balance_100_times() {
     // Arrange
     let mut test_runner = TestRunner::builder().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
@@ -127,11 +162,13 @@ fn should_be_able_invoke_account_balance_50_times() {
     // Act
     let mut builder = ManifestBuilder::new();
     builder.lock_fee(account, 100u32.into());
-    for _ in 0..50 {
+    for _ in 0..100 {
         builder.call_method(account, "balance", args!(RADIX_TOKEN));
     }
     let manifest = builder.build();
-    let receipt = test_runner.execute_manifest(
+
+    let (receipt, _) = execute_with_time_logging(
+        &mut test_runner,
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -154,11 +191,57 @@ fn should_be_able_to_generate_5_proofs_and_then_lock_fee() {
     }
     builder.lock_fee(account, 100u32.into());
     let manifest = builder.build();
-    let receipt = test_runner.execute_manifest(
+
+    let (receipt, _) = execute_with_time_logging(
+        &mut test_runner,
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
 
     // Assert
     receipt.expect_commit_success();
+}
+
+fn setup_test_runner_with_fee_blueprint_component() -> (TestRunner, ComponentAddress) {
+    // Basic setup
+    let mut test_runner = TestRunner::builder().build();
+    let (public_key, _, account) = test_runner.new_allocated_account();
+
+    // Publish package and instantiate component
+    let package_address = test_runner.compile_and_publish("./tests/blueprints/fee");
+    let receipt1 = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee(account, 10u32.into())
+            .withdraw_from_account_by_amount(account, 10u32.into(), RADIX_TOKEN)
+            .take_from_worktop(RADIX_TOKEN, |builder, bucket_id| {
+                builder.call_function(package_address, "Fee", "new", args!(bucket_id));
+                builder
+            })
+            .build(),
+        vec![NonFungibleGlobalId::from_public_key(&public_key)],
+    );
+    let component_address = receipt1
+        .expect_commit()
+        .entity_changes
+        .new_component_addresses[0];
+
+    (test_runner, component_address)
+}
+
+#[test]
+fn spin_loop_should_end_in_reasonable_amount_of_time() {
+    let (mut test_runner, component_address) = setup_test_runner_with_fee_blueprint_component();
+
+    let manifest = ManifestBuilder::new()
+        // First, lock the fee so that the loan will be repaid
+        .call_method(component_address, "lock_fee", args!(Decimal::from(10)))
+        // Now spin-loop to wait for the fee loan to burn through
+        .call_method(component_address, "spin_loop", args!())
+        .build();
+
+    let (receipt, _) = execute_with_time_logging(&mut test_runner, manifest, vec![]);
+
+    // No assertion here - this is just a sanity-test
+    println!("{:?}", receipt);
+    receipt.expect_commit_failure();
 }

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -33,19 +33,20 @@ fn test_basic_transfer() {
     // Or you can run just this test with the below:
     // (cd radix-engine && cargo test --test metering -- test_basic_transfer)
     assert_eq!(
-        30000 /* create_node */
-        + 88000 /* drop_lock */
-        + 20000 /* drop_node */
-        + 13000 /* invoke */
-        + 119000 /* lock_substate */
-        + 70000 /* read_owned_nodes */
-        + 400000 /* read_substate */
-        + 40000 /* run_native_method */
+        60000 /* create_node */
+        + 176000 /* drop_lock */
+        + 40000 /* drop_node */
+        + 902454 /* instantiate_wasm */
+        + 26000 /* invoke */
+        + 238000 /* lock_substate */
+        + 140000 /* read_owned_nodes */
+        + 800000 /* read_substate */
+        + 80000 /* run_native_method */
         + 7931440 /* run_wasm */
-        + 100000 /* tx_base_fee */
-        + 2740 /* tx_payload_cost */
-        + 37500 /* tx_signature_verification */
-        + 230000, /* write_substate */
+        + 200000 /* tx_base_fee */
+        + 5480 /* tx_payload_cost */
+        + 375000 /* tx_signature_verification */
+        + 460000, /* write_substate */
         receipt.execution.fee_summary.cost_unit_consumed
     );
 }

--- a/radix-engine/tests/metering.rs
+++ b/radix-engine/tests/metering.rs
@@ -33,19 +33,19 @@ fn test_basic_transfer() {
     // Or you can run just this test with the below:
     // (cd radix-engine && cargo test --test metering -- test_basic_transfer)
     assert_eq!(
-        3000 /* create_node */
-        + 8800 /* drop_lock */
-        + 2000 /* drop_node */
-        + 1300 /* invoke */
-        + 11900 /* lock_substate */
-        + 7000 /* read_owned_nodes */
-        + 40000 /* read_substate */
-        + 4000 /* run_native_method */
-        + 187672 /* run_wasm */
-        + 10000 /* tx_base_fee */
-        + 274 /* tx_payload_cost */
-        + 3750 /* tx_signature_verification */
-        + 23000, /* write_substate */
+        30000 /* create_node */
+        + 88000 /* drop_lock */
+        + 20000 /* drop_node */
+        + 13000 /* invoke */
+        + 119000 /* lock_substate */
+        + 70000 /* read_owned_nodes */
+        + 400000 /* read_substate */
+        + 40000 /* run_native_method */
+        + 7931440 /* run_wasm */
+        + 100000 /* tx_base_fee */
+        + 2740 /* tx_payload_cost */
+        + 37500 /* tx_signature_verification */
+        + 230000, /* write_substate */
         receipt.execution.fee_summary.cost_unit_consumed
     );
 }

--- a/radix-engine/tests/wasm_metering.rs
+++ b/radix-engine/tests/wasm_metering.rs
@@ -8,7 +8,7 @@ fn test_loop() {
     let mut test_runner = TestRunner::builder().build();
 
     // Act
-    let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "100000"));
+    let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "1000"));
     let package_address = test_runner.publish_package(
         code,
         generate_single_function_abi(
@@ -26,7 +26,7 @@ fn test_loop() {
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_function(package_address, "Test", "f", args!())
         .build();
-    let receipt = test_runner.execute_manifest_with_cost_unit_limit(manifest, vec![], 1_200_000);
+    let receipt = test_runner.execute_manifest_with_cost_unit_limit(manifest, vec![], 15_000_000);
 
     // Assert
     receipt.expect_commit_success();
@@ -40,7 +40,7 @@ fn test_loop_out_of_cost_unit() {
     let mut test_runner = TestRunner::builder().build();
 
     // Act
-    let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "200000"));
+    let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "2000000"));
     let package_address = test_runner.publish_package(
         code,
         generate_single_function_abi(
@@ -55,10 +55,10 @@ fn test_loop_out_of_cost_unit() {
         AccessRules::new(),
     );
     let manifest = ManifestBuilder::new()
-        .lock_fee(FAUCET_COMPONENT, 45.into())
+        .lock_fee(FAUCET_COMPONENT, 450.into())
         .call_function(package_address, "Test", "f", args!())
         .build();
-    let receipt = test_runner.execute_manifest_with_cost_unit_limit(manifest, vec![], 1_200_000);
+    let receipt = test_runner.execute_manifest_with_cost_unit_limit(manifest, vec![], 15_000_000);
 
     // Assert
     receipt.expect_specific_failure(is_costing_error)


### PR DESCRIPTION
Rough and dirty to make a spin-loop in a modified `should_be_aborted_when_loan_repaid` test run out of juice in 350ms (on my laptop).

Also adjusted the system loan. There's still a _lot_ of adjustment to do here, which is waiting on a more holistic review.
