### PR TITLE
fix: Fix Describe for code larger than 1024 bytes

### DIFF
--- a/radix-engine-derive/src/describe.rs
+++ b/radix-engine-derive/src/describe.rs
@@ -32,7 +32,7 @@ mod tests {
                         stringify!(MyStruct),
                         &[],
                         &[
-                            166u8 , 8u8 , 203u8 , 237u8 , 240u8 , 100u8 , 48u8 , 65u8 , 192u8 , 182u8 , 26u8 , 218u8 , 100u8 , 240u8 , 229u8 , 17u8 , 92u8 , 21u8 , 151u8 , 203u8
+                            10u8, 39u8, 14u8, 207u8, 57u8, 233u8, 147u8, 10u8, 71u8, 184u8, 189u8, 42u8, 152u8, 227u8, 9u8, 254u8, 53u8, 33u8, 170u8, 163u8
                         ]
                     );
                     fn type_data() -> Option<::sbor::TypeData<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>, ::sbor::GlobalTypeId>> {
@@ -63,7 +63,7 @@ mod tests {
                         stringify!(MyEnum),
                         &[T::TYPE_ID,],
                         &[
-                            202u8 , 64u8 , 77u8 , 129u8 , 131u8 , 173u8 , 166u8 , 2u8 , 101u8 , 2u8 , 106u8 , 141u8 , 244u8 , 11u8 , 198u8 , 78u8 , 18u8 , 157u8 , 25u8 , 72u8
+                            114u8, 163u8, 82u8, 202u8, 41u8, 220u8, 108u8, 111u8, 255u8, 110u8, 181u8, 107u8, 236u8, 117u8, 168u8, 151u8, 231u8, 247u8, 144u8, 85u8
                         ]
                     );
                     fn type_data() -> Option<::sbor::TypeData<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>, ::sbor::GlobalTypeId>> {
@@ -71,8 +71,8 @@ mod tests {
                         Some(::sbor::TypeData::named_enum(
                             stringify!(MyEnum),
                             :: sbor :: rust :: collections :: btree_map :: btreemap ! [
-                                0u8 => :: sbor :: TypeData :: named_fields_tuple ("A" , :: sbor :: rust :: vec ! [("named" , < T as :: sbor :: Describe < radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >> :: TYPE_ID) ,] ,) ,
-                                1u8 => :: sbor :: TypeData :: named_tuple ("B" , :: sbor :: rust :: vec ! [< String as :: sbor :: Describe < radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >> :: TYPE_ID ,] ,) ,
+                                0u8 => :: sbor :: TypeData :: named_fields_tuple ("A", :: sbor :: rust :: vec ! [("named", < T as :: sbor :: Describe < radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >> :: TYPE_ID) ,] ,) ,
+                                1u8 => :: sbor :: TypeData :: named_tuple ("B", :: sbor :: rust :: vec ! [< String as :: sbor :: Describe < radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >> :: TYPE_ID ,] ,) ,
                                 2u8 => :: sbor :: TypeData :: named_unit ("C") ,
                             ],
                         ))

--- a/sbor-derive-common/src/describe.rs
+++ b/sbor-derive-common/src/describe.rs
@@ -262,7 +262,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[159u8 , 209u8 , 242u8 , 94u8 , 4u8 , 85u8 , 29u8 , 88u8 , 103u8 , 42u8 , 6u8 , 107u8 , 55u8 , 82u8 , 41u8 , 37u8 , 138u8 , 251u8 , 115u8 , 188u8]
+                        &[63u8, 255u8, 173u8, 220u8, 251u8, 214u8, 95u8, 139u8, 106u8, 20u8, 23u8, 4u8, 15u8, 10u8, 124u8, 49u8, 219u8, 44u8, 235u8, 215u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -304,7 +304,7 @@ mod tests {
                         stringify!(Test),
                         &[],
                         &[
-                            159u8 , 209u8 , 242u8 , 94u8 , 4u8 , 85u8 , 29u8 , 88u8 , 103u8 , 42u8 , 6u8 , 107u8 , 55u8 , 82u8 , 41u8 , 37u8 , 138u8 , 251u8 , 115u8 , 188u8
+                            63u8, 255u8, 173u8, 220u8, 251u8, 214u8, 95u8, 139u8, 106u8, 20u8, 23u8, 4u8, 15u8, 10u8, 124u8, 49u8, 219u8, 44u8, 235u8, 215u8
                         ]
                     );
                     fn type_data() -> Option<
@@ -360,7 +360,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[34u8 , 114u8 , 203u8 , 221u8 , 124u8 , 31u8 , 95u8 , 225u8 , 232u8 , 133u8 , 214u8 , 82u8 , 163u8 , 166u8 , 47u8 , 94u8 , 1u8 , 45u8 , 24u8 , 85u8]
+                        &[85u8, 53u8, 15u8, 85u8, 176u8, 230u8, 4u8, 110u8, 15u8, 96u8, 35u8, 64u8, 192u8, 210u8, 254u8, 146u8, 192u8, 7u8, 246u8, 5u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -395,7 +395,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[191u8 , 160u8 , 163u8 , 134u8 , 72u8 , 226u8 , 165u8 , 105u8 , 145u8 , 247u8 , 102u8 , 49u8 , 49u8 , 92u8 , 177u8 , 109u8 , 66u8 , 111u8 , 153u8 , 93u8]
+                        &[167u8, 108u8, 181u8, 130u8, 168u8, 229u8, 85u8, 237u8, 66u8, 69u8, 34u8, 138u8, 113u8, 220u8, 225u8, 107u8, 0u8, 247u8, 189u8, 58u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -419,7 +419,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[T::TYPE_ID, T2::TYPE_ID,],
-                        &[128u8 , 130u8 , 11u8 , 0u8 , 197u8 , 86u8 , 125u8 , 186u8 , 15u8 , 144u8 , 196u8 , 61u8 , 236u8 , 39u8 , 235u8 , 228u8 , 7u8 , 225u8 , 251u8 , 25u8]
+                        &[107u8, 144u8, 17u8, 82u8, 110u8, 162u8, 58u8, 11u8, 170u8, 99u8, 11u8, 157u8, 132u8, 243u8, 106u8, 138u8, 8u8, 152u8, 239u8, 22u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -146,9 +146,7 @@ pub fn get_code_hash_const_array_token_stream(input: &TokenStream) -> TokenStrea
 }
 
 pub fn get_hash_of_code(input: &TokenStream) -> [u8; 20] {
-    let buffer = const_sha1::ConstSlice::new();
-    let buffer = buffer.push_slice(input.to_string().as_bytes());
-    const_sha1::sha1(buffer.as_slice()).as_bytes()
+    const_sha1::sha1(input.to_string().as_bytes()).as_bytes()
 }
 
 pub fn get_unique_types<'a>(types: &[&'a syn::Type]) -> Vec<&'a syn::Type> {


### PR DESCRIPTION
Tiny fix which fixes the `ScryptoSbor` derive