### PR TITLE
Moving JMT's codec code to scrypto repo (using SBOR derive)

### DIFF
--- a/radix-engine-stores/src/hash_tree/mod.rs
+++ b/radix-engine-stores/src/hash_tree/mod.rs
@@ -63,11 +63,12 @@ pub fn put_at_next_version<S: TreeStore>(
             current_version.unwrap_or(0) + 1,
         )
         .expect("error while reading tree during put");
-    for (key, node) in update_result.node_batch.iter().flatten() {
-        store.insert_node(key, TreeNode::from(key, node));
+    for (key, node) in update_result.node_batch.into_iter().flatten() {
+        let node = TreeNode::from(&key, &node);
+        store.insert_node(key, node);
     }
-    for stale_node in update_result.stale_node_index_batch.iter().flatten() {
-        store.record_stale_node(&stale_node.node_key);
+    for stale_node in update_result.stale_node_index_batch.into_iter().flatten() {
+        store.record_stale_node(stale_node.node_key);
     }
     root_hash
 }

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -167,8 +167,7 @@ impl<E: Encoder<ScryptoCustomValueKind>> Encode<ScryptoCustomValueKind, E> for N
 
     #[inline]
     fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        encoder.write_byte(u8::from(*self))?;
-        Ok(())
+        u8::from(*self).encode_body(encoder)
     }
 }
 
@@ -177,8 +176,9 @@ impl<D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D> for N
         decoder: &mut D,
         value_kind: ValueKind<ScryptoCustomValueKind>,
     ) -> Result<Self, DecodeError> {
-        decoder.check_preloaded_value_kind(value_kind, Self::value_kind())?;
-        Ok(Nibble::from(decoder.read_byte()?))
+        Ok(Nibble::from(u8::decode_body_with_value_kind(
+            decoder, value_kind,
+        )?))
     }
 }
 
@@ -207,7 +207,6 @@ impl<D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D> for N
         decoder: &mut D,
         value_kind: ValueKind<ScryptoCustomValueKind>,
     ) -> Result<Self, DecodeError> {
-        decoder.check_preloaded_value_kind(value_kind, Self::value_kind())?;
         let (even, bytes): (bool, Vec<u8>) =
             Decode::<ScryptoCustomValueKind, D>::decode_body_with_value_kind(decoder, value_kind)?;
         let path = if even {

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -1,12 +1,15 @@
+use radix_engine::types::{ScryptoDecode, ScryptoEncode};
 use sbor::rust::collections::HashMap;
 use sbor::rust::vec::Vec;
 
 pub use super::types::{Nibble, NibblePath, NodeKey, Version};
 use radix_engine_interface::api::types::SubstateId;
 use radix_engine_interface::crypto::Hash;
+use radix_engine_interface::data::{scrypto_decode, scrypto_encode, ScryptoCustomValueKind};
+use sbor::{Categorize, Decode, DecodeError, Decoder, Encode, EncodeError, Encoder, ValueKind};
 
 /// A physical tree node, to be used in the storage.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Categorize, ScryptoEncode, ScryptoDecode)]
 pub enum TreeNode {
     /// Internal node - always metadata-only, as per JMT design.
     Internal(TreeInternalNode),
@@ -17,14 +20,14 @@ pub enum TreeNode {
 }
 
 /// Internal node.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Categorize, ScryptoEncode, ScryptoDecode)]
 pub struct TreeInternalNode {
     /// Metadata of each existing child.
     pub children: Vec<TreeChildEntry>,
 }
 
 /// Child node metadata.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Categorize, ScryptoEncode, ScryptoDecode)]
 pub struct TreeChildEntry {
     /// First of the remaining nibbles in the key.
     pub nibble: Nibble,
@@ -37,7 +40,7 @@ pub struct TreeChildEntry {
 }
 
 /// Physical leaf node (which may represent a ReNode or a Substate).
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Categorize, ScryptoEncode, ScryptoDecode)]
 pub struct TreeLeafNode {
     /// All the remaining nibbles in the _hashed_ `substate_id`.
     pub key_suffix: NibblePath,
@@ -56,11 +59,11 @@ pub trait ReadableTreeStore {
 /// The "write" part of a physical tree node storage SPI.
 pub trait WriteableTreeStore {
     /// Inserts the node under a new, unique key (i.e. never an update).
-    fn insert_node(&mut self, key: &NodeKey, node: TreeNode);
+    fn insert_node(&mut self, key: NodeKey, node: TreeNode);
 
     /// Marks the given node for a (potential) future removal by an arbitrary
     /// external pruning process.
-    fn record_stale_node(&mut self, key: &NodeKey);
+    fn record_stale_node(&mut self, key: NodeKey);
 }
 
 /// A complete tree node storage SPI.
@@ -68,68 +71,150 @@ pub trait TreeStore: ReadableTreeStore + WriteableTreeStore {}
 impl<S: ReadableTreeStore + WriteableTreeStore> TreeStore for S {}
 
 /// A `TreeStore` based on memory object copies (i.e. no serialization).
-pub struct MemoryTreeStore {
+#[derive(Debug, PartialEq, Eq)]
+pub struct TypedInMemoryTreeStore {
     pub memory: HashMap<NodeKey, TreeNode>,
     pub stale_key_buffer: Vec<NodeKey>,
 }
 
-impl MemoryTreeStore {
+impl TypedInMemoryTreeStore {
     /// A constructor of a newly-initialized, empty store.
-    pub fn new() -> MemoryTreeStore {
-        MemoryTreeStore {
+    pub fn new() -> TypedInMemoryTreeStore {
+        TypedInMemoryTreeStore {
             memory: HashMap::new(),
             stale_key_buffer: Vec::new(),
         }
     }
 }
 
-impl ReadableTreeStore for MemoryTreeStore {
+impl ReadableTreeStore for TypedInMemoryTreeStore {
     fn get_node(&self, key: &NodeKey) -> Option<TreeNode> {
         self.memory.get(key).cloned()
     }
 }
 
-impl WriteableTreeStore for MemoryTreeStore {
-    fn insert_node(&mut self, key: &NodeKey, node: TreeNode) {
-        self.memory.insert(key.clone(), node);
+impl WriteableTreeStore for TypedInMemoryTreeStore {
+    fn insert_node(&mut self, key: NodeKey, node: TreeNode) {
+        self.memory.insert(key, node);
     }
 
-    fn record_stale_node(&mut self, key: &NodeKey) {
-        self.stale_key_buffer.push(key.clone());
+    fn record_stale_node(&mut self, key: NodeKey) {
+        self.stale_key_buffer.push(key);
     }
 }
 
-/// A [`TreeStore`] which overlays a "base" read-only store with a read-write
-/// [`MemoryTreeStore`] layer.
-pub struct StagedTreeStore<'s, R: ReadableTreeStore> {
-    base: &'s R,
-    overlay: MemoryTreeStore,
+/// A `TreeStore` based on serialized payloads stored in memory.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SerializedInMemoryTreeStore {
+    pub memory: HashMap<Vec<u8>, Vec<u8>>,
+    pub stale_key_buffer: Vec<Vec<u8>>,
 }
 
-impl<'s, R: ReadableTreeStore> StagedTreeStore<'s, R> {
-    /// A direct constructor.
-    pub fn new(base: &'s R) -> StagedTreeStore<'s, R> {
-        StagedTreeStore {
-            base,
-            overlay: MemoryTreeStore::new(),
+impl SerializedInMemoryTreeStore {
+    /// A constructor of a newly-initialized, empty store.
+    pub fn new() -> Self {
+        Self {
+            memory: HashMap::new(),
+            stale_key_buffer: Vec::new(),
         }
     }
 }
 
-impl<'s, R: ReadableTreeStore> ReadableTreeStore for StagedTreeStore<'s, R> {
+impl ReadableTreeStore for SerializedInMemoryTreeStore {
     fn get_node(&self, key: &NodeKey) -> Option<TreeNode> {
-        self.overlay
-            .get_node(key)
-            .or_else(|| self.base.get_node(key))
+        self.memory
+            .get(&encode_key(key))
+            .map(|bytes| scrypto_decode(bytes).unwrap())
     }
 }
 
-impl<'s, R: ReadableTreeStore> WriteableTreeStore for StagedTreeStore<'s, R> {
-    fn insert_node(&mut self, key: &NodeKey, node: TreeNode) {
-        self.overlay.insert_node(key, node);
+impl WriteableTreeStore for SerializedInMemoryTreeStore {
+    fn insert_node(&mut self, key: NodeKey, node: TreeNode) {
+        self.memory
+            .insert(encode_key(&key), scrypto_encode(&node).unwrap());
     }
 
-    fn record_stale_node(&mut self, key: &NodeKey) {
-        self.overlay.record_stale_node(key)
+    fn record_stale_node(&mut self, key: NodeKey) {
+        self.stale_key_buffer.push(encode_key(&key));
+    }
+}
+
+/// Encodes the given node key in a format friendly to Level-like databases (i.e. strictly ordered
+/// by numeric version).
+pub fn encode_key(key: &NodeKey) -> Vec<u8> {
+    let m = &key.version().to_be_bytes();
+    let x = &[(key.nibble_path().num_nibbles() % 2) as u8; 1];
+    let k = key.nibble_path().bytes();
+    [m, k, x].concat()
+}
+
+// Note: We need completely custom serialization scheme only for the node keys. The remaining
+// structures can simply use SBOR, with only the most efficiency-sensitive parts having custom
+// codecs, implemented below:
+
+impl Categorize<ScryptoCustomValueKind> for Nibble {
+    #[inline]
+    fn value_kind() -> ValueKind<ScryptoCustomValueKind> {
+        ValueKind::U8
+    }
+}
+
+impl<E: Encoder<ScryptoCustomValueKind>> Encode<ScryptoCustomValueKind, E> for Nibble {
+    #[inline]
+    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        encoder.write_value_kind(Self::value_kind())
+    }
+
+    #[inline]
+    fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        encoder.write_byte(u8::from(*self))?;
+        Ok(())
+    }
+}
+
+impl<D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D> for Nibble {
+    fn decode_body_with_value_kind(
+        decoder: &mut D,
+        value_kind: ValueKind<ScryptoCustomValueKind>,
+    ) -> Result<Self, DecodeError> {
+        decoder.check_preloaded_value_kind(value_kind, Self::value_kind())?;
+        Ok(Nibble::from(decoder.read_byte()?))
+    }
+}
+
+impl Categorize<ScryptoCustomValueKind> for NibblePath {
+    #[inline]
+    fn value_kind() -> ValueKind<ScryptoCustomValueKind> {
+        ValueKind::Tuple
+    }
+}
+
+impl<E: Encoder<ScryptoCustomValueKind>> Encode<ScryptoCustomValueKind, E> for NibblePath {
+    #[inline]
+    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        encoder.write_value_kind(Self::value_kind())
+    }
+
+    #[inline]
+    fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        let even = self.num_nibbles() % 2 == 0;
+        (even, self.bytes()).encode_body(encoder)
+    }
+}
+
+impl<D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D> for NibblePath {
+    fn decode_body_with_value_kind(
+        decoder: &mut D,
+        value_kind: ValueKind<ScryptoCustomValueKind>,
+    ) -> Result<Self, DecodeError> {
+        decoder.check_preloaded_value_kind(value_kind, Self::value_kind())?;
+        let (even, bytes): (bool, Vec<u8>) =
+            Decode::<ScryptoCustomValueKind, D>::decode_body_with_value_kind(decoder, value_kind)?;
+        let path = if even {
+            NibblePath::new_even(bytes)
+        } else {
+            NibblePath::new_odd(bytes)
+        };
+        Ok(path)
     }
 }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -34,7 +34,7 @@ use radix_engine_interface::math::Decimal;
 use radix_engine_interface::time::Instant;
 use radix_engine_interface::{dec, rule};
 use radix_engine_stores::hash_tree::put_at_next_version;
-use radix_engine_stores::hash_tree::tree_store::{MemoryTreeStore, Version};
+use radix_engine_stores::hash_tree::tree_store::{TypedInMemoryTreeStore, Version};
 use scrypto::component::Mutability;
 use scrypto::component::Mutability::*;
 use scrypto::NonFungibleData;
@@ -1074,7 +1074,7 @@ impl TestRunner {
 }
 
 pub struct StateHashSupport {
-    tree_store: MemoryTreeStore,
+    tree_store: TypedInMemoryTreeStore,
     current_version: Version,
     current_hash: Hash,
 }
@@ -1082,7 +1082,7 @@ pub struct StateHashSupport {
 impl StateHashSupport {
     fn new() -> Self {
         StateHashSupport {
-            tree_store: MemoryTreeStore::new(),
+            tree_store: TypedInMemoryTreeStore::new(),
             current_version: 0,
             current_hash: Hash([0; Hash::LENGTH]),
         }


### PR DESCRIPTION
A refactoring requested at https://github.com/radixdlt/babylon-node/pull/298/files#r1097250673.