### PR TITLE
feature: Many improvements to the ResourceBuilder

### DIFF
--- a/assets/template/src/lib.rs
+++ b/assets/template/src/lib.rs
@@ -16,7 +16,7 @@ mod hello {
             let my_bucket: Bucket = ResourceBuilder::new_fungible()
                 .metadata("name", "HelloToken")
                 .metadata("symbol", "HT")
-                .initial_supply(1000);
+                .mint_initial_supply(1000);
 
             // Instantiate a Hello component, populating its vault with our supply of 1000 HelloToken
             Self {

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -61,7 +61,7 @@ To define a new resource, we use the `ResourceBuilder`, specifying the metadata 
 let my_bucket: Bucket = ResourceBuilder::new_fungible()
     .metadata("name", "HelloToken")
     .metadata("symbol", "HT")
-    .initial_supply(1000);
+    .mint_initial_supply(1000);
 ```
 
 Once created, the 1000 resource-based `HelloToken` tokens are held in transient container `my_bucket`. To permanently store the created resources, we need to put them into a `Vault` like this:

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -17,7 +17,7 @@ mod hello {
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "HelloToken")
                 .metadata("symbol", "HT")
-                .initial_supply(1000);
+                .mint_initial_supply(1000);
 
             // Instantiate a Hello component, populating its vault with our supply of 1000 HelloToken
             Self {

--- a/radix-engine/tests/blueprints/bucket/src/badge.rs
+++ b/radix-engine/tests/blueprints/bucket/src/badge.rs
@@ -10,7 +10,7 @@ mod badge_test {
                 .divisibility(DIVISIBILITY_NONE)
                 .restrict_withdraw(rule!(allow_all), rule!(deny_all))
                 .metadata("name", "TestBadge")
-                .initial_supply(amount)
+                .mint_initial_supply(amount)
         }
 
         pub fn combine() -> Bucket {

--- a/radix-engine/tests/blueprints/bucket/src/bucket.rs
+++ b/radix-engine/tests/blueprints/bucket/src/bucket.rs
@@ -11,7 +11,7 @@ mod bucket_test {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(amount);
+                .mint_initial_supply(amount);
             let proof1 = bucket.create_proof();
             let proof2 = proof1.clone();
             proof1.drop();
@@ -48,14 +48,14 @@ mod bucket_test {
         pub fn test_restricted_transfer() -> Vec<Bucket> {
             let auth_bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .restrict_withdraw(
                     rule!(require(auth_bucket.resource_address())),
                     rule!(deny_all),
                 )
-                .initial_supply(5);
+                .mint_initial_supply(5);
             let mut vault = Vault::with_bucket(bucket);
 
             let token_bucket = auth_bucket.authorize(|| vault.take(1));
@@ -67,11 +67,11 @@ mod bucket_test {
         pub fn test_burn() -> Vec<Bucket> {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .burnable(rule!(require(badge.resource_address())), rule!(deny_all))
-                .initial_supply(5);
+                .mint_initial_supply(5);
             badge.authorize(|| bucket.burn());
             vec![badge]
         }
@@ -79,11 +79,11 @@ mod bucket_test {
         pub fn test_burn_freely() -> Vec<Bucket> {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let mut bucket1 = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .burnable(rule!(allow_all), rule!(deny_all))
-                .initial_supply(5);
+                .mint_initial_supply(5);
             let bucket2 = bucket1.take(2);
             badge.authorize(|| bucket1.burn());
             bucket2.burn();
@@ -100,7 +100,8 @@ mod bucket_test {
         }
 
         pub fn create_empty_bucket_non_fungible() -> Bucket {
-            let resource_address = ResourceBuilder::new_uuid_non_fungible().no_initial_supply();
+            let resource_address =
+                ResourceBuilder::new_uuid_non_fungible().create_with_no_initial_supply();
             Bucket::new(resource_address)
         }
     }

--- a/radix-engine/tests/blueprints/component/src/component.rs
+++ b/radix-engine/tests/blueprints/component/src/component.rs
@@ -12,7 +12,7 @@ mod component_test {
             ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(amount)
+                .mint_initial_supply(amount)
         }
 
         pub fn create_component() -> ComponentAddress {

--- a/radix-engine/tests/blueprints/core/src/lib.rs
+++ b/radix-engine/tests/blueprints/core/src/lib.rs
@@ -11,7 +11,7 @@ mod move_test {
             ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(amount)
+                .mint_initial_supply(amount)
         }
 
         pub fn receive_bucket(&mut self, t: Bucket) {

--- a/radix-engine/tests/blueprints/execution_trace/src/execution_trace.rs
+++ b/radix-engine/tests/blueprints/execution_trace/src/execution_trace.rs
@@ -12,7 +12,7 @@ mod execution_trace_test {
         ) -> (ResourceAddress, ComponentAddress, ComponentAddress) {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
-                .initial_supply(1000000);
+                .mint_initial_supply(1000000);
 
             let resource_address = bucket.resource_address();
 

--- a/radix-engine/tests/blueprints/fee/src/lib.rs
+++ b/radix-engine/tests/blueprints/fee/src/lib.rs
@@ -13,7 +13,7 @@ mod fee {
         pub fn new(xrd: Bucket) -> ComponentAddress {
             let doge_tokens = ResourceBuilder::new_fungible()
                 .metadata("name", "DogeCoin")
-                .initial_supply(100);
+                .mint_initial_supply(100);
 
             Self {
                 xrd: Vault::with_bucket(xrd),

--- a/radix-engine/tests/blueprints/kv_store/src/precommitted.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/precommitted.rs
@@ -14,7 +14,7 @@ mod precommitted {
             let bucket: Bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let vault = Vault::with_bucket(bucket);
             store.insert(0u32, vault);
             {
@@ -54,7 +54,7 @@ mod precommitted {
             let bucket: Bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let vault = Vault::with_bucket(bucket);
             sub_store.insert(0u32, vault);
             deep_vault.insert(0u32, sub_store);

--- a/radix-engine/tests/blueprints/kv_store/src/ref_check.rs
+++ b/radix-engine/tests/blueprints/kv_store/src/ref_check.rs
@@ -13,7 +13,7 @@ mod ref_check {
             let bucket: Bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let vault = Vault::with_bucket(bucket);
             let vault_id = vault.0.clone();
             store.insert(0u32, vault);
@@ -34,7 +34,7 @@ mod ref_check {
             let bucket: Bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let vault = Vault::with_bucket(bucket);
             let vault_id = vault.0.clone();
             store.insert(0u32, vault);
@@ -60,7 +60,7 @@ mod ref_check {
             let bucket: Bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let vault = Vault::with_bucket(bucket);
             let vault_id = vault.0.clone();
             store.insert(0u32, vault);

--- a/radix-engine/tests/blueprints/leaks/src/lib.rs
+++ b/radix-engine/tests/blueprints/leaks/src/lib.rs
@@ -13,14 +13,14 @@ mod leaks {
             let _bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
         }
 
         pub fn dangling_vault() {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let _vault = Vault::with_bucket(bucket);
         }
 
@@ -28,7 +28,7 @@ mod leaks {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
             bucket
         }
 
@@ -42,7 +42,7 @@ mod leaks {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1);
+                .mint_initial_supply(1);
 
             bucket.create_proof()
         }

--- a/radix-engine/tests/blueprints/non_fungible/src/lib.rs
+++ b/radix-engine/tests/blueprints/non_fungible/src/lib.rs
@@ -20,7 +20,7 @@ mod non_fungible_test {
             // Create a mint badge
             let mint_badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
 
             // Create non-fungible resource with mutable supply
             let resource_address = ResourceBuilder::new_integer_non_fungible()
@@ -34,7 +34,7 @@ mod non_fungible_test {
                     rule!(require(mint_badge.resource_address())),
                     rule!(deny_all),
                 )
-                .no_initial_supply();
+                .create_with_no_initial_supply();
 
             // Mint a non-fungible
             let non_fungible = mint_badge.authorize(|| {
@@ -69,7 +69,7 @@ mod non_fungible_test {
             ResourceBuilder::new_uuid_non_fungible()
                 .metadata("name", "Katz's Sandwiches")
                 .burnable(rule!(allow_all), rule!(deny_all))
-                .initial_supply_uuid([
+                .mint_initial_supply([
                     Sandwich {
                         name: "Zero".to_owned(),
                         available: true,
@@ -84,7 +84,7 @@ mod non_fungible_test {
         pub fn create_non_fungible_fixed() -> Bucket {
             ResourceBuilder::new_integer_non_fungible()
                 .metadata("name", "Katz's Sandwiches")
-                .initial_supply([
+                .mint_initial_supply([
                     (
                         1u64.into(),
                         Sandwich {
@@ -317,7 +317,7 @@ mod non_fungible_test {
 
         pub fn create_string_non_fungible() -> Bucket {
             // creating non-fungible id with id type set to default (UUID)
-            ResourceBuilder::new_string_non_fungible().initial_supply([
+            ResourceBuilder::new_string_non_fungible().mint_initial_supply([
                 (
                     "1".try_into().unwrap(),
                     Sandwich {
@@ -336,7 +336,7 @@ mod non_fungible_test {
         }
 
         pub fn create_bytes_non_fungible() -> Bucket {
-            ResourceBuilder::new_bytes_non_fungible().initial_supply([
+            ResourceBuilder::new_bytes_non_fungible().mint_initial_supply([
                 (
                     1u32.to_le_bytes().to_vec().try_into().unwrap(),
                     Sandwich {
@@ -355,7 +355,7 @@ mod non_fungible_test {
         }
 
         pub fn create_uuid_non_fungible() -> Bucket {
-            ResourceBuilder::new_uuid_non_fungible().initial_supply_uuid([Sandwich {
+            ResourceBuilder::new_uuid_non_fungible().mint_initial_supply([Sandwich {
                 name: "Zero".to_owned(),
                 available: true,
             }])
@@ -364,7 +364,7 @@ mod non_fungible_test {
         pub fn create_mintable_uuid_non_fungible() -> ResourceAddress {
             ResourceBuilder::new_uuid_non_fungible()
                 .mintable(rule!(allow_all), rule!(deny_all))
-                .no_initial_supply()
+                .create_with_no_initial_supply()
         }
 
         pub fn create_uuid_non_fungible_and_mint() -> Bucket {
@@ -372,7 +372,7 @@ mod non_fungible_test {
             let resource_address = ResourceBuilder::new_uuid_non_fungible()
                 .mintable(rule!(allow_all), rule!(deny_all))
                 .metadata("name", "Katz's Sandwiches")
-                .no_initial_supply();
+                .create_with_no_initial_supply();
 
             borrow_resource_manager!(resource_address).mint_uuid_non_fungible(Sandwich {
                 name: "Test".to_owned(),

--- a/radix-engine/tests/blueprints/resource/src/lib.rs
+++ b/radix-engine/tests/blueprints/resource/src/lib.rs
@@ -16,7 +16,7 @@ mod resource_test {
             let super_admin_badge: ResourceAddress = ResourceBuilder::new_uuid_non_fungible()
                 .metadata("name", "Super Admin Badge")
                 .mintable(rule!(allow_all), rule!(allow_all))
-                .no_initial_supply();
+                .create_with_no_initial_supply();
 
             let super_admin_manager: &mut ResourceManager =
                 borrow_resource_manager!(super_admin_badge);
@@ -26,13 +26,13 @@ mod resource_test {
         pub fn create_fungible() -> (Bucket, ResourceAddress) {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let token_address = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
                 .mintable(rule!(require(badge.resource_address())), rule!(deny_all))
                 .burnable(rule!(require(badge.resource_address())), rule!(deny_all))
-                .no_initial_supply();
+                .create_with_no_initial_supply();
             (badge, token_address)
         }
 
@@ -42,13 +42,13 @@ mod resource_test {
         ) -> (Bucket, Bucket, ResourceAddress) {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let token_address = ResourceBuilder::new_fungible()
                 .divisibility(divisibility)
                 .metadata("name", "TestToken")
                 .mintable(rule!(require(badge.resource_address())), rule!(deny_all))
                 .burnable(rule!(require(badge.resource_address())), rule!(deny_all))
-                .no_initial_supply();
+                .create_with_no_initial_supply();
             let tokens = badge.authorize(|| borrow_resource_manager!(token_address).mint(amount));
             (badge, tokens, token_address)
         }
@@ -57,7 +57,7 @@ mod resource_test {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1u32);
+                .mint_initial_supply(1u32);
             bucket
         }
 
@@ -65,7 +65,7 @@ mod resource_test {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1u32);
+                .mint_initial_supply(1u32);
             bucket
         }
 
@@ -73,13 +73,13 @@ mod resource_test {
         {
             let badge = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
-                .initial_supply(1);
+                .mint_initial_supply(1);
             let token_address = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
                 .mintable(rule!(require(badge.resource_address())), rule!(deny_all))
                 .burnable(rule!(require(badge.resource_address())), rule!(deny_all))
-                .no_initial_supply();
+                .create_with_no_initial_supply();
             (badge, token_address)
         }
 
@@ -104,20 +104,21 @@ mod resource_test {
         }
 
         pub fn update_resource_metadata() -> Bucket {
-            let badge = ResourceBuilder::new_integer_non_fungible().initial_supply(vec![(
+            let badge = ResourceBuilder::new_integer_non_fungible().mint_initial_supply(vec![(
                 0u64.into(),
                 Sandwich {
                     name: "name".to_string(),
                     available: false,
                 },
             )]);
-            let manager_address =
+            let manager_badge =
                 NonFungibleGlobalId::new(badge.resource_address(), NonFungibleLocalId::integer(0));
 
             let resource_address = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .no_initial_supply_with_owner(manager_address);
+                .owner_non_fungible_badge(manager_badge)
+                .create_with_no_initial_supply();
 
             badge.authorize(|| {
                 let token_resource_manager = borrow_resource_manager!(resource_address);

--- a/radix-engine/tests/blueprints/stored_resource/src/lib.rs
+++ b/radix-engine/tests/blueprints/stored_resource/src/lib.rs
@@ -8,7 +8,7 @@ mod stored_resource {
 
     impl StoredResource {
         pub fn create() -> ComponentAddress {
-            let resource_address = ResourceBuilder::new_fungible().no_initial_supply();
+            let resource_address = ResourceBuilder::new_fungible().create_with_no_initial_supply();
             Self { resource_address }.instantiate().globalize()
         }
 

--- a/radix-engine/tests/blueprints/stored_values/src/lib.rs
+++ b/radix-engine/tests/blueprints/stored_values/src/lib.rs
@@ -11,7 +11,7 @@ mod invalid_init_stored_bucket {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
                 .restrict_withdraw(rule!(allow_all), rule!(deny_all))
-                .initial_supply(Decimal::from(5));
+                .mint_initial_supply(Decimal::from(5));
 
             let component = InvalidInitStoredBucket { bucket }.instantiate();
             component.globalize()
@@ -34,7 +34,7 @@ mod invalid_stored_bucket_in_owned_component {
             let bucket = ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_NONE)
                 .restrict_withdraw(rule!(allow_all), rule!(deny_all))
-                .initial_supply(Decimal::from(5));
+                .mint_initial_supply(Decimal::from(5));
 
             let component = InvalidStoredBucketInOwnedComponent {
                 bucket: Option::None,

--- a/radix-engine/tests/blueprints/vault/src/vault.rs
+++ b/radix-engine/tests/blueprints/vault/src/vault.rs
@@ -16,7 +16,7 @@ mod vault_test {
             ResourceBuilder::new_fungible()
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata("name", "TestToken")
-                .initial_supply(1)
+                .mint_initial_supply(1)
         }
 
         pub fn new_vault_into_map() -> ComponentAddress {
@@ -125,7 +125,7 @@ mod vault_test {
         fn create_non_fungible_vault() -> Vault {
             let bucket = ResourceBuilder::new_integer_non_fungible()
                 .metadata("name", "TestToken")
-                .initial_supply([(1u64.into(), Data {})]);
+                .mint_initial_supply([(1u64.into(), Data {})]);
             Vault::with_bucket(bucket)
         }
 

--- a/scrypto/src/resource/mod.rs
+++ b/scrypto/src/resource/mod.rs
@@ -13,7 +13,10 @@ pub use bucket::*;
 pub use non_fungible::NonFungible;
 pub use proof::*;
 pub use proof_rule::*;
-pub use resource_builder::{ResourceBuilder, DIVISIBILITY_MAXIMUM, DIVISIBILITY_NONE};
+pub use resource_builder::{
+    CreateWithNoSupplyBuilder, ResourceBuilder, SetOwnerBuilder, UpdateAuthBuilder,
+    UpdateMetadataBuilder, UpdateNonFungibleAuthBuilder, DIVISIBILITY_MAXIMUM, DIVISIBILITY_NONE,
+};
 pub use resource_manager::*;
 pub use system::{init_resource_system, resource_system, ResourceSystem};
 pub use vault::*;

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -179,13 +179,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be mintable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .mintable(rule!(require(badge.resource_address())), LOCKED);
+    ///    .mintable(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to not be mintable, but this is can be changed in future by the second rule
     /// ResourceBuilder::new_fungible()
-    ///    .mintable(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    ///    .mintable(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn mintable<R: Into<AccessRule>>(
         self,
@@ -205,13 +207,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be burnable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .burnable(rule!(require(badge.resource_address())), LOCKED);
+    ///    .burnable(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be freely burnable, but this is can be changed in future by the second rule.
     /// ResourceBuilder::new_fungible()
-    ///    .burnable(rule!(allow_all), MUTABLE(rule!(/* ... */)));
+    ///    .burnable(rule!(allow_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn burnable<R: Into<AccessRule>>(
         self,
@@ -231,13 +235,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be recallable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .recallable(rule!(require(badge.resource_address())), LOCKED);
+    ///    .recallable(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to not be recallable, but this is can be changed in future by the second rule
     /// ResourceBuilder::new_fungible()
-    ///    .recallable(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    ///    .recallable(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn recallable<R: Into<AccessRule>>(
         self,
@@ -257,13 +263,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be withdrawable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .restrict_withdraw(rule!(require(badge.resource_address())), LOCKED);
+    ///    .restrict_withdraw(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to not be withdrawable, but this is can be changed in future by the second rule
     /// ResourceBuilder::new_fungible()
-    ///    .restrict_withdraw(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    ///    .restrict_withdraw(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn restrict_withdraw<R: Into<AccessRule>>(
         self,
@@ -283,13 +291,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to be depositable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .restrict_deposit(rule!(require(badge.resource_address())), LOCKED);
+    ///    .restrict_deposit(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to not be depositable, but this is can be changed in future by the second rule
     /// ResourceBuilder::new_fungible()
-    ///    .restrict_deposit(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    ///    .restrict_deposit(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn restrict_deposit<R: Into<AccessRule>>(
         self,
@@ -309,13 +319,15 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to allow its metadata to be updated with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
-    ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
+    ///    .updateable_metadata(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Sets the resource to not allow its metadata to be updated, but this is can be changed in future by the second rule.
     /// ResourceBuilder::new_fungible()
-    ///    .updateable_metadata(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    ///    .updateable_metadata(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn updateable_metadata<R: Into<AccessRule>>(
         self,
@@ -338,13 +350,15 @@ pub trait UpdateNonFungibleAuthBuilder: IsNonFungibleBuilder + private::CanAddAu
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Permits the updating of non-fungible mutable data with a proof of a specific resource, and this is locked forever.
-    /// ResourceBuilder::new_fungible()
-    ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
+    /// ResourceBuilder::new_uuid_non_fungible()
+    ///    .updateable_non_fungible_data(rule!(require(resource_address)), LOCKED);
     ///
+    /// # let resource_address = RADIX_TOKEN;
     /// // Does not currently permit the updating of non-fungible mutable data, but this is can be changed in future by the second rule.
-    /// ResourceBuilder::new_fungible()
-    ///    .updateable_metadata(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ResourceBuilder::new_uuid_non_fungible()
+    ///    .updateable_non_fungible_data(rule!(deny_all), MUTABLE(rule!(require(resource_address))));
     /// ```
     fn updateable_non_fungible_data<R: Into<AccessRule>>(
         self,

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -1,10 +1,10 @@
 use crate::engine::scrypto_env::ScryptoEnv;
 use crate::radix_engine_interface::api::Invokable;
+use radix_engine_interface::api::wasm::SerializableInvocation;
 use radix_engine_interface::math::Decimal;
 use radix_engine_interface::model::resource_access_rules_from_owner_badge;
 use radix_engine_interface::model::*;
-use sbor::rust::borrow::ToOwned;
-use sbor::rust::collections::{BTreeMap, BTreeSet};
+use sbor::rust::collections::*;
 use sbor::rust::marker::PhantomData;
 use sbor::rust::string::String;
 
@@ -14,476 +14,401 @@ pub const DIVISIBILITY_NONE: u8 = 0;
 pub const DIVISIBILITY_MAXIMUM: u8 = 18;
 
 /// Utility for setting up a new resource.
+///
+/// * You start the building process with one of the methods starting with `new_`.
+/// * The allowed methods change depending on which methods have already been called.
+///   For example, you can either use `owner_non_fungible_badge` or set access rules individually, but not both.
+/// * You can complete the building process using either `create_with_no_initial_supply()` or `mint_initial_supply(..)`.
+///
+/// ### Example
+/// ```no_run
+/// let bucket = ResourceBuilder::new_fungible()
+///     .metadata("name", "TestToken")
+///     .mint_initial_supply(5);
+/// ```
 pub struct ResourceBuilder;
 
 impl ResourceBuilder {
     /// Starts a new builder to create a fungible resource.
-    pub fn new_fungible() -> FungibleResourceBuilder {
-        FungibleResourceBuilder::new()
+    pub fn new_fungible() -> InProgressResourceBuilder<FungibleResourceType, NoAuth> {
+        InProgressResourceBuilder::default()
     }
 
     /// Starts a new builder to create a non-fungible resource with a `NonFungibleIdType::String`
-    pub fn new_string_non_fungible() -> NonFungibleResourceBuilder<StringNonFungibleLocalId> {
-        NonFungibleResourceBuilder::new()
+    pub fn new_string_non_fungible(
+    ) -> InProgressResourceBuilder<NonFungibleResourceType<StringNonFungibleLocalId>, NoAuth> {
+        InProgressResourceBuilder::default()
     }
 
     /// Starts a new builder to create a non-fungible resource with a `NonFungibleIdType::Integer`
-    pub fn new_integer_non_fungible() -> NonFungibleResourceBuilder<IntegerNonFungibleLocalId> {
-        NonFungibleResourceBuilder::new()
+    pub fn new_integer_non_fungible(
+    ) -> InProgressResourceBuilder<NonFungibleResourceType<IntegerNonFungibleLocalId>, NoAuth> {
+        InProgressResourceBuilder::default()
     }
 
     /// Starts a new builder to create a non-fungible resource with a `NonFungibleIdType::Bytes`
-    pub fn new_bytes_non_fungible() -> NonFungibleResourceBuilder<BytesNonFungibleLocalId> {
-        NonFungibleResourceBuilder::new()
+    pub fn new_bytes_non_fungible(
+    ) -> InProgressResourceBuilder<NonFungibleResourceType<BytesNonFungibleLocalId>, NoAuth> {
+        InProgressResourceBuilder::default()
     }
 
     /// Starts a new builder to create a non-fungible resource with a `NonFungibleIdType::UUID`
-    pub fn new_uuid_non_fungible() -> NonFungibleResourceBuilder<UUIDNonFungibleLocalId> {
-        NonFungibleResourceBuilder::new()
+    pub fn new_uuid_non_fungible(
+    ) -> InProgressResourceBuilder<NonFungibleResourceType<UUIDNonFungibleLocalId>, NoAuth> {
+        InProgressResourceBuilder::default()
     }
 }
 
-/// A resource builder which builds fungible resources that may or may not have an owner badge.
+/// Utility for setting up a new resource, which has building in progress.
 ///
-/// # Note
+/// * You start the building process with one of the methods starting with `ResourceBuilder::new_`.
+/// * The allowed methods change depending on which methods have already been called.
+///   For example, you can either use `owner_non_fungible_badge` or set access rules individually, but not both.
+/// * You can complete the building process using either `create_with_no_initial_supply()` or `mint_initial_supply(..)`.
 ///
-/// Once one of the methods that set behavior is called, a new [`FungibleResourceWithAuthBuilder`]
-/// is created which commits the developer to building a resource that does not have an owner badge.
-/// If none of these methods are called, then the developer has the choice to either building a
-/// resource with an owner badge or without one.
-pub struct FungibleResourceBuilder {
-    divisibility: u8,
+/// ### Example
+/// ```no_run
+/// let bucket = ResourceBuilder::new_fungible()
+///     .metadata("name", "TestToken")
+///     .mint_initial_supply(5);
+/// ```
+#[must_use]
+pub struct InProgressResourceBuilder<T: ResourceType, A: ConfiguredAuth> {
+    resource_type: T,
     metadata: BTreeMap<String, String>,
+    auth: A,
 }
 
-impl FungibleResourceBuilder {
-    pub fn new() -> Self {
+impl<T: ResourceType> Default for InProgressResourceBuilder<T, NoAuth> {
+    fn default() -> Self {
+        Self {
+            resource_type: T::default(),
+            metadata: BTreeMap::new(),
+            auth: NoAuth,
+        }
+    }
+}
+
+pub trait ConfiguredAuth {
+    fn into_access_rules(self) -> BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)>;
+}
+
+pub struct NoAuth;
+impl ConfiguredAuth for NoAuth {
+    fn into_access_rules(self) -> BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)> {
+        BTreeMap::new()
+    }
+}
+
+pub struct AccessRuleAuth(BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)>);
+
+impl ConfiguredAuth for AccessRuleAuth {
+    fn into_access_rules(self) -> BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)> {
+        self.0
+    }
+}
+
+pub struct OwnerBadgeAuth(NonFungibleGlobalId);
+impl ConfiguredAuth for OwnerBadgeAuth {
+    fn into_access_rules(self) -> BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)> {
+        resource_access_rules_from_owner_badge(&self.0)
+    }
+}
+
+// Various types for ResourceType
+pub trait ResourceType: Default {}
+
+pub struct FungibleResourceType {
+    divisibility: u8,
+}
+impl ResourceType for FungibleResourceType {}
+impl Default for FungibleResourceType {
+    fn default() -> Self {
         Self {
             divisibility: DIVISIBILITY_MAXIMUM,
-            metadata: BTreeMap::new(),
         }
     }
+}
 
-    /// Set the divisibility.
+pub struct NonFungibleResourceType<T: IsNonFungibleLocalId>(PhantomData<T>);
+impl<T: IsNonFungibleLocalId> ResourceType for NonFungibleResourceType<T> {}
+impl<T: IsNonFungibleLocalId> Default for NonFungibleResourceType<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+// Builder types
+pub trait IsFungibleBuilder {}
+impl<A: ConfiguredAuth> IsFungibleBuilder for InProgressResourceBuilder<FungibleResourceType, A> {}
+
+pub trait IsNonFungibleBuilder {}
+impl<A: ConfiguredAuth, Y: IsNonFungibleLocalId> IsNonFungibleBuilder
+    for InProgressResourceBuilder<NonFungibleResourceType<Y>, A>
+{
+}
+
+////////////////////////////////////////////////////////////
+/// PUBLIC TRAITS AND METHODS
+/// All public methods first - these all need good rust docs
+////////////////////////////////////////////////////////////
+
+pub trait UpdateMetadataBuilder: private::CanAddMetadata {
+    /// Adds a resource metadata.
     ///
-    /// `0` means the resource is not divisible; `18` is the max divisibility.
+    /// If a previous attribute with the same name has been set, it will be overwritten.
+    fn metadata<K: Into<String>, V: Into<String>>(self, name: K, value: V) -> Self::OutputBuilder {
+        self.add_metadata(name.into(), value.into())
+    }
+}
+impl<B: private::CanAddMetadata> UpdateMetadataBuilder for B {}
+
+pub trait UpdateAuthBuilder: private::CanAddAuth {
+    /// Sets the resource to be mintable.
+    ///
+    /// * The first parameter is the access rule which allows minting of the resource.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to be mintable with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .mintable(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to not be mintable, but this is can be changed in future by the second rule
+    /// ResourceBuilder::new_fungible()
+    ///    .mintable(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn mintable<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(Mint, method_auth, mutability.into())
+    }
+
+    /// Sets the resource to be burnable.
+    ///
+    /// * The first parameter is the access rule which allows minting of the resource.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to be burnable with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .burnable(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to be freely burnable, but this is can be changed in future by the second rule.
+    /// ResourceBuilder::new_fungible()
+    ///    .burnable(rule!(allow_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn burnable<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(Burn, method_auth, mutability.into())
+    }
+
+    /// Sets the resource to be recallable from vaults.
+    ///
+    /// * The first parameter is the access rule which allows recalling of the resource.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to be recallable with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .recallable(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to not be recallable, but this is can be changed in future by the second rule
+    /// ResourceBuilder::new_fungible()
+    ///    .recallable(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn recallable<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(Recall, method_auth, mutability.into())
+    }
+
+    /// Sets the resource to not be freely withdrawable from a vault.
+    ///
+    /// * The first parameter is the access rule which allows withdrawing from a vault.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to be withdrawable with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .restrict_withdraw(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to not be withdrawable, but this is can be changed in future by the second rule
+    /// ResourceBuilder::new_fungible()
+    ///    .restrict_withdraw(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn restrict_withdraw<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(Withdraw, method_auth, mutability.into())
+    }
+
+    /// Sets the resource to not be freely depositable into a vault.
+    ///
+    /// * The first parameter is the access rule which allows depositing into a vault.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to be depositable with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .restrict_deposit(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to not be depositable, but this is can be changed in future by the second rule
+    /// ResourceBuilder::new_fungible()
+    ///    .restrict_deposit(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn restrict_deposit<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(Deposit, method_auth, mutability.into())
+    }
+
+    /// Sets how the resource's metadata can be updated.
+    ///
+    /// * The first parameter is the access rule which allows updating the metadata of the resource.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Sets the resource to allow its metadata to be updated with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Sets the resource to not allow its metadata to be updated, but this is can be changed in future by the second rule.
+    /// ResourceBuilder::new_fungible()
+    ///    .updateable_metadata(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn updateable_metadata<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(UpdateMetadata, method_auth, mutability.into())
+    }
+}
+impl<B: private::CanAddAuth> UpdateAuthBuilder for B {}
+
+pub trait UpdateNonFungibleAuthBuilder: IsNonFungibleBuilder + private::CanAddAuth {
+    /// Sets how each non-fungible's mutable data can be updated.
+    ///
+    /// * The first parameter is the access rule which allows updating the mutable data of each non-fungible.
+    /// * The second parameter is the mutability / access rule which controls if and how the access rule can be updated.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Permits the updating of non-fungible mutable data with a proof of a specific resource, and this is locked forever.
+    /// ResourceBuilder::new_fungible()
+    ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
+    ///
+    /// // Does not currently permit the updating of non-fungible mutable data, but this is can be changed in future by the second rule.
+    /// ResourceBuilder::new_fungible()
+    ///    .updateable_metadata(rule!(deny_all), MUTABLE(rule!(/* ... */)));
+    /// ```
+    fn updateable_non_fungible_data<R: Into<AccessRule>>(
+        self,
+        method_auth: AccessRule,
+        mutability: R,
+    ) -> Self::OutputBuilder {
+        self.add_auth(UpdateNonFungibleData, method_auth, mutability.into())
+    }
+}
+impl<B: IsNonFungibleBuilder + private::CanAddAuth> UpdateNonFungibleAuthBuilder for B {}
+
+pub trait SetOwnerBuilder: private::CanAddOwner {
+    /// Sets the owner badge to be the given non-fungible.
+    ///
+    /// The owner badge is given starting permissions to update the metadata/data associated with the resource,
+    /// and to change any of the access rules after creation.
+    fn owner_non_fungible_badge(self, owner_badge: NonFungibleGlobalId) -> Self::OutputBuilder {
+        self.set_owner(owner_badge)
+    }
+}
+impl<B: private::CanAddOwner> SetOwnerBuilder for B {}
+
+pub trait CreateWithNoSupplyBuilder: private::CanCreateWithNoSupply {
+    /// Creates the resource with no initial supply.
+    ///
+    /// The resource's address is returned.
+    fn create_with_no_initial_supply(self) -> ResourceAddress {
+        ScryptoEnv
+            .invoke(self.into_create_with_no_supply_invocation())
+            .unwrap()
+    }
+}
+impl<B: private::CanCreateWithNoSupply> CreateWithNoSupplyBuilder for B {}
+
+impl<A: ConfiguredAuth> InProgressResourceBuilder<FungibleResourceType, A> {
+    /// Set the resource's divisibility: the number of digits of precision after the decimal point in its balances.
+    ///
+    /// * `0` means the resource is not divisible (balances are always whole numbers)
+    /// * `18` is the maximum divisibility, and the default.
+    ///
+    /// ### Examples
+    ///
+    /// ```no_run
+    /// // Only permits whole-number balances.
+    /// ResourceBuilder::new_fungible()
+    ///    .divisibility(0);
+    ///
+    /// // Only permits balances to 3 decimal places.
+    /// ResourceBuilder::new_fungible()
+    ///    .divisibility(3);
+    /// ```
     pub fn divisibility(mut self, divisibility: u8) -> Self {
         assert!(divisibility <= 18);
-        self.divisibility = divisibility;
+        self.resource_type = FungibleResourceType { divisibility };
         self
     }
+}
 
-    /// Adds a resource metadata.
-    ///
-    /// If a previous attribute with the same name has been set, it will be overwritten.
-    pub fn metadata<K: AsRef<str>, V: AsRef<str>>(mut self, name: K, value: V) -> Self {
-        self.metadata
-            .insert(name.as_ref().to_owned(), value.as_ref().to_owned());
-        self
-    }
-
-    pub fn mintable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Mint, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn burnable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Burn, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn recallable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Recall, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn restrict_withdraw<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Withdraw, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn restrict_deposit<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Deposit, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn updateable_metadata<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> FungibleResourceWithAuthBuilder {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(UpdateMetadata, (method_auth, mutability.into()));
-        FungibleResourceWithAuthBuilder {
-            divisibility: self.divisibility,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
+impl<A: ConfiguredAuth> InProgressResourceBuilder<FungibleResourceType, A> {
     /// Creates resource with the given initial supply.
     ///
     /// # Example
-    /// ```ignore
+    /// ```no_run
     /// let bucket = ResourceBuilder::new_fungible()
-    ///     .metadata("name", "TestToken")
-    ///     .initial_supply(5);
+    ///     .mint_initial_supply(5);
     /// ```
-    pub fn initial_supply<T: Into<Decimal>>(self, amount: T) -> Bucket {
-        let (_resource_address, bucket) = ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleWithInitialSupplyInvocation {
-                resource_address: None,
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: BTreeMap::new(),
-                initial_supply: amount.into(),
-            })
-            .unwrap();
-
-        bucket
-    }
-
-    pub fn no_initial_supply(self) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleInvocation {
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: BTreeMap::new(),
-            })
-            .unwrap()
-    }
-
-    pub fn initial_supply_with_owner<T: Into<Decimal>>(
-        self,
-        amount: T,
-        owner_badge: NonFungibleGlobalId,
-    ) -> Bucket {
-        let (_resource_address, bucket) = ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleWithInitialSupplyInvocation {
-                resource_address: None,
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: resource_access_rules_from_owner_badge(&owner_badge),
-                initial_supply: amount.into(),
-            })
-            .unwrap();
-
-        bucket
-    }
-
-    pub fn no_initial_supply_with_owner(self, owner_badge: NonFungibleGlobalId) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleInvocation {
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: resource_access_rules_from_owner_badge(&owner_badge),
-            })
-            .unwrap()
+    pub fn mint_initial_supply<T: Into<Decimal>>(self, amount: T) -> Bucket {
+        mint_from_invocation(ResourceManagerCreateFungibleWithInitialSupplyInvocation {
+            resource_address: None,
+            divisibility: self.resource_type.divisibility,
+            metadata: self.metadata,
+            access_rules: self.auth.into_access_rules(),
+            initial_supply: amount.into(),
+        })
     }
 }
 
-/// A resource builder which builds fungible resources that do not have an owner-badge where
-/// resource behavior is completely handled by the developer.
-///  
-/// Typically this resource builder is created from the [`FungibleResourceBuilder`] once the
-/// developer has called one of the methods that set resource behavior. This is done as a static
-/// way of committing the developer to this choice by transitioning into a builder which does not
-/// offer the `initial_supply_with_owner` and `no_initial_supply_with_owner` methods.
-pub struct FungibleResourceWithAuthBuilder {
-    divisibility: u8,
-    metadata: BTreeMap<String, String>,
-    authorization: BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)>,
-}
-
-impl FungibleResourceWithAuthBuilder {
-    /// Adds a resource metadata.
+impl<A: ConfiguredAuth>
+    InProgressResourceBuilder<NonFungibleResourceType<StringNonFungibleLocalId>, A>
+{
+    /// Creates the non-fungible resource, and mints an individual non-fungible for each key/data pair provided.
     ///
-    /// If a previous attribute with the same name has been set, it will be overwritten.
-    pub fn metadata<K: AsRef<str>, V: AsRef<str>>(mut self, name: K, value: V) -> Self {
-        self.metadata
-            .insert(name.as_ref().to_owned(), value.as_ref().to_owned());
-        self
-    }
-
-    pub fn mintable<R: Into<AccessRule>>(mut self, method_auth: AccessRule, mutability: R) -> Self {
-        self.authorization
-            .insert(Mint, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn burnable<R: Into<AccessRule>>(mut self, method_auth: AccessRule, mutability: R) -> Self {
-        self.authorization
-            .insert(Burn, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn recallable<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Recall, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn restrict_withdraw<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Withdraw, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn restrict_deposit<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Deposit, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn updateable_metadata<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(UpdateMetadata, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn initial_supply<T: Into<Decimal>>(self, amount: T) -> Bucket {
-        let (_resource_address, bucket) = ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleWithInitialSupplyInvocation {
-                resource_address: None,
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: self.authorization,
-                initial_supply: amount.into(),
-            })
-            .unwrap();
-
-        bucket
-    }
-
-    /// Creates resource with no initial supply.
-    pub fn no_initial_supply(self) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateFungibleInvocation {
-                divisibility: self.divisibility,
-                metadata: self.metadata,
-                access_rules: self.authorization,
-            })
-            .unwrap()
-    }
-}
-
-/// A resource builder which builds non-fungible resources that may or may not have an owner badge.
-///
-/// # Note
-///
-/// Once one of the methods that set behavior is called, a new [`NonFungibleResourceWithAuthBuilder`]
-/// is created which commits the developer to building a resource that does not have an owner badge.
-/// If none of these methods are called, then the developer has the choice to either building a
-/// resource with an owner badge or without one.
-pub struct NonFungibleResourceBuilder<Y: IsNonFungibleLocalId> {
-    metadata: BTreeMap<String, String>,
-    id_type: PhantomData<Y>,
-}
-
-impl<Y: IsNonFungibleLocalId> NonFungibleResourceBuilder<Y> {
-    pub fn new() -> Self {
-        Self {
-            metadata: BTreeMap::new(),
-            id_type: PhantomData,
-        }
-    }
-
-    /// Adds a resource metadata.
-    ///
-    /// If a previous attribute with the same name has been set, it will be overwritten.
-    pub fn metadata<K: AsRef<str>, V: AsRef<str>>(mut self, name: K, value: V) -> Self {
-        self.metadata
-            .insert(name.as_ref().to_owned(), value.as_ref().to_owned());
-        self
-    }
-
-    pub fn mintable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Mint, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn burnable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Burn, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn recallable<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Recall, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn restrict_withdraw<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Withdraw, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn restrict_deposit<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(Deposit, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn updateable_metadata<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(UpdateMetadata, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    pub fn updateable_non_fungible_data<R: Into<AccessRule>>(
-        self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> NonFungibleResourceWithAuthBuilder<Y> {
-        let mut authorization = BTreeMap::new();
-        authorization.insert(UpdateNonFungibleData, (method_auth, mutability.into()));
-        NonFungibleResourceWithAuthBuilder {
-            id_type: PhantomData,
-            metadata: self.metadata,
-            authorization,
-        }
-    }
-
-    /// Creates resource with no initial supply.
-    pub fn no_initial_supply(self) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateNonFungibleInvocation {
-                resource_address: None,
-                id_type: Y::id_type(),
-                metadata: self.metadata,
-                access_rules: BTreeMap::new(),
-            })
-            .unwrap()
-    }
-
-    pub fn no_initial_supply_with_owner(self, owner_badge: NonFungibleGlobalId) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateNonFungibleInvocation {
-                resource_address: None,
-                id_type: Y::id_type(),
-                metadata: self.metadata,
-                access_rules: resource_access_rules_from_owner_badge(&owner_badge),
-            })
-            .unwrap()
-    }
-}
-
-impl<Y: IsNonAutoGeneratedNonFungibleLocalId> NonFungibleResourceBuilder<Y> {
-    /// Creates resource with the given initial supply.
-    ///
-    /// # Example
+    /// ### Example
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
@@ -494,56 +419,34 @@ impl<Y: IsNonAutoGeneratedNonFungibleLocalId> NonFungibleResourceBuilder<Y> {
     ///     pub flag: bool,
     /// }
     ///
-    /// let bucket1 = ResourceBuilder::new_string_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply([
+    /// let bucket = ResourceBuilder::new_string_non_fungible()
+    ///     .mint_initial_supply([
     ///         ("One".try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
     ///         ("Two".try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
     ///     ]);
-    ///
-    /// let bucket2 = ResourceBuilder::new_integer_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply([
-    ///         (1u64.into(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         (2u64.into(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ]);
-    ///
-    /// let bucket3 = ResourceBuilder::new_bytes_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply([
-    ///         (vec![1u8].try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         (vec![2u8].try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ]);
     /// ```
-    pub fn initial_supply<T, V>(self, entries: T) -> Bucket
+    pub fn mint_initial_supply<T, V>(self, entries: T) -> Bucket
     where
-        T: IntoIterator<Item = (Y, V)>,
+        T: IntoIterator<Item = (StringNonFungibleLocalId, V)>,
         V: NonFungibleData,
     {
-        let mut encoded = BTreeMap::new();
-        for (id, e) in entries {
-            encoded.insert(
-                id.into(),
-                (e.immutable_data().unwrap(), e.mutable_data().unwrap()),
-            );
-        }
-
-        ScryptoEnv
-            .invoke(
-                ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
-                    id_type: Y::id_type(),
-                    metadata: self.metadata,
-                    access_rules: BTreeMap::new(),
-                    entries: encoded,
-                },
-            )
-            .unwrap()
-            .1
+        mint_from_invocation(
+            ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
+                id_type: StringNonFungibleLocalId::id_type(),
+                metadata: self.metadata,
+                access_rules: self.auth.into_access_rules(),
+                entries: map_entries(entries),
+            },
+        )
     }
+}
 
-    /// Creates resource with the given initial supply.
+impl<A: ConfiguredAuth>
+    InProgressResourceBuilder<NonFungibleResourceType<IntegerNonFungibleLocalId>, A>
+{
+    /// Creates the non-fungible resource, and mints an individual non-fungible for each key/data pair provided.
     ///
-    /// # Example
+    /// ### Example
     /// ```no_run
     /// use scrypto::prelude::*;
     ///
@@ -554,269 +457,263 @@ impl<Y: IsNonAutoGeneratedNonFungibleLocalId> NonFungibleResourceBuilder<Y> {
     ///     pub flag: bool,
     /// }
     ///
-    /// # let owner_badge = NonFungibleGlobalId::new(ECDSA_SECP256K1_TOKEN, NonFungibleLocalId::integer(1));
-    ///
-    /// let bucket1 = ResourceBuilder::new_string_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply_with_owner([
-    ///         ("One".try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         ("Two".try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ], owner_badge);
-    ///
-    /// # let owner_badge = NonFungibleGlobalId::new(ECDSA_SECP256K1_TOKEN, NonFungibleLocalId::integer(1));
-    ///
-    /// let bucket2 = ResourceBuilder::new_integer_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply_with_owner([
+    /// let bucket = ResourceBuilder::new_integer_non_fungible()
+    ///     .mint_initial_supply([
     ///         (1u64.into(), NFData { name: "NF One".to_owned(), flag: true }),
     ///         (2u64.into(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ], owner_badge);
-    ///
-    /// # let owner_badge = NonFungibleGlobalId::new(ECDSA_SECP256K1_TOKEN, NonFungibleLocalId::integer(1));
-    ///
-    /// let bucket3 = ResourceBuilder::new_bytes_non_fungible()
-    ///     .metadata("name", "TestNonFungible")
-    ///     .initial_supply_with_owner([
-    ///         (vec![1u8].try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         (vec![2u8].try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ], owner_badge);
+    ///     ]);
     /// ```
-    pub fn initial_supply_with_owner<T, V>(
-        self,
-        entries: T,
-        owner_badge: NonFungibleGlobalId,
-    ) -> Bucket
+    pub fn mint_initial_supply<T, V>(self, entries: T) -> Bucket
     where
-        T: IntoIterator<Item = (Y, V)>,
+        T: IntoIterator<Item = (IntegerNonFungibleLocalId, V)>,
         V: NonFungibleData,
     {
-        let mut encoded = BTreeMap::new();
-        for (id, e) in entries {
-            encoded.insert(
-                id.into(),
-                (e.immutable_data().unwrap(), e.mutable_data().unwrap()),
-            );
-        }
-
-        let (_resource_address, bucket) = ScryptoEnv
-            .invoke(
-                ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
-                    id_type: Y::id_type(),
-                    metadata: self.metadata,
-                    access_rules: resource_access_rules_from_owner_badge(&owner_badge),
-                    entries: encoded,
-                },
-            )
-            .unwrap();
-
-        bucket
+        mint_from_invocation(
+            ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
+                id_type: IntegerNonFungibleLocalId::id_type(),
+                metadata: self.metadata,
+                access_rules: self.auth.into_access_rules(),
+                entries: map_entries(entries),
+            },
+        )
     }
 }
 
-impl NonFungibleResourceBuilder<UUIDNonFungibleLocalId> {
-    pub fn initial_supply_uuid<T, V>(self, entries: T) -> Bucket
+impl<A: ConfiguredAuth>
+    InProgressResourceBuilder<NonFungibleResourceType<BytesNonFungibleLocalId>, A>
+{
+    /// Creates the non-fungible resource, and mints an individual non-fungible for each key/data pair provided.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
+    /// #[derive(NonFungibleData)]
+    /// struct NFData {
+    ///     pub name: String,
+    ///     #[mutable]
+    ///     pub flag: bool,
+    /// }
+    ///
+    /// let bucket = ResourceBuilder::new_bytes_non_fungible()
+    ///     .mint_initial_supply([
+    ///         (vec![1u8].try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
+    ///         (vec![2u8].try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
+    ///     ]);
+    /// ```
+    pub fn mint_initial_supply<T, V>(self, entries: T) -> Bucket
+    where
+        T: IntoIterator<Item = (BytesNonFungibleLocalId, V)>,
+        V: NonFungibleData,
+    {
+        mint_from_invocation(
+            ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
+                id_type: BytesNonFungibleLocalId::id_type(),
+                metadata: self.metadata,
+                access_rules: self.auth.into_access_rules(),
+                entries: map_entries(entries),
+            },
+        )
+    }
+}
+
+impl<A: ConfiguredAuth>
+    InProgressResourceBuilder<NonFungibleResourceType<UUIDNonFungibleLocalId>, A>
+{
+    /// Creates the UUID non-fungible resource, and mints an individual non-fungible for each piece of data provided.
+    ///
+    /// The system automatically generates a new UUID `NonFungibleLocalId` for each non-fungible,
+    /// and assigns the given data to each.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
+    /// #[derive(NonFungibleData)]
+    /// struct NFData {
+    ///     pub name: String,
+    ///     #[mutable]
+    ///     pub flag: bool,
+    /// }
+    ///
+    /// let bucket = ResourceBuilder::new_uuid_non_fungible()
+    ///     .mint_initial_supply([
+    ///         (NFData { name: "NF One".to_owned(), flag: true }),
+    ///         (NFData { name: "NF Two".to_owned(), flag: true }),
+    ///     ]);
+    /// ```
+    pub fn mint_initial_supply<T, V>(self, entries: T) -> Bucket
     where
         T: IntoIterator<Item = V>,
         V: NonFungibleData,
     {
-        let mut encoded = BTreeSet::new();
-        for e in entries {
-            encoded.insert((e.immutable_data().unwrap(), e.mutable_data().unwrap()));
-        }
-
-        ScryptoEnv
-            .invoke(
-                ResourceManagerCreateUuidNonFungibleWithInitialSupplyInvocation {
-                    metadata: self.metadata,
-                    access_rules: BTreeMap::new(),
-                    entries: encoded,
-                },
-            )
-            .unwrap()
-            .1
-    }
-}
-
-/// A resource builder which builds non-fungible resources that do not have an owner-badge where
-/// resource behavior is completely handled by the developer.
-///  
-/// Typically this resource builder is created from the [`NonFungibleResourceBuilder`] once the
-/// developer has called one of the methods that set resource behavior. This is done as a static
-/// way of committing the developer to this choice by transitioning into a builder which does not
-/// offer the `initial_supply_with_owner` and `no_initial_supply_with_owner` methods.
-pub struct NonFungibleResourceWithAuthBuilder<Y: IsNonFungibleLocalId> {
-    metadata: BTreeMap<String, String>,
-    authorization: BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)>,
-    id_type: PhantomData<Y>,
-}
-
-impl<Y: IsNonFungibleLocalId> NonFungibleResourceWithAuthBuilder<Y> {
-    /// Adds a resource metadata.
-    ///
-    /// If a previous attribute with the same name has been set, it will be overwritten.
-    pub fn metadata<K: AsRef<str>, V: AsRef<str>>(mut self, name: K, value: V) -> Self {
-        self.metadata
-            .insert(name.as_ref().to_owned(), value.as_ref().to_owned());
-        self
-    }
-
-    pub fn mintable<R: Into<AccessRule>>(mut self, method_auth: AccessRule, mutability: R) -> Self {
-        self.authorization
-            .insert(Mint, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn burnable<R: Into<AccessRule>>(mut self, method_auth: AccessRule, mutability: R) -> Self {
-        self.authorization
-            .insert(Burn, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn recallable<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Recall, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn restrict_withdraw<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Withdraw, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn restrict_deposit<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(Deposit, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn updateable_metadata<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(UpdateMetadata, (method_auth, mutability.into()));
-        self
-    }
-
-    pub fn updateable_non_fungible_data<R: Into<AccessRule>>(
-        mut self,
-        method_auth: AccessRule,
-        mutability: R,
-    ) -> Self {
-        self.authorization
-            .insert(UpdateNonFungibleData, (method_auth, mutability.into()));
-        self
-    }
-
-    /// Creates resource with no initial supply.
-    pub fn no_initial_supply(self) -> ResourceAddress {
-        ScryptoEnv
-            .invoke(ResourceManagerCreateNonFungibleInvocation {
-                resource_address: None,
-                id_type: Y::id_type(),
+        mint_from_invocation(
+            ResourceManagerCreateUuidNonFungibleWithInitialSupplyInvocation {
                 metadata: self.metadata,
-                access_rules: self.authorization,
-            })
-            .unwrap()
+                access_rules: self.auth.into_access_rules(),
+                entries: entries
+                    .into_iter()
+                    .map(|data| (data.immutable_data().unwrap(), data.mutable_data().unwrap()))
+                    .collect(),
+            },
+        )
     }
 }
 
-impl<Y: IsNonAutoGeneratedNonFungibleLocalId> NonFungibleResourceWithAuthBuilder<Y> {
-    /// Creates resource with the given initial supply.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use scrypto::prelude::*;
-    ///
-    /// #[derive(NonFungibleData)]
-    /// struct NFData {
-    ///     pub name: String,
-    ///     #[mutable]
-    ///     pub flag: bool,
-    /// }
-    ///
-    /// let bucket1 = ResourceBuilder::new_string_non_fungible()
-    ///     .burnable(rule!(allow_all), rule!(deny_all))
-    ///     .initial_supply([
-    ///         ("One".try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         ("Two".try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ]);
-    ///
-    /// let bucket2 = ResourceBuilder::new_integer_non_fungible()
-    ///     .burnable(rule!(allow_all), rule!(deny_all))
-    ///     .initial_supply([
-    ///         (1u64.into(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         (2u64.into(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ]);
-    ///
-    /// let bucket3 = ResourceBuilder::new_bytes_non_fungible()
-    ///     .burnable(rule!(allow_all), rule!(deny_all))
-    ///     .initial_supply([
-    ///         (vec![1u8].try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
-    ///         (vec![2u8].try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
-    ///     ]);
-    /// ```
-    pub fn initial_supply<T, V>(self, entries: T) -> Bucket
-    where
-        T: IntoIterator<Item = (Y, V)>,
-        V: NonFungibleData,
-    {
-        let mut encoded = BTreeMap::new();
-        for (id, e) in entries {
-            encoded.insert(
+///////////////////////////////////
+/// PRIVATE TRAIT IMPLEMENTATIONS
+/// These don't need good rust docs
+///////////////////////////////////
+
+fn map_entries<T: IntoIterator<Item = (Y, V)>, V: NonFungibleData, Y: IsNonFungibleLocalId>(
+    entries: T,
+) -> BTreeMap<NonFungibleLocalId, (Vec<u8>, Vec<u8>)> {
+    entries
+        .into_iter()
+        .map(|(id, data)| {
+            (
                 id.into(),
-                (e.immutable_data().unwrap(), e.mutable_data().unwrap()),
-            );
-        }
-
-        ScryptoEnv
-            .invoke(
-                ResourceManagerCreateNonFungibleWithInitialSupplyInvocation {
-                    id_type: Y::id_type(),
-                    metadata: self.metadata,
-                    access_rules: self.authorization,
-                    entries: encoded,
-                },
+                (data.immutable_data().unwrap(), data.mutable_data().unwrap()),
             )
-            .unwrap()
-            .1
+        })
+        .collect()
+}
+
+fn mint_from_invocation(
+    invocation: impl SerializableInvocation<ScryptoOutput = (ResourceAddress, Bucket)>,
+) -> Bucket {
+    let (_resource_address, bucket) = ScryptoEnv.invoke(invocation).unwrap();
+
+    bucket
+}
+
+impl<T: ResourceType, A: ConfiguredAuth> private::CanAddMetadata
+    for InProgressResourceBuilder<T, A>
+{
+    type OutputBuilder = Self;
+
+    fn add_metadata(mut self, key: String, value: String) -> Self::OutputBuilder {
+        self.metadata.insert(key, value);
+        self
     }
 }
 
-impl NonFungibleResourceWithAuthBuilder<UUIDNonFungibleLocalId> {
-    pub fn initial_supply_uuid<T, V>(self, entries: T) -> Bucket
-    where
-        T: IntoIterator<Item = V>,
-        V: NonFungibleData,
-    {
-        let mut encoded = BTreeSet::new();
-        for e in entries {
-            encoded.insert((e.immutable_data().unwrap(), e.mutable_data().unwrap()));
-        }
+impl<T: ResourceType> private::CanAddAuth for InProgressResourceBuilder<T, NoAuth> {
+    type OutputBuilder = InProgressResourceBuilder<T, AccessRuleAuth>;
 
-        ScryptoEnv
-            .invoke(
-                ResourceManagerCreateUuidNonFungibleWithInitialSupplyInvocation {
-                    metadata: self.metadata,
-                    access_rules: self.authorization,
-                    entries: encoded,
-                },
-            )
-            .unwrap()
-            .1
+    fn add_auth(
+        self,
+        method: ResourceMethodAuthKey,
+        method_auth: AccessRule,
+        mutability: AccessRule,
+    ) -> Self::OutputBuilder {
+        Self::OutputBuilder {
+            resource_type: self.resource_type,
+            metadata: self.metadata,
+            auth: AccessRuleAuth(btreemap! { method => (method_auth, mutability) }),
+        }
+    }
+}
+
+impl<T: ResourceType> private::CanAddAuth for InProgressResourceBuilder<T, AccessRuleAuth> {
+    type OutputBuilder = Self;
+
+    fn add_auth(
+        mut self,
+        method: ResourceMethodAuthKey,
+        method_auth: AccessRule,
+        mutability: AccessRule,
+    ) -> Self::OutputBuilder {
+        self.auth.0.insert(method, (method_auth, mutability));
+        self
+    }
+}
+
+impl<T: ResourceType> private::CanAddOwner for InProgressResourceBuilder<T, NoAuth> {
+    type OutputBuilder = InProgressResourceBuilder<T, OwnerBadgeAuth>;
+
+    fn set_owner(self, owner_badge: NonFungibleGlobalId) -> Self::OutputBuilder {
+        Self::OutputBuilder {
+            resource_type: self.resource_type,
+            metadata: self.metadata,
+            auth: OwnerBadgeAuth(owner_badge),
+        }
+    }
+}
+
+impl<A: ConfiguredAuth> private::CanCreateWithNoSupply
+    for InProgressResourceBuilder<FungibleResourceType, A>
+{
+    type Invocation = ResourceManagerCreateFungibleInvocation;
+
+    fn into_create_with_no_supply_invocation(self) -> Self::Invocation {
+        Self::Invocation {
+            divisibility: self.resource_type.divisibility,
+            metadata: self.metadata,
+            access_rules: self.auth.into_access_rules(),
+        }
+    }
+}
+
+impl<A: ConfiguredAuth, Y: IsNonFungibleLocalId> private::CanCreateWithNoSupply
+    for InProgressResourceBuilder<NonFungibleResourceType<Y>, A>
+{
+    type Invocation = ResourceManagerCreateNonFungibleInvocation;
+
+    fn into_create_with_no_supply_invocation(self) -> Self::Invocation {
+        Self::Invocation {
+            resource_address: None,
+            id_type: Y::id_type(),
+            metadata: self.metadata,
+            access_rules: self.auth.into_access_rules(),
+        }
+    }
+}
+
+/// This file was experiencing combinatorial explosion - as part of the clean-up, we've used private traits to keep things simple.
+///
+/// Each public method has essentially one implementation, and one Rust doc (where there weren't clashes due to Rust trait issues -
+/// eg with the `mint_initial_supply` methods).
+///
+/// Internally, the various builders implement these private traits, and then automatically implement the "nice" public traits.
+/// The methods defined in the private traits are less nice, and so are hidden in order to not pollute the user facing API.
+///
+/// As users will nearly always use `scrypto::prelude::*`, as long as we make sure that the public traits are exported, this will
+/// be seamless for the user.
+///
+/// See https://stackoverflow.com/a/53207767 for more information on this.
+mod private {
+    use radix_engine_interface::{
+        api::wasm::SerializableInvocation,
+        model::{AccessRule, NonFungibleGlobalId, ResourceAddress, ResourceMethodAuthKey},
+    };
+
+    pub trait CanAddMetadata: Sized {
+        type OutputBuilder;
+
+        fn add_metadata(self, key: String, value: String) -> Self::OutputBuilder;
+    }
+
+    pub trait CanAddAuth: Sized {
+        type OutputBuilder;
+
+        fn add_auth(
+            self,
+            method: ResourceMethodAuthKey,
+            auth: AccessRule,
+            mutability: AccessRule,
+        ) -> Self::OutputBuilder;
+    }
+
+    pub trait CanAddOwner: Sized {
+        type OutputBuilder;
+
+        fn set_owner(self, owner_badge: NonFungibleGlobalId) -> Self::OutputBuilder;
+    }
+
+    pub trait CanCreateWithNoSupply: Sized {
+        type Invocation: SerializableInvocation<ScryptoOutput = ResourceAddress>;
+
+        fn into_create_with_no_supply_invocation(self) -> Self::Invocation;
     }
 }

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -22,6 +22,8 @@ pub const DIVISIBILITY_MAXIMUM: u8 = 18;
 ///
 /// ### Example
 /// ```no_run
+/// use scrypto::prelude::*;
+///
 /// let bucket = ResourceBuilder::new_fungible()
 ///     .metadata("name", "TestToken")
 ///     .mint_initial_supply(5);
@@ -68,6 +70,8 @@ impl ResourceBuilder {
 ///
 /// ### Example
 /// ```no_run
+/// use scrypto::prelude::*;
+///
 /// let bucket = ResourceBuilder::new_fungible()
 ///     .metadata("name", "TestToken")
 ///     .mint_initial_supply(5);
@@ -172,6 +176,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to be mintable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .mintable(rule!(require(badge.resource_address())), LOCKED);
@@ -196,6 +202,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to be burnable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .burnable(rule!(require(badge.resource_address())), LOCKED);
@@ -220,6 +228,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to be recallable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .recallable(rule!(require(badge.resource_address())), LOCKED);
@@ -244,6 +254,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to be withdrawable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .restrict_withdraw(rule!(require(badge.resource_address())), LOCKED);
@@ -268,6 +280,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to be depositable with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .restrict_deposit(rule!(require(badge.resource_address())), LOCKED);
@@ -292,6 +306,8 @@ pub trait UpdateAuthBuilder: private::CanAddAuth {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Sets the resource to allow its metadata to be updated with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
@@ -319,6 +335,8 @@ pub trait UpdateNonFungibleAuthBuilder: IsNonFungibleBuilder + private::CanAddAu
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Permits the updating of non-fungible mutable data with a proof of a specific resource, and this is locked forever.
     /// ResourceBuilder::new_fungible()
     ///    .updateable_metadata(rule!(require(badge.resource_address())), LOCKED);
@@ -369,6 +387,8 @@ impl<A: ConfiguredAuth> InProgressResourceBuilder<FungibleResourceType, A> {
     /// ### Examples
     ///
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// // Only permits whole-number balances.
     /// ResourceBuilder::new_fungible()
     ///    .divisibility(0);
@@ -389,6 +409,8 @@ impl<A: ConfiguredAuth> InProgressResourceBuilder<FungibleResourceType, A> {
     ///
     /// # Example
     /// ```no_run
+    /// use scrypto::prelude::*;
+    ///
     /// let bucket = ResourceBuilder::new_fungible()
     ///     .mint_initial_supply(5);
     /// ```

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -7,6 +7,7 @@ use radix_engine_interface::model::*;
 use sbor::rust::collections::*;
 use sbor::rust::marker::PhantomData;
 use sbor::rust::string::String;
+use sbor::rust::vec::Vec;
 
 /// Not divisible.
 pub const DIVISIBILITY_NONE: u8 = 0;
@@ -705,6 +706,7 @@ impl<A: ConfiguredAuth, Y: IsNonFungibleLocalId> private::CanCreateWithNoSupply
 ///
 /// See https://stackoverflow.com/a/53207767 for more information on this.
 mod private {
+    use super::*;
     use radix_engine_interface::{
         api::wasm::SerializableInvocation,
         model::{AccessRule, NonFungibleGlobalId, ResourceAddress, ResourceMethodAuthKey},

--- a/simulator/tests/blueprints/src/nfts.rs
+++ b/simulator/tests/blueprints/src/nfts.rs
@@ -15,7 +15,7 @@ mod foo {
             ResourceBuilder::new_uuid_non_fungible()
                 .metadata("name", "Cars!")
                 .metadata("description", "Fast Cars")
-                .initial_supply_uuid(vec![
+                .mint_initial_supply(vec![
                     Car {
                         manufacturer: "Ford".to_string(),
                         name: "Raptor".to_string(),

--- a/simulator/tests/blueprints/src/proofs.rs
+++ b/simulator/tests/blueprints/src/proofs.rs
@@ -20,7 +20,7 @@ mod proofs {
             let token = ResourceBuilder::new_fungible()
                 .mintable(organizational_access_rule.clone(), LOCKED)
                 .restrict_withdraw(organizational_access_rule.clone(), LOCKED)
-                .initial_supply(100);
+                .mint_initial_supply(100);
 
             // Creating the access rules for the component and instantiating an new component
             let access_rules: AccessRules = AccessRules::new()
@@ -44,7 +44,7 @@ mod proofs {
             ResourceBuilder::new_fungible()
                 .divisibility(0)
                 .metadata("name", name)
-                .initial_supply(1)
+                .mint_initial_supply(1)
         }
 
         pub fn organizational_authenticated_method(&self) {


### PR DESCRIPTION
Many improvements to the ResourceBuilder

Notably:
* `initial_supply` replaced by `mint_initial_supply`
* `initial_supply_uuid` replaced by `mint_initial_supply`
* `no_initial_supply` replaced by `create_with_no_initial_supply`
* `no_initial_supply_with_owner(x)` replaced by `owner_non_fungible_badge(x).create_with_no_initial_supply()`
* `initial_supply_with_owner(x, y)` replaced by `owner_non_fungible_badge(x).mint_initial_supply(y)`
* Much improved rust docs
* Much cleaner / less duplicated code 👍

Example:
![Screenshot 2023-02-12 at 03 30 20](https://user-images.githubusercontent.com/8008816/218291420-030d5c21-d274-4465-9b97-5f050b4f5bda.png)
