### PR TITLE
Refactor: Wasmi with references

### DIFF
--- a/radix-engine/benches/wasm.rs
+++ b/radix-engine/benches/wasm.rs
@@ -27,7 +27,7 @@ fn bench_wasm_instantiation(c: &mut Criterion) {
     c.bench_function("WASM instantiation", |b| {
         b.iter(|| {
             let engine = DefaultWasmEngine::default();
-            engine.instantiate(&pretend_instrumented_code);
+            engine.instantiate_template_instance(&pretend_instrumented_code);
         })
     });
 }
@@ -40,10 +40,10 @@ fn bench_wasm_instantiation_pre_loaded(c: &mut Criterion) {
         code: Arc::new(code),
     };
     let engine = DefaultWasmEngine::default();
-    engine.instantiate(&pretend_instrumented_code);
+    engine.instantiate_template_instance(&pretend_instrumented_code);
     c.bench_function("WASM instantiation (pre-loaded)", |b| {
         b.iter(|| {
-            engine.instantiate(&pretend_instrumented_code);
+            engine.instantiate_template_instance(&pretend_instrumented_code);
         })
     });
 }

--- a/radix-engine/src/engine/kernel.rs
+++ b/radix-engine/src/engine/kernel.rs
@@ -637,7 +637,7 @@ where
     R: FeeReserve,
     M: BaseModule<R>,
 {
-    fn vm(&mut self) -> &ScryptoInterpreter<W> {
+    fn vm(&self) -> &ScryptoInterpreter<W> {
         self.scrypto_interpreter
     }
 

--- a/radix-engine/src/engine/system_api.rs
+++ b/radix-engine/src/engine/system_api.rs
@@ -81,7 +81,7 @@ pub trait SystemApi {
 
 pub trait VmApi<W: WasmEngine> {
     fn on_wasm_instantiation(&mut self, code: &[u8]) -> Result<(), RuntimeError>;
-    fn vm(&mut self) -> &ScryptoInterpreter<W>;
+    fn vm(&self) -> &ScryptoInterpreter<W>;
 }
 
 // TODO: Clean this up

--- a/radix-engine/src/model/package_extractor.rs
+++ b/radix-engine/src/model/package_extractor.rs
@@ -29,11 +29,14 @@ pub fn extract_abi(code: &[u8]) -> Result<BTreeMap<String, BlueprintAbi>, Extrac
     );
     let fee_reserve = SystemLoanFeeReserve::no_fee();
     let mut runtime: Box<dyn WasmRuntime> = Box::new(NopWasmRuntime::new(fee_reserve));
-    let mut instance = wasm_engine.instantiate(&instrumented_code);
+    let mut instance = wasm_engine
+        .instantiate_template_instance(&instrumented_code)
+        .install_runtime(&mut runtime);
+
     let mut blueprints = BTreeMap::new();
     for method_name in function_exports {
         let rtn = instance
-            .invoke_export(&method_name, vec![], &mut runtime)
+            .invoke_export(&method_name, vec![])
             .map_err(ExtractAbiError::FailedToExportBlueprintAbi)?;
 
         let abi: BlueprintAbi =

--- a/radix-engine/src/wasm/mod.rs
+++ b/radix-engine/src/wasm/mod.rs
@@ -25,12 +25,12 @@ pub use wasm_validator::*;
 #[cfg(feature = "wasmer")]
 pub type DefaultWasmEngine = WasmerEngine;
 #[cfg(feature = "wasmer")]
-pub type DefaultWasmInstance = WasmerInstance;
+pub type DefaultWasmInstance<'r, 'a> = WasmerInstance<'r, 'a>;
 
 #[cfg(not(feature = "wasmer"))]
 pub type DefaultWasmEngine = WasmiEngine;
 #[cfg(not(feature = "wasmer"))]
-pub type DefaultWasmInstance = WasmiInstance;
+pub type DefaultWasmInstance<'r, 'a> = WasmiInstance<'r, 'a>;
 
 // TODO: expand if package is upgradable.
 use radix_engine_interface::model::PackageAddress;


### PR DESCRIPTION
An example refactor where I've made Wasmi store an actual reference to the runtime - not just a usize pointer in disguise...

Although all the sins get hidden in:
* An implicit understanding that `WasmiInstanceEnv<'static, 'static'>` is the template instance, and a manual implementation of `Send` + `Sync` for that template instance.
* A transmute call mapping `WasmiInstanceEnv<'static, 'static'>` to `WasmiInstanceEnv<'r, 'a'>`
 
So I'm not sure it's considerably better...

Note that this is just food for thought at this stage, and _in particular_ I haven't updated the Wasmer interface to match.

If we want this, we'd need to fix the following before merge:
* Compare performance
* Update wasmer impl to match
* Update the code comments
* Consider using `MaybeUninit` instead of Option