### PR TITLE
Feature: blueprint attribute macro

### DIFF
--- a/assets/blueprints/account/src/lib.rs
+++ b/assets/blueprints/account/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod account {
     struct Account {
         vaults: KeyValueStore<ResourceAddress, Vault>,
     }

--- a/assets/blueprints/faucet/src/lib.rs
+++ b/assets/blueprints/faucet/src/lib.rs
@@ -1,7 +1,8 @@
 use scrypto::prelude::*;
 
 // Faucet - TestNet only
-blueprint! {
+#[blueprint]
+mod faucet {
     struct Faucet {
         vault: Vault,
         transactions: KeyValueStore<Hash, u64>,

--- a/assets/template/src/lib.rs
+++ b/assets/template/src/lib.rs
@@ -1,14 +1,15 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod hello {
     struct Hello {
         // Define what resources and data will be managed by Hello components
-        sample_vault: Vault
+        sample_vault: Vault,
     }
 
     impl Hello {
         // Implement the functions and methods which will manage those resources and data
-        
+
         // This is a function, and can be called directly on the blueprint once deployed
         pub fn instantiate_hello() -> ComponentAddress {
             // Create a new token called "HelloToken," with a fixed supply of 1000, and put that supply into a bucket
@@ -21,8 +22,8 @@ blueprint! {
             Self {
                 sample_vault: Vault::with_bucket(my_bucket)
             }
-            .instantiate()
-            .globalize()
+                .instantiate()
+                .globalize()
         }
 
         // This is a method, because it needs a reference to self.  Methods can only be called on components

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -22,7 +22,8 @@ In this example, we have only one blueprint in the package called `Hello`, which
 ```rust
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod hello {
     struct Hello {
         sample_vault: Vault,
     }

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod hello {
     struct Hello {
         // Define what resources and data will be managed by Hello components
         sample_vault: Vault,

--- a/examples/no-std/src/lib.rs
+++ b/examples/no-std/src/lib.rs
@@ -19,7 +19,8 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod no_std {
     struct NoStd;
 
     impl NoStd {

--- a/radix-engine/tests/blueprints/abi/src/lib.rs
+++ b/radix-engine/tests/blueprints/abi/src/lib.rs
@@ -2,7 +2,8 @@ use radix_engine_interface::api::wasm::*;
 use scrypto::abi::{BlueprintAbi, Fields, Fn, Type};
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod abi_component {
     struct AbiComponent {}
 
     impl AbiComponent {
@@ -212,7 +213,8 @@ pub extern "C" fn AbiComponent2_abi() -> Slice {
     ::scrypto::engine::wasm_api::forget_vec(::scrypto::data::scrypto_encode(&abi).unwrap())
 }
 
-blueprint! {
+#[blueprint]
+mod simple {
     struct Simple {
         state: u32,
     }

--- a/radix-engine/tests/blueprints/access_rules/src/assert_access_rule.rs
+++ b/radix-engine/tests/blueprints/access_rules/src/assert_access_rule.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod assert_access_rule {
     struct AssertAccessRule {}
 
     impl AssertAccessRule {

--- a/radix-engine/tests/blueprints/access_rules/src/mutable_access_rules.rs
+++ b/radix-engine/tests/blueprints/access_rules/src/mutable_access_rules.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod mutable_access_rules_component {
     struct MutableAccessRulesComponent {}
 
     impl MutableAccessRulesComponent {

--- a/radix-engine/tests/blueprints/arguments/src/lib.rs
+++ b/radix-engine/tests/blueprints/arguments/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod arguments {
     struct Arguments {}
 
     impl Arguments {

--- a/radix-engine/tests/blueprints/bucket/src/badge.rs
+++ b/radix-engine/tests/blueprints/bucket/src/badge.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod badge_test {
     struct BadgeTest;
 
     impl BadgeTest {

--- a/radix-engine/tests/blueprints/bucket/src/bucket.rs
+++ b/radix-engine/tests/blueprints/bucket/src/bucket.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod bucket_test {
     struct BucketTest {
         vault: Vault,
     }

--- a/radix-engine/tests/blueprints/clock/src/lib.rs
+++ b/radix-engine/tests/blueprints/clock/src/lib.rs
@@ -2,7 +2,8 @@ use radix_engine_interface::api::Invokable;
 use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod clock_test {
     struct ClockTest;
 
     impl ClockTest {

--- a/radix-engine/tests/blueprints/component/src/auth_component.rs
+++ b/radix-engine/tests/blueprints/component/src/auth_component.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod auth_component {
     struct AuthComponent {
         some_non_fungible: NonFungibleGlobalId,
     }

--- a/radix-engine/tests/blueprints/component/src/auth_list_component.rs
+++ b/radix-engine/tests/blueprints/component/src/auth_list_component.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod auth_list_component {
     struct AuthListComponent {
         count: u8,
         auth: Vec<NonFungibleGlobalId>,

--- a/radix-engine/tests/blueprints/component/src/chess.rs
+++ b/radix-engine/tests/blueprints/component/src/chess.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod chess {
     struct Chess {
         players: [NonFungibleGlobalId; 2],
     }

--- a/radix-engine/tests/blueprints/component/src/component.rs
+++ b/radix-engine/tests/blueprints/component/src/component.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod component_test {
     struct ComponentTest {
         test_vault: Vault,
         secret: String,

--- a/radix-engine/tests/blueprints/component/src/cross_component.rs
+++ b/radix-engine/tests/blueprints/component/src/cross_component.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod cross_component {
     struct CrossComponent {
         secret: String,
         auth_vault: Option<Vault>,

--- a/radix-engine/tests/blueprints/component/src/external_blueprint_target.rs
+++ b/radix-engine/tests/blueprints/component/src/external_blueprint_target.rs
@@ -11,7 +11,8 @@ pub enum ExtraEnum {
     EntryTwo,
 }
 
-blueprint! {
+#[blueprint]
+mod external_blueprint_target {
     struct ExternalBlueprintTarget {
         some_field: ExtraStruct,
     }

--- a/radix-engine/tests/blueprints/core/src/lib.rs
+++ b/radix-engine/tests/blueprints/core/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod move_test {
     struct MoveTest {
         vaults: Vec<Vault>,
     }
@@ -43,7 +44,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod core_test {
     struct CoreTest;
 
     impl CoreTest {

--- a/radix-engine/tests/blueprints/data_access/src/lib.rs
+++ b/radix-engine/tests/blueprints/data_access/src/lib.rs
@@ -3,7 +3,8 @@ use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 use scrypto::radix_engine_interface::api::EngineApi;
 
-blueprint! {
+#[blueprint]
+mod data_access {
     struct DataAccess {}
 
     impl DataAccess {

--- a/radix-engine/tests/blueprints/deep_sbor/src/deep_authrules_on_create.rs
+++ b/radix-engine/tests/blueprints/deep_sbor/src/deep_authrules_on_create.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod deep_auth_rules_on_create {
     struct DeepAuthRulesOnCreate {}
 
     impl DeepAuthRulesOnCreate {

--- a/radix-engine/tests/blueprints/deep_sbor/src/deep_struct.rs
+++ b/radix-engine/tests/blueprints/deep_sbor/src/deep_struct.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod deep_struct {
     struct DeepStruct {
         deep_object: Option<AccessRules>,
     }

--- a/radix-engine/tests/blueprints/deref/src/lib.rs
+++ b/radix-engine/tests/blueprints/deref/src/lib.rs
@@ -3,7 +3,8 @@ use radix_engine_interface::api::EngineApi;
 use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod deref {
     struct Deref {}
 
     impl Deref {

--- a/radix-engine/tests/blueprints/epoch_manager/src/lib.rs
+++ b/radix-engine/tests/blueprints/epoch_manager/src/lib.rs
@@ -2,7 +2,8 @@ use radix_engine_interface::api::Invokable;
 use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod epoch_manager_test {
     struct EpochManagerTest;
 
     impl EpochManagerTest {

--- a/radix-engine/tests/blueprints/execution_trace/src/execution_trace.rs
+++ b/radix-engine/tests/blueprints/execution_trace/src/execution_trace.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod execution_trace_test {
     struct ExecutionTraceTest {
         vault: Vault,
     }

--- a/radix-engine/tests/blueprints/external_blueprint_caller/src/external_blueprint_caller.rs
+++ b/radix-engine/tests/blueprints/external_blueprint_caller/src/external_blueprint_caller.rs
@@ -25,7 +25,8 @@ external_component! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod external_blueprint_caller {
     struct ExternalBlueprintCaller {}
 
     impl ExternalBlueprintCaller {

--- a/radix-engine/tests/blueprints/fee/src/lib.rs
+++ b/radix-engine/tests/blueprints/fee/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod fee {
     struct Fee {
         xrd: Vault,
         xrd_empty: Vault,

--- a/radix-engine/tests/blueprints/kernel/src/lib.rs
+++ b/radix-engine/tests/blueprints/kernel/src/lib.rs
@@ -13,7 +13,8 @@ pub enum GlobalAddressSubstate {
     Clock(ClockId),
 }
 
-blueprint! {
+#[blueprint]
+mod read {
     struct Read {}
 
     impl Read {
@@ -29,7 +30,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod node_create {
     struct NodeCreate {}
 
     impl NodeCreate {

--- a/radix-engine/tests/blueprints/kv_store/src/cyclic_map.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/cyclic_map.rs
@@ -4,7 +4,8 @@ use sbor::rust::marker::PhantomData;
 use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod cyclic_map {
     struct CyclicMap {
         store: KeyValueStore<u32, KeyValueStore<u32, u32>>,
     }

--- a/radix-engine/tests/blueprints/kv_store/src/kv_store.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/kv_store.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod key_value_store_test {
     struct KeyValueStoreTest {
         map: KeyValueStore<String, String>,
         vector: Vec<KeyValueStore<String, String>>,

--- a/radix-engine/tests/blueprints/kv_store/src/multiple_reads.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/multiple_reads.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod multiple_reads {
     struct MultipleReads {
         map: KeyValueStore<String, String>,
     }

--- a/radix-engine/tests/blueprints/kv_store/src/precommitted.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/precommitted.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod precommitted {
     struct Precommitted {
         store: KeyValueStore<u32, Vault>,
         deep_store: KeyValueStore<u32, KeyValueStore<u32, u32>>,

--- a/radix-engine/tests/blueprints/kv_store/src/ref_check.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/ref_check.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod ref_check {
     struct RefCheck {
         store: KeyValueStore<u32, Vault>,
         store_store: KeyValueStore<u32, KeyValueStore<u32, Vault>>,

--- a/radix-engine/tests/blueprints/kv_store/src/super_kv_store.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/super_kv_store.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod super_key_value_store {
     struct SuperKeyValueStore {
         maps: KeyValueStore<
             u32,

--- a/radix-engine/tests/blueprints/leaks/src/lib.rs
+++ b/radix-engine/tests/blueprints/leaks/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod leaks {
     struct Leaks {}
 
     impl Leaks {

--- a/radix-engine/tests/blueprints/local_component/src/lib.rs
+++ b/radix-engine/tests/blueprints/local_component/src/lib.rs
@@ -114,7 +114,7 @@ mod stored_kv_local {
 }
 
 #[blueprint]
-mod stored_kv_local {
+mod stored_secret {
     struct StoredSecret {
         component: SecretComponent,
     }

--- a/radix-engine/tests/blueprints/local_component/src/lib.rs
+++ b/radix-engine/tests/blueprints/local_component/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod secret {
     struct Secret {
         secret: u32,
     }
@@ -64,7 +65,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod stored_kv_local {
     struct StoredKVLocal {
         components: KeyValueStore<u32, SecretComponent>,
     }
@@ -111,7 +113,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod stored_kv_local {
     struct StoredSecret {
         component: SecretComponent,
     }

--- a/radix-engine/tests/blueprints/local_recursion/src/lib.rs
+++ b/radix-engine/tests/blueprints/local_recursion/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod local_recursion_bomb {
     struct LocalRecursionBomb {
         vault: Vault,
     }
@@ -31,7 +32,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod local_recursion_bomb {
     struct LocalRecursionBomb2 {
         vaults: KeyValueStore<u32, Vault>,
     }

--- a/radix-engine/tests/blueprints/local_recursion/src/lib.rs
+++ b/radix-engine/tests/blueprints/local_recursion/src/lib.rs
@@ -23,7 +23,7 @@ mod local_recursion_bomb {
             let local_component = Self {
                 vault: Vault::with_bucket(bucket),
             }
-                .instantiate();
+            .instantiate();
 
             let rtn_bucket = local_component.recurse();
             local_component.globalize();

--- a/radix-engine/tests/blueprints/local_recursion/src/lib.rs
+++ b/radix-engine/tests/blueprints/local_recursion/src/lib.rs
@@ -23,7 +23,7 @@ mod local_recursion_bomb {
             let local_component = Self {
                 vault: Vault::with_bucket(bucket),
             }
-            .instantiate();
+                .instantiate();
 
             let rtn_bucket = local_component.recurse();
             local_component.globalize();
@@ -33,7 +33,7 @@ mod local_recursion_bomb {
 }
 
 #[blueprint]
-mod local_recursion_bomb {
+mod local_recursion_bomb2 {
     struct LocalRecursionBomb2 {
         vaults: KeyValueStore<u32, Vault>,
     }

--- a/radix-engine/tests/blueprints/math-ops-check/src/lib.rs
+++ b/radix-engine/tests/blueprints/math-ops-check/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod hello {
     struct Hello {}
 
     impl Hello {

--- a/radix-engine/tests/blueprints/metadata_component/src/lib.rs
+++ b/radix-engine/tests/blueprints/metadata_component/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod metadata_component {
     struct MetadataComponent {}
 
     impl MetadataComponent {

--- a/radix-engine/tests/blueprints/non_fungible/src/lib.rs
+++ b/radix-engine/tests/blueprints/non_fungible/src/lib.rs
@@ -9,7 +9,8 @@ pub struct Sandwich {
     pub available: bool,
 }
 
-blueprint! {
+#[blueprint]
+mod non_fungible_test {
     struct NonFungibleTest {
         vault: Vault,
     }

--- a/radix-engine/tests/blueprints/package_token/src/lib.rs
+++ b/radix-engine/tests/blueprints/package_token/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod factory {
     struct Factory {
         my_address: Option<ComponentAddress>,
     }

--- a/radix-engine/tests/blueprints/proof/src/bucket_proof.rs
+++ b/radix-engine/tests/blueprints/proof/src/bucket_proof.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod bucket_proof {
     struct BucketProof;
 
     impl BucketProof {

--- a/radix-engine/tests/blueprints/proof/src/receiver.rs
+++ b/radix-engine/tests/blueprints/proof/src/receiver.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod receiver {
     struct Receiver {
         vault: Vault,
     }

--- a/radix-engine/tests/blueprints/proof/src/vault_proof.rs
+++ b/radix-engine/tests/blueprints/proof/src/vault_proof.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod vault_proof {
     struct VaultProof {
         vault: Vault,
     }

--- a/radix-engine/tests/blueprints/recursion/src/caller.rs
+++ b/radix-engine/tests/blueprints/recursion/src/caller.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod caller {
     struct Caller;
 
     impl Caller {

--- a/radix-engine/tests/blueprints/reentrancy/src/lib.rs
+++ b/radix-engine/tests/blueprints/reentrancy/src/lib.rs
@@ -2,7 +2,8 @@ use radix_engine_interface::api::Invokable;
 use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod reentrant_component {
     struct ReentrantComponent {}
 
     impl ReentrantComponent {

--- a/radix-engine/tests/blueprints/resource/src/lib.rs
+++ b/radix-engine/tests/blueprints/resource/src/lib.rs
@@ -7,7 +7,8 @@ pub struct Sandwich {
     pub available: bool,
 }
 
-blueprint! {
+#[blueprint]
+mod resource_test {
     struct ResourceTest;
 
     impl ResourceTest {

--- a/radix-engine/tests/blueprints/resource_creator/src/resource_creator.rs
+++ b/radix-engine/tests/blueprints/resource_creator/src/resource_creator.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod resource_creator {
     struct ResourceCreator {}
 
     impl ResourceCreator {

--- a/radix-engine/tests/blueprints/royalty-auth/src/lib.rs
+++ b/radix-engine/tests/blueprints/royalty-auth/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod royalty_test {
     struct RoyaltyTest {}
 
     impl RoyaltyTest {

--- a/radix-engine/tests/blueprints/royalty/src/lib.rs
+++ b/radix-engine/tests/blueprints/royalty/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod royalty_test {
     struct RoyaltyTest {}
 
     impl RoyaltyTest {

--- a/radix-engine/tests/blueprints/stored_external_component/src/lib.rs
+++ b/radix-engine/tests/blueprints/stored_external_component/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod external_component {
     struct ExternalComponent {
         external_component: Option<ComponentAddress>,
     }

--- a/radix-engine/tests/blueprints/stored_resource/src/lib.rs
+++ b/radix-engine/tests/blueprints/stored_resource/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod stored_resource {
     struct StoredResource {
         resource_address: ResourceAddress,
     }

--- a/radix-engine/tests/blueprints/stored_values/src/lib.rs
+++ b/radix-engine/tests/blueprints/stored_values/src/lib.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod invalid_init_stored_bucket {
     struct InvalidInitStoredBucket {
         bucket: Bucket,
     }
@@ -18,7 +19,8 @@ blueprint! {
     }
 }
 
-blueprint! {
+#[blueprint]
+mod invalid_stored_bucket_in_owned_component {
     struct InvalidStoredBucketInOwnedComponent {
         bucket: Option<Bucket>,
     }

--- a/radix-engine/tests/blueprints/vault/src/non_existent_vault.rs
+++ b/radix-engine/tests/blueprints/vault/src/non_existent_vault.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod non_existent_vault {
     struct NonExistentVault {
         vault: Option<Vault>,
         vaults: KeyValueStore<u128, Vault>,

--- a/radix-engine/tests/blueprints/vault/src/vault.rs
+++ b/radix-engine/tests/blueprints/vault/src/vault.rs
@@ -3,7 +3,8 @@ use scrypto::prelude::*;
 #[derive(NonFungibleData)]
 pub struct Data {}
 
-blueprint! {
+#[blueprint]
+mod vault_test {
     struct VaultTest {
         vault: Vault,
         vaults: KeyValueStore<u128, Vault>,

--- a/scrypto-derive/src/ast.rs
+++ b/scrypto-derive/src/ast.rs
@@ -6,7 +6,7 @@ use syn::{braced, Ident, ItemImpl, ItemStruct, Result, Token, Visibility};
 pub struct BlueprintMod {
     pub vis: Visibility,
     pub mod_token: Token![mod],
-    pub ident: Ident,
+    pub module_ident: Ident,
     pub brace: Brace,
     pub structure: ItemStruct,
     pub implementation: ItemImpl,
@@ -19,7 +19,7 @@ impl Parse for BlueprintMod {
         Ok(Self {
             vis: input.parse()?,
             mod_token: input.parse()?,
-            ident: input.parse()?,
+            module_ident: input.parse()?,
             brace: braced!(content in input),
             structure: content.parse()?,
             implementation: content.parse()?,

--- a/scrypto-derive/src/ast.rs
+++ b/scrypto-derive/src/ast.rs
@@ -1,17 +1,29 @@
 use syn::parse::{Parse, ParseStream};
-use syn::{ItemImpl, ItemStruct, Result};
+use syn::token::Brace;
+use syn::{braced, Ident, ItemImpl, ItemStruct, Result, Token, Visibility};
 
-/// Represents the AST of blueprint.
-pub struct Blueprint {
+/// Represents a Blueprint module which consists of a struct and an implementation of said struct
+pub struct BlueprintMod {
+    pub vis: Visibility,
+    pub mod_token: Token![mod],
+    pub ident: Ident,
+    pub brace: Brace,
     pub structure: ItemStruct,
     pub implementation: ItemImpl,
+    pub semi: Option<Token![;]>,
 }
 
-impl Parse for Blueprint {
+impl Parse for BlueprintMod {
     fn parse(input: ParseStream) -> Result<Self> {
+        let content;
         Ok(Self {
-            structure: input.parse()?,
-            implementation: input.parse()?,
+            vis: input.parse()?,
+            mod_token: input.parse()?,
+            ident: input.parse()?,
+            brace: braced!(content in input),
+            structure: content.parse()?,
+            implementation: content.parse()?,
+            semi: input.parse()?,
         })
     }
 }

--- a/scrypto-derive/src/ast.rs
+++ b/scrypto-derive/src/ast.rs
@@ -1,6 +1,6 @@
 use syn::parse::{Parse, ParseStream};
 use syn::token::Brace;
-use syn::{braced, Ident, ItemImpl, ItemStruct, Result, Token, Visibility};
+use syn::{braced, Ident, ItemImpl, ItemStruct, ItemUse, Result, Token, Visibility};
 
 /// Represents a Blueprint module which consists of a struct and an implementation of said struct
 pub struct BlueprintMod {
@@ -8,6 +8,7 @@ pub struct BlueprintMod {
     pub mod_token: Token![mod],
     pub module_ident: Ident,
     pub brace: Brace,
+    pub use_statements: Vec<ItemUse>,
     pub structure: ItemStruct,
     pub implementation: ItemImpl,
     pub semi: Option<Token![;]>,
@@ -16,14 +17,31 @@ pub struct BlueprintMod {
 impl Parse for BlueprintMod {
     fn parse(input: ParseStream) -> Result<Self> {
         let content;
+
+        let vis = input.parse()?;
+        let mod_token = input.parse()?;
+        let module_ident = input.parse()?;
+        let brace = braced!(content in input);
+        let use_statements = {
+            let mut use_statements = Vec::new();
+            while content.peek(Token![use]) {
+                use_statements.push(content.call(ItemUse::parse)?)
+            }
+            use_statements
+        };
+        let structure = content.parse()?;
+        let implementation = content.parse()?;
+        let semi = input.parse()?;
+
         Ok(Self {
-            vis: input.parse()?,
-            mod_token: input.parse()?,
-            module_ident: input.parse()?,
-            brace: braced!(content in input),
-            structure: content.parse()?,
-            implementation: content.parse()?,
-            semi: input.parse()?,
+            vis,
+            mod_token,
+            module_ident,
+            brace,
+            use_statements,
+            structure,
+            implementation,
+            semi,
         })
     }
 }

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -17,7 +17,7 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
     trace!("handle_blueprint() starts");
 
     // parse blueprint struct and impl
-    let bp = parse2::<ast::Blueprint>(input)?;
+    let bp = parse2::<ast::BlueprintMod>(input)?;
     let bp_strut = &bp.structure;
     let bp_fields = &bp_strut.fields;
     let bp_semi_token = &bp_strut.semi_token;
@@ -126,7 +126,7 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
     };
 
     #[cfg(feature = "trace")]
-    crate::utils::print_generated_code("blueprint!", &output);
+    crate::utils::print_generated_code("blueprint", &output);
 
     trace!("handle_blueprint() finishes");
     Ok(output)
@@ -612,7 +612,7 @@ mod tests {
     #[test]
     fn test_blueprint() {
         let input = TokenStream::from_str(
-            "struct Test {a: u32, admin: ResourceManager} impl Test { pub fn x(&self, i: u32) -> u32 { i + self.a } pub fn y(i: u32) -> u32 { i * 2 } }",
+            "mod test { struct Test {a: u32, admin: ResourceManager} impl Test { pub fn x(&self, i: u32) -> u32 { i + self.a } pub fn y(i: u32) -> u32 { i * 2 } } }",
         )
         .unwrap();
         let output = handle_blueprint(input).unwrap();
@@ -827,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_empty_blueprint() {
-        let input = TokenStream::from_str("struct Test {} impl Test {}").unwrap();
+        let input = TokenStream::from_str("mod test { struct Test {} impl Test {} }").unwrap();
         let output = handle_blueprint(input).unwrap();
 
         assert_code_eq(

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -42,7 +42,7 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
         ));
     }
 
-    let module_ident = format_ident!("{}_impl", bp_ident);
+    let module_ident = bp.module_ident;
     let component_ident = format_ident!("{}Component", bp_ident);
     let component_ref_ident = format_ident!("{}GlobalComponentRef", bp_ident);
 
@@ -621,7 +621,7 @@ mod tests {
             output,
             quote! {
                 #[allow(non_snake_case)]
-                pub mod Test_impl {
+                pub mod test {
                     use super::*;
 
                     #[derive(::sbor::Categorize, ::sbor::Encode, ::sbor::Decode, ::scrypto::LegacyDescribe)]
@@ -680,9 +680,9 @@ mod tests {
                         radix_engine_interface::api::types::RENodeId::Component(component_id),
                         radix_engine_interface::api::types::SubstateOffset::Component(radix_engine_interface::api::types::ComponentOffset::State),
                     );
-                    let state: DataRef<Test_impl::Test> = component_data.get();
+                    let state: DataRef<test::Test> = component_data.get();
 
-                    let return_data = Test_impl::Test::x(state.deref(), input.arg0);
+                    let return_data = test::Test::x(state.deref(), input.arg0);
                     return ::scrypto::engine::wasm_api::forget_vec(::scrypto::data::scrypto_encode(&return_data).unwrap());
                 }
 
@@ -698,7 +698,7 @@ mod tests {
                     ::scrypto::resource::init_resource_system(::scrypto::resource::ResourceSystem::new());
 
                     let input: Test_y_Input = ::scrypto::data::scrypto_decode(&::scrypto::engine::wasm_api::copy_buffer(args)).unwrap();
-                    let return_data = Test_impl::Test::y(input.arg0);
+                    let return_data = test::Test::y(input.arg0);
                     return ::scrypto::engine::wasm_api::forget_vec(::scrypto::data::scrypto_encode(&return_data).unwrap());
                 }
 
@@ -724,7 +724,7 @@ mod tests {
                             export_name: "Test_y".to_string(),
                         }
                     ];
-                    let structure: Type = Test_impl::Test::describe();
+                    let structure: Type = test::Test::describe();
                     let return_data = BlueprintAbi {
                         structure,
                         fns,
@@ -834,7 +834,7 @@ mod tests {
             output,
             quote! {
                 #[allow(non_snake_case)]
-                pub mod Test_impl {
+                pub mod test {
                     use super::*;
 
                     #[derive(::sbor::Categorize, ::sbor::Encode, ::sbor::Decode, ::scrypto::LegacyDescribe)]
@@ -865,7 +865,7 @@ mod tests {
                     use ::sbor::rust::vec;
                     use ::sbor::rust::vec::Vec;
                     let fns: Vec<Fn> = vec![];
-                    let structure: Type = Test_impl::Test::describe();
+                    let structure: Type = test::Test::describe();
                     let return_data = BlueprintAbi {
                         structure,
                         fns,

--- a/scrypto-derive/src/lib.rs
+++ b/scrypto-derive/src/lib.rs
@@ -7,7 +7,7 @@ use proc_macro::TokenStream;
 
 /// Declares a blueprint.
 ///
-/// The `blueprint!` macro is a convenient way to define a new blueprint. It takes
+/// The `blueprint` macro is a convenient way to define a new blueprint. It takes
 /// two arguments:
 /// - A `struct` which defines the structure
 /// - A `impl` which defines the implementation.
@@ -19,7 +19,8 @@ use proc_macro::TokenStream;
 /// ```ignore
 /// use scrypto::prelude::*;
 ///
-/// blueprint! {
+/// #[blueprint]
+/// mod counter {
 ///     struct Counter {
 ///         count: u32
 ///     }
@@ -39,8 +40,8 @@ use proc_macro::TokenStream;
 ///     }
 /// }
 /// ```
-#[proc_macro]
-pub fn blueprint(input: TokenStream) -> TokenStream {
+#[proc_macro_attribute]
+pub fn blueprint(_: TokenStream, input: TokenStream) -> TokenStream {
     blueprint::handle_blueprint(proc_macro2::TokenStream::from(input))
         .unwrap_or_else(|err| err.to_compile_error())
         .into()

--- a/scrypto-tests/tests/blueprint.rs
+++ b/scrypto-tests/tests/blueprint.rs
@@ -2,7 +2,8 @@
 
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod empty {
   struct Empty {
   }
 
@@ -11,7 +12,8 @@ blueprint! {
   }
 }
 
-blueprint! {
+#[blueprint]
+mod simple {
     struct Simple {
         state: u32,
     }

--- a/scrypto-tests/tests/blueprint.rs
+++ b/scrypto-tests/tests/blueprint.rs
@@ -41,3 +41,13 @@ mod simple {
         }
     }
 }
+
+#[blueprint]
+mod empty_with_use_statements {
+    use sbor::BasicValue;
+    use scrypto::model::ComponentAddress;
+
+    struct Empty1 {}
+
+    impl Empty1 {}
+}

--- a/scrypto-tests/tests/blueprint.rs
+++ b/scrypto-tests/tests/blueprint.rs
@@ -4,12 +4,9 @@ use scrypto::prelude::*;
 
 #[blueprint]
 mod empty {
-  struct Empty {
-  }
+    struct Empty {}
 
-  impl Empty {
-
-  }
+    impl Empty {}
 }
 
 #[blueprint]
@@ -20,11 +17,7 @@ mod simple {
 
     impl Simple {
         pub fn new() -> ComponentAddress {
-            Self {
-                state: 0
-            }
-            .instantiate()
-            .globalize()
+            Self { state: 0 }.instantiate().globalize()
         }
 
         pub fn get_state(&self) -> u32 {
@@ -35,7 +28,15 @@ mod simple {
             self.state = new_state;
         }
 
-        pub fn custom_types() -> (Decimal, PackageAddress, KeyValueStore<String, String>, Hash, Bucket, Proof, Vault) {
+        pub fn custom_types() -> (
+            Decimal,
+            PackageAddress,
+            KeyValueStore<String, String>,
+            Hash,
+            Bucket,
+            Proof,
+            Vault,
+        ) {
             todo!()
         }
     }

--- a/scrypto-tests/tests/import.rs
+++ b/scrypto-tests/tests/import.rs
@@ -164,7 +164,8 @@ import! {
 "#
 }
 
-blueprint! {
+#[blueprint]
+mod use_import {
     struct UseImport {
         simple: SimpleGlobalComponentRef
     }

--- a/scrypto-tests/tests/import.rs
+++ b/scrypto-tests/tests/import.rs
@@ -167,7 +167,7 @@ import! {
 #[blueprint]
 mod use_import {
     struct UseImport {
-        simple: SimpleGlobalComponentRef
+        simple: SimpleGlobalComponentRef,
     }
 
     impl UseImport {

--- a/scrypto-tests/tests/import2.rs
+++ b/scrypto-tests/tests/import2.rs
@@ -72,7 +72,8 @@ import! {
     "#
 }
 
-blueprint! {
+#[blueprint]
+mod import {
     struct Import {}
 
     impl Import {}

--- a/scrypto-tests/tests/math.rs
+++ b/scrypto-tests/tests/math.rs
@@ -2,15 +2,13 @@ use scrypto::prelude::*;
 
 #[blueprint]
 mod test_decimal {
-    struct TestDecimal {
-    }
+    struct TestDecimal {}
 
     impl TestDecimal {
         pub fn test_dec_macro() -> Decimal {
             dec!(1) + dec!("2") - dec!("3.5") * dec!(5, 6) / dec!("7", -8)
         }
     }
-
 }
 
 #[test]

--- a/scrypto-tests/tests/math.rs
+++ b/scrypto-tests/tests/math.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod test_decimal {
     struct TestDecimal {
     }
 

--- a/simulator/tests/blueprints/src/nfts.rs
+++ b/simulator/tests/blueprints/src/nfts.rs
@@ -6,7 +6,8 @@ struct Car {
     manufacturer: String,
 }
 
-blueprint! {
+#[blueprint]
+mod foo {
     struct Foo {}
 
     impl Foo {

--- a/simulator/tests/blueprints/src/numbers.rs
+++ b/simulator/tests/blueprints/src/numbers.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod numbers {
     struct Numbers {}
 
     impl Numbers {

--- a/simulator/tests/blueprints/src/proofs.rs
+++ b/simulator/tests/blueprints/src/proofs.rs
@@ -1,6 +1,7 @@
 use scrypto::prelude::*;
 
-blueprint! {
+#[blueprint]
+mod proofs {
     struct Proofs {}
 
     impl Proofs {


### PR DESCRIPTION
A majority of this PR is just me changing the different blueprints that we have to use `#[blueprint]` instead of `blueprint!`. Main files to review are:

* [scrypto-derive/src/lib.rs](https://github.com/radixdlt/radixdlt-scrypto/pull/801/files#diff-c097b6d3fa83f84b040b861c0fd676ac372d9989d756a8cbf0687254ea5815a5)
* [scrypto-derive/src/ast.rs](https://github.com/radixdlt/radixdlt-scrypto/pull/801/files#diff-73ccbca9d64652baae1a8005225b0b07965d53a2c8dd48248726396585a0f402)
* [scrypto-derive/src/blueprint.rs](https://github.com/radixdlt/radixdlt-scrypto/pull/801/files#diff-3d419f60a40ada399912bb3cd6ef019c416933ac2244f1591138970712da684d)