### PR TITLE
Minor renames + Convenience method in StateDiff

### DIFF
--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -142,10 +142,10 @@ impl WriteableTreeStore for SerializedInMemoryTreeStore {
 /// Encodes the given node key in a format friendly to Level-like databases (i.e. strictly ordered
 /// by numeric version).
 pub fn encode_key(key: &NodeKey) -> Vec<u8> {
-    let m = &key.version().to_be_bytes();
-    let x = &[(key.nibble_path().num_nibbles() % 2) as u8; 1];
-    let k = key.nibble_path().bytes();
-    [m, k, x].concat()
+    let version_bytes = &key.version().to_be_bytes();
+    let nibble_path_bytes = key.nibble_path().bytes();
+    let parity_byte = &[(key.nibble_path().num_nibbles() % 2) as u8; 1];
+    [version_bytes, nibble_path_bytes, parity_byte].concat()
 }
 
 // Note: We need completely custom serialization scheme only for the node keys. The remaining

--- a/radix-engine/src/kernel/track.rs
+++ b/radix-engine/src/kernel/track.rs
@@ -818,7 +818,7 @@ impl<'s> FinalizingTrack<'s> {
                 Self::get_substate_output_id(substate_store, &substate_id)
             {
                 let next_version = existing_output_id.version + 1;
-                diff.down_substates.push(existing_output_id);
+                diff.down_substates.insert(existing_output_id);
                 next_version
             } else {
                 0

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -8,7 +8,18 @@ pub trait QueryableSubstateStore {
     ) -> HashMap<Vec<u8>, PersistedSubstate>;
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(
+    Debug,
+    Clone,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    ScryptoCategorize,
+    ScryptoEncode,
+    ScryptoDecode,
+)]
 pub struct OutputId {
     pub substate_id: SubstateId,
     pub substate_hash: Hash,

--- a/radix-engine/src/state_manager/state_diff.rs
+++ b/radix-engine/src/state_manager/state_diff.rs
@@ -7,15 +7,24 @@ use radix_engine_interface::crypto::hash;
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct StateDiff {
     pub up_substates: BTreeMap<SubstateId, OutputValue>,
-    pub down_substates: Vec<OutputId>,
+    pub down_substates: BTreeSet<OutputId>,
 }
 
 impl StateDiff {
     pub fn new() -> Self {
         Self {
             up_substates: BTreeMap::new(),
-            down_substates: Vec::new(),
+            down_substates: BTreeSet::new(),
         }
+    }
+
+    /// Merges the changes from the given other diff into this one in a naive way, by simply
+    /// extending the tracked up/down substate collections (i.e. without resolving any potential
+    /// up->down or down->up interactions coming from the other diff).
+    pub fn extend(&mut self, other: StateDiff) {
+        let mut other = other;
+        self.up_substates.extend(other.up_substates);
+        self.down_substates.append(&mut other.down_substates);
     }
 
     /// Applies the state changes to some substate store.


### PR DESCRIPTION
A small follow-up to https://github.com/radixdlt/radixdlt-scrypto/pull/806.

The convenience method should be useful in Node, at https://github.com/radixdlt/babylon-node/pull/298/files#diff-5230880996b770cf628e475ce1143be291e99fd9801f307fd1702a525c351aadR971-R972.