### PR TITLE
Feature: Schemas can be encoded

### DIFF
--- a/radix-engine-derive/src/decode.rs
+++ b/radix-engine-derive/src/decode.rs
@@ -55,9 +55,12 @@ mod tests {
             output,
             quote! {
                 impl<
-                        T: Bound + ::sbor::Decode<radix_engine_interface::data::ScryptoCustomValueKind, D>,
+                        T: Bound,
                         D: ::sbor::Decoder<radix_engine_interface::data::ScryptoCustomValueKind>
                     > ::sbor::Decode<radix_engine_interface::data::ScryptoCustomValueKind, D> for MyEnum<T>
+                where
+                    T: ::sbor::Decode<radix_engine_interface::data::ScryptoCustomValueKind, D>,
+                    T: ::sbor::Categorize<radix_engine_interface::data::ScryptoCustomValueKind>
                 {
                     #[inline]
                     fn decode_body_with_value_kind(

--- a/radix-engine-derive/src/describe.rs
+++ b/radix-engine-derive/src/describe.rs
@@ -56,12 +56,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<T: Bound + ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> > >
+                impl<T: Bound>
                     ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> > for MyEnum<T>
+                where
+                    T: ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >,
+                    T: ::sbor::Categorize<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>::CustomValueKind >
                 {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(MyEnum),
-                        &[T::TYPE_ID,],
+                        &[<T>::TYPE_ID,],
                         &[
                             202u8 , 64u8 , 77u8 , 129u8 , 131u8 , 173u8 , 166u8 , 2u8 , 101u8 , 2u8 , 106u8 , 141u8 , 244u8 , 11u8 , 198u8 , 78u8 , 18u8 , 157u8 , 25u8 , 72u8
                         ]

--- a/radix-engine-derive/src/encode.rs
+++ b/radix-engine-derive/src/encode.rs
@@ -55,9 +55,12 @@ mod tests {
             output,
             quote! {
                 impl<
-                        T: Bound + ::sbor::Encode<radix_engine_interface::data::ScryptoCustomValueKind, E>,
+                        T: Bound,
                         E: ::sbor::Encoder<radix_engine_interface::data::ScryptoCustomValueKind>
                     > ::sbor::Encode<radix_engine_interface::data::ScryptoCustomValueKind, E> for MyEnum<T>
+                where
+                    T: ::sbor::Encode<radix_engine_interface::data::ScryptoCustomValueKind, E>,
+                    T: ::sbor::Categorize<radix_engine_interface::data::ScryptoCustomValueKind>
                 {
                     #[inline]
                     fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {

--- a/sbor-derive-common/src/decode.rs
+++ b/sbor-derive-common/src/decode.rs
@@ -272,7 +272,13 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <T: ::sbor::Decode<X, D0>, D: Clashing + ::sbor::Decode<X, D0>, D0: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D0> for Test<T, D > {
+                impl <T, D: Clashing, D0: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind> ::sbor::Decode<X, D0> for Test<T, D>
+                    where
+                        T : ::sbor::Decode<X, D0>,
+                        D : ::sbor::Decode<X, D0>,
+                        T : ::sbor::Categorize<X>,
+                        D : ::sbor::Categorize<X>
+                {
                     #[inline]
                     fn decode_body_with_value_kind(decoder: &mut D0, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
                         use ::sbor::{self, Decode};
@@ -316,13 +322,20 @@ mod tests {
 
     #[test]
     fn test_decode_struct_with_generic_params() {
-        let input = TokenStream::from_str("#[sbor(generic_categorize_bounds = \"T1, T2\")] struct Test<'a, S, T1, T2> {a: &'a u32, b: S, c: Vec<T1>, d: Vec<T2>}").unwrap();
+        let input = TokenStream::from_str("#[sbor(categorize_types = \"T1, T2\")] struct Test<'a, S, T1, T2> {a: &'a u32, b: S, c: Vec<T1>, d: Vec<T2>}").unwrap();
         let output = handle_decode(input, None).unwrap();
 
         assert_code_eq(
             output,
             quote! {
-                impl <'a, S: ::sbor::Decode<X, D>, T1: ::sbor::Decode<X,D> + ::sbor::Categorize<X>, T2: ::sbor::Decode <X, D>, D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test<'a, S, T1, T2> {
+                impl <'a, S, T1, T2, D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test<'a, S, T1, T2>
+                where
+                    S: ::sbor::Decode<X, D>,
+                    T1: ::sbor::Decode<X, D>,
+                    T2: ::sbor::Decode<X, D>,
+                    T1: ::sbor::Categorize<X>,
+                    T2: ::sbor::Categorize<X>
+                {
                     #[inline]
                     fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
                         use ::sbor::{self, Decode};

--- a/sbor-derive-common/src/describe.rs
+++ b/sbor-derive-common/src/describe.rs
@@ -46,7 +46,7 @@ fn handle_transparent_describe(
         generics,
         ..
     } = parsed;
-    let (impl_generics, ty_generics, where_clause, custom_type_kind_generic) =
+    let (impl_generics, ty_generics, where_clause, _, custom_type_kind_generic) =
         build_describe_generics(&generics, &attrs, context_custom_type_kind)?;
 
     let output = match data {
@@ -99,13 +99,8 @@ fn handle_normal_describe(
         generics,
         ..
     } = parsed;
-    let (impl_generics, ty_generics, where_clause, custom_type_kind_generic) =
+    let (impl_generics, ty_generics, where_clause, child_types, custom_type_kind_generic) =
         build_describe_generics(&generics, &attrs, context_custom_type_kind)?;
-
-    let generic_type_idents = ty_generics
-        .type_params()
-        .map(|t| &t.ident)
-        .collect::<Vec<_>>();
 
     let output = match data {
         Data::Struct(s) => match s.fields {
@@ -137,7 +132,7 @@ fn handle_normal_describe(
                             // Note that it might seem possible to still hit issues with infinite recursion, if you pass a type as its own generic type parameter.
                             // EG (via a type alias B = A<B>), but these types won't come up in practice because they require an infinite generic depth
                             // which the compiler will throw out for other reasons.
-                            &[#(<#generic_type_idents>::TYPE_ID,)*],
+                            &[#(<#child_types>::TYPE_ID,)*],
                             &#code_hash
                         );
 
@@ -176,7 +171,7 @@ fn handle_normal_describe(
                             // Note that it might seem possible to still hit issues with infinite recursion, if you pass a type as its own generic type parameter.
                             // EG (via a type alias B = A<B>), but these types won't come up in practice because they require an infinite generic depth
                             // which the compiler will throw out for other reasons.
-                            &[#(#generic_type_idents::TYPE_ID,)*],
+                            &[#(<#child_types>::TYPE_ID,)*],
                             &#code_hash
                         );
 
@@ -200,7 +195,7 @@ fn handle_normal_describe(
                     impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
                         const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                             stringify!(#ident),
-                            &[#(#generic_type_idents::TYPE_ID,)*],
+                            &[#(<#child_types>::TYPE_ID,)*],
                             &#code_hash
                         );
 
@@ -280,7 +275,7 @@ fn handle_normal_describe(
                 impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(#ident),
-                        &[#(#generic_type_idents::TYPE_ID,)*],
+                        &[#(<#child_types>::TYPE_ID,)*],
                         &#code_hash
                     );
 
@@ -331,7 +326,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[159u8 , 209u8 , 242u8 , 94u8 , 4u8 , 85u8 , 29u8 , 88u8 , 103u8 , 42u8 , 6u8 , 107u8 , 55u8 , 82u8 , 41u8 , 37u8 , 138u8 , 251u8 , 115u8 , 188u8]
+                        &[159u8, 209u8, 242u8, 94u8, 4u8, 85u8, 29u8, 88u8, 103u8, 42u8, 6u8, 107u8, 55u8, 82u8, 41u8, 37u8, 138u8, 251u8, 115u8, 188u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -373,7 +368,7 @@ mod tests {
                         stringify!(Test),
                         &[],
                         &[
-                            159u8 , 209u8 , 242u8 , 94u8 , 4u8 , 85u8 , 29u8 , 88u8 , 103u8 , 42u8 , 6u8 , 107u8 , 55u8 , 82u8 , 41u8 , 37u8 , 138u8 , 251u8 , 115u8 , 188u8
+                            159u8, 209u8, 242u8, 94u8, 4u8, 85u8, 29u8, 88u8, 103u8, 42u8, 6u8, 107u8, 55u8, 82u8, 41u8, 37u8, 138u8, 251u8, 115u8, 188u8
                         ]
                     );
                     fn type_data() -> Option<
@@ -429,7 +424,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[34u8 , 114u8 , 203u8 , 221u8 , 124u8 , 31u8 , 95u8 , 225u8 , 232u8 , 133u8 , 214u8 , 82u8 , 163u8 , 166u8 , 47u8 , 94u8 , 1u8 , 45u8 , 24u8 , 85u8]
+                        &[34u8, 114u8, 203u8, 221u8, 124u8, 31u8, 95u8, 225u8, 232u8, 133u8, 214u8, 82u8, 163u8, 166u8, 47u8, 94u8, 1u8, 45u8, 24u8, 85u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -464,7 +459,7 @@ mod tests {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
                         &[],
-                        &[191u8 , 160u8 , 163u8 , 134u8 , 72u8 , 226u8 , 165u8 , 105u8 , 145u8 , 247u8 , 102u8 , 49u8 , 49u8 , 92u8 , 177u8 , 109u8 , 66u8 , 111u8 , 153u8 , 93u8]
+                        &[191u8, 160u8, 163u8, 134u8, 72u8, 226u8, 165u8, 105u8, 145u8, 247u8, 102u8, 49u8, 49u8, 92u8, 177u8, 109u8, 66u8, 111u8, 153u8, 93u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {
@@ -478,17 +473,22 @@ mod tests {
     #[test]
     fn test_complex_enum_schema() {
         let input =
-            TokenStream::from_str("#[sbor(generic_categorize_bounds = \"T2\")] enum Test<T: SomeTrait, T2> {A, B (T, Vec<T2>, #[sbor(skip)] i32), C {x: [u8; 5]}}").unwrap();
+            TokenStream::from_str("#[sbor(categorize_types = \"T2\")] enum Test<T: SomeTrait, T2> {A, B (T, Vec<T2>, #[sbor(skip)] i32), C {x: [u8; 5]}}").unwrap();
         let output = handle_describe(input, None).unwrap();
 
         assert_code_eq(
             output,
             quote! {
-                impl <T: SomeTrait + ::sbor::Describe<C>, T2: ::sbor::Describe<C> + ::sbor::Categorize<C::CustomValueKind>, C: ::sbor::CustomTypeKind<::sbor::GlobalTypeId> > ::sbor::Describe<C> for Test<T, T2> {
+                impl <T: SomeTrait, T2, C: ::sbor::CustomTypeKind<::sbor::GlobalTypeId> > ::sbor::Describe<C> for Test<T, T2>
+                where
+                    T: ::sbor::Describe<C>,
+                    T2: ::sbor::Describe<C>,
+                    T2: ::sbor::Categorize<C::CustomValueKind>
+                {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),
-                        &[T::TYPE_ID, T2::TYPE_ID,],
-                        &[128u8 , 130u8 , 11u8 , 0u8 , 197u8 , 86u8 , 125u8 , 186u8 , 15u8 , 144u8 , 196u8 , 61u8 , 236u8 , 39u8 , 235u8 , 228u8 , 7u8 , 225u8 , 251u8 , 25u8]
+                        &[<T>::TYPE_ID, <T2>::TYPE_ID,],
+                        &[53u8, 102u8, 114u8, 88u8, 176u8, 193u8, 133u8, 184u8, 140u8, 124u8, 151u8, 120u8, 108u8, 184u8, 217u8, 14u8, 89u8, 95u8, 159u8, 189u8]
                     );
 
                     fn type_data() -> Option<::sbor::TypeData <C, ::sbor::GlobalTypeId>> {

--- a/sbor-derive-common/src/encode.rs
+++ b/sbor-derive-common/src/encode.rs
@@ -291,7 +291,13 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <T: ::sbor::Encode<X, E0>, E: Clashing + ::sbor::Encode<X, E0>, E0: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E0> for Test<T, E > {
+                impl <T, E: Clashing, E0: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E0> for Test<T, E >
+                where
+                    T: ::sbor::Encode<X, E0>,
+                    E: ::sbor::Encode<X, E0>,
+                    T: ::sbor::Categorize<X>,
+                    E: ::sbor::Categorize<X>
+                {
                     #[inline]
                     fn encode_value_kind(&self, encoder: &mut E0) -> Result<(), ::sbor::EncodeError> {
                         encoder.write_value_kind(::sbor::ValueKind::Tuple)

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -76,6 +76,14 @@ pub fn extract_attributes(
     None
 }
 
+fn get_sbor_attribute_field_value(attributes: &[Attribute], field_name: &str) -> Option<String> {
+    if let Some(fields) = extract_attributes(attributes, "sbor") {
+        fields.get(field_name).cloned().unwrap_or_default()
+    } else {
+        None
+    }
+}
+
 pub fn is_categorize_skipped(f: &Field) -> bool {
     if let Some(fields) = extract_attributes(&f.attrs, "sbor") {
         fields.contains_key("skip") || fields.contains_key("skip_categorize")
@@ -117,42 +125,59 @@ pub fn is_transparent(attributes: &[Attribute]) -> bool {
 }
 
 pub fn get_custom_value_kind(attributes: &[Attribute]) -> Option<String> {
-    if let Some(fields) = extract_attributes(attributes, "sbor") {
-        fields.get("custom_value_kind").cloned().unwrap_or_default()
-    } else {
-        None
-    }
+    get_sbor_attribute_field_value(attributes, "custom_value_kind")
 }
 
 pub fn get_custom_type_kind(attributes: &[Attribute]) -> Option<String> {
-    if let Some(fields) = extract_attributes(attributes, "sbor") {
-        fields.get("custom_type_kind").cloned().unwrap_or_default()
-    } else {
-        None
-    }
+    get_sbor_attribute_field_value(attributes, "custom_type_kind")
 }
 
-pub fn get_generic_categorize_bounds(attributes: &[Attribute]) -> Option<String> {
-    if let Some(fields) = extract_attributes(attributes, "sbor") {
-        fields
-            .get("generic_categorize_bounds")
-            .cloned()
-            .unwrap_or_default()
-    } else {
-        None
-    }
-}
-
-pub fn get_generic_type_names_requiring_categorize_bound(
-    attributes: &[Attribute],
-) -> HashSet<String> {
-    let Some(comma_separated_types) = get_generic_categorize_bounds(attributes) else {
-        return HashSet::new();
-    };
-    comma_separated_types
-        .split(',')
-        .map(|s| s.to_owned())
+pub fn get_generic_types(generics: &Generics) -> Vec<Type> {
+    generics
+        .type_params()
+        .map(|type_param| {
+            let ident = &type_param.ident;
+            parse_quote!(#ident)
+        })
         .collect()
+}
+
+pub fn parse_comma_separated_types(source_string: &str) -> syn::Result<Vec<Type>> {
+    source_string
+        .split(',')
+        .map(|s| s.trim().to_owned())
+        .filter(|f| f.len() > 0)
+        .map(|s| parse_str(&s))
+        .collect()
+}
+
+fn get_child_types(
+    attributes: &[Attribute],
+    existing_generics: &Generics,
+) -> syn::Result<Vec<Type>> {
+    let Some(comma_separated_types) = get_sbor_attribute_field_value(attributes, "child_types") else {
+        // If no explicit child_types list is set, we use all pre-existing generic type parameters.
+        // This means (eg) that they all have to implement the relevant trait (Encode/Decode/Describe)
+        // This is essentially what derived traits such as Clone do: https://github.com/rust-lang/rust/issues/26925
+        // It's not perfect - but it's typically good enough!
+        return Ok(get_generic_types(existing_generics));
+    };
+
+    parse_comma_separated_types(&comma_separated_types)
+}
+
+fn get_types_requiring_categorize_bound(
+    attributes: &[Attribute],
+    child_types: &[Type],
+) -> syn::Result<Vec<Type>> {
+    let Some(comma_separated_types) = get_sbor_attribute_field_value(attributes, "categorize_types") else {
+        // A categorize bound is only needed for child types when you have a collection, eg Vec<T>
+        // But if no explicit "categorize_types" is set, we assume all are needed.
+        // These can be removed / overriden with the "categorize_types" field
+        return Ok(child_types.to_owned());
+    };
+
+    parse_comma_separated_types(&comma_separated_types)
 }
 
 pub fn get_code_hash_const_array_token_stream(input: &TokenStream) -> TokenStream {
@@ -295,16 +320,8 @@ pub fn build_decode_generics<'a>(
     original_generics: &'a Generics,
     attributes: &'a [Attribute],
     context_custom_value_kind: Option<&'static str>,
-) -> syn::Result<(
-    Generics,
-    TypeGenerics<'a>,
-    Option<&'a WhereClause>,
-    Path,
-    Path,
-)> {
+) -> syn::Result<(Generics, TypeGenerics<'a>, Option<WhereClause>, Path, Path)> {
     let custom_value_kind = get_custom_value_kind(&attributes);
-    let generic_type_names_needing_categorize_bound =
-        get_generic_type_names_requiring_categorize_bound(&attributes);
     let (impl_generics, ty_generics, where_clause) = original_generics.split_for_impl();
 
     // Extract owned generic to allow mutation
@@ -323,23 +340,26 @@ pub fn build_decode_generics<'a>(
     let decoder_label = find_free_generic_name(original_generics, "D")?;
     let decoder_generic: Path = parse_str(&decoder_label)?;
 
-    // Add a bound that all pre-existing type parameters have to implement Decode<X, D>
-    // This is essentially what derived traits such as Clone do: https://github.com/rust-lang/rust/issues/26925
-    // It's not perfect - but it's typically good enough!
+    let child_types = get_child_types(&attributes, &impl_generics)?;
+    let categorize_types = get_types_requiring_categorize_bound(&attributes, &child_types)?;
 
-    for param in impl_generics.params.iter_mut() {
-        let GenericParam::Type(type_param) = param else {
-            continue;
-        };
-        type_param
-            .bounds
-            .push(parse_quote!(::sbor::Decode<#custom_value_kind_generic, #decoder_generic>));
-
-        if generic_type_names_needing_categorize_bound.contains(&type_param.ident.to_string()) {
-            type_param
-                .bounds
-                .push(parse_quote!(::sbor::Categorize<#custom_value_kind_generic>));
+    let mut where_clause = where_clause.cloned();
+    if child_types.len() > 0 || categorize_types.len() > 0 {
+        let mut new_where_clause = where_clause.unwrap_or(WhereClause {
+            where_token: Default::default(),
+            predicates: Default::default(),
+        });
+        for child_type in child_types {
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#child_type: ::sbor::Decode<#custom_value_kind_generic, #decoder_generic>));
         }
+        for categorize_type in categorize_types {
+            new_where_clause.predicates.push(
+                parse_quote!(#categorize_type: ::sbor::Categorize<#custom_value_kind_generic>),
+            );
+        }
+        where_clause = Some(new_where_clause);
     }
 
     impl_generics
@@ -365,16 +385,8 @@ pub fn build_encode_generics<'a>(
     original_generics: &'a Generics,
     attributes: &'a [Attribute],
     context_custom_value_kind: Option<&'static str>,
-) -> syn::Result<(
-    Generics,
-    TypeGenerics<'a>,
-    Option<&'a WhereClause>,
-    Path,
-    Path,
-)> {
+) -> syn::Result<(Generics, TypeGenerics<'a>, Option<WhereClause>, Path, Path)> {
     let custom_value_kind = get_custom_value_kind(&attributes);
-    let generic_type_names_needing_categorize_bound =
-        get_generic_type_names_requiring_categorize_bound(&attributes);
     let (impl_generics, ty_generics, where_clause) = original_generics.split_for_impl();
 
     // Extract owned generic to allow mutation
@@ -393,23 +405,26 @@ pub fn build_encode_generics<'a>(
     let encoder_label = find_free_generic_name(original_generics, "E")?;
     let encoder_generic: Path = parse_str(&encoder_label)?;
 
-    // Add a bound that all pre-existing type parameters have to implement Encode<X, E>
-    // This is essentially what derived traits such as Clone do: https://github.com/rust-lang/rust/issues/26925
-    // It's not perfect - but it's typically good enough!
+    let child_types = get_child_types(&attributes, &impl_generics)?;
+    let categorize_types = get_types_requiring_categorize_bound(&attributes, &child_types)?;
 
-    for param in impl_generics.params.iter_mut() {
-        let GenericParam::Type(type_param) = param else {
-            continue;
-        };
-        type_param
-            .bounds
-            .push(parse_quote!(::sbor::Encode<#custom_value_kind_generic, #encoder_generic>));
-
-        if generic_type_names_needing_categorize_bound.contains(&type_param.ident.to_string()) {
-            type_param
-                .bounds
-                .push(parse_quote!(::sbor::Categorize<#custom_value_kind_generic>));
+    let mut where_clause = where_clause.cloned();
+    if child_types.len() > 0 || categorize_types.len() > 0 {
+        let mut new_where_clause = where_clause.unwrap_or(WhereClause {
+            where_token: Default::default(),
+            predicates: Default::default(),
+        });
+        for child_type in child_types {
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#child_type: ::sbor::Encode<#custom_value_kind_generic, #encoder_generic>));
         }
+        for categorize_type in categorize_types {
+            new_where_clause.predicates.push(
+                parse_quote!(#categorize_type: ::sbor::Categorize<#custom_value_kind_generic>),
+            );
+        }
+        where_clause = Some(new_where_clause);
     }
 
     impl_generics
@@ -435,10 +450,8 @@ pub fn build_describe_generics<'a>(
     original_generics: &'a Generics,
     attributes: &'a [Attribute],
     context_custom_type_kind: Option<&'static str>,
-) -> syn::Result<(Generics, Generics, Option<&'a WhereClause>, Path)> {
+) -> syn::Result<(Generics, Generics, Option<WhereClause>, Vec<Type>, Path)> {
     let custom_type_kind = get_custom_type_kind(attributes);
-    let generic_type_names_needing_categorize_bound =
-        get_generic_type_names_requiring_categorize_bound(&attributes);
 
     let (impl_generics, ty_generics, where_clause) = original_generics.split_for_impl();
 
@@ -455,23 +468,26 @@ pub fn build_describe_generics<'a>(
             (parse_str(&custom_type_label)?, true)
         };
 
-    // Add a bound that all pre-existing type parameters have to implement Encode<X, E>
-    // This is essentially what derived traits such as Clone do: https://github.com/rust-lang/rust/issues/26925
-    // It's not perfect - but it's typically good enough!
+    let child_types = get_child_types(&attributes, &impl_generics)?;
+    let categorize_types = get_types_requiring_categorize_bound(&attributes, &child_types)?;
 
-    for param in impl_generics.params.iter_mut() {
-        let GenericParam::Type(type_param) = param else {
-            continue;
-        };
-        type_param
-            .bounds
-            .push(parse_quote!(::sbor::Describe<#custom_type_kind_generic>));
-
-        if generic_type_names_needing_categorize_bound.contains(&type_param.ident.to_string()) {
-            type_param
-                .bounds
-                .push(parse_quote!(::sbor::Categorize<#custom_type_kind_generic::CustomValueKind>));
+    let mut where_clause = where_clause.cloned();
+    if child_types.len() > 0 || categorize_types.len() > 0 {
+        let mut new_where_clause = where_clause.unwrap_or(WhereClause {
+            where_token: Default::default(),
+            predicates: Default::default(),
+        });
+        for child_type in child_types.iter() {
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#child_type: ::sbor::Describe<#custom_type_kind_generic>));
         }
+        for categorize_type in categorize_types {
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#categorize_type: ::sbor::Categorize<#custom_type_kind_generic::CustomValueKind>));
+        }
+        where_clause = Some(new_where_clause);
     }
 
     if need_to_add_ctk_generic {
@@ -486,6 +502,7 @@ pub fn build_describe_generics<'a>(
         impl_generics,
         ty_generics,
         where_clause,
+        child_types,
         custom_type_kind_generic,
     ))
 }

--- a/sbor-tests/tests/schema.rs
+++ b/sbor-tests/tests/schema.rs
@@ -17,7 +17,7 @@ pub struct BasicSample {
 }
 
 #[derive(Categorize, Encode, Decode, Describe)]
-#[sbor(generic_categorize_bounds = "S,T")]
+#[sbor(categorize_types = "S, T")]
 pub struct AdvancedSample<T, S> {
     pub a: (),
     pub b: u32,

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -47,6 +47,9 @@ impl<T: for<'a> Decode<NoCustomValueKind, BasicDecoder<'a>>> BasicDecode for T {
 pub trait BasicEncode: for<'a> Encode<NoCustomValueKind, BasicEncoder<'a>> {}
 impl<T: for<'a> Encode<NoCustomValueKind, BasicEncoder<'a>> + ?Sized> BasicEncode for T {}
 
+pub trait BasicDescribe: for<'a> Describe<NoCustomTypeKind> {}
+impl<T: Describe<NoCustomTypeKind> + ?Sized> BasicDescribe for T {}
+
 /// Encode a `T` into byte array.
 pub fn basic_encode<T: BasicEncode + ?Sized>(v: &T) -> Result<Vec<u8>, EncodeError> {
     let mut buf = Vec::with_capacity(512);
@@ -94,7 +97,7 @@ pub use schema::*;
 mod schema {
     use super::*;
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq, Sbor)]
     pub enum NoCustomTypeKind {}
 
     impl<L: SchemaTypeLink> CustomTypeKind<L> for NoCustomTypeKind {
@@ -103,7 +106,7 @@ mod schema {
         type CustomTypeExtension = NoCustomTypeExtension;
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone, PartialEq, Eq, Sbor)]
     pub enum NoCustomTypeValidation {}
 
     impl CustomTypeValidation for NoCustomTypeValidation {}

--- a/sbor/src/rust.rs
+++ b/sbor/src/rust.rs
@@ -22,6 +22,7 @@ pub mod prelude {
     pub use super::iter::FromIterator;
 
     // And some extra useful additions we use a lot:
+    pub use super::borrow::Cow;
     pub use super::collections::*;
     pub use super::fmt::{Debug, Display};
     pub use super::format;
@@ -152,6 +153,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! btreemap {
+            ( ) => ({
+                $crate::rust::collections::btree_map::BTreeMap::new()
+            });
             ( $($key:expr => $value:expr),* ) => ({
                 let mut temp = $crate::rust::collections::btree_map::BTreeMap::new();
                 $(
@@ -182,6 +186,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! btreeset {
+            ( ) => ({
+                $crate::rust::collections::btree_set::BTreeSet::new()
+            });
             ( $($value:expr),* ) => ({
                 let mut temp = $crate::rust::collections::btree_set::BTreeSet::new();
                 $(
@@ -210,6 +217,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! hashmap {
+            ( ) => ({
+                $crate::rust::collections::hash_map::HashMap::default()
+            });
             ( $($key:expr => $value:expr),* ) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,
                 // but we throw away that string literal during constant evaluation.
@@ -241,6 +251,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! hashset {
+            ( ) => ({
+                $crate::rust::collections::hash_set::HashSet::default()
+            });
             ( $($key:expr),* ) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,
                 // but we throw away that string literal during constant evaluation.
@@ -305,6 +318,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! indexmap {
+            ( ) => ({
+                $crate::rust::collections::index_map::index_map_new()
+            });
             ($($key:expr => $value:expr,)+) => ( $crate::rust::collections::index_map::indexmap!{$($key => $value),*} );
             ($($key:expr => $value:expr),*) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,
@@ -362,6 +378,9 @@ pub mod collections {
 
         #[macro_export]
         macro_rules! indexset {
+            ( ) => ({
+                $crate::rust::collections::index_set_new()
+            });
             ($($key:expr,)+) => ( $crate::rust::collections::index_set::indexset!{$($key),*} );
             ($($key:expr),*) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,

--- a/sbor/src/schema/custom_traits.rs
+++ b/sbor/src/schema/custom_traits.rs
@@ -1,7 +1,5 @@
-use super::*;
-use crate::rust::collections::*;
-use crate::rust::fmt::Debug;
-use crate::CustomValueKind;
+use crate::rust::prelude::*;
+use crate::*;
 
 pub trait CustomTypeKind<L: SchemaTypeLink>: Debug + Clone + PartialEq + Eq {
     type CustomValueKind: CustomValueKind;

--- a/sbor/src/schema/schema.rs
+++ b/sbor/src/schema/schema.rs
@@ -3,7 +3,8 @@ use crate::rust::vec::Vec;
 use crate::*;
 
 /// An array of custom type kinds, and associated extra information which can attach to the type kinds
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Sbor)]
+#[sbor(child_types = "E::CustomTypeKind<LocalTypeIndex>, E::CustomTypeValidation")]
 pub struct Schema<E: CustomTypeExtension> {
     pub type_kinds: Vec<SchemaTypeKind<E>>,
     pub type_metadata: Vec<NovelTypeMetadata>,

--- a/sbor/src/schema/type_data/type_kind.rs
+++ b/sbor/src/schema/type_data/type_kind.rs
@@ -3,8 +3,8 @@ use crate::rust::collections::BTreeMap;
 use crate::rust::vec::Vec;
 
 /// A schema for the values that a codec can decode / views as valid
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
-#[sbor(generic_categorize_bounds = "L")]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+#[sbor(child_types = "C,L")]
 pub enum TypeKind<X: CustomValueKind, C: CustomTypeKind<L, CustomValueKind = X>, L: SchemaTypeLink>
 {
     Any,

--- a/sbor/src/schema/type_data/type_metadata.rs
+++ b/sbor/src/schema/type_data/type_metadata.rs
@@ -1,10 +1,8 @@
-use crate::rust::borrow::Cow;
-use crate::rust::collections::BTreeMap;
-use crate::rust::vec::Vec;
-use crate::TypeHash;
+use crate::rust::prelude::*;
+use crate::*;
 
 /// This is the struct used in the Schema
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub struct NovelTypeMetadata {
     pub type_hash: TypeHash,
     pub type_metadata: TypeMetadata,
@@ -12,7 +10,7 @@ pub struct NovelTypeMetadata {
 
 /// This enables the type to be represented as eg JSON
 /// Also used to facilitate type reconstruction
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Sbor)]
 pub struct TypeMetadata {
     pub type_name: Cow<'static, str>,
     pub children: Children,
@@ -57,7 +55,7 @@ impl TypeMetadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Sbor)]
 pub enum Children {
     #[default]
     None,
@@ -65,7 +63,7 @@ pub enum Children {
     Variants(BTreeMap<u8, TypeMetadata>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Sbor)]
 pub struct FieldMetadata {
     pub field_name: Cow<'static, str>,
 }

--- a/sbor/src/schema/type_data/type_validation.rs
+++ b/sbor/src/schema/type_data/type_validation.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// Additional validation to apply to a payload of the given type, beyond validation from the [`TypeKind`]'s type structure.
 ///
 /// Each [`TypeKind`] typically can have either `None` or its type-specific validation.
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum TypeValidation<V: CustomTypeValidation> {
     None,
 
@@ -25,7 +25,7 @@ pub enum TypeValidation<V: CustomTypeValidation> {
 }
 
 /// Represents additional validation that should be performed on the size.
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Decode, Encode, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Sbor)]
 pub struct LengthValidation {
     pub min: Option<u32>,
     pub max: Option<u32>,
@@ -41,7 +41,7 @@ impl LengthValidation {
 }
 
 /// Represents additional validation that should be performed on the numeric value.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Sbor)]
 pub struct NumericValidation<T> {
     pub min: Option<T>,
     pub max: Option<T>,

--- a/sbor/src/schema/type_link.rs
+++ b/sbor/src/schema/type_link.rs
@@ -7,7 +7,7 @@ use sbor::*;
 pub trait SchemaTypeLink: Debug + Clone + PartialEq + Eq {}
 
 /// This is a global identifier for a type.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Sbor)]
 pub enum GlobalTypeId {
     /// This takes a well_known type index.
     ///
@@ -102,7 +102,7 @@ const fn capture_dependent_type_ids(
 }
 
 /// This is the [`SchemaTypeLink`] used in a linearized [`Schema`] to link [`TypeKind`]s.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Sbor)]
 pub enum LocalTypeIndex {
     /// This takes a well_known type index
     WellKnown(u8),


### PR DESCRIPTION
Includes further tweaks to the SBOR derive macros, to finally enable properly fixing the child types.

I'm finally happy I've got the abstraction right now! See eg the magic annotations needed to get `Schema` working.