### PR TITLE
feat: Add derive support for sbor(transparent)

### DIFF
--- a/radix-engine-interface/src/data/custom_schema.rs
+++ b/radix-engine-interface/src/data/custom_schema.rs
@@ -45,6 +45,7 @@ pub enum ScryptoCustomTypeValidation {}
 
 impl CustomTypeValidation for ScryptoCustomTypeValidation {}
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScryptoCustomTypeExtension {}
 
 impl CustomTypeExtension for ScryptoCustomTypeExtension {

--- a/sbor-derive-common/src/categorize.rs
+++ b/sbor-derive-common/src/categorize.rs
@@ -17,15 +17,35 @@ pub fn handle_categorize(
 ) -> Result<TokenStream> {
     trace!("handle_categorize() starts");
 
+    let parsed: DeriveInput = parse2(input)?;
+    let is_transparent = is_transparent(&parsed.attrs);
+
+    let output = if is_transparent {
+        handle_transparent_categorize(parsed, context_custom_value_kind)?
+    } else {
+        handle_normal_categorize(parsed, context_custom_value_kind)?
+    };
+
+    #[cfg(feature = "trace")]
+    crate::utils::print_generated_code("Categorize", &output);
+
+    trace!("handle_categorize() finishes");
+    Ok(output)
+}
+
+fn handle_normal_categorize(
+    parsed: DeriveInput,
+    context_custom_value_kind: Option<&'static str>,
+) -> Result<TokenStream> {
     let DeriveInput {
         attrs,
         ident,
         data,
         generics,
         ..
-    } = parse2(input)?;
+    } = parsed;
     let (impl_generics, ty_generics, where_clause, sbor_cvk) =
-        build_custom_categorize_generic(&generics, &attrs, context_custom_value_kind)?;
+        build_custom_categorize_generic(&generics, &attrs, context_custom_value_kind, false)?;
 
     let output = match data {
         Data::Struct(_) => quote! {
@@ -49,10 +69,50 @@ pub fn handle_categorize(
         }
     };
 
-    #[cfg(feature = "trace")]
-    crate::utils::print_generated_code("Categorize", &output);
+    Ok(output)
+}
 
-    trace!("handle_categorize() finishes");
+fn handle_transparent_categorize(
+    parsed: DeriveInput,
+    context_custom_value_kind: Option<&'static str>,
+) -> Result<TokenStream> {
+    let DeriveInput {
+        attrs,
+        ident,
+        data,
+        generics,
+        ..
+    } = parsed;
+    let (impl_generics, ty_generics, where_clause, sbor_cvk) =
+        build_custom_categorize_generic(&generics, &attrs, context_custom_value_kind, true)?;
+    let output = match data {
+        Data::Struct(s) => {
+            let FieldsData {
+                unskipped_field_types,
+                ..
+            } = process_fields_for_categorize(&s.fields);
+            if unskipped_field_types.len() != 1 {
+                return Err(Error::new(Span::call_site(), "The transparent attribute is only supported for structs with a single unskipped field."));
+            }
+            let field_type = &unskipped_field_types[0];
+
+            quote! {
+                impl #impl_generics ::sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
+                    #[inline]
+                    fn value_kind() -> ::sbor::ValueKind <#sbor_cvk> {
+                        <#field_type as ::sbor::Categorize::<#sbor_cvk>>::value_kind()
+                    }
+                }
+            }
+        }
+        Data::Enum(_) => {
+            return Err(Error::new(Span::call_site(), "The transparent attribute is only supported for structs with a single unskipped field."));
+        }
+        Data::Union(_) => {
+            return Err(Error::new(Span::call_site(), "Union is not supported!"));
+        }
+    };
+
     Ok(output)
 }
 
@@ -86,6 +146,26 @@ mod tests {
     }
 
     #[test]
+    fn test_categorize_transparent_struct() {
+        let input =
+            TokenStream::from_str("#[sbor(transparent)] struct Test {a: u32, #[sbor(skip)]b: u16}")
+                .unwrap();
+        let output = handle_categorize(input, None).unwrap();
+
+        assert_code_eq(
+            output,
+            quote! {
+                impl <X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test {
+                    #[inline]
+                    fn value_kind() -> ::sbor::ValueKind<X> {
+                        <u32 as ::sbor::Categorize::<X>>::value_kind()
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
     fn test_categorize_struct_generics() {
         let input = TokenStream::from_str("struct Test<A> {a: A}").unwrap();
         let output = handle_categorize(input, None).unwrap();
@@ -97,6 +177,24 @@ mod tests {
                     #[inline]
                     fn value_kind() -> ::sbor::ValueKind<X> {
                         ::sbor::ValueKind::Tuple
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn test_categorize_transparent_struct_generics() {
+        let input = TokenStream::from_str("#[sbor(transparent)] struct Test<A> {a: A}").unwrap();
+        let output = handle_categorize(input, None).unwrap();
+
+        assert_code_eq(
+            output,
+            quote! {
+                impl <A: ::sbor::Categorize<X>, X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test<A> {
+                    #[inline]
+                    fn value_kind() -> ::sbor::ValueKind<X> {
+                        <A as ::sbor::Categorize::<X>>::value_kind()
                     }
                 }
             },

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -6,6 +6,7 @@ use std::process::Stdio;
 
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
+use quote::format_ident;
 use quote::quote;
 use syn::*;
 
@@ -75,6 +76,14 @@ pub fn extract_attributes(
     None
 }
 
+pub fn is_categorize_skipped(f: &Field) -> bool {
+    if let Some(fields) = extract_attributes(&f.attrs, "sbor") {
+        fields.contains_key("skip") || fields.contains_key("skip_categorize")
+    } else {
+        false
+    }
+}
+
 pub fn is_decoding_skipped(f: &Field) -> bool {
     if let Some(fields) = extract_attributes(&f.attrs, "sbor") {
         fields.contains_key("skip") || fields.contains_key("skip_decode")
@@ -94,6 +103,14 @@ pub fn is_encoding_skipped(f: &Field) -> bool {
 pub fn is_describing_skipped(f: &Field) -> bool {
     if let Some(fields) = extract_attributes(&f.attrs, "sbor") {
         fields.contains_key("skip") || fields.contains_key("skip_describe")
+    } else {
+        false
+    }
+}
+
+pub fn is_transparent(attributes: &[Attribute]) -> bool {
+    if let Some(fields) = extract_attributes(attributes, "sbor") {
+        fields.contains_key("transparent")
     } else {
         false
     }
@@ -162,6 +179,116 @@ pub fn get_unique_types<'a>(types: &[&'a syn::Type]) -> Vec<&'a syn::Type> {
         out.push(t);
     }
     out
+}
+
+pub(crate) struct FieldsData {
+    pub unskipped_self_field_names: Vec<TokenStream>,
+    pub unskipped_field_types: Vec<Type>,
+    pub skipped_self_field_names: Vec<TokenStream>,
+    pub skipped_field_types: Vec<Type>,
+    pub fields_unpacking: TokenStream,
+    pub unskipped_unpacked_field_names: Vec<TokenStream>,
+    pub unskipped_field_count: Index,
+}
+
+pub(crate) fn process_fields_for_categorize(fields: &syn::Fields) -> FieldsData {
+    process_fields(fields, is_categorize_skipped)
+}
+
+pub(crate) fn process_fields_for_encode(fields: &syn::Fields) -> FieldsData {
+    process_fields(fields, is_encoding_skipped)
+}
+
+pub(crate) fn process_fields_for_decode(fields: &syn::Fields) -> FieldsData {
+    process_fields(fields, is_decoding_skipped)
+}
+
+pub(crate) fn process_fields_for_describe(fields: &syn::Fields) -> FieldsData {
+    process_fields(fields, is_describing_skipped)
+}
+
+fn process_fields(fields: &syn::Fields, is_skipped: impl Fn(&Field) -> bool) -> FieldsData {
+    match fields {
+        Fields::Named(fields) => {
+            let mut unskipped_self_field_names = Vec::new();
+            let mut unskipped_field_types = Vec::new();
+            let mut skipped_self_field_names = Vec::new();
+            let mut skipped_field_types = Vec::new();
+            for f in fields.named.iter() {
+                let ident = &f.ident;
+                if !is_skipped(f) {
+                    unskipped_self_field_names.push(quote! { #ident });
+                    unskipped_field_types.push(f.ty.clone());
+                } else {
+                    skipped_self_field_names.push(quote! { #ident });
+                    skipped_field_types.push(f.ty.clone());
+                }
+            }
+
+            let fields_unpacking = quote! {
+                {#(#unskipped_self_field_names,)* ..}
+            };
+            let unskipped_unpacked_field_names = unskipped_self_field_names.clone();
+
+            let unskipped_field_count = Index::from(unskipped_self_field_names.len());
+
+            FieldsData {
+                unskipped_self_field_names,
+                unskipped_field_types,
+                skipped_self_field_names,
+                skipped_field_types,
+                fields_unpacking,
+                unskipped_unpacked_field_names,
+                unskipped_field_count,
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let mut unskipped_indices = Vec::new();
+            let mut unskipped_field_types = Vec::new();
+            let mut unskipped_unpacked_field_names = Vec::new();
+            let mut skipped_indices = Vec::new();
+            let mut skipped_field_types = Vec::new();
+            let mut unpacking_idents = Vec::new();
+            for (i, f) in fields.unnamed.iter().enumerate() {
+                let index = Index::from(i);
+                if !is_skipped(f) {
+                    unskipped_indices.push(quote! { #index });
+                    unskipped_field_types.push(f.ty.clone());
+                    let unpacked_name_ident = format_ident!("a{}", i);
+                    unskipped_unpacked_field_names.push(quote! { #unpacked_name_ident });
+                    unpacking_idents.push(unpacked_name_ident);
+                } else {
+                    skipped_indices.push(quote! { #index });
+                    skipped_field_types.push(f.ty.clone());
+                    unpacking_idents.push(format_ident!("_"));
+                }
+            }
+            let fields_unpacking = quote! {
+                (#(#unpacking_idents),*)
+            };
+
+            let unskipped_field_count = Index::from(unskipped_indices.len());
+
+            FieldsData {
+                unskipped_self_field_names: unskipped_indices,
+                unskipped_field_types,
+                skipped_self_field_names: skipped_indices,
+                skipped_field_types,
+                fields_unpacking,
+                unskipped_unpacked_field_names,
+                unskipped_field_count,
+            }
+        }
+        Fields::Unit => FieldsData {
+            unskipped_self_field_names: vec![],
+            unskipped_field_types: vec![],
+            skipped_self_field_names: vec![],
+            skipped_field_types: vec![],
+            fields_unpacking: quote! {},
+            unskipped_unpacked_field_names: vec![],
+            unskipped_field_count: Index::from(0),
+        },
+    }
 }
 
 pub fn build_decode_generics<'a>(
@@ -367,6 +494,7 @@ pub fn build_custom_categorize_generic<'a>(
     original_generics: &'a Generics,
     attributes: &'a [Attribute],
     context_custom_value_kind: Option<&'static str>,
+    require_categorize_on_generic_params: bool,
 ) -> syn::Result<(Generics, TypeGenerics<'a>, Option<&'a WhereClause>, Path)> {
     let custom_value_kind = get_custom_value_kind(&attributes);
     let (impl_generics, ty_generics, where_clause) = original_generics.split_for_impl();
@@ -374,20 +502,45 @@ pub fn build_custom_categorize_generic<'a>(
     // Unwrap for mutation
     let mut impl_generics: Generics = parse_quote! { #impl_generics };
 
-    let sbor_cvk = if let Some(path) = custom_value_kind {
-        parse_str(path.as_str())?
-    } else if let Some(path) = context_custom_value_kind {
-        parse_str(path)?
-    } else {
-        let custom_type_label = find_free_generic_name(original_generics, "X")?;
-        let custom_value_kind_generic = parse_str(&custom_type_label)?;
+    let (custom_value_kind_generic, need_to_add_cvk_generic): (Path, bool) =
+        if let Some(path) = custom_value_kind {
+            (parse_str(path.as_str())?, false)
+        } else if let Some(path) = context_custom_value_kind {
+            (parse_str(path)?, false)
+        } else {
+            let custom_type_label = find_free_generic_name(original_generics, "X")?;
+            (parse_str(&custom_type_label)?, true)
+        };
+
+    if require_categorize_on_generic_params {
+        // In order to implement transparent Categorize, we need to pass through Categorize to the child field.
+        // To do this, we need to ensure that type is Categorize.
+        // So we add a bound that all pre-existing type parameters have to implement Categorize<X>
+        // This is essentially what derived traits such as Clone do: https://github.com/rust-lang/rust/issues/26925
+        // It's not perfect - but it's typically good enough!
+
+        for param in impl_generics.params.iter_mut() {
+            let GenericParam::Type(type_param) = param else {
+                continue;
+            };
+            type_param
+                .bounds
+                .push(parse_quote!(::sbor::Categorize<#custom_value_kind_generic>));
+        }
+    }
+
+    if need_to_add_cvk_generic {
         impl_generics
             .params
             .push(parse_quote!(#custom_value_kind_generic: ::sbor::CustomValueKind));
-        custom_value_kind_generic
-    };
+    }
 
-    Ok((impl_generics, ty_generics, where_clause, sbor_cvk))
+    Ok((
+        impl_generics,
+        ty_generics,
+        where_clause,
+        custom_value_kind_generic,
+    ))
 }
 
 fn find_free_generic_name(generics: &Generics, name_prefix: &str) -> syn::Result<String> {

--- a/sbor-tests/tests/transparent.rs
+++ b/sbor-tests/tests/transparent.rs
@@ -1,0 +1,151 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sbor::*;
+
+#[derive(Sbor, PartialEq, Eq, Debug)]
+#[sbor(transparent)]
+pub struct TestStructNamed {
+    pub state: u32,
+}
+
+#[derive(Sbor, PartialEq, Eq, Debug)]
+#[sbor(transparent)]
+pub struct TestStructUnnamed(u32);
+
+#[derive(Sbor, PartialEq, Eq, Debug)]
+#[sbor(transparent)]
+pub struct TestStruct<T> {
+    #[sbor(skip)]
+    pub abc: u32,
+    pub state: T,
+}
+
+#[test]
+fn categorize_is_correct() {
+    // With inner u32
+    assert_eq!(get_value_kind::<TestStructNamed>(), ValueKind::U32);
+    assert_eq!(get_value_kind::<TestStructUnnamed>(), ValueKind::U32);
+    assert_eq!(get_value_kind::<TestStruct::<u32>>(), ValueKind::U32);
+
+    // And with inner tuple
+    assert_eq!(get_value_kind::<TestStruct::<()>>(), ValueKind::Tuple);
+
+    // With multiple layers of transparent
+    assert_eq!(
+        get_value_kind::<TestStruct::<TestStructNamed>>(),
+        ValueKind::U32
+    );
+}
+
+fn get_value_kind<T: Categorize<NoCustomValueKind>>() -> ValueKind<NoCustomValueKind> {
+    T::value_kind()
+}
+
+#[test]
+fn encode_is_correct() {
+    // With inner u32
+    let inner_value = 45u32;
+    assert_eq!(
+        basic_encode(&TestStructNamed { state: inner_value }).unwrap(),
+        basic_encode(&inner_value).unwrap()
+    );
+    assert_eq!(
+        basic_encode(&TestStructUnnamed(inner_value)).unwrap(),
+        basic_encode(&inner_value).unwrap()
+    );
+    assert_eq!(
+        basic_encode(&TestStruct::<u32> {
+            state: inner_value,
+            abc: 0
+        })
+        .unwrap(),
+        basic_encode(&inner_value).unwrap()
+    );
+
+    // With inner tuple
+    let inner_value = ();
+    assert_eq!(
+        basic_encode(&TestStruct::<()> {
+            state: inner_value,
+            abc: 0
+        })
+        .unwrap(),
+        basic_encode(&()).unwrap()
+    );
+
+    // With multiple layers of transparent
+    let inner_value = 45u32;
+    assert_eq!(
+        basic_encode(&TestStruct::<TestStructNamed> {
+            state: TestStructNamed { state: inner_value },
+            abc: 0
+        })
+        .unwrap(),
+        basic_encode(&inner_value).unwrap()
+    );
+}
+
+#[test]
+fn decode_is_correct() {
+    // With inner u32
+    let inner_value = 45u32;
+    let payload = basic_encode(&inner_value).unwrap();
+    assert_eq!(
+        basic_decode::<TestStructNamed>(&payload).unwrap(),
+        TestStructNamed { state: inner_value }
+    );
+    assert_eq!(
+        basic_decode::<TestStructUnnamed>(&payload).unwrap(),
+        TestStructUnnamed(inner_value)
+    );
+    assert_eq!(
+        basic_decode::<TestStruct::<u32>>(&payload).unwrap(),
+        TestStruct::<u32> {
+            state: inner_value,
+            abc: Default::default()
+        }
+    );
+
+    // With inner tuple
+    let inner_value = ();
+    let payload = basic_encode(&inner_value).unwrap();
+    assert_eq!(
+        basic_decode::<TestStruct::<()>>(&payload).unwrap(),
+        TestStruct {
+            state: inner_value,
+            abc: Default::default()
+        }
+    );
+
+    // With multiple layers of transparent
+    let inner_value = 45u32;
+    let payload = basic_encode(&inner_value).unwrap();
+    assert_eq!(
+        basic_decode::<TestStruct::<TestStructNamed>>(&payload).unwrap(),
+        TestStruct {
+            state: TestStructNamed { state: inner_value },
+            abc: 0
+        }
+    );
+}
+
+#[test]
+fn describe_is_correct() {
+    // With inner u32
+    check_identical_schemas::<TestStructNamed, u32>();
+    check_identical_schemas::<TestStructUnnamed, u32>();
+    check_identical_schemas::<TestStruct<u32>, u32>();
+
+    // With inner tuple
+    check_identical_schemas::<TestStruct<()>, ()>();
+
+    // With multiple layers of transparent
+    check_identical_schemas::<TestStruct<TestStructNamed>, u32>();
+}
+
+fn check_identical_schemas<T1: Describe<NoCustomTypeKind>, T2: Describe<NoCustomTypeKind>>() {
+    let (type_ref1, schema1) = generate_full_schema_from_single_type::<T1, NoCustomTypeExtension>();
+    let (type_ref2, schema2) = generate_full_schema_from_single_type::<T2, NoCustomTypeExtension>();
+    assert_eq!(type_ref1, type_ref2);
+    assert_eq!(schema1, schema2);
+}

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -108,6 +108,7 @@ mod schema {
 
     impl CustomTypeValidation for NoCustomTypeValidation {}
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum NoCustomTypeExtension {}
 
     impl CustomTypeExtension for NoCustomTypeExtension {

--- a/sbor/src/schema/custom_traits.rs
+++ b/sbor/src/schema/custom_traits.rs
@@ -3,7 +3,7 @@ use crate::rust::collections::*;
 use crate::rust::fmt::Debug;
 use crate::CustomValueKind;
 
-pub trait CustomTypeKind<L: SchemaTypeLink>: Clone + PartialEq + Eq {
+pub trait CustomTypeKind<L: SchemaTypeLink>: Debug + Clone + PartialEq + Eq {
     type CustomValueKind: CustomValueKind;
     type CustomTypeExtension: CustomTypeExtension<
         CustomValueKind = Self::CustomValueKind,
@@ -13,7 +13,7 @@ pub trait CustomTypeKind<L: SchemaTypeLink>: Clone + PartialEq + Eq {
 
 pub trait CustomTypeValidation: Debug + Clone + PartialEq + Eq {}
 
-pub trait CustomTypeExtension {
+pub trait CustomTypeExtension: Debug + Clone + PartialEq + Eq {
     type CustomValueKind: CustomValueKind;
     type CustomTypeKind<L: SchemaTypeLink>: CustomTypeKind<
         L,

--- a/sbor/src/schema/type_link.rs
+++ b/sbor/src/schema/type_link.rs
@@ -1,9 +1,10 @@
+use sbor::rust::fmt::Debug;
 use sbor::*;
 
 /// Marker trait for a link between [`TypeKind`]s:
 /// - [`GlobalTypeId`]: A global identifier for a type (a well known id, or type hash)
 /// - [`LocalTypeIndex`]: A link in the context of a schema (a well known id, or a local index)
-pub trait SchemaTypeLink: Clone + PartialEq + Eq {}
+pub trait SchemaTypeLink: Debug + Clone + PartialEq + Eq {}
 
 /// This is a global identifier for a type.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Encode, Decode, Categorize)]


### PR DESCRIPTION
I've been meaning to do this for a while - this adds the ability to use "#[sbor(transparent)]" with a single-child [new type](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) - ie it basically encodes itself as its singular child, and decodes itself similarly.

This is a parallel to `repr(transparent)` and [serde(transparent)](https://serde.rs/container-attrs.html)

This will be useful for various helper types, and also for easily creating slightly more performant SBOR encodes (see eg https://github.com/radixdlt/radixdlt-scrypto/pull/806 )