### PR TITLE
Feature/SCRY-319 transaction limit substate read

### DIFF
--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -50,4 +50,4 @@ pub const DEFAULT_MAX_WASM_MEM_PER_TRANSACTION: usize = 10 * 1024 * 1024;
 pub const DEFAULT_MAX_WASM_MEM_PER_CALL_FRAME: usize = 4 * 1024 * 1024;
 
 /// The default maximum substates reads count per transaction.
-pub const DEFAULT_MAX_SUBSTATE_READS_PER_TRANSACTION: usize = 4096;
+pub const DEFAULT_MAX_SUBSTATE_READS_PER_TRANSACTION: usize = 20_000;

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -48,3 +48,6 @@ pub const DEFAULT_MAX_WASM_MEM_PER_TRANSACTION: usize = 10 * 1024 * 1024;
 
 /// The default maximum WASM memory per WASM call frame.
 pub const DEFAULT_MAX_WASM_MEM_PER_CALL_FRAME: usize = 4 * 1024 * 1024;
+
+/// The default maximum substates reads count per transaction.
+pub const DEFAULT_MAX_SUBSTATE_READS_PER_TRANSACTION: usize = 4096;

--- a/radix-engine/src/kernel/module_mixer.rs
+++ b/radix-engine/src/kernel/module_mixer.rs
@@ -12,7 +12,9 @@ use crate::system::kernel_modules::execution_trace::ExecutionTraceModule;
 use crate::system::kernel_modules::kernel_debug::KernelDebugModule;
 use crate::system::kernel_modules::logger::LoggerModule;
 use crate::system::kernel_modules::node_move::NodeMoveModule;
-use crate::system::kernel_modules::transaction_limits::TransactionLimitsModule;
+use crate::system::kernel_modules::transaction_limits::{
+    TransactionLimitsConfig, TransactionLimitsModule,
+};
 use crate::system::kernel_modules::transaction_runtime::TransactionRuntimeModule;
 use crate::system::node::RENodeInit;
 use crate::system::node::RENodeModuleInit;
@@ -68,7 +70,8 @@ impl KernelModuleMixer {
         max_call_depth: usize,
         max_kernel_call_depth_traced: Option<usize>,
         max_wasm_memory: usize,
-        max_wasm_call_frame_memory: usize,
+        max_wasm_memory_per_call_frame: usize,
+        max_substate_reads: usize,
     ) -> Self {
         let mut modules = EnabledModules::empty();
         if debug {
@@ -98,10 +101,11 @@ impl KernelModuleMixer {
             },
             logger: LoggerModule {},
             transaction_runtime: TransactionRuntimeModule { tx_hash },
-            transaction_limits: TransactionLimitsModule::new(
+            transaction_limits: TransactionLimitsModule::new(TransactionLimitsConfig {
                 max_wasm_memory,
-                max_wasm_call_frame_memory,
-            ),
+                max_wasm_memory_per_call_frame,
+                max_substate_reads,
+            }),
             execution_trace: ExecutionTraceModule::new(max_kernel_call_depth_traced.unwrap_or(0)),
         }
     }

--- a/radix-engine/src/system/kernel_modules/transaction_limits/module.rs
+++ b/radix-engine/src/system/kernel_modules/transaction_limits/module.rs
@@ -7,8 +7,9 @@ use crate::{
     },
     types::Vec,
 };
-
-use radix_engine_interface::*;
+use radix_engine_interface::{
+    api::types::LockHandle, ScryptoCategorize, ScryptoDecode, ScryptoEncode,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub enum TransactionLimitsError {
@@ -20,6 +21,15 @@ pub enum TransactionLimitsError {
     MaxWasmInstanceMemoryExceeded(usize),
 }
 
+/// Representatino of data which needs to be limited for each call frame.
+#[derive(Default)]
+struct CallFrameInfo {
+    /// Consumed WASM memory.
+    wasm_memory_usage: usize,
+    /// Substate store read count.
+    substate_store_read: usize,
+}
+
 /// Tracks and verifies transaction limits during transactino execution,
 /// if exceeded breaks execution with appropriate error.
 pub struct TransactionLimitsModule {
@@ -27,8 +37,8 @@ pub struct TransactionLimitsModule {
     max_wasm_memory: usize,
     /// Maximum WASM memory which can be consumed during transaction execution.
     max_wasm_memory_per_call_frame: usize,
-    /// Consumed WASM memory for each invocation call.
-    wasm_memory_usage_stack: Vec<usize>,
+    /// Internal stack of data for each call frame.
+    call_frames_stack: Vec<CallFrameInfo>,
 }
 
 impl TransactionLimitsModule {
@@ -36,29 +46,35 @@ impl TransactionLimitsModule {
         TransactionLimitsModule {
             max_wasm_memory,
             max_wasm_memory_per_call_frame: max_wasm_instance_memory,
-            wasm_memory_usage_stack: Vec::with_capacity(8),
+            call_frames_stack: Vec::with_capacity(8),
         }
     }
 
     /// Checks if maximum WASM memory limit for one instance was exceeded and then
     /// checks if memory limit for all instances was exceeded.
-    fn validate(&self) -> Result<(), RuntimeError> {
+    fn validate_wasm_memory(&self) -> Result<(), RuntimeError> {
         // check last (current) call frame
-        let current_instance_memory = *self
-            .wasm_memory_usage_stack
+        let current_call_frame = self
+            .call_frames_stack
             .last()
-            .expect("Wasm memory usage stack should not be empty.");
-        if current_instance_memory > self.max_wasm_memory_per_call_frame {
+            .expect("Call frames stack (Wasm memory) should not be empty.");
+        if current_call_frame.wasm_memory_usage > self.max_wasm_memory_per_call_frame {
             return Err(RuntimeError::ModuleError(
                 ModuleError::TransactionLimitsError(
-                    TransactionLimitsError::MaxWasmInstanceMemoryExceeded(current_instance_memory),
+                    TransactionLimitsError::MaxWasmInstanceMemoryExceeded(
+                        current_call_frame.wasm_memory_usage,
+                    ),
                 ),
             ));
         };
 
         // calculate current maximum consumed memory
         // sum all call stack values
-        let max_value = self.wasm_memory_usage_stack.iter().sum();
+        let max_value = self
+            .call_frames_stack
+            .iter()
+            .map(|item| item.wasm_memory_usage)
+            .sum();
 
         // validate if limit was exceeded
         if max_value > self.max_wasm_memory {
@@ -71,6 +87,10 @@ impl TransactionLimitsModule {
             Ok(())
         }
     }
+
+    fn validate_substates(&self) -> Result<(), RuntimeError> {
+        Ok(())
+    }
 }
 
 impl KernelModule for TransactionLimitsModule {
@@ -82,8 +102,8 @@ impl KernelModule for TransactionLimitsModule {
         // push new empty wasm memory value refencing current call frame to internal stack
         api.kernel_get_module_state()
             .transaction_limits
-            .wasm_memory_usage_stack
-            .push(0);
+            .call_frames_stack
+            .push(CallFrameInfo::default());
         Ok(())
     }
 
@@ -91,9 +111,32 @@ impl KernelModule for TransactionLimitsModule {
         // pop from internal stack
         api.kernel_get_module_state()
             .transaction_limits
-            .wasm_memory_usage_stack
+            .call_frames_stack
             .pop();
         Ok(())
+    }
+
+    fn on_read_substate<Y: KernelModuleApi<RuntimeError>>(
+        api: &mut Y,
+        _lock_handle: LockHandle,
+        _size: usize,
+    ) -> Result<(), RuntimeError> {
+        let depth = api.kernel_get_current_depth();
+        let tlimit = &mut api.kernel_get_module_state().transaction_limits;
+
+        // update current frame substate read count
+        if let Some(val) = tlimit.call_frames_stack.get_mut(depth) {
+            val.substate_store_read += 1;
+        } else {
+            // Kernel can call this event before calling before_push_frame()
+            // in that case we are pushing new itme on internal stack.
+            tlimit.call_frames_stack.push(CallFrameInfo {
+                wasm_memory_usage: 0,
+                substate_store_read: 1,
+            })
+        }
+
+        tlimit.validate_substates()
     }
 
     // This event handler is called from two places:
@@ -107,15 +150,18 @@ impl KernelModule for TransactionLimitsModule {
         let tlimit = &mut api.kernel_get_module_state().transaction_limits;
 
         // update current frame consumed memory
-        if let Some(val) = tlimit.wasm_memory_usage_stack.get_mut(depth) {
-            *val = consumed_memory;
+        if let Some(val) = tlimit.call_frames_stack.get_mut(depth) {
+            val.wasm_memory_usage = consumed_memory;
         } else {
             // When kernel pops the call frame there are some nested calls which
             // are not aligned with before_push_frame() which requires pushing
             // new value on a stack instead of updating it.
-            tlimit.wasm_memory_usage_stack.push(consumed_memory)
+            tlimit.call_frames_stack.push(CallFrameInfo {
+                wasm_memory_usage: consumed_memory,
+                substate_store_read: 0,
+            })
         }
 
-        tlimit.validate()
+        tlimit.validate_wasm_memory()
     }
 }

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -42,6 +42,7 @@ pub struct ExecutionConfig {
     pub abort_when_loan_repaid: bool,
     pub max_wasm_mem_per_transaction: usize,
     pub max_wasm_mem_per_call_frame: usize,
+    pub max_substate_reads_per_transaction: usize,
 }
 
 impl Default for ExecutionConfig {
@@ -59,6 +60,7 @@ impl ExecutionConfig {
             abort_when_loan_repaid: false,
             max_wasm_mem_per_transaction: DEFAULT_MAX_WASM_MEM_PER_TRANSACTION,
             max_wasm_mem_per_call_frame: DEFAULT_MAX_WASM_MEM_PER_CALL_FRAME,
+            max_substate_reads_per_transaction: DEFAULT_MAX_SUBSTATE_READS_PER_TRANSACTION,
         }
     }
 
@@ -240,6 +242,7 @@ where
                 execution_config.max_kernel_call_depth_traced,
                 execution_config.max_wasm_mem_per_transaction,
                 execution_config.max_wasm_mem_per_call_frame,
+                execution_config.max_substate_reads_per_transaction,
             );
             let mut kernel = Kernel::new(
                 &mut id_allocator,


### PR DESCRIPTION
## Summary

Implementation of transaction execution substate reads limit.

## Details

Functionality implemented in Kernel module: `TransactionLimitsModule` - added `on_read_substate` event handler with  implementation of counting and validation functionalities.

Additionally introduced `TransactionLimitsConfig` struct for better encapsulation of the limits values.

Default value of substate read limit is set to 20000, it was chosen basing on tests execution - highest value which causes tests execution fail (`should_be_able_run_large_manifest`) is around 16700 reads.

## Testing

Added new test by just modification of `should_be_able_run_large_manifest`. I was unable to create other test using some blueprint function with high count of substate reads because earlier error: `FeeReserveError(LimitExceeded)` was arising.

## Update Recommendations

As new transaction execution limit has been added, it may cause transactions working so far to fail with an error: `TransactionLimitsError(MaxSubstateReadsCountExceeded)`.
For internal discussion how we should handle such a situation (options: increase limit or refactor transaction to use less substate reads).