### PR TITLE
Fix conversions for Decimal, PreciceDecimal and BnumXYZ types.

### DIFF
--- a/radix-engine-interface/src/macros.rs
+++ b/radix-engine-interface/src/macros.rs
@@ -3,14 +3,14 @@
 #[macro_export]
 macro_rules! dec {
     ($x:literal) => {
-        Decimal::from($x)
+        Decimal::try_from($x).unwrap()
     };
 
     ($base:literal, $shift:literal) => {
         // Base can be any type that converts into a Decimal, and shift must support
         // comparison and `-` unary operation, enforced by rustc.
         {
-            let base = Decimal::from($base);
+            let base = Decimal::try_from($base).unwrap();
             if $shift >= 0 {
                 base * Decimal::try_from(
                     BnumI256::from(10u8).pow(u32::try_from($shift).expect("Shift overflow")),
@@ -42,14 +42,14 @@ macro_rules! i {
 #[macro_export]
 macro_rules! pdec {
     ($x:literal) => {
-        PreciseDecimal::from($x)
+        PreciseDecimal::try_from($x).unwrap()
     };
 
     ($base:literal, $shift:literal) => {
         // Base can be any type that converts into a PreciseDecimal, and shift must support
         // comparison and `-` unary operation, enforced by rustc.
         {
-            let base = PreciseDecimal::from($base);
+            let base = PreciseDecimal::try_from($base).unwrap();
             if $shift >= 0 {
                 base * PreciseDecimal::try_from(
                     BnumI512::from(10u8).pow(u32::try_from($shift).expect("Shift overflow")),

--- a/radix-engine-interface/src/math/bnum_integer.rs
+++ b/radix-engine-interface/src/math/bnum_integer.rs
@@ -144,6 +144,12 @@ pub trait CheckedSub {
         Self: Sized;
 }
 
+pub trait CheckedMul {
+    fn checked_mul(self, other: Self) -> Option<Self>
+    where
+        Self: Sized;
+}
+
 macro_rules! forward_ref_unop {
     (impl $imp:ident, $method:ident for $t:ty) => {
         impl $imp for &$t {
@@ -342,6 +348,14 @@ macro_rules! op_impl {
                 {
                     fn checked_sub(self, other: Self) -> Option<Self> {
                         let opt = self.0.checked_sub(other.0);
+                        opt.map(|v| Self(v))
+                    }
+                }
+
+                impl CheckedMul for $t
+                {
+                    fn checked_mul(self, other: Self) -> Option<Self> {
+                        let opt = self.0.checked_mul(other.0);
                         opt.map(|v| Self(v))
                     }
                 }

--- a/radix-engine-interface/src/math/bnum_integer/bits.rs
+++ b/radix-engine-interface/src/math/bnum_integer/bits.rs
@@ -75,7 +75,7 @@ macro_rules! impl_bits {
                     #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
                     pub fn rotate_left(self, other: Self) -> Self {
-                        Self(self.0.rotate_left(u32::from(other)))
+                        Self(self.0.rotate_left(u32::try_from(other).unwrap()))
                     }
 
                     /// Shifts the bits to the right by a specified amount, `n`,
@@ -89,7 +89,7 @@ macro_rules! impl_bits {
                     #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
                     pub fn rotate_right(self, other: Self) -> Self {
-                        Self(self.0.rotate_right(u32::from(other)))
+                        Self(self.0.rotate_right(u32::try_from(other).unwrap()))
                     }
 
                     /// Converts an integer from big endian to the target's endianness.

--- a/radix-engine-interface/src/math/bnum_integer/convert.rs
+++ b/radix-engine-interface/src/math/bnum_integer/convert.rs
@@ -162,16 +162,6 @@ macro_rules! impl_from_string {
                         }
                     }
                 }
-                impl From<&str> for $t {
-                    fn from(val: &str) -> Self {
-                        Self::from_str(&val).unwrap()
-                    }
-                }
-                impl From<String> for $t {
-                    fn from(val: String) -> Self {
-                        Self::from_str(&val).unwrap()
-                    }
-                }
             }
         )*
     };

--- a/radix-engine-interface/src/math/bnum_integer/convert.rs
+++ b/radix-engine-interface/src/math/bnum_integer/convert.rs
@@ -72,6 +72,25 @@ macro_rules! impl_from_builtin{
     };
 }
 
+macro_rules! impl_try_from_builtin{
+    ($t:ident, $wrapped:ty, ($($o:ident),*)) => {
+        paste! {
+            $(
+                impl TryFrom<$o> for $t {
+                    type Error = [<Parse $t Error>];
+
+                    fn try_from(val: $o) -> Result<Self, Self::Error> {
+                        match Self::[<from_$o>](val) {
+                            Some(val) => Ok(val),
+                            None => Err([<Parse $t Error>]::Overflow),
+                        }
+                    }
+                }
+            )*
+        }
+    };
+}
+
 macro_rules! impl_to_builtin{
     ($t:ident, $wrapped:ty, ($($o:ident),*)) => {
         paste! {
@@ -89,11 +108,17 @@ macro_rules! impl_to_builtin{
 impl_from_builtin! { BnumI256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 impl_from_builtin! { BnumI384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 impl_from_builtin! { BnumI512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI768, BInt::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU256, BUint::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU384, BUint::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU512, BUint::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU768, BUint::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { BnumI768, BInt::<12>,(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { BnumU256, BUint::<4>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { BnumU384, BUint::<6>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { BnumU512, BUint::<8>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { BnumU768, BUint::<8>, (u8, u16, u32, u64, u128, usize)}
+
+impl_try_from_builtin! { BnumU256, BUint::<4>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { BnumU384, BUint::<6>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { BnumU512, BUint::<8>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { BnumU768, BUint::<12>, (i8, i16, i32, i64, i128, isize)}
+
 impl_to_builtin! { BnumI256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 impl_to_builtin! { BnumI384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 impl_to_builtin! { BnumI512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}

--- a/radix-engine-interface/src/math/bnum_integer/convert.rs
+++ b/radix-engine-interface/src/math/bnum_integer/convert.rs
@@ -14,7 +14,9 @@ macro_rules! impl_from_primitive {
             impl FromPrimitive for $t {
                 $(
                     fn [< from_$type >](n: [<$type>]) -> Option<Self> {
-                        Some(Self(<$wrapped>::try_from(n).unwrap()))
+                        <$wrapped>::try_from(n)
+                            .map(|val| Self(val))
+                            .ok()
                     }
                 )*
             }
@@ -95,9 +97,12 @@ macro_rules! impl_to_builtin{
     ($t:ident, $wrapped:ty, ($($o:ident),*)) => {
         paste! {
             $(
-                impl From<$t> for $o {
-                    fn from(val: $t) -> $o {
-                        $o::try_from(val.0).unwrap()
+                impl TryFrom<$t> for $o {
+                    type Error = [<Parse $t Error>];
+
+                    fn try_from(val: $t) -> Result<Self, Self::Error> {
+                        $o::try_from(val.0)
+                            .map_err(|_| [<Parse $t Error>]::Overflow)
                     }
                 }
             )*

--- a/radix-engine-interface/src/math/bnum_integer/convert.rs
+++ b/radix-engine-interface/src/math/bnum_integer/convert.rs
@@ -103,14 +103,19 @@ impl_to_builtin! { BnumU384, BUint::<6>, (i8, i16, i32, i64, i128, isize, u8, u1
 impl_to_builtin! { BnumU512, BUint::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 impl_to_builtin! { BnumU768, BUint::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 
-macro_rules! impl_from_bigint {
+macro_rules! impl_try_from_bigint {
     ($($t:ident, $wrapped:ty),*) => {
         paste! {
             $(
-                impl From<BigInt> for $t {
-                    fn from(val: BigInt) -> Self {
+                impl TryFrom<BigInt> for $t {
+                    type Error = [<Parse $t Error>];
+
+                    fn try_from(val: BigInt) -> Result<Self, Self::Error> {
                         let bytes = val.to_signed_bytes_le();
-                        Self(<$wrapped>::from_le_slice(&bytes).expect("Overflow"))
+                        match <$wrapped>::from_le_slice(&bytes) {
+                            Some(val) => Ok(Self(val)),
+                            None => Err([<Parse $t Error>]::Overflow),
+                        }
                     }
                 }
             )*
@@ -132,14 +137,14 @@ macro_rules! impl_to_bigint {
         }
     };
 }
-impl_from_bigint! { BnumI256, BInt::<4> }
-impl_from_bigint! { BnumI384, BInt::<6> }
-impl_from_bigint! { BnumI512, BInt::<8> }
-impl_from_bigint! { BnumI768, BInt::<12> }
-impl_from_bigint! { BnumU256, BUint::<4> }
-impl_from_bigint! { BnumU384, BUint::<6> }
-impl_from_bigint! { BnumU512, BUint::<8> }
-impl_from_bigint! { BnumU768, BUint::<12> }
+impl_try_from_bigint! { BnumI256, BInt::<4> }
+impl_try_from_bigint! { BnumI384, BInt::<6> }
+impl_try_from_bigint! { BnumI512, BInt::<8> }
+impl_try_from_bigint! { BnumI768, BInt::<12> }
+impl_try_from_bigint! { BnumU256, BUint::<4> }
+impl_try_from_bigint! { BnumU384, BUint::<6> }
+impl_try_from_bigint! { BnumU512, BUint::<8> }
+impl_try_from_bigint! { BnumU768, BUint::<12> }
 impl_to_bigint! { BnumI256, BInt::<4> }
 impl_to_bigint! { BnumI384, BInt::<6> }
 impl_to_bigint! { BnumI512, BInt::<8> }

--- a/radix-engine-interface/src/math/bnum_integer/test.rs
+++ b/radix-engine-interface/src/math/bnum_integer/test.rs
@@ -320,7 +320,7 @@ fn test_bnum_to_bnum() {
     assert_eq!(b, BnumU256::ONE);
 
     let a = BnumI256::from(-123);
-    let b = BnumI512::try_from(a).unwrap();
+    let b = BnumI512::from(a);
     assert_eq!(a.to_string(), b.to_string());
 
     let a = BnumI256::MAX;
@@ -328,11 +328,15 @@ fn test_bnum_to_bnum() {
     assert_eq!(a.to_string(), b.to_string());
 
     let a = BnumI256::MIN;
-    let b = BnumI512::try_from(a).unwrap();
+    let b = BnumI512::from(a);
     assert_eq!(a.to_string(), b.to_string());
 
     let a = BnumU256::MAX;
-    let b = BnumI512::try_from(a).unwrap();
+    let b = BnumI512::from(a);
+    assert_eq!(a.to_string(), b.to_string());
+
+    let a = BnumU256::MAX;
+    let b = BnumI384::from(a);
     assert_eq!(a.to_string(), b.to_string());
 }
 
@@ -375,7 +379,11 @@ fn test_bnum_to_bnum_errors() {
     let err = BnumU256::try_from(i512).unwrap_err();
     assert_eq!(err, ParseBnumU256Error::NegativeToUnsigned);
 
-    let a = BnumI256::from(-123);
-    let b = BnumU512::try_from(a).unwrap_err();
-    assert_eq!(b, ParseBnumU512Error::NegativeToUnsigned);
+    let i256 = BnumI256::from(-123);
+    let err = BnumU512::try_from(i256).unwrap_err();
+    assert_eq!(err, ParseBnumU512Error::NegativeToUnsigned);
+
+    let i384 = BnumI384::MAX;
+    let err = BnumU256::try_from(i384).unwrap_err();
+    assert_eq!(err, ParseBnumU256Error::Overflow);
 }

--- a/radix-engine-interface/src/math/bnum_integer/test.rs
+++ b/radix-engine-interface/src/math/bnum_integer/test.rs
@@ -212,8 +212,16 @@ macro_rules! test_bnums {
                     let bnum: $t = 21_u32.into();
                     assert_eq!(bnum.to_string(), 21.to_string());
 
-                    let i: i128 = <$t>::from(21_u8).into();
+                    let i: i128 = <$t>::from(21_u8).try_into().unwrap();
                     assert_eq!(i, 21_i128);
+
+                    let val = u8::try_from(<$t>::from(300_u32)).unwrap_err();
+                    assert_eq!(val, [< Parse $t Error >]::Overflow);
+
+                    if <$t>::MIN < <$t>::ZERO {
+                        let val = u8::try_from(<$t>::try_from(-300_i32).unwrap()).unwrap_err();
+                        assert_eq!(val, [< Parse $t Error >]::Overflow);
+                    }
                 }
 
                 #[test]
@@ -223,24 +231,24 @@ macro_rules! test_bnums {
                 }
 
                 #[test]
-                #[should_panic(expected = "TryFromIntError")]
+                #[should_panic(expected = "Overflow")]
                 fn [< test_ $t:lower _to_u128_panic >]() {
                     if <$t>::MIN < <$t>::ZERO {
-                        let _u: u128 = <$t>::try_from(-21).unwrap().into();
+                        let _u: u128 = <$t>::try_from(-21).unwrap().try_into().unwrap();
                     } else {
-                        let _u: u128 = <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().into();
+                        let _u: u128 = <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().try_into().unwrap();
                     }
                 }
                 #[test]
-                #[should_panic(expected = "TryFromIntError")]
+                #[should_panic(expected = "Overflow")]
                 fn [< test_ $t:lower _to_i8_panic >]() {
-                    let _i: i8 = <$t>::try_from(-260).unwrap().into();
+                    let _i: i8 = <$t>::try_from(-260).unwrap().try_into().unwrap();
                 }
 
                 #[test]
-                #[should_panic(expected = "TryFromIntError")]
+                #[should_panic(expected = "Overflow")]
                 fn [< test_ $t:lower _u16_panic >]() {
-                    let _i: u16 = <$t>::from(123123123_u32).into();
+                    let _i: u16 = <$t>::from(123123123_u32).try_into().unwrap();
                 }
 
             )*

--- a/radix-engine-interface/src/math/bnum_integer/test.rs
+++ b/radix-engine-interface/src/math/bnum_integer/test.rs
@@ -75,14 +75,14 @@ macro_rules! test_bnums {
                 #[test]
                 fn [<test_ $t:lower _add>] () {
                     assert_eq!((<$t>::ONE + <$t>::ONE).to_string(), "2");
-                    assert_eq!(<$t>::from(17) + <$t>::from(31), <$t>::from(48));
+                    assert_eq!(<$t>::from(17_u32) + <$t>::from(31_u32), <$t>::from(48_u32));
                     let mut bnum = <$t>::ONE;
                     bnum += <$t>::from_str("101").unwrap();
                     assert_eq!(bnum, <$t>::from_str("102").unwrap());
 
                     if <$t>::MIN < <$t>::ZERO {
                         let mut bnum = <$t>::MAX;
-                        bnum += <$t>::from(-1);
+                        bnum += <$t>::try_from(-1_i32).unwrap();
                         assert_eq!(bnum, <$t>::MAX - <$t>::ONE);
 
                         assert_eq!(<$t>::MIN + <$t>::MAX, <$t>::ZERO - <$t>::ONE);
@@ -94,8 +94,8 @@ macro_rules! test_bnums {
                     assert_eq!(<$t>::ONE - <$t>::ONE, <$t>::ZERO);
 
                     if <$t>::MIN < <$t>::ZERO {
-                        assert_eq!(<$t>::from(17) - <$t>::from(31), <$t>::from(-14));
-                        let mut bnum = <$t>::from(101);
+                        assert_eq!(<$t>::from(17_u32) - <$t>::from(31_u32), <$t>::try_from(-14).unwrap());
+                        let mut bnum = <$t>::from(101_u32);
                         bnum -= <$t>::from_str("102").unwrap();
                         assert_eq!(bnum, <$t>::from_str("-1").unwrap());
                     }
@@ -109,7 +109,7 @@ macro_rules! test_bnums {
                 #[should_panic(expected = "Overflow")]
                 fn [<test_ $t:lower _add_overflow_panic_1>] () {
                     let mut bnum = <$t>::MAX;
-                    bnum += <$t>::from(1);
+                    bnum += <$t>::from(1_u32);
                 }
 
                 #[test]
@@ -121,15 +121,15 @@ macro_rules! test_bnums {
 
                 #[test]
                 fn [< test_ $t:lower _mul >]() {
-                    assert_eq!(<$t>::from(4) * <$t>::from(5), <$t>::from(20));
-                    let mut bnum = <$t>::from(12387);
+                    assert_eq!(<$t>::from(4_u32) * <$t>::from(5_u32), <$t>::from(20_u32));
+                    let mut bnum = <$t>::from(12387_u32);
                     bnum *= <$t>::from_str("1203203031").unwrap();
-                    assert_eq!(bnum, <$t>::from(14904075944997_i128));
+                    assert_eq!(bnum, <$t>::from(14904075944997_u128));
 
                     if <$t>::MIN < <$t>::ZERO {
-                        let mut bnum = <$t>::from(12387);
+                        let mut bnum = <$t>::from(12387_u32);
                         bnum *= <$t>::from_str("-1203203031").unwrap();
-                        assert_eq!(bnum, <$t>::from(-14904075944997_i128));
+                        assert_eq!(bnum, <$t>::try_from(-14904075944997_i128).unwrap());
                     }
                 }
 
@@ -137,20 +137,20 @@ macro_rules! test_bnums {
                 #[should_panic(expected = "Overflow")]
                 fn [< test_ $t:lower _mul_overflow_panic_1 >] () {
                     let mut bnum = <$t>::MAX;
-                    bnum *= <$t>::from(2);
+                    bnum *= <$t>::from(2_u32);
                 }
 
 
                 #[test]
                 fn [< test_ $t:lower _pow >](){
-                    assert_eq!(<$t>::from(3).pow(3), <$t>::from(27));
+                    assert_eq!(<$t>::from(3_u32).pow(3), <$t>::from(27_u32));
 
                     assert_eq!(
-                        <$t>::from(153).pow(20),
+                        <$t>::from(153_u32).pow(20),
                         <$t>::from_str("49411565790213547262766437937260727785410401").unwrap()
                     );
                     assert_eq!(
-                        <$t>::from(153).pow(30),
+                        <$t>::from(153_u32).pow(30),
                         <$t>::from_str("347330502405572936124071262363392351825462559418275421545603605649").unwrap()
                     );
                 }
@@ -159,13 +159,13 @@ macro_rules! test_bnums {
                 #[should_panic(expected = "Overflow")]
                 fn [< test_ $t:lower _pow_overflow_panic_1 >]() {
                     if <$t>::BITS == 256 {
-                        let _ = <$t>::from(153).pow(40);
+                        let _ = <$t>::from(153_u32).pow(40);
                     } else if <$t>::BITS == 384 {
-                        let _ = <$t>::from(153).pow(60);
+                        let _ = <$t>::from(153_u32).pow(60);
                     } else if <$t>::BITS == 512 {
-                        let _ = <$t>::from(153).pow(80);
+                        let _ = <$t>::from(153_u32).pow(80);
                     } else if <$t>::BITS == 768 {
-                        let _ = <$t>::from(153).pow(120);
+                        let _ = <$t>::from(153_u32).pow(120);
                     } else {
                         panic!("Unknown bits size {}", <$t>::BITS);
                     }
@@ -173,20 +173,20 @@ macro_rules! test_bnums {
 
                 #[test]
                 fn [< test_ $t:lower _root >]() {
-                    assert_eq!(<$t>::from(9).sqrt(), <$t>::from(3));
-                    assert_eq!(<$t>::from(27).cbrt(), <$t>::from(3));
+                    assert_eq!(<$t>::from(9_u32).sqrt(), <$t>::from(3_u32));
+                    assert_eq!(<$t>::from(27_u32).cbrt(), <$t>::from(3_u32));
 
-                    assert_eq!(<$t>::from(9).nth_root(2), <$t>::from(3));
-                    assert_eq!(<$t>::from(27).nth_root(3), <$t>::from(3));
-                    assert_eq!(<$t>::from(14966675814359580587845230627_i128).nth_root(13), <$t>::from(147));
+                    assert_eq!(<$t>::from(9_u32).nth_root(2), <$t>::from(3_u32));
+                    assert_eq!(<$t>::from(27_u32).nth_root(3), <$t>::from(3_u32));
+                    assert_eq!(<$t>::from(14966675814359580587845230627_u128).nth_root(13), <$t>::from(147_u32));
                     assert_eq!(
                         <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().nth_root(17),
                         <$t>::from_str("1396").unwrap()
                     );
 
                     if <$t>::MIN < <$t>::ZERO {
-                        assert_eq!(<$t>::from(-27).nth_root(3), <$t>::from(-3));
-                        assert_eq!(<$t>::from(-14966675814359580587845230627_i128).nth_root(13), <$t>::from(-147));
+                        assert_eq!(<$t>::try_from(-27).unwrap().nth_root(3), <$t>::try_from(-3).unwrap());
+                        assert_eq!(<$t>::try_from(-14966675814359580587845230627_i128).unwrap().nth_root(13), <$t>::try_from(-147).unwrap());
                     }
                 }
 
@@ -197,9 +197,9 @@ macro_rules! test_bnums {
                     assert_eq!(<$t>::from_str("0").unwrap(), <$t>::ZERO);
 
                     if <$t>::MIN < <$t>::ZERO {
-                        assert_eq!(<$t>::from(-1).to_string(), "-1");
+                        assert_eq!(<$t>::try_from(-1).unwrap().to_string(), "-1");
 
-                        assert_eq!(<$t>::from_str("-1").unwrap(), <$t>::from(-1));
+                        assert_eq!(<$t>::from_str("-1").unwrap(), <$t>::try_from(-1).unwrap());
                     }
                 }
 
@@ -209,7 +209,7 @@ macro_rules! test_bnums {
                     assert_eq!(<$t>::try_from(21).unwrap().to_string(), "21");
                     assert_eq!(<$t>::from(21_u8).to_string(), "21");
 
-                    let bnum: $t = 21.into();
+                    let bnum: $t = 21_u32.into();
                     assert_eq!(bnum.to_string(), 21.to_string());
 
                     let i: i128 = <$t>::from(21_u8).into();
@@ -219,14 +219,14 @@ macro_rules! test_bnums {
                 #[test]
                 #[should_panic(expected = "Err")]
                 fn [< test_ $t:lower _from_string_panic_1 >]() {
-                    assert_eq!(<$t>::from_str("0x01").unwrap(), <$t>::from(-1));
+                    assert_eq!(<$t>::from_str("0x01").unwrap(), <$t>::try_from(-1).unwrap());
                 }
 
                 #[test]
                 #[should_panic(expected = "TryFromIntError")]
                 fn [< test_ $t:lower _to_u128_panic >]() {
                     if <$t>::MIN < <$t>::ZERO {
-                        let _u: u128 = <$t>::from(-21).into();
+                        let _u: u128 = <$t>::try_from(-21).unwrap().into();
                     } else {
                         let _u: u128 = <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().into();
                     }
@@ -234,13 +234,13 @@ macro_rules! test_bnums {
                 #[test]
                 #[should_panic(expected = "TryFromIntError")]
                 fn [< test_ $t:lower _to_i8_panic >]() {
-                    let _i: i8 = <$t>::from(-260).into();
+                    let _i: i8 = <$t>::try_from(-260).unwrap().into();
                 }
 
                 #[test]
                 #[should_panic(expected = "TryFromIntError")]
                 fn [< test_ $t:lower _u16_panic >]() {
-                    let _i: u16 = <$t>::from(123123123).into();
+                    let _i: u16 = <$t>::from(123123123_u32).into();
                 }
 
             )*
@@ -287,18 +287,18 @@ macro_rules! test_to_from_bigint {
             $(
                 #[test]
                 fn [<test_to_from_bigint_ $t:lower>]() {
-                    assert_eq!($t::try_from(BigInt::from(147)).unwrap(), $t::from(147));
+                    assert_eq!($t::try_from(BigInt::from(147)).unwrap(), $t::from(147_u32));
 
                     assert_eq!(
                         $t::try_from(BigInt::from(1470198230918_i128)).unwrap(),
-                        $t::from(1470198230918_i128)
+                        $t::from(1470198230918_u128)
                     );
 
                     let big = BigInt::from($t::MAX) + BigInt::from(1);
                     let err = $t::try_from(big).unwrap_err();
                     assert_eq!(err, [<Parse $t Error>]::Overflow);
 
-                    assert_eq!(BigInt::try_from($t::from(123)).unwrap(), BigInt::from(123));
+                    assert_eq!(BigInt::try_from($t::from(123_u32)).unwrap(), BigInt::from(123));
                     assert_eq!(BigInt::from($t::ONE), BigInt::from(1));
 
                     assert_eq!(
@@ -319,10 +319,10 @@ macro_rules! test_to_from_bigint {
 
                     // test signed types
                     if $t::MIN != $t::ZERO {
-                        assert_eq!($t::try_from(BigInt::from(-147)).unwrap(), $t::from(-147));
+                        assert_eq!($t::try_from(BigInt::from(-147)).unwrap(), $t::try_from(-147).unwrap());
                         assert_eq!(
                             $t::try_from(BigInt::from(-1470198230918_i128)).unwrap(),
-                            $t::from(-1470198230918_i128)
+                            $t::try_from(-1470198230918_i128).unwrap()
                         );
                         let big = BigInt::from($t::MIN) - BigInt::from(1);
                         let err = $t::try_from(big).unwrap_err();

--- a/radix-engine-interface/src/math/bnum_integer/test.rs
+++ b/radix-engine-interface/src/math/bnum_integer/test.rs
@@ -77,8 +77,8 @@ macro_rules! test_bnums {
                     assert_eq!((<$t>::ONE + <$t>::ONE).to_string(), "2");
                     assert_eq!(<$t>::from(17) + <$t>::from(31), <$t>::from(48));
                     let mut bnum = <$t>::ONE;
-                    bnum += <$t>::from("101");
-                    assert_eq!(bnum, <$t>::from("102"));
+                    bnum += <$t>::from_str("101").unwrap();
+                    assert_eq!(bnum, <$t>::from_str("102").unwrap());
 
                     if <$t>::MIN < <$t>::ZERO {
                         let mut bnum = <$t>::MAX;
@@ -96,8 +96,8 @@ macro_rules! test_bnums {
                     if <$t>::MIN < <$t>::ZERO {
                         assert_eq!(<$t>::from(17) - <$t>::from(31), <$t>::from(-14));
                         let mut bnum = <$t>::from(101);
-                        bnum -= <$t>::from("102");
-                        assert_eq!(bnum, <$t>::from("-1"));
+                        bnum -= <$t>::from_str("102").unwrap();
+                        assert_eq!(bnum, <$t>::from_str("-1").unwrap());
                     }
 
                     let mut bnum = <$t>::MAX;
@@ -123,12 +123,12 @@ macro_rules! test_bnums {
                 fn [< test_ $t:lower _mul >]() {
                     assert_eq!(<$t>::from(4) * <$t>::from(5), <$t>::from(20));
                     let mut bnum = <$t>::from(12387);
-                    bnum *= <$t>::from("1203203031");
+                    bnum *= <$t>::from_str("1203203031").unwrap();
                     assert_eq!(bnum, <$t>::from(14904075944997_i128));
 
                     if <$t>::MIN < <$t>::ZERO {
                         let mut bnum = <$t>::from(12387);
-                        bnum *= <$t>::from("-1203203031");
+                        bnum *= <$t>::from_str("-1203203031").unwrap();
                         assert_eq!(bnum, <$t>::from(-14904075944997_i128));
                     }
                 }
@@ -147,11 +147,11 @@ macro_rules! test_bnums {
 
                     assert_eq!(
                         <$t>::from(153).pow(20),
-                        <$t>::from("49411565790213547262766437937260727785410401")
+                        <$t>::from_str("49411565790213547262766437937260727785410401").unwrap()
                     );
                     assert_eq!(
                         <$t>::from(153).pow(30),
-                        <$t>::from("347330502405572936124071262363392351825462559418275421545603605649")
+                        <$t>::from_str("347330502405572936124071262363392351825462559418275421545603605649").unwrap()
                     );
                 }
 
@@ -180,8 +180,8 @@ macro_rules! test_bnums {
                     assert_eq!(<$t>::from(27).nth_root(3), <$t>::from(3));
                     assert_eq!(<$t>::from(14966675814359580587845230627_i128).nth_root(13), <$t>::from(147));
                     assert_eq!(
-                        <$t>::from("290437112829027226192310037731274304321654649956335616").nth_root(17),
-                        <$t>::from("1396")
+                        <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().nth_root(17),
+                        <$t>::from_str("1396").unwrap()
                     );
 
                     if <$t>::MIN < <$t>::ZERO {
@@ -194,7 +194,7 @@ macro_rules! test_bnums {
                 fn [< test_ $t:lower _to_string >]() {
                     assert_eq!(<$t>::ONE.to_string(), "1");
                     assert_eq!(<$t>::ZERO.to_string(), "0");
-                    assert_eq!(<$t>::from("0"), <$t>::ZERO);
+                    assert_eq!(<$t>::from_str("0").unwrap(), <$t>::ZERO);
 
                     if <$t>::MIN < <$t>::ZERO {
                         assert_eq!(<$t>::from(-1).to_string(), "-1");
@@ -228,7 +228,7 @@ macro_rules! test_bnums {
                     if <$t>::MIN < <$t>::ZERO {
                         let _u: u128 = <$t>::from(-21).into();
                     } else {
-                        let _u: u128 = <$t>::from("290437112829027226192310037731274304321654649956335616").into();
+                        let _u: u128 = <$t>::from_str("290437112829027226192310037731274304321654649956335616").unwrap().into();
                     }
                 }
                 #[test]
@@ -274,9 +274,10 @@ test_bnums_signed! { BnumI256, BnumI384, BnumI512, BnumI768 }
 fn test_string_to_bnum_panic_2() {
     assert_eq!(
         BnumI256::MAX,
-        BnumI256::from(
+        BnumI256::from_str(
             "578960446186580977117854925043439539266349923328202820197287920039565648199670"
         )
+        .unwrap()
     );
 }
 
@@ -348,13 +349,13 @@ fn test_bnum_to_bnum_errors() {
 
     // I256::MAX + 1
     let i256_str = BnumI256::MAX.to_string();
-    let i512 = BnumI512::from(i256_str) + BnumI512::ONE;
+    let i512 = BnumI512::from_str(&i256_str).unwrap() + BnumI512::ONE;
     let err = BnumI256::try_from(i512).unwrap_err();
     assert_eq!(err, ParseBnumI256Error::Overflow);
 
     // I256::MIN - 1
     let i256_str = BnumI256::MIN.to_string();
-    let i512 = BnumI512::from(i256_str) - BnumI512::ONE;
+    let i512 = BnumI512::from_str(&i256_str).unwrap() - BnumI512::ONE;
     let err = BnumI256::try_from(i512).unwrap_err();
     assert_eq!(err, ParseBnumI256Error::Overflow);
 
@@ -363,7 +364,7 @@ fn test_bnum_to_bnum_errors() {
     assert_eq!(err, ParseBnumI256Error::Overflow);
 
     let i512_str = BnumI512::MAX.to_string();
-    let u512 = BnumU512::from(i512_str) + BnumU512::ONE;
+    let u512 = BnumU512::from_str(&i512_str).unwrap() + BnumU512::ONE;
     let err = BnumU256::try_from(u512).unwrap_err();
     assert_eq!(err, ParseBnumU256Error::Overflow);
 

--- a/radix-engine-interface/src/math/decimal.rs
+++ b/radix-engine-interface/src/math/decimal.rs
@@ -460,7 +460,7 @@ impl FromStr for Decimal {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let tens = BnumI256::from(10);
-        let v: Vec<&str> = s.split(".").collect();
+        let v: Vec<&str> = s.split('.').collect();
 
         let mut int = match BnumI256::from_str(v[0]) {
             Ok(val) => val,
@@ -472,12 +472,16 @@ impl FromStr for Decimal {
         if v.len() == 2 {
             let scale: u32 = Self::SCALE - (v[1].len() as u32);
 
+            let frac = match BnumI256::from_str(v[1]) {
+                Ok(val) => val,
+                Err(_) => return Err(ParseDecimalError::InvalidDigit),
+            };
             // if input is -0. then from_str returns 0 and we loose '-' sign.
             // Therefore check for '-' in input directly
             if int.is_negative() || v[0].starts_with('-') {
-                int -= BnumI256::from(v[1]) * tens.pow(scale);
+                int -= frac * tens.pow(scale);
             } else {
-                int += BnumI256::from(v[1]) * tens.pow(scale);
+                int += frac * tens.pow(scale);
             }
         }
         Ok(Self(int))

--- a/radix-engine-interface/src/math/decimal.rs
+++ b/radix-engine-interface/src/math/decimal.rs
@@ -185,8 +185,8 @@ impl Decimal {
 
     /// Calculates power using exponentiation by squaring".
     pub fn powi(&self, exp: i64) -> Self {
-        let one_384 = BnumI384::try_from(Self::ONE.0).unwrap();
-        let base_384 = BnumI384::try_from(self.0).unwrap();
+        let one_384 = BnumI384::from(Self::ONE.0);
+        let base_384 = BnumI384::from(self.0);
         let div = |x: i64, y: i64| x.checked_div(y).expect("Overflow");
         let sub = |x: i64, y: i64| x.checked_sub(y).expect("Overflow");
         let mul = |x: i64, y: i64| x.checked_mul(y).expect("Overflow");
@@ -223,8 +223,8 @@ impl Decimal {
         // The BnumI256 i associated to a Decimal d is : i = d*10^18.
         // Therefore, taking sqrt yields sqrt(i) = sqrt(d)*10^9 => We lost precision
         // To get the right precision, we compute : sqrt(i*10^18) = sqrt(d)*10^18
-        let self_384: BnumI384 = BnumI384::try_from(self.0).unwrap();
-        let correct_nb = self_384 * BnumI384::try_from(Decimal::one().0).unwrap();
+        let self_384: BnumI384 = BnumI384::from(self.0);
+        let correct_nb = self_384 * BnumI384::from(Decimal::one().0);
         let sqrt = BnumI256::try_from(correct_nb.sqrt()).expect("Overflow");
         Some(Decimal(sqrt))
     }
@@ -236,8 +236,8 @@ impl Decimal {
         }
 
         // By reasoning in the same way as before, we realise that we need to multiply by 10^36
-        let self_384: BnumI384 = BnumI384::try_from(self.0).unwrap();
-        let correct_nb = self_384 * BnumI384::try_from(Decimal::one().0).unwrap().pow(2);
+        let self_384: BnumI384 = BnumI384::from(self.0);
+        let correct_nb = self_384 * BnumI384::from(Decimal::one().0).pow(2);
         let cbrt = BnumI256::try_from(correct_nb.cbrt()).expect("Overflow");
         Decimal(cbrt)
     }
@@ -345,11 +345,11 @@ where
 
     fn mul(self, other: T) -> Self::Output {
         // Use BnumI384 (BInt<6>) to not overflow.
-        let a = BnumI384::try_from(self.0).unwrap();
+        let a = BnumI384::from(self.0);
         let b_dec: Decimal = other.try_into().expect("Overflow");
-        let b = BnumI384::try_from(b_dec.0).unwrap();
-        let c = a * b / BnumI384::try_from(Self::ONE.0).unwrap();
-        let c_256 = BnumI256::try_from(c).unwrap();
+        let b = BnumI384::from(b_dec.0);
+        let c = a * b / BnumI384::from(Self::ONE.0);
+        let c_256 = BnumI256::try_from(c).expect("Overflow");
         Decimal(c_256)
     }
 }
@@ -362,11 +362,11 @@ where
 
     fn div(self, other: T) -> Self::Output {
         // Use BnumI384 (BInt<6>) to not overflow.
-        let a = BnumI384::try_from(self.0).unwrap();
+        let a = BnumI384::from(self.0);
         let b_dec: Decimal = other.try_into().expect("Overflow");
-        let b = BnumI384::try_from(b_dec.0).unwrap();
-        let c = a * BnumI384::try_from(Self::ONE.0).unwrap() / b;
-        let c_256 = BnumI256::try_from(c).unwrap();
+        let b = BnumI384::from(b_dec.0);
+        let c = a * BnumI384::from(Self::ONE.0) / b;
+        let c_256 = BnumI256::try_from(c).expect("Overflow");
         Decimal(c_256)
     }
 }

--- a/radix-engine-interface/src/math/decimal.rs
+++ b/radix-engine-interface/src/math/decimal.rs
@@ -285,15 +285,20 @@ from_int!(i64);
 from_int!(i128);
 from_int!(isize);
 
-impl From<&str> for Decimal {
-    fn from(val: &str) -> Self {
-        Self::from_str(&val).unwrap()
+// from_str() should be enough, but we want to have try_from() to simplify dec! macro
+impl TryFrom<&str> for Decimal {
+    type Error = ParseDecimalError;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
+        Self::from_str(val)
     }
 }
 
-impl From<String> for Decimal {
-    fn from(val: String) -> Self {
-        Self::from_str(&val).unwrap()
+impl TryFrom<String> for Decimal {
+    type Error = ParseDecimalError;
+
+    fn try_from(val: String) -> Result<Self, Self::Error> {
+        Self::from_str(&val)
     }
 }
 
@@ -1102,7 +1107,7 @@ mod tests {
             $(
                 #[test]
                 fn [<test_from_into_precise_decimal_decimal_ $suffix>]() {
-                    let pdec = PreciseDecimal::from($from);
+                    let pdec = PreciseDecimal::try_from($from).unwrap();
                     let dec = Decimal::try_from(pdec).unwrap();
                     assert_eq!(dec.to_string(), $expected);
 

--- a/radix-engine-interface/src/math/integer_test_macros.rs
+++ b/radix-engine-interface/src/math/integer_test_macros.rs
@@ -802,10 +802,10 @@ macro_rules! test_math {
                 let mut a: $i = <$i>::from_str("118").unwrap();
                 assert_eq!(a.to_string(), "118");
                 let b: String = a.to_string();
-                a = <$i>::from(b);
+                a = <$i>::from_str(&b).unwrap();
                 assert_eq!(a.to_string(), "118");
                 let c: &str = &a.to_string();
-                a = <$i>::from(c);
+                a = <$i>::from_str(c).unwrap();
                 assert_eq!(a.to_string(), "118");
             }
 

--- a/radix-engine-interface/src/math/precise_decimal.rs
+++ b/radix-engine-interface/src/math/precise_decimal.rs
@@ -297,15 +297,20 @@ from_int!(i64);
 from_int!(i128);
 from_int!(isize);
 
-impl From<&str> for PreciseDecimal {
-    fn from(val: &str) -> Self {
-        Self::from_str(&val).unwrap()
+// from_str() should be enough, but we want to have try_from() to simplify pdec! macro
+impl TryFrom<&str> for PreciseDecimal {
+    type Error = ParsePreciseDecimalError;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
+        Self::from_str(val)
     }
 }
 
-impl From<String> for PreciseDecimal {
-    fn from(val: String) -> Self {
-        Self::from_str(&val).unwrap()
+impl TryFrom<String> for PreciseDecimal {
+    type Error = ParsePreciseDecimalError;
+
+    fn try_from(val: String) -> Result<Self, Self::Error> {
+        Self::from_str(&val)
     }
 }
 

--- a/radix-engine-tests/tests/auth_account.rs
+++ b/radix-engine-tests/tests/auth_account.rs
@@ -295,7 +295,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET_COMPONENT, 10.into())
         .call_method(FAUCET_COMPONENT, "free", args!())
-        .take_from_worktop_by_amount(Decimal::from("0.9"), RADIX_TOKEN, |builder, bucket_id| {
+        .take_from_worktop_by_amount(dec!("0.9"), RADIX_TOKEN, |builder, bucket_id| {
             builder.create_proof_from_bucket(&bucket_id, |builder, proof_id| {
                 builder.push_to_auth_zone(proof_id);
                 builder.withdraw_all_from_account(account, RADIX_TOKEN);

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -68,7 +68,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
 
     match action {
         Action::Mint => builder
-            .mint_fungible(token_address, Decimal::from("1.0"))
+            .mint_fungible(token_address, dec!("1.0"))
             .call_method(
                 account,
                 "deposit_batch",
@@ -76,15 +76,15 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
             ),
         Action::Burn => builder
             .create_proof_from_account(account, withdraw_auth)
-            .withdraw_from_account(account, token_address, Decimal::from("1.0"))
-            .burn(Decimal::from("1.0"), token_address)
+            .withdraw_from_account(account, token_address, dec!("1.0"))
+            .burn(dec!("1.0"), token_address)
             .call_method(
                 account,
                 "deposit_batch",
                 args!(ManifestExpression::EntireWorktop),
             ),
         Action::Withdraw => builder
-            .withdraw_from_account(account, token_address, Decimal::from("1.0"))
+            .withdraw_from_account(account, token_address, dec!("1.0"))
             .call_method(
                 account,
                 "deposit_batch",
@@ -92,7 +92,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
             ),
         Action::Deposit => builder
             .create_proof_from_account(account, withdraw_auth)
-            .withdraw_from_account(account, token_address, Decimal::from("1.0"))
+            .withdraw_from_account(account, token_address, dec!("1.0"))
             .take_from_worktop(token_address, |builder, bucket_id| {
                 builder.call_method(account, "deposit", args!(bucket_id))
             })

--- a/radix-engine-tests/tests/common_transactions.rs
+++ b/radix-engine-tests/tests/common_transactions.rs
@@ -3,6 +3,7 @@ use radix_engine::types::{
     NonFungibleGlobalId, NonFungibleLocalId, ResourceAddress, FAUCET_COMPONENT, RADIX_TOKEN,
 };
 use radix_engine_interface::blueprints::resource::*;
+use radix_engine_interface::dec;
 use radix_engine_interface::rule;
 use scrypto::NonFungibleData;
 use scrypto_unit::TestRunner;
@@ -90,7 +91,7 @@ fn creating_a_fungible_resource_with_no_initial_supply_succeeds() {
 #[test]
 fn creating_a_fungible_resource_with_initial_supply_succeeds() {
     test_manifest(|account_component_address, bech32_encoder| {
-        let initial_supply = Decimal::from("10000000");
+        let initial_supply = dec!("10000000");
 
         let manifest = replace_variables!(
             include_str!(
@@ -184,7 +185,7 @@ fn minting_of_fungible_resource_succeeds() {
          minter_badge_resource_address,
          mintable_resource_address,
          bech32_encoder| {
-            let mint_amount = Decimal::from("800");
+            let mint_amount = dec!("800");
 
             let manifest = replace_variables!(
                 include_str!("../../transaction/examples/resources/mint/fungible/mint.rtm"),
@@ -272,7 +273,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
 
     // Creating the minter badge and the requested resource
     let minter_badge_resource_address =
-        test_runner.create_fungible_resource("1".into(), 0, component_address);
+        test_runner.create_fungible_resource(dec!("1"), 0, component_address);
 
     let access_rules = BTreeMap::from([(
         ResourceMethodAuthKey::Mint,

--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -98,7 +98,7 @@ fn mint_with_bad_granularity_should_fail() {
             ResourceManagerError::InvalidAmount(amount, granularity),
         )) = e
         {
-            amount.eq(&Decimal::from("0.1")) && *granularity == 0
+            amount.eq(&dec!("0.1")) && *granularity == 0
         } else {
             false
         }

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1456,7 +1456,7 @@ mod tests {
         AccessRule, AccessRules, NonFungibleIdType, ResourceMethodAuthKey,
     };
     use radix_engine_interface::network::NetworkDefinition;
-    use radix_engine_interface::pdec;
+    use radix_engine_interface::{dec, pdec};
 
     #[macro_export]
     macro_rules! generate_value_ok {
@@ -1554,7 +1554,7 @@ mod tests {
             Value::Tuple {
                 fields: vec![
                     Value::Custom {
-                        value: ScryptoCustomValue::Decimal(Decimal::from_str("1").unwrap())
+                        value: ScryptoCustomValue::Decimal(dec!("1"))
                     },
                     Value::Custom {
                         value: ScryptoCustomValue::Hash(
@@ -1717,7 +1717,7 @@ mod tests {
             r#"MINT_FUNGIBLE ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak") Decimal("100");"#,
             BasicInstruction::MintFungible {
                 resource_address: resource,
-                amount: Decimal::from_str("100").unwrap()
+                amount: dec!("100")
             },
         );
         generate_instruction_ok!(
@@ -1727,7 +1727,7 @@ mod tests {
                 entries: BTreeMap::from([(
                     NonFungibleLocalId::integer(1),
                     (
-                        args!(String::from("Hello World"), Decimal::from("12")),
+                        args!(String::from("Hello World"), dec!("12")),
                         args!(12u8, 19u128)
                     )
                 )])
@@ -1787,7 +1787,7 @@ mod tests {
                     entries: BTreeMap::from([(
                         NonFungibleLocalId::integer(1),
                         (
-                            args!(String::from("Hello World"), Decimal::from("12")),
+                            args!(String::from("Hello World"), dec!("12")),
                             args!(12u8, 19u128)
                         )
                     )]),
@@ -1875,7 +1875,7 @@ mod tests {
             BasicInstruction::MintUuidNonFungible {
                 resource_address: resource,
                 entries: Vec::from([(
-                    args!(String::from("Hello World"), Decimal::from("12")),
+                    args!(String::from("Hello World"), dec!("12")),
                     args!(12u8, 19u128)
                 )])
             },


### PR DESCRIPTION
## Summary

Fix conversions for `Decimal,` `PreciceDecimal` and `BnumXYZ` types.

## Details
This PR fix conversions according to the Rust approach:
- `From` used for conversions that not fail
- `TryFrom` used for conversion that can fail

Affected conversions:
- `Decimal`/`PreciseDecimal` from `BnumXYZ`
- `Decimal`/`PreciseDecimal` from string types
- `BnumXYZ` from `BigInt`
- `BnumXYZ` from builtin integer types

## Testing
Unit tests updated accordingly to test modified conversions.

## Update Recommendations

### For Dapp Developers
Some conversions used so far are no longer available, eg.

| No longer available           | What to use now                                               |
|-------------------------------|------------------------------------------------------------   |
|`Decimal::from("0.9")`         | `dec!("0.9")` or `Decimal::from_str("0.9").unwrap()`          |
|`PreciseDecimal::from("0.9")`  | `pdec!("0.9")` or `PreciseDecimal::from_str("0.9").unwrap()`  |
|`Decimal::from(BnumI256::ONE)` | `Decimal::try_from(BnumI256::ONE).unwrap()`                   |
|`Decimal::from(BnumI512::ONE)` | `Decimal::try_from(BnumI512::ONE).unwrap()`                   |
|`Decimal::from(BnumU256::ONE)` | `Decimal::try_from(BnumU256::ONE).unwrap()`                   |
|`Decimal::from(BnumU512::ONE)` | `Decimal::try_from(BnumU512::ONE).unwrap()`                   |
|`PreciseDecimal::from(BnumI512::ONE)` | `PreciseDecimal::try_from(BnumI512::ONE).unwrap()`     |
|`PreciseDecimal::from(BnumU512::ONE)` | `PreciseDecimal::try_from(BnumU512::ONE).unwrap()`     |

