### PR TITLE
Feature: `Sbor`/`ScryptoSbor` switchover

### DIFF
--- a/native-sdk/src/lib.rs
+++ b/native-sdk/src/lib.rs
@@ -15,6 +15,6 @@ pub use macros::*;
 
 // Re-export radix engine derives
 pub extern crate radix_engine_derive;
-pub use radix_engine_derive::{LegacyDescribe, ScryptoCategorize, ScryptoDecode, ScryptoEncode};
+pub use radix_engine_derive::{LegacyDescribe, ScryptoSbor};
 
 pub extern crate radix_engine_interface;

--- a/native-sdk/src/lib.rs
+++ b/native-sdk/src/lib.rs
@@ -15,6 +15,8 @@ pub use macros::*;
 
 // Re-export radix engine derives
 pub extern crate radix_engine_derive;
-pub use radix_engine_derive::{LegacyDescribe, ScryptoSbor};
+pub use radix_engine_derive::{
+    LegacyDescribe, ScryptoCategorize, ScryptoDecode, ScryptoDescribe, ScryptoEncode, ScryptoSbor,
+};
 
 pub extern crate radix_engine_interface;

--- a/radix-engine-interface/src/api/component/kv_store_substates.rs
+++ b/radix-engine-interface/src/api/component/kv_store_substates.rs
@@ -6,7 +6,7 @@ use sbor::rust::collections::*;
 
 // TODO: Josh is leaning towards keeping `Entry::Key` as part of the substate key.
 // We will change this implementation if that is agreed.
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode, PartialEq, Eq)]
+#[derive(Debug, Clone, ScryptoSbor, PartialEq, Eq)]
 pub enum KeyValueStoreEntrySubstate {
     Some(ScryptoValue, ScryptoValue),
     None,

--- a/radix-engine-interface/src/api/component/substates.rs
+++ b/radix-engine-interface/src/api/component/substates.rs
@@ -2,7 +2,7 @@ use crate::api::types::*;
 use crate::data::types::Own;
 use radix_engine_derive::*;
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct ComponentStateSubstate {
     pub raw: Vec<u8>,
 }
@@ -13,7 +13,7 @@ impl ComponentStateSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ComponentInfoSubstate {
     pub package_address: PackageAddress,
     pub blueprint_name: String,
@@ -28,12 +28,12 @@ impl ComponentInfoSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ComponentRoyaltyConfigSubstate {
     pub royalty_config: RoyaltyConfig,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ComponentRoyaltyAccumulatorSubstate {
     pub royalty: Own,
 }

--- a/radix-engine-interface/src/api/node_modules/auth/access_rules/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/auth/access_rules/invocations.rs
@@ -3,7 +3,7 @@ use crate::blueprints::resource::*;
 use crate::*;
 use sbor::rust::fmt::Debug;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesAddAccessCheckInvocation {
     pub receiver: RENodeId,
     pub access_rules: AccessRules,
@@ -33,7 +33,7 @@ impl Into<CallTableInvocation> for AccessRulesAddAccessCheckInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesSetMethodAccessRuleInvocation {
     pub receiver: RENodeId,
     pub index: u32,
@@ -66,7 +66,7 @@ impl Into<CallTableInvocation> for AccessRulesSetMethodAccessRuleInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesSetGroupAccessRuleInvocation {
     pub receiver: RENodeId,
     pub index: u32,
@@ -99,7 +99,7 @@ impl Into<CallTableInvocation> for AccessRulesSetGroupAccessRuleInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesSetMethodMutabilityInvocation {
     pub receiver: RENodeId,
     pub index: u32,
@@ -132,7 +132,7 @@ impl Into<CallTableInvocation> for AccessRulesSetMethodMutabilityInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesSetGroupMutabilityInvocation {
     pub receiver: RENodeId,
     pub index: u32,
@@ -165,7 +165,7 @@ impl Into<CallTableInvocation> for AccessRulesSetGroupMutabilityInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessRulesGetLengthInvocation {
     pub receiver: RENodeId,
 }

--- a/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
@@ -2,7 +2,7 @@ use crate::api::types::*;
 use crate::*;
 use sbor::rust::fmt::Debug;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct MetadataSetInvocation {
     pub receiver: RENodeId,
     pub key: String,
@@ -31,7 +31,7 @@ impl Into<CallTableInvocation> for MetadataSetInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct MetadataGetInvocation {
     pub receiver: RENodeId,
     pub key: String,

--- a/radix-engine-interface/src/api/node_modules/royalty/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/royalty/invocations.rs
@@ -3,7 +3,7 @@ use crate::blueprints::resource::Bucket;
 use crate::*;
 use sbor::rust::fmt::Debug;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ComponentSetRoyaltyConfigInvocation {
     /// TODO: change to component id, after `borrow_component` returns component id
     pub receiver: RENodeId,
@@ -34,7 +34,7 @@ impl Into<CallTableInvocation> for ComponentSetRoyaltyConfigInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ComponentClaimRoyaltyInvocation {
     /// TODO: change to component id, after `borrow_component` returns component id
     pub receiver: RENodeId,

--- a/radix-engine-interface/src/api/package/invocations.rs
+++ b/radix-engine-interface/src/api/package/invocations.rs
@@ -5,7 +5,7 @@ use sbor::rust::collections::BTreeMap;
 use sbor::rust::string::String;
 use sbor::rust::vec::Vec;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct PackagePublishInvocation {
     pub package_address: Option<[u8; 26]>, // TODO: Clean this up
     pub code: Vec<u8>,
@@ -37,7 +37,7 @@ impl Into<CallTableInvocation> for PackagePublishInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct PackagePublishNativeInvocation {
     pub package_address: Option<[u8; 26]>, // TODO: Clean this up
     pub native_package_code_id: u8,
@@ -70,7 +70,7 @@ impl Into<CallTableInvocation> for PackagePublishNativeInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct PackageSetRoyaltyConfigInvocation {
     pub receiver: PackageAddress,
     pub royalty_config: BTreeMap<String, RoyaltyConfig>, // TODO: optimize to allow per blueprint configuration.
@@ -98,13 +98,13 @@ impl Into<CallTableInvocation> for PackageSetRoyaltyConfigInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct PackageSetRoyaltyConfigExecutable {
     pub receiver: RENodeId,
     pub royalty_config: BTreeMap<String, RoyaltyConfig>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct PackageClaimRoyaltyInvocation {
     pub receiver: PackageAddress,
 }
@@ -131,7 +131,7 @@ impl Into<CallTableInvocation> for PackageClaimRoyaltyInvocation {
     }
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, ScryptoSbor)]
 pub struct PackageClaimRoyaltyExecutable {
     pub receiver: RENodeId,
 }

--- a/radix-engine-interface/src/api/package/substates.rs
+++ b/radix-engine-interface/src/api/package/substates.rs
@@ -16,13 +16,13 @@ pub const TRANSACTION_RUNTIME_CODE_ID: u8 = 7u8;
 pub const AUTH_ZONE_CODE_ID: u8 = 8u8;
 
 /// A collection of blueprints, compiled and published as a single unit.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct NativeCodeSubstate {
     pub native_package_code_id: u8,
 }
 
 /// A collection of blueprints, compiled and published as a single unit.
-#[derive(Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Clone, Sbor, PartialEq, Eq)]
 pub struct WasmCodeSubstate {
     pub code: Vec<u8>,
 }
@@ -39,7 +39,7 @@ impl Debug for WasmCodeSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct PackageInfoSubstate {
     pub blueprint_abis: BTreeMap<String, BlueprintAbi>,
     pub dependent_resources: BTreeSet<ResourceAddress>,
@@ -65,12 +65,12 @@ impl PackageInfoSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct PackageRoyaltyConfigSubstate {
     pub royalty_config: BTreeMap<String, RoyaltyConfig>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct PackageRoyaltyAccumulatorSubstate {
     pub royalty: Own,
 }

--- a/radix-engine-interface/src/api/types/actor.rs
+++ b/radix-engine-interface/src/api/types/actor.rs
@@ -3,13 +3,13 @@ use crate::api::types::*;
 use crate::*;
 use sbor::rust::string::String;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum PackageIdentifier {
     Scrypto(PackageAddress),
     Native(NativePackage),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum NativePackage {
     Auth,
     Royalty,
@@ -19,7 +19,7 @@ pub enum NativePackage {
     Root,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum FnIdentifier {
     Scrypto(ScryptoFnIdentifier),
     Native(NativeFn),
@@ -42,7 +42,7 @@ impl FnIdentifier {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ScryptoFnIdentifier {
     pub package_address: PackageAddress,
     pub blueprint_name: String,
@@ -67,20 +67,7 @@ impl ScryptoFnIdentifier {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor, LegacyDescribe)]
 pub enum NativeFn {
     AccessRulesChain(AccessRulesChainFn),
     ComponentRoyalty(ComponentRoyaltyFn),
@@ -117,9 +104,7 @@ impl NativeFn {
     IntoStaticStr,
     AsRefStr,
     Display,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     LegacyDescribe,
 )]
 #[strum(serialize_all = "snake_case")]
@@ -146,9 +131,7 @@ pub enum AccessRulesChainFn {
     IntoStaticStr,
     AsRefStr,
     Display,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     LegacyDescribe,
 )]
 #[strum(serialize_all = "snake_case")]
@@ -171,9 +154,7 @@ pub enum MetadataFn {
     IntoStaticStr,
     AsRefStr,
     Display,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     LegacyDescribe,
 )]
 #[strum(serialize_all = "snake_case")]
@@ -196,9 +177,7 @@ pub enum ComponentRoyaltyFn {
     IntoStaticStr,
     AsRefStr,
     Display,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     LegacyDescribe,
 )]
 #[strum(serialize_all = "snake_case")]
@@ -223,9 +202,7 @@ pub enum PackageFn {
     IntoStaticStr,
     AsRefStr,
     Display,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     LegacyDescribe,
 )]
 #[strum(serialize_all = "snake_case")]

--- a/radix-engine-interface/src/api/types/call_table_invocation.rs
+++ b/radix-engine-interface/src/api/types/call_table_invocation.rs
@@ -14,13 +14,13 @@ use sbor::rust::string::String;
 use sbor::rust::vec::Vec;
 
 // TODO: Remove enum
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, ScryptoSbor)]
 pub enum CallTableInvocation {
     Native(NativeInvocation),
     Scrypto(ScryptoInvocation),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ScryptoInvocation {
     pub package_address: PackageAddress,
     pub blueprint_name: String,
@@ -47,7 +47,7 @@ impl Into<CallTableInvocation> for ScryptoInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum NativeInvocation {
     AccessRulesChain(AccessRulesChainInvocation),
     Metadata(MetadataInvocation),
@@ -61,7 +61,7 @@ impl Into<CallTableInvocation> for NativeInvocation {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum AccessRulesChainInvocation {
     AddAccessCheck(AccessRulesAddAccessCheckInvocation),
     SetMethodAccessRule(AccessRulesSetMethodAccessRuleInvocation),
@@ -71,19 +71,19 @@ pub enum AccessRulesChainInvocation {
     GetLength(AccessRulesGetLengthInvocation),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum MetadataInvocation {
     Set(MetadataSetInvocation),
     Get(MetadataGetInvocation),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum ComponentInvocation {
     SetRoyaltyConfig(ComponentSetRoyaltyConfigInvocation),
     ClaimRoyalty(ComponentClaimRoyaltyInvocation),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum PackageInvocation {
     Publish(PackagePublishInvocation),
     PublishNative(PackagePublishNativeInvocation),

--- a/radix-engine-interface/src/api/types/re_node.rs
+++ b/radix-engine-interface/src/api/types/re_node.rs
@@ -6,19 +6,7 @@ use crate::blueprints::resource::ResourceAddress;
 use crate::*;
 
 // TODO: Remove when better type system implemented
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor)]
 pub enum RENodeType {
     Bucket,
     Proof,
@@ -49,19 +37,7 @@ pub enum RENodeType {
     AccessController,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor)]
 pub enum RENodeId {
     Bucket(BucketId),
     Proof(ProofId),
@@ -137,19 +113,7 @@ impl Into<ResourceAddress> for RENodeId {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor)]
 pub enum GlobalAddress {
     Component(ComponentAddress),
     Package(PackageAddress),
@@ -183,19 +147,7 @@ impl Into<ResourceAddress> for GlobalAddress {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor)]
 pub enum NodeModuleId {
     PackageTypeInfo, // TODO: Unify with ComponentTypeInfo
     SELF,
@@ -207,157 +159,124 @@ pub enum NodeModuleId {
     PackageRoyalty,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum AuthZoneStackOffset {
     AuthZoneStack,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum AccessRulesChainOffset {
     AccessRulesChain,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ComponentTypeInfoOffset {
     TypeInfo,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum MetadataOffset {
     Metadata,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum RoyaltyOffset {
     RoyaltyConfig,
     RoyaltyAccumulator,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ComponentOffset {
     /// Component application state at offset `0x00`.
     State0,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PackageOffset {
     NativeCode,
     WasmCode,
     Info,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum GlobalOffset {
     Global,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ResourceManagerOffset {
     ResourceManager,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-)]
+#[derive(Debug, Clone, ScryptoSbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum KeyValueStoreOffset {
     Entry(Vec<u8>),
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor)]
 pub enum NonFungibleStoreOffset {
     Entry(NonFungibleLocalId),
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum VaultOffset {
     Vault,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EpochManagerOffset {
     EpochManager,
     CurrentValidatorSet,
     PreparingValidatorSet,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ValidatorOffset {
     Validator,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum BucketOffset {
     Bucket,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ProofOffset {
     Proof,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorktopOffset {
     Worktop,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum LoggerOffset {
     Logger,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ClockOffset {
     CurrentTimeRoundedToMinutes,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TransactionRuntimeOffset {
     TransactionRuntime,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum AccountOffset {
     Account,
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum AccessControllerOffset {
     AccessController,
 }
 
 /// Specifies a specific Substate into a given RENode
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor)]
 pub enum SubstateOffset {
     PackageTypeInfo, // TODO: Unify with ComponentTypeInfo
     Global(GlobalOffset),
@@ -388,16 +307,5 @@ pub enum SubstateOffset {
 }
 
 /// TODO: separate space addresses?
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor)]
 pub struct SubstateId(pub RENodeId, pub NodeModuleId, pub SubstateOffset);

--- a/radix-engine-interface/src/api/types/royalty_config.rs
+++ b/radix-engine-interface/src/api/types/royalty_config.rs
@@ -6,9 +6,7 @@ use sbor::rust::string::ToString;
 use crate::*;
 
 /// Royalty rules
-#[derive(
-    Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, LegacyDescribe)]
 pub struct RoyaltyConfig {
     pub rules: HashMap<String, u32>,
     pub default_rule: u32,

--- a/radix-engine-interface/src/api/types/scrypto_receiver.rs
+++ b/radix-engine-interface/src/api/types/scrypto_receiver.rs
@@ -1,7 +1,7 @@
 use crate::api::types::*;
 use crate::*;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum ScryptoReceiver {
     Global(ComponentAddress),
     Resource(ResourceAddress),

--- a/radix-engine-interface/src/blueprints/access_controller/data.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/data.rs
@@ -2,19 +2,7 @@ use crate::blueprints::resource::AccessRule;
 use crate::*;
 
 /// An enum of the roles in the Access Controller component
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialOrd,
-    PartialEq,
-    Ord,
-    Eq,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    Hash,
-)]
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, ScryptoSbor, Hash)]
 pub enum Role {
     Primary,
     Recovery,
@@ -23,19 +11,7 @@ pub enum Role {
 
 /// The set of roles allowed to propose recoveries. Only Primary and Recovery roles can initiate,
 /// or propose recoveries, Confirmation can't initiate nor propose.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialOrd,
-    PartialEq,
-    Ord,
-    Eq,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    Hash,
-)]
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Ord, Eq, ScryptoSbor, Hash)]
 pub enum Proposer {
     Primary,
     Recovery,
@@ -52,14 +28,14 @@ impl From<Proposer> for Role {
 
 /// A struct with the set of rule associated with each role - used when creating a new access
 /// controller for the initial rules and also used during recovery for proposing a rule set.
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct RuleSet {
     pub primary_role: AccessRule,
     pub recovery_role: AccessRule,
     pub confirmation_role: AccessRule,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct RecoveryProposal {
     /// The set of rules being proposed for the different roles.
     pub rule_set: RuleSet,

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -22,7 +22,7 @@ pub const ACCESS_CONTROLLER_BLUEPRINT: &str = "AccessController";
 
 pub const ACCESS_CONTROLLER_CREATE_GLOBAL_IDENT: &str = "create_global";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerCreateGlobalInput {
     pub controlled_asset: Bucket,
     pub rule_set: RuleSet,
@@ -45,7 +45,7 @@ impl Clone for AccessControllerCreateGlobalInput {
 
 pub const ACCESS_CONTROLLER_CREATE_PROOF_IDENT: &str = "create_proof";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerCreateProofInput {}
 
 //================================================
@@ -55,7 +55,7 @@ pub struct AccessControllerCreateProofInput {}
 pub const ACCESS_CONTROLLER_INITIATE_RECOVERY_AS_PRIMARY_IDENT: &str =
     "initiate_recovery_as_primary";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerInitiateRecoveryAsPrimaryInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,
@@ -68,7 +68,7 @@ pub struct AccessControllerInitiateRecoveryAsPrimaryInput {
 pub const ACCESS_CONTROLLER_INITIATE_RECOVERY_AS_RECOVERY_IDENT: &str =
     "initiate_recovery_as_recovery";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerInitiateRecoveryAsRecoveryInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,
@@ -81,7 +81,7 @@ pub struct AccessControllerInitiateRecoveryAsRecoveryInput {
 pub const ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_RECOVERY_PROPOSAL_IDENT: &str =
     "quick_confirm_primary_role_recovery_proposal";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,
@@ -94,7 +94,7 @@ pub struct AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput {
 pub const ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_RECOVERY_PROPOSAL_IDENT: &str =
     "quick_confirm_recovery_role_recovery_proposal";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,
@@ -106,7 +106,7 @@ pub struct AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput {
 
 pub const ACCESS_CONTROLLER_TIMED_CONFIRM_RECOVERY_IDENT: &str = "timed_confirm_recovery";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerTimedConfirmRecoveryInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,
@@ -119,7 +119,7 @@ pub struct AccessControllerTimedConfirmRecoveryInput {
 pub const ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_RECOVERY_PROPOSAL_IDENT: &str =
     "cancel_primary_role_recovery_proposal";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerCancelPrimaryRoleRecoveryProposalInput;
 
 //==========================================================
@@ -129,7 +129,7 @@ pub struct AccessControllerCancelPrimaryRoleRecoveryProposalInput;
 pub const ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_RECOVERY_PROPOSAL_IDENT: &str =
     "cancel_recovery_role_recovery_proposal";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerCancelRecoveryRoleRecoveryProposalInput;
 
 //=====================================
@@ -138,7 +138,7 @@ pub struct AccessControllerCancelRecoveryRoleRecoveryProposalInput;
 
 pub const ACCESS_CONTROLLER_LOCK_PRIMARY_ROLE: &str = "lock_primary_role";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerLockPrimaryRoleInput;
 
 //=======================================
@@ -147,7 +147,7 @@ pub struct AccessControllerLockPrimaryRoleInput;
 
 pub const ACCESS_CONTROLLER_UNLOCK_PRIMARY_ROLE: &str = "unlock_primary_role";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerUnlockPrimaryRoleInput;
 
 //=======================================
@@ -156,7 +156,7 @@ pub struct AccessControllerUnlockPrimaryRoleInput;
 
 pub const ACCESS_CONTROLLER_STOP_TIMED_RECOVERY: &str = "stop_timed_recovery";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AccessControllerStopTimedRecoveryInput {
     pub rule_set: RuleSet,
     pub timed_recovery_delay_in_minutes: Option<u32>,

--- a/radix-engine-interface/src/blueprints/account/invocations.rs
+++ b/radix-engine-interface/src/blueprints/account/invocations.rs
@@ -6,8 +6,7 @@ use radix_engine_interface::abi::LegacyDescribe;
 use radix_engine_interface::math::Decimal;
 use sbor::rust::collections::{BTreeMap, BTreeSet};
 use sbor::rust::fmt::Debug;
-use scrypto_abi::Fn;
-use scrypto_abi::{BlueprintAbi, Fields, Type};
+use scrypto_abi::{BlueprintAbi, Fields, Fn, Type};
 
 pub struct AccountAbi;
 
@@ -170,9 +169,7 @@ pub const ACCOUNT_BLUEPRINT: &str = "Account";
 
 pub const ACCOUNT_CREATE_LOCAL_IDENT: &str = "create_local";
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountCreateLocalInput {
     pub withdraw_rule: AccessRule,
 }
@@ -185,9 +182,7 @@ pub type AccountCreateLocalOutput = Own;
 
 pub const ACCOUNT_CREATE_GLOBAL_IDENT: &str = "create_global";
 
-#[derive(
-    Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountCreateGlobalInput {
     pub withdraw_rule: AccessRule,
 }
@@ -200,7 +195,7 @@ pub type AccountCreateGlobalOutput = ComponentAddress;
 
 pub const ACCOUNT_LOCK_FEE_IDENT: &str = "lock_fee";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountLockFeeInput {
     pub amount: Decimal,
 }
@@ -213,7 +208,7 @@ pub type AccountLockFeeOutput = ();
 
 pub const ACCOUNT_LOCK_CONTINGENT_FEE_IDENT: &str = "lock_contingent_fee";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountLockContingentFeeInput {
     pub amount: Decimal,
 }
@@ -226,7 +221,7 @@ pub type AccountLockContingentFeeOutput = ();
 
 pub const ACCOUNT_DEPOSIT_IDENT: &str = "deposit";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountDepositInput {
     pub bucket: Bucket,
 }
@@ -239,7 +234,7 @@ pub type AccountDepositOutput = ();
 
 pub const ACCOUNT_DEPOSIT_BATCH_IDENT: &str = "deposit_batch";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountDepositBatchInput {
     pub buckets: Vec<Bucket>,
 }
@@ -252,7 +247,7 @@ pub type AccountDepositBatchOutput = ();
 
 pub const ACCOUNT_WITHDRAW_IDENT: &str = "withdraw";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountWithdrawInput {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,
@@ -266,7 +261,7 @@ pub type AccountWithdrawOutput = Bucket;
 
 pub const ACCOUNT_WITHDRAW_ALL_IDENT: &str = "withdraw_all";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountWithdrawAllInput {
     pub resource_address: ResourceAddress,
 }
@@ -279,7 +274,7 @@ pub type AccountWithdrawAllOutput = Bucket;
 
 pub const ACCOUNT_WITHDRAW_NON_FUNGIBLES_IDENT: &str = "withdraw_non_fungibles";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountWithdrawNonFungiblesInput {
     pub resource_address: ResourceAddress,
     pub ids: BTreeSet<NonFungibleLocalId>,
@@ -293,7 +288,7 @@ pub type AccountWithdrawNonFungiblesOutput = Bucket;
 
 pub const ACCOUNT_LOCK_FEE_AND_WITHDRAW_IDENT: &str = "lock_fee_and_withdraw";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountLockFeeAndWithdrawInput {
     pub amount_to_lock: Decimal,
     pub resource_address: ResourceAddress,
@@ -308,7 +303,7 @@ pub type AccountLockFeeAndWithdrawOutput = ();
 
 pub const ACCOUNT_LOCK_FEE_AND_WITHDRAW_ALL_IDENT: &str = "lock_fee_and_withdraw_all";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountLockFeeAndWithdrawAllInput {
     pub amount_to_lock: Decimal,
     pub resource_address: ResourceAddress,
@@ -323,7 +318,7 @@ pub type AccountLockFeeAndWithdrawAllOutput = ();
 pub const ACCOUNT_LOCK_FEE_AND_WITHDRAW_NON_FUNGIBLES_IDENT: &str =
     "lock_fee_and_withdraw_non_fungibles";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountLockFeeAndWithdrawNonFungiblesInput {
     pub amount_to_lock: Decimal,
     pub resource_address: ResourceAddress,
@@ -338,7 +333,7 @@ pub type AccountLockFeeAndWithdrawNonFungiblesOutput = ();
 
 pub const ACCOUNT_CREATE_PROOF_IDENT: &str = "create_proof";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountCreateProofInput {
     pub resource_address: ResourceAddress,
 }
@@ -351,7 +346,7 @@ pub type AccountCreateProofOutput = Proof;
 
 pub const ACCOUNT_CREATE_PROOF_BY_AMOUNT_IDENT: &str = "create_proof_by_amount";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountCreateProofByAmountInput {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,
@@ -365,7 +360,7 @@ pub type AccountCreateProofByAmountOutput = Proof;
 
 pub const ACCOUNT_CREATE_PROOF_BY_IDS_IDENT: &str = "create_proof_by_ids";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, LegacyDescribe)]
 pub struct AccountCreateProofByIdsInput {
     pub resource_address: ResourceAddress,
     pub ids: BTreeSet<NonFungibleLocalId>,

--- a/radix-engine-interface/src/blueprints/auth_zone/invocations.rs
+++ b/radix-engine-interface/src/blueprints/auth_zone/invocations.rs
@@ -18,12 +18,12 @@ pub const AUTH_ZONE_BLUEPRINT: &str = "AuthZone";
 
 pub const AUTH_ZONE_POP_IDENT: &str = "pop";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZonePopInput {}
 
 pub const AUTH_ZONE_PUSH_IDENT: &str = "push";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZonePushInput {
     pub proof: Proof,
 }
@@ -38,14 +38,14 @@ impl Clone for AuthZonePushInput {
 
 pub const AUTH_ZONE_CREATE_PROOF_IDENT: &str = "create_proof";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneCreateProofInput {
     pub resource_address: ResourceAddress,
 }
 
 pub const AUTH_ZONE_CREATE_PROOF_BY_AMOUNT_IDENT: &str = "create_proof_by_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneCreateProofByAmountInput {
     pub amount: Decimal,
     pub resource_address: ResourceAddress,
@@ -53,7 +53,7 @@ pub struct AuthZoneCreateProofByAmountInput {
 
 pub const AUTH_ZONE_CREATE_PROOF_BY_IDS_IDENT: &str = "create_proof_by_ids";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneCreateProofByIdsInput {
     pub ids: BTreeSet<NonFungibleLocalId>,
     pub resource_address: ResourceAddress,
@@ -61,17 +61,17 @@ pub struct AuthZoneCreateProofByIdsInput {
 
 pub const AUTH_ZONE_CLEAR_IDENT: &str = "clear";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneClearInput {}
 
 pub const AUTH_ZONE_DRAIN_IDENT: &str = "drain";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneDrainInput {}
 
 pub const AUTH_ZONE_ASSERT_ACCESS_RULE_IDENT: &str = "assert_access_rule";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZoneAssertAccessRuleInput {
     pub access_rule: AccessRule,
 }

--- a/radix-engine-interface/src/blueprints/clock/data.rs
+++ b/radix-engine-interface/src/blueprints/clock/data.rs
@@ -1,6 +1,6 @@
 use sbor::*;
 
-#[derive(Encode, Decode, Categorize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Sbor, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TimePrecision {
     Minute,
 }

--- a/radix-engine-interface/src/blueprints/clock/invocations.rs
+++ b/radix-engine-interface/src/blueprints/clock/invocations.rs
@@ -18,21 +18,21 @@ pub const CLOCK_BLUEPRINT: &str = "Clock";
 
 pub const CLOCK_CREATE_IDENT: &str = "create";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ClockCreateInput {
     pub component_address: [u8; 26], // TODO: Clean this up
 }
 
 pub const CLOCK_GET_CURRENT_TIME_IDENT: &str = "get_current_time";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ClockGetCurrentTimeInput {
     pub precision: TimePrecision,
 }
 
 pub const CLOCK_COMPARE_CURRENT_TIME_IDENT: &str = "compare_current_time";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ClockCompareCurrentTimeInput {
     pub instant: Instant,
     pub precision: TimePrecision,
@@ -41,7 +41,7 @@ pub struct ClockCompareCurrentTimeInput {
 
 pub const CLOCK_SET_CURRENT_TIME_IDENT: &str = "set_current_time";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ClockSetCurrentTimeInput {
     pub current_time_ms: i64,
 }

--- a/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
@@ -22,14 +22,14 @@ pub const VALIDATOR_BLUEPRINT: &str = "Validator";
 
 // TODO: Remove this and replace with a macro/function making it easy
 // TODO: to use manifest buckets for any input struct
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ManifestValidatorInit {
     pub validator_account_address: ComponentAddress,
     pub initial_stake: ManifestBucket,
     pub stake_account_address: ComponentAddress,
 }
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorInit {
     pub validator_account_address: ComponentAddress,
     pub initial_stake: Bucket,
@@ -38,7 +38,7 @@ pub struct ValidatorInit {
 
 pub const EPOCH_MANAGER_CREATE_IDENT: &str = "create";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerCreateInput {
     pub olympia_validator_token_address: [u8; 26], // TODO: Clean this up
     pub component_address: [u8; 26],               // TODO: Clean this up
@@ -75,26 +75,26 @@ impl Clone for EpochManagerCreateInput {
 
 pub const EPOCH_MANAGER_GET_CURRENT_EPOCH_IDENT: &str = "get_current_epoch";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerGetCurrentEpochInput;
 
 pub const EPOCH_MANAGER_SET_EPOCH_IDENT: &str = "set_epoch";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerSetEpochInput {
     pub epoch: u64,
 }
 
 pub const EPOCH_MANAGER_NEXT_ROUND_IDENT: &str = "next_round";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerNextRoundInput {
     pub round: u64,
 }
 
 pub const EPOCH_MANAGER_CREATE_VALIDATOR_IDENT: &str = "create_validator";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerCreateValidatorInput {
     pub key: EcdsaSecp256k1PublicKey,
     pub owner_access_rule: AccessRule,
@@ -102,13 +102,13 @@ pub struct EpochManagerCreateValidatorInput {
 
 pub const EPOCH_MANAGER_UPDATE_VALIDATOR_IDENT: &str = "update_validator";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum UpdateValidator {
     Register(EcdsaSecp256k1PublicKey, Decimal),
     Unregister,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct EpochManagerUpdateValidatorInput {
     pub validator_address: ComponentAddress,
     pub update: UpdateValidator,
@@ -116,45 +116,45 @@ pub struct EpochManagerUpdateValidatorInput {
 
 pub const VALIDATOR_REGISTER_IDENT: &str = "register";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorRegisterInput {}
 
 pub const VALIDATOR_UNREGISTER_IDENT: &str = "unregister";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorUnregisterInput {}
 
 pub const VALIDATOR_STAKE_IDENT: &str = "stake";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorStakeInput {
     pub stake: Bucket,
 }
 
 pub const VALIDATOR_UNSTAKE_IDENT: &str = "unstake";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorUnstakeInput {
     pub lp_tokens: Bucket,
 }
 
 pub const VALIDATOR_CLAIM_XRD_IDENT: &str = "claim_xrd";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorClaimXrdInput {
     pub bucket: Bucket,
 }
 
 pub const VALIDATOR_UPDATE_KEY_IDENT: &str = "update_key";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorUpdateKeyInput {
     pub key: EcdsaSecp256k1PublicKey,
 }
 
 pub const VALIDATOR_UPDATE_ACCEPT_DELEGATED_STAKE_IDENT: &str = "update_accept_delegated_stake";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorUpdateAcceptDelegatedStakeInput {
     pub accept_delegated_stake: bool,
 }

--- a/radix-engine-interface/src/blueprints/identity/invocations.rs
+++ b/radix-engine-interface/src/blueprints/identity/invocations.rs
@@ -17,7 +17,7 @@ pub const IDENTITY_BLUEPRINT: &str = "Identity";
 
 pub const IDENTITY_CREATE_IDENT: &str = "create";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct IdentityCreateInput {
     pub access_rule: AccessRule,
 }

--- a/radix-engine-interface/src/blueprints/logger/invocations.rs
+++ b/radix-engine-interface/src/blueprints/logger/invocations.rs
@@ -15,7 +15,7 @@ impl LoggerAbi {
 }
 
 /// Represents the level of a log message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Categorize, Encode, Decode, LegacyDescribe)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Sbor, LegacyDescribe)]
 pub enum Level {
     Error,
     Warn,
@@ -40,7 +40,7 @@ pub const LOGGER_BLUEPRINT: &str = "Logger";
 
 pub const LOGGER_LOG_IDENT: &str = "log";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct LoggerLogInput {
     pub level: Level,
     pub message: String,

--- a/radix-engine-interface/src/blueprints/resource/access_rules.rs
+++ b/radix-engine-interface/src/blueprints/resource/access_rules.rs
@@ -11,37 +11,13 @@ use sbor::rust::string::ToString;
 
 use super::AccessRule;
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum AccessRuleKey {
     ScryptoMethod(String),
     Native(NativeFn),
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum AccessRuleEntry {
     AccessRule(AccessRule),
     Group(String),
@@ -60,9 +36,7 @@ impl From<String> for AccessRuleEntry {
 }
 
 /// Method authorization rules for a component
-#[derive(
-    Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, LegacyDescribe)]
 pub struct AccessRules {
     method_auth: BTreeMap<AccessRuleKey, AccessRuleEntry>,
     grouped_auth: BTreeMap<String, AccessRule>,

--- a/radix-engine-interface/src/blueprints/resource/bucket.rs
+++ b/radix-engine-interface/src/blueprints/resource/bucket.rs
@@ -2,6 +2,7 @@ use crate::abi::*;
 use crate::api::types::*;
 use crate::blueprints::resource::*;
 use crate::data::types::Own;
+use crate::data::ScryptoCustomTypeKind;
 use crate::data::ScryptoCustomValueKind;
 use crate::math::*;
 use crate::*;
@@ -12,14 +13,14 @@ pub const BUCKET_BLUEPRINT: &str = "Bucket";
 
 pub const BUCKET_TAKE_IDENT: &str = "Bucket_take";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketTakeInput {
     pub amount: Decimal,
 }
 
 pub const BUCKET_PUT_IDENT: &str = "Bucket_put";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketPutInput {
     pub bucket: Bucket,
 }
@@ -34,29 +35,29 @@ impl Clone for BucketPutInput {
 
 pub const BUCKET_TAKE_NON_FUNGIBLES_IDENT: &str = "Bucket_take_non_fungibles";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketTakeNonFungiblesInput {
     pub ids: BTreeSet<NonFungibleLocalId>,
 }
 
 pub const BUCKET_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT: &str = "Bucket_get_non_fungible_local_ids";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketGetNonFungibleLocalIdsInput {}
 
 pub const BUCKET_GET_AMOUNT_IDENT: &str = "Bucket_get_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketGetAmountInput {}
 
 pub const BUCKET_GET_RESOURCE_ADDRESS_IDENT: &str = "Bucket_get_resource_address";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketGetResourceAddressInput {}
 
 pub const BUCKET_CREATE_PROOF_IDENT: &str = "Bucket_create_proof";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct BucketCreateProofInput {}
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -102,4 +103,9 @@ impl scrypto_abi::LegacyDescribe for Bucket {
     fn describe() -> scrypto_abi::Type {
         Type::Bucket
     }
+}
+
+impl Describe<ScryptoCustomTypeKind<GlobalTypeId>> for Bucket {
+    const TYPE_ID: GlobalTypeId =
+        GlobalTypeId::well_known(crate::data::well_known_scrypto_custom_types::OWN_BUCKET_ID);
 }

--- a/radix-engine-interface/src/blueprints/resource/non_fungible_global_id.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible_global_id.rs
@@ -14,9 +14,7 @@ use scrypto_abi::Type;
 use utils::ContextualDisplay;
 
 /// Represents the global id of a non-fungible.
-#[derive(
-    Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
-)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor)]
 pub struct NonFungibleGlobalId(ResourceAddress, NonFungibleLocalId);
 
 impl LegacyDescribe for NonFungibleGlobalId {

--- a/radix-engine-interface/src/blueprints/resource/non_fungible_id_type.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible_id_type.rs
@@ -2,9 +2,7 @@ use crate::*;
 use sbor::*;
 
 /// Represents type of non-fungible id
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Sbor, LegacyDescribe)]
 pub enum NonFungibleIdType {
     String,
     Integer,

--- a/radix-engine-interface/src/blueprints/resource/proof.rs
+++ b/radix-engine-interface/src/blueprints/resource/proof.rs
@@ -2,7 +2,7 @@ use crate::abi::*;
 use crate::api::types::*;
 use crate::blueprints::resource::*;
 use crate::data::types::Own;
-use crate::data::ScryptoCustomValueKind;
+use crate::data::{ScryptoCustomTypeKind, ScryptoCustomValueKind};
 use crate::math::*;
 use sbor::rust::collections::BTreeSet;
 #[cfg(not(feature = "alloc"))]
@@ -13,22 +13,22 @@ pub const PROOF_BLUEPRINT: &str = "Proof";
 
 pub const PROOF_GET_AMOUNT_IDENT: &str = "Proof_get_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub struct ProofGetAmountInput {}
 
 pub const PROOF_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT: &str = "Proof_get_non_fungible_local_ids";
 
-#[derive(Debug, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub struct ProofGetNonFungibleLocalIdsInput {}
 
 pub const PROOF_GET_RESOURCE_ADDRESS_IDENT: &str = "Proof_get_resource_address";
 
-#[derive(Debug, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub struct ProofGetResourceAddressInput {}
 
 pub const PROOF_CLONE_IDENT: &str = "clone";
 
-#[derive(Debug, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub struct ProofCloneInput {}
 
 // TODO: Evaluate if we should have a ProofValidationModeBuilder to construct more complex validation modes.
@@ -127,4 +127,9 @@ impl scrypto_abi::LegacyDescribe for Proof {
     fn describe() -> scrypto_abi::Type {
         Type::Proof
     }
+}
+
+impl Describe<ScryptoCustomTypeKind<GlobalTypeId>> for Proof {
+    const TYPE_ID: GlobalTypeId =
+        GlobalTypeId::well_known(crate::data::well_known_scrypto_custom_types::OWN_PROOF_ID);
 }

--- a/radix-engine-interface/src/blueprints/resource/proof_rule.rs
+++ b/radix-engine-interface/src/blueprints/resource/proof_rule.rs
@@ -10,19 +10,7 @@ use sbor::rust::vec;
 use sbor::rust::vec::Vec;
 use scrypto_abi::{Fields, Type, Variant};
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum SoftDecimal {
     Static(Decimal),
     Dynamic(SchemaPath),
@@ -47,19 +35,7 @@ impl From<&str> for SoftDecimal {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum SoftCount {
     Static(u8),
     Dynamic(SchemaPath),
@@ -84,19 +60,7 @@ impl From<&str> for SoftCount {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum SoftResource {
     Static(ResourceAddress),
     Dynamic(SchemaPath),
@@ -121,19 +85,7 @@ impl From<&str> for SoftResource {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum SoftResourceOrNonFungible {
     StaticNonFungible(NonFungibleGlobalId),
     StaticResource(ResourceAddress),
@@ -165,19 +117,7 @@ impl From<&str> for SoftResourceOrNonFungible {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum SoftResourceOrNonFungibleList {
     Static(Vec<SoftResourceOrNonFungible>),
     Dynamic(SchemaPath),
@@ -206,19 +146,7 @@ where
 }
 
 /// Resource Proof Rules
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum ProofRule {
     Require(SoftResourceOrNonFungible),
     AmountOf(SoftDecimal, SoftResource),
@@ -233,18 +161,7 @@ impl From<ResourceAddress> for ProofRule {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor)]
 pub enum AccessRuleNode {
     ProofRule(ProofRule),
     AnyOf(Vec<AccessRuleNode>),
@@ -343,19 +260,7 @@ where
     ProofRule::AmountOf(amount.into(), resource.into())
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Ord,
-    PartialOrd,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, LegacyDescribe)]
 pub enum AccessRule {
     AllowAll,
     DenyAll,

--- a/radix-engine-interface/src/blueprints/resource/resource.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::api::types::{BucketId, VaultId};
 use radix_engine_interface::blueprints::resource::*;
 use sbor::rust::collections::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ResourceOperationError {
     /// Resource addresses do not match.
     ResourceAddressNotMatching,
@@ -24,7 +24,7 @@ pub enum ResourceOperationError {
 }
 
 /// A raw record of resource persisted in the substate store
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum Resource {
     Fungible {
         /// The resource address.
@@ -276,7 +276,7 @@ pub enum LockableResource {
 /// The locked amount or non-fungible IDs.
 ///
 /// Invariant: always consistent with resource fungibility.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum LockedAmountOrIds {
     Amount(Decimal),
     Ids(BTreeSet<NonFungibleLocalId>),

--- a/radix-engine-interface/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource_manager.rs
@@ -23,40 +23,14 @@ impl ResourceManagerAbi {
 
 pub const RESOURCE_MANAGER_BLUEPRINT: &str = "ResourceManager";
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor, LegacyDescribe)]
 pub enum VaultMethodAuthKey {
     Withdraw,
     Deposit,
     Recall,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor, LegacyDescribe)]
 pub enum ResourceMethodAuthKey {
     Mint,
     Burn,
@@ -69,7 +43,7 @@ pub enum ResourceMethodAuthKey {
 
 pub const RESOURCE_MANAGER_CREATE_FUNGIBLE_IDENT: &str = "create_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateFungibleInput {
     pub divisibility: u8,
     pub metadata: BTreeMap<String, String>,
@@ -79,7 +53,7 @@ pub struct ResourceManagerCreateFungibleInput {
 pub const RESOURCE_MANAGER_CREATE_FUNGIBLE_WITH_INITIAL_SUPPLY_IDENT: &str =
     "create_fungible_with_initial_supply";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateFungibleWithInitialSupplyInput {
     pub divisibility: u8,
     pub metadata: BTreeMap<String, String>,
@@ -90,7 +64,7 @@ pub struct ResourceManagerCreateFungibleWithInitialSupplyInput {
 pub const RESOURCE_MANAGER_CREATE_FUNGIBLE_WITH_INITIAL_SUPPLY_AND_ADDRESS_IDENT: &str =
     "create_fungible_with_initial_supply_and_address";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateFungibleWithInitialSupplyAndAddressInput {
     pub divisibility: u8,
     pub metadata: BTreeMap<String, String>,
@@ -101,7 +75,7 @@ pub struct ResourceManagerCreateFungibleWithInitialSupplyAndAddressInput {
 
 pub const RESOURCE_MANAGER_CREATE_NON_FUNGIBLE_IDENT: &str = "create_non_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateNonFungibleInput {
     pub id_type: NonFungibleIdType,
     pub metadata: BTreeMap<String, String>,
@@ -111,7 +85,7 @@ pub struct ResourceManagerCreateNonFungibleInput {
 pub const RESOURCE_MANAGER_CREATE_NON_FUNGIBLE_WITH_INITIAL_SUPPLY_IDENT: &str =
     "create_non_fungible_with_initial_supply";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateNonFungibleWithInitialSupplyInput {
     pub id_type: NonFungibleIdType,
     pub metadata: BTreeMap<String, String>,
@@ -122,7 +96,7 @@ pub struct ResourceManagerCreateNonFungibleWithInitialSupplyInput {
 pub const RESOURCE_MANAGER_CREATE_NON_FUNGIBLE_WITH_ADDRESS_IDENT: &str =
     "create_non_fungible_with_address";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateNonFungibleWithAddressInput {
     pub id_type: NonFungibleIdType,
     pub metadata: BTreeMap<String, String>,
@@ -133,7 +107,7 @@ pub struct ResourceManagerCreateNonFungibleWithAddressInput {
 pub const RESOURCE_MANAGER_CREATE_UUID_NON_FUNGIBLE_WITH_INITIAL_SUPPLY: &str =
     "create_uuid_non_fungible_with_initial_supply";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateUuidNonFungibleWithInitialSupplyInput {
     pub metadata: BTreeMap<String, String>,
     pub access_rules: BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)>,
@@ -142,7 +116,7 @@ pub struct ResourceManagerCreateUuidNonFungibleWithInitialSupplyInput {
 
 pub const RESOURCE_MANAGER_BURN_BUCKET_IDENT: &str = "burn_bucket";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerBurnBucketInput {
     pub bucket: Bucket,
 }
@@ -157,24 +131,24 @@ impl Clone for ResourceManagerBurnBucketInput {
 
 pub const RESOURCE_MANAGER_BURN_IDENT: &str = "burn";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerBurnInput {
     pub bucket: Bucket,
 }
 
 pub const RESOURCE_MANAGER_CREATE_VAULT_IDENT: &str = "create_vault";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateVaultInput {}
 
 pub const RESOURCE_MANAGER_CREATE_BUCKET_IDENT: &str = "create_bucket";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerCreateBucketInput {}
 
 pub const RESOURCE_MANAGER_UPDATE_VAULT_AUTH_IDENT: &str = "update_vault_auth";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerUpdateVaultAuthInput {
     pub method: VaultMethodAuthKey,
     pub access_rule: AccessRule,
@@ -182,7 +156,7 @@ pub struct ResourceManagerUpdateVaultAuthInput {
 
 pub const RESOURCE_MANAGER_SET_VAULT_AUTH_MUTABILITY_IDENT: &str = "set_vault_auth_mutability";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerSetVaultAuthMutabilityInput {
     pub method: VaultMethodAuthKey,
     pub mutability: AccessRule,
@@ -190,7 +164,7 @@ pub struct ResourceManagerSetVaultAuthMutabilityInput {
 
 pub const RESOURCE_MANAGER_UPDATE_NON_FUNGIBLE_DATA_IDENT: &str = "update_non_fungible_data";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerUpdateNonFungibleDataInput {
     pub id: NonFungibleLocalId,
     pub data: Vec<u8>,
@@ -198,47 +172,47 @@ pub struct ResourceManagerUpdateNonFungibleDataInput {
 
 pub const RESOURCE_MANAGER_NON_FUNGIBLE_EXISTS_IDENT: &str = "non_fungible_exists";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerNonFungibleExistsInput {
     pub id: NonFungibleLocalId,
 }
 
 pub const RESOURCE_MANAGER_GET_NON_FUNGIBLE_IDENT: &str = "get_non_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerGetNonFungibleInput {
     pub id: NonFungibleLocalId,
 }
 
 pub const RESOURCE_MANAGER_MINT_NON_FUNGIBLE: &str = "mint_non_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerMintNonFungibleInput {
     pub entries: BTreeMap<NonFungibleLocalId, (Vec<u8>, Vec<u8>)>,
 }
 
 pub const RESOURCE_MANAGER_MINT_UUID_NON_FUNGIBLE: &str = "mint_uuid_non_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerMintUuidNonFungibleInput {
     pub entries: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 pub const RESOURCE_MANAGER_MINT_FUNGIBLE: &str = "mint_fungible";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerMintFungibleInput {
     pub amount: Decimal,
 }
 
 pub const RESOURCE_MANAGER_GET_RESOURCE_TYPE_IDENT: &str = "get_resource_type";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerGetResourceTypeInput {}
 
 pub const RESOURCE_MANAGER_GET_TOTAL_SUPPLY_IDENT: &str = "get_total_supply";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResourceManagerGetTotalSupplyInput {}
 
 /// Represents a resource address.

--- a/radix-engine-interface/src/blueprints/resource/resource_type.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource_type.rs
@@ -3,7 +3,7 @@ use crate::*;
 use sbor::*;
 
 /// Represents the type of a resource.
-#[derive(Debug, Clone, Copy, Categorize, Encode, Decode, LegacyDescribe, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Sbor, LegacyDescribe, Eq, PartialEq)]
 pub enum ResourceType {
     /// Represents a fungible resource
     Fungible { divisibility: u8 },

--- a/radix-engine-interface/src/blueprints/resource/vault.rs
+++ b/radix-engine-interface/src/blueprints/resource/vault.rs
@@ -8,7 +8,7 @@ pub const VAULT_BLUEPRINT: &str = "Vault";
 
 pub const VAULT_PUT_IDENT: &str = "put";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultPutInput {
     pub bucket: Bucket,
 }
@@ -23,21 +23,21 @@ impl Clone for VaultPutInput {
 
 pub const VAULT_TAKE_IDENT: &str = "take";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultTakeInput {
     pub amount: Decimal,
 }
 
 pub const VAULT_TAKE_NON_FUNGIBLES_IDENT: &str = "take_non_fungibles";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultTakeNonFungiblesInput {
     pub non_fungible_local_ids: BTreeSet<NonFungibleLocalId>,
 }
 
 pub const VAULT_LOCK_FEE_IDENT: &str = "lock_fee";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultLockFeeInput {
     pub amount: Decimal,
     pub contingent: bool,
@@ -45,48 +45,48 @@ pub struct VaultLockFeeInput {
 
 pub const VAULT_RECALL_IDENT: &str = "recall";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultRecallInput {
     pub amount: Decimal,
 }
 
 pub const VAULT_RECALL_NON_FUNGIBLES_IDENT: &str = "recall_non_fungibles";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultRecallNonFungiblesInput {
     pub non_fungible_local_ids: BTreeSet<NonFungibleLocalId>,
 }
 
 pub const VAULT_GET_AMOUNT_IDENT: &str = "get_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultGetAmountInput {}
 
 pub const VAULT_GET_RESOURCE_ADDRESS_IDENT: &str = "get_resource_address";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultGetResourceAddressInput {}
 
 pub const VAULT_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT: &str = "get_non_fungible_local_ids";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultGetNonFungibleLocalIdsInput {}
 
 pub const VAULT_CREATE_PROOF_IDENT: &str = "create_proof";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultCreateProofInput {}
 
 pub const VAULT_CREATE_PROOF_BY_AMOUNT_IDENT: &str = "create_proof_by_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultCreateProofByAmountInput {
     pub amount: Decimal,
 }
 
 pub const VAULT_CREATE_PROOF_BY_IDS_IDENT: &str = "create_proof_by_ids";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct VaultCreateProofByIdsInput {
     pub ids: BTreeSet<NonFungibleLocalId>,
 }

--- a/radix-engine-interface/src/blueprints/resource/worktop.rs
+++ b/radix-engine-interface/src/blueprints/resource/worktop.rs
@@ -7,7 +7,7 @@ pub const WORKTOP_BLUEPRINT: &str = "Worktop";
 
 pub const WORKTOP_PUT_IDENT: &str = "Worktop_put";
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopPutInput {
     pub bucket: Bucket,
 }
@@ -22,7 +22,7 @@ impl Clone for WorktopPutInput {
 
 pub const WORKTOP_TAKE_IDENT: &str = "Worktop_take";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopTakeInput {
     pub amount: Decimal,
     pub resource_address: ResourceAddress,
@@ -30,7 +30,7 @@ pub struct WorktopTakeInput {
 
 pub const WORKTOP_TAKE_NON_FUNGIBLES_IDENT: &str = "Worktop_take_non_fungibles";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopTakeNonFungiblesInput {
     pub ids: BTreeSet<NonFungibleLocalId>,
     pub resource_address: ResourceAddress,
@@ -38,21 +38,21 @@ pub struct WorktopTakeNonFungiblesInput {
 
 pub const WORKTOP_TAKE_ALL_IDENT: &str = "Worktop_take_all";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopTakeAllInput {
     pub resource_address: ResourceAddress,
 }
 
 pub const WORKTOP_ASSERT_CONTAINS_IDENT: &str = "Worktop_assert_contains";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopAssertContainsInput {
     pub resource_address: ResourceAddress,
 }
 
 pub const WORKTOP_ASSERT_CONTAINS_AMOUNT_IDENT: &str = "Worktop_assert_contains_amount";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopAssertContainsAmountInput {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,
@@ -61,7 +61,7 @@ pub struct WorktopAssertContainsAmountInput {
 pub const WORKTOP_ASSERT_CONTAINS_NON_FUNGIBLES_IDENT: &str =
     "Worktop_assert_contains_non_fungibles";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopAssertContainsNonFungiblesInput {
     pub resource_address: ResourceAddress,
     pub ids: BTreeSet<NonFungibleLocalId>,
@@ -69,5 +69,5 @@ pub struct WorktopAssertContainsNonFungiblesInput {
 
 pub const WORKTOP_DRAIN_IDENT: &str = "Worktop_drain";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopDrainInput {}

--- a/radix-engine-interface/src/blueprints/transaction_runtime/invocations.rs
+++ b/radix-engine-interface/src/blueprints/transaction_runtime/invocations.rs
@@ -16,10 +16,10 @@ pub const TRANSACTION_RUNTIME_BLUEPRINT: &str = "TransactionRuntime";
 
 pub const TRANSACTION_RUNTIME_GET_HASH_IDENT: &str = "get_hash";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct TransactionRuntimeGetHashInput {}
 
 pub const TRANSACTION_RUNTIME_GENERATE_UUID_IDENT: &str = "generate_uuid";
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct TransactionRuntimeGenerateUuid {}

--- a/radix-engine-interface/src/crypto/public_key.rs
+++ b/radix-engine-interface/src/crypto/public_key.rs
@@ -7,9 +7,7 @@ use crate::*;
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type", content = "public_key")
 )]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum PublicKey {
     EcdsaSecp256k1(EcdsaSecp256k1PublicKey),
     EddsaEd25519(EddsaEd25519PublicKey),

--- a/radix-engine-interface/src/data/custom_schema.rs
+++ b/radix-engine-interface/src/data/custom_schema.rs
@@ -6,7 +6,7 @@ pub type ScryptoTypeKind<L> = TypeKind<ScryptoCustomValueKind, ScryptoCustomType
 pub type ScryptoSchema = Schema<ScryptoCustomTypeExtension>;
 
 /// A schema for the values that a codec can decode / views as valid
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum ScryptoCustomTypeKind<L: SchemaTypeLink> {
     // Global address types
     PackageAddress,

--- a/radix-engine-interface/src/data/custom_value_kind.rs
+++ b/radix-engine-interface/src/data/custom_value_kind.rs
@@ -4,6 +4,7 @@ pub const VALUE_KIND_PACKAGE_ADDRESS: u8 = 0x80;
 pub const VALUE_KIND_COMPONENT_ADDRESS: u8 = 0x81;
 pub const VALUE_KIND_RESOURCE_ADDRESS: u8 = 0x82;
 pub const VALUE_KIND_OWN: u8 = 0x90;
+// 90-9f reserved for well-known own subtypes
 
 pub const VALUE_KIND_BUCKET: u8 = 0xa0;
 pub const VALUE_KIND_PROOF: u8 = 0xa1;

--- a/radix-engine-interface/src/data/custom_well_known_types.rs
+++ b/radix-engine-interface/src/data/custom_well_known_types.rs
@@ -11,6 +11,13 @@ pub mod well_known_scrypto_custom_types {
     pub const RESOURCE_ADDRESS_ID: u8 = VALUE_KIND_RESOURCE_ADDRESS;
 
     pub const OWN_ID: u8 = VALUE_KIND_OWN;
+    pub const OWN_BUCKET_ID: u8 = VALUE_KIND_OWN + 1;
+    pub const OWN_PROOF_ID: u8 = VALUE_KIND_OWN + 2;
+    pub const OWN_VAULT_ID: u8 = VALUE_KIND_OWN + 3;
+    pub const OWN_COMPONENT_ID: u8 = VALUE_KIND_OWN + 4;
+    pub const OWN_KEY_VALUE_STORE_ID: u8 = VALUE_KIND_OWN + 5;
+    pub const OWN_ACCOUNT_ID: u8 = VALUE_KIND_OWN + 6;
+
     // We skip KeyValueStore because it has generic parameters
 
     pub const HASH_ID: u8 = VALUE_KIND_HASH;
@@ -32,6 +39,12 @@ pub(crate) fn resolve_scrypto_custom_well_known_type(
         RESOURCE_ADDRESS_ID => ("ResourceAddress", ScryptoCustomTypeKind::ResourceAddress),
 
         OWN_ID => ("Own", ScryptoCustomTypeKind::Own),
+        OWN_BUCKET_ID => ("Bucket", ScryptoCustomTypeKind::Own),
+        OWN_PROOF_ID => ("Proof", ScryptoCustomTypeKind::Own),
+        OWN_VAULT_ID => ("Vault", ScryptoCustomTypeKind::Own),
+        OWN_COMPONENT_ID => ("Component", ScryptoCustomTypeKind::Own),
+        OWN_KEY_VALUE_STORE_ID => ("KeyValueStore", ScryptoCustomTypeKind::Own),
+        OWN_ACCOUNT_ID => ("Account", ScryptoCustomTypeKind::Own),
 
         HASH_ID => ("Hash", ScryptoCustomTypeKind::Hash),
         ECDSA_SECP256K1_PUBLIC_KEY_ID => (

--- a/radix-engine-interface/src/data/indexed_value.rs
+++ b/radix-engine-interface/src/data/indexed_value.rs
@@ -14,13 +14,13 @@ use sbor::rust::vec::Vec;
 use utils::ContextualDisplay;
 
 /// Represents an error when reading the owned node ids from a value.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ReadOwnedNodesError {
     DuplicateOwn,
 }
 
 /// Represents an error when replacing manifest values.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ReplaceManifestValuesError {
     BucketNotFound(ManifestBucket),
     ProofNotFound(ManifestProof),
@@ -373,7 +373,7 @@ pub struct ScryptoValueVisitor {
     pub maps: Vec<(ScryptoValueKind, ScryptoValueKind, SborPath)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum ValueIndexingError {
     DuplicateOwnership,
     DuplicateManifestBucket,

--- a/radix-engine-interface/src/data/mod.rs
+++ b/radix-engine-interface/src/data/mod.rs
@@ -28,10 +28,7 @@ pub use custom_value_kind::*;
 pub use custom_well_known_types::*;
 pub use indexed_value::*;
 use sbor::rust::vec::Vec;
-use sbor::{
-    Categorize, Decode, DecodeError, Decoder, Encode, EncodeError, Encoder, Value, ValueKind,
-    VecDecoder, VecEncoder,
-};
+use sbor::*;
 pub use schema_matcher::*;
 pub use schema_path::*;
 pub use value_formatter::*;
@@ -67,6 +64,12 @@ impl<T: for<'a> Decode<ScryptoCustomValueKind, ScryptoDecoder<'a>>> ScryptoDecod
 
 pub trait ScryptoEncode: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> {}
 impl<T: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> + ?Sized> ScryptoEncode for T {}
+
+pub trait ScryptoDescribe: Describe<ScryptoCustomTypeKind<GlobalTypeId>> {}
+impl<T: Describe<ScryptoCustomTypeKind<GlobalTypeId>>> ScryptoDescribe for T {}
+
+pub trait ScryptoSbor: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe {}
+impl<T: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe> ScryptoSbor for T {}
 
 /// Encodes a data structure into byte array.
 pub fn scrypto_encode<T: ScryptoEncode + ?Sized>(value: &T) -> Result<Vec<u8>, EncodeError> {
@@ -126,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_args() {
-        #[derive(ScryptoEncode, ScryptoDecode, ScryptoCategorize)]
+        #[derive(ScryptoSbor)]
         struct A {
             a: u32,
             b: String,

--- a/radix-engine-interface/src/data/schema_path.rs
+++ b/radix-engine-interface/src/data/schema_path.rs
@@ -10,9 +10,7 @@ use self::SchemaSubPath::{Field, Index};
 use crate::*;
 use scrypto_abi::*;
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, LegacyDescribe, Categorize, Encode, Decode, Ord, PartialOrd,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, LegacyDescribe, Sbor, Ord, PartialOrd)]
 pub enum SchemaSubPath {
     Index(usize),
     Field(String),
@@ -32,9 +30,7 @@ impl FromStr for SchemaSubPath {
 }
 
 /// Describes a value located in some sbor given a schema for that sbor
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, LegacyDescribe, Categorize, Encode, Decode, Ord, PartialOrd,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, LegacyDescribe, Sbor, Ord, PartialOrd)]
 pub struct SchemaPath(pub Vec<SchemaSubPath>);
 
 impl SchemaPath {

--- a/radix-engine-interface/src/data/types/manifest_blob.rs
+++ b/radix-engine-interface/src/data/types/manifest_blob.rs
@@ -54,3 +54,8 @@ impl ManifestBlobRef {
 }
 
 schemaless_scrypto_custom_type!(ManifestBlobRef, ScryptoCustomValueKind::Blob, 32);
+
+// Temporary until ManifestBlobRef is no longer in the ScryptoValue model
+impl<C: CustomTypeKind<GlobalTypeId>> Describe<C> for ManifestBlobRef {
+    const TYPE_ID: GlobalTypeId = GlobalTypeId::well_known(basic_well_known_types::ANY_ID);
+}

--- a/radix-engine-interface/src/data/types/manifest_bucket.rs
+++ b/radix-engine-interface/src/data/types/manifest_bucket.rs
@@ -52,3 +52,8 @@ impl ManifestBucket {
 }
 
 schemaless_scrypto_custom_type!(ManifestBucket, ScryptoCustomValueKind::Bucket, 4);
+
+// Temporary until ManifestBucket is no longer in the ScryptoValue model
+impl<C: CustomTypeKind<GlobalTypeId>> Describe<C> for ManifestBucket {
+    const TYPE_ID: GlobalTypeId = GlobalTypeId::well_known(basic_well_known_types::ANY_ID);
+}

--- a/radix-engine-interface/src/data/types/manifest_expression.rs
+++ b/radix-engine-interface/src/data/types/manifest_expression.rs
@@ -69,3 +69,8 @@ impl ManifestExpression {
 }
 
 schemaless_scrypto_custom_type!(ManifestExpression, ScryptoCustomValueKind::Expression, 1);
+
+// Temporary until ManifestExpression is no longer in the ScryptoValue model
+impl<C: CustomTypeKind<GlobalTypeId>> Describe<C> for ManifestExpression {
+    const TYPE_ID: GlobalTypeId = GlobalTypeId::well_known(basic_well_known_types::ANY_ID);
+}

--- a/radix-engine-interface/src/data/types/manifest_proof.rs
+++ b/radix-engine-interface/src/data/types/manifest_proof.rs
@@ -52,3 +52,8 @@ impl ManifestProof {
 }
 
 schemaless_scrypto_custom_type!(ManifestProof, ScryptoCustomValueKind::Proof, 4);
+
+// Temporary until ManifestProof is no longer in the ScryptoValue model
+impl<C: CustomTypeKind<GlobalTypeId>> Describe<C> for ManifestProof {
+    const TYPE_ID: GlobalTypeId = GlobalTypeId::well_known(basic_well_known_types::ANY_ID);
+}

--- a/radix-engine-interface/src/data/types/ownership.rs
+++ b/radix-engine-interface/src/data/types/ownership.rs
@@ -1,7 +1,7 @@
 use crate::abi::*;
 use crate::api::types::*;
 use crate::blueprints::resource::*;
-use crate::data::ScryptoCustomValueKind;
+use crate::data::{ScryptoCustomTypeKind, ScryptoCustomValueKind};
 use crate::*;
 #[cfg(not(feature = "alloc"))]
 use sbor::rust::fmt;
@@ -155,4 +155,9 @@ impl scrypto_abi::LegacyDescribe for Own {
     fn describe() -> scrypto_abi::Type {
         Type::Own
     }
+}
+
+impl Describe<ScryptoCustomTypeKind<GlobalTypeId>> for Own {
+    const TYPE_ID: GlobalTypeId =
+        GlobalTypeId::well_known(crate::data::well_known_scrypto_custom_types::OWN_ID);
 }

--- a/radix-engine-interface/src/data/types/reference.rs
+++ b/radix-engine-interface/src/data/types/reference.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(ScryptoSbor)]
 pub enum Reference {
     // TODO: add more
 }

--- a/radix-engine-interface/src/data/value_serializer.rs
+++ b/radix-engine-interface/src/data/value_serializer.rs
@@ -657,7 +657,7 @@ mod tests {
         data::{scrypto_decode, scrypto_encode, ScryptoValue},
     };
 
-    #[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+    #[derive(ScryptoSbor)]
     pub struct Sample {
         pub a: ResourceAddress,
     }

--- a/radix-engine-interface/src/network/mod.rs
+++ b/radix-engine-interface/src/network/mod.rs
@@ -1,9 +1,9 @@
 use sbor::rust::str::FromStr;
 use sbor::rust::string::String;
-use sbor::{Categorize, Decode, Encode};
+use sbor::*;
 
 /// Network Definition is intended to be the actual definition of a network
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct NetworkDefinition {
     // TODO: we may be able to squeeze network identifier into the other fields, like the `v` byte in signature.
     pub id: u8,

--- a/radix-engine-interface/src/time/instant.rs
+++ b/radix-engine-interface/src/time/instant.rs
@@ -4,7 +4,7 @@ use sbor::*;
 /// Represents a Unix timestamp, capturing the seconds since the unix epoch.
 ///
 /// See also the [`UtcDateTime`](super::UtcDateTime) type which supports conversion to/from `Instant`.
-#[derive(Encode, Decode, Categorize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Sbor, Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Instant {
     pub seconds_since_unix_epoch: i64,
 }
@@ -56,7 +56,7 @@ impl Instant {
     }
 }
 
-#[derive(Encode, Decode, Categorize, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Sbor, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TimeComparisonOperator {
     Eq,
     Lt,

--- a/radix-engine-interface/src/time/utc_date_time.rs
+++ b/radix-engine-interface/src/time/utc_date_time.rs
@@ -41,7 +41,7 @@ const MIN_SUPPORTED_TIMESTAMP: i64 = -62135596800;
 /// where year `4294967295` equals `u32::MAX`.
 const MAX_SUPPORTED_TIMESTAMP: i64 = 135536014634284799;
 
-#[derive(Encode, Decode, Categorize, PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(Sbor, PartialEq, Eq, Copy, Clone, Debug)]
 pub enum DateTimeError {
     InvalidYear,
     InvalidMonth,
@@ -88,7 +88,7 @@ impl fmt::Display for DateTimeError {
 ///
 /// `UtcDateTime` supports methods for easy conversion to and from the [`Instant`](super::Instant) type, which
 /// can be queried from the Radix Engine.
-#[derive(Encode, Decode, Categorize, PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(Sbor, PartialEq, Eq, Copy, Clone, Debug)]
 pub struct UtcDateTime {
     year: u32,
     month: u8,

--- a/radix-engine-interface/tests/encode_decode_describe.rs
+++ b/radix-engine-interface/tests/encode_decode_describe.rs
@@ -1,7 +1,7 @@
 use radix_engine_interface::math::*;
 use radix_engine_interface::*;
 
-#[derive(NonFungibleData, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(NonFungibleData, ScryptoSbor, LegacyDescribe)]
 pub struct TestStruct {
     pub a: u32,
     #[legacy_skip]
@@ -10,7 +10,7 @@ pub struct TestStruct {
     pub c: Decimal,
 }
 
-#[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+#[derive(ScryptoSbor, LegacyDescribe)]
 pub enum TestEnum {
     A { named: String },
     B(u32, u8, Decimal),

--- a/radix-engine-tests/tests/blueprints/component/src/external_blueprint_target.rs
+++ b/radix-engine-tests/tests/blueprints/component/src/external_blueprint_target.rs
@@ -1,11 +1,11 @@
 use scrypto::prelude::*;
 
-#[derive(Categorize, Encode, Decode, LegacyDescribe, Clone)]
+#[derive(Sbor, LegacyDescribe, Clone)]
 pub struct ExtraStruct {
     field_one: String,
 }
 
-#[derive(Categorize, Encode, Decode, LegacyDescribe, Clone)]
+#[derive(Sbor, LegacyDescribe, Clone)]
 pub enum ExtraEnum {
     EntryOne,
     EntryTwo,

--- a/radix-engine-tests/tests/blueprints/external_blueprint_caller/src/external_blueprint_caller.rs
+++ b/radix-engine-tests/tests/blueprints/external_blueprint_caller/src/external_blueprint_caller.rs
@@ -1,11 +1,11 @@
 use scrypto::prelude::*;
 
-#[derive(Categorize, Encode, Decode, LegacyDescribe, PartialEq)]
+#[derive(Sbor, LegacyDescribe, PartialEq)]
 struct ExtraStruct {
     field_one: String,
 }
 
-#[derive(Categorize, Encode, Decode, LegacyDescribe, PartialEq)]
+#[derive(Sbor, LegacyDescribe, PartialEq)]
 enum ExtraEnum {
     EntryOne,
     EntryTwo,

--- a/radix-engine-tests/tests/blueprints/kernel/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/kernel/src/lib.rs
@@ -3,7 +3,7 @@ use scrypto::engine::scrypto_env::*;
 use scrypto::prelude::*;
 
 // TODO: de-dup
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum GlobalAddressSubstate {
     Component(ComponentId),
     Resource(ResourceManagerId),

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -18,7 +18,7 @@ use radix_engine_interface::*;
 use radix_engine_interface::{api::*, rule};
 use sbor::rust::collections::BTreeMap;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct AccessControllerSubstate {
     /// A vault where the asset controlled by the access controller lives.
     pub controlled_asset: VaultId,
@@ -46,28 +46,28 @@ impl AccessControllerSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
 pub enum PrimaryRoleState {
     #[default]
     Unlocked,
     Locked,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
 pub enum PrimaryOperationState {
     #[default]
     Normal,
     Recovery(RecoveryProposal),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
 pub enum RecoveryOperationState {
     #[default]
     Normal,
     Recovery(RecoveryRecoveryState),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum RecoveryRecoveryState {
     Untimed(RecoveryProposal),
     Timed {
@@ -76,7 +76,7 @@ pub enum RecoveryRecoveryState {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum AccessControllerError {
     /// Occurs when some action requires that the primary role is unlocked to happen.
     OperationRequiresUnlockedPrimaryRole,

--- a/radix-engine/src/blueprints/account/package.rs
+++ b/radix-engine/src/blueprints/account/package.rs
@@ -23,14 +23,14 @@ use crate::system::node_modules::metadata::MetadataSubstate;
 use native_sdk::resource::{SysBucket, Vault};
 use radix_engine_interface::data::ScryptoValue;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct AccountSubstate {
     /// An owned [`KeyValueStore`] which maps the [`ResourceAddress`] to an [`Own`] of the vault
     /// containing that resource.
     pub vaults: Own,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum AccountError {
     VaultDoesNotExist { resource_address: ResourceAddress },
 }

--- a/radix-engine/src/blueprints/auth_zone/package.rs
+++ b/radix-engine/src/blueprints/auth_zone/package.rs
@@ -15,7 +15,7 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 use sbor::rust::vec::Vec;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum AuthZoneError {
     EmptyAuthZone,
     ProofError(ProofError),

--- a/radix-engine/src/blueprints/clock/package.rs
+++ b/radix-engine/src/blueprints/clock/package.rs
@@ -21,7 +21,7 @@ use radix_engine_interface::data::ScryptoValue;
 use radix_engine_interface::rule;
 use radix_engine_interface::time::*;
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct CurrentTimeRoundedToMinutesSubstate {
     pub current_time_rounded_to_minutes_ms: i64,
 }

--- a/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
+++ b/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
@@ -19,7 +19,7 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 use radix_engine_interface::rule;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct EpochManagerSubstate {
     pub address: ComponentAddress, // TODO: Does it make sense for this to be stored here?
     pub epoch: u64,
@@ -30,21 +30,19 @@ pub struct EpochManagerSubstate {
     pub num_unstake_epochs: u64,
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Ord, PartialOrd, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, ScryptoSbor)]
 pub struct Validator {
     pub key: EcdsaSecp256k1PublicKey,
     pub stake: Decimal,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ValidatorSetSubstate {
     pub validator_set: BTreeMap<ComponentAddress, Validator>,
     pub epoch: u64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub enum EpochManagerError {
     InvalidRoundUpdate { from: u64, to: u64 },
 }

--- a/radix-engine/src/blueprints/epoch_manager/validator.rs
+++ b/radix-engine/src/blueprints/epoch_manager/validator.rs
@@ -17,7 +17,7 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 use radix_engine_interface::rule;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ValidatorSubstate {
     pub manager: ComponentAddress,
     pub address: ComponentAddress,
@@ -30,13 +30,13 @@ pub struct ValidatorSubstate {
     pub pending_xrd_withdraw_vault_id: VaultId,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct UnstakeData {
     epoch_unlocked: u64,
     amount: Decimal,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ValidatorError {
     InvalidClaimResource,
     EpochUnlockHasNotOccurredYet,

--- a/radix-engine/src/blueprints/logger/package.rs
+++ b/radix-engine/src/blueprints/logger/package.rs
@@ -9,7 +9,7 @@ use radix_engine_interface::data::{
     scrypto_decode, scrypto_encode, IndexedScryptoValue, ScryptoValue,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct LoggerSubstate {
     pub logs: Vec<(Level, String)>,
 }

--- a/radix-engine/src/blueprints/resource/bucket.rs
+++ b/radix-engine/src/blueprints/resource/bucket.rs
@@ -10,7 +10,7 @@ use radix_engine_interface::api::ClientApi;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum BucketError {
     InvalidDivisibility,
     InvalidRequestData(DecodeError),

--- a/radix-engine/src/blueprints/resource/executables/non_fungible.rs
+++ b/radix-engine/src/blueprints/resource/executables/non_fungible.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 
 /// A non-fungible is a piece of data that is uniquely identified within a resource.
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct NonFungible {
     immutable_data: Vec<u8>,
     mutable_data: Vec<u8>,

--- a/radix-engine/src/blueprints/resource/proof.rs
+++ b/radix-engine/src/blueprints/resource/proof.rs
@@ -10,7 +10,7 @@ use radix_engine_interface::api::{ClientApi, ClientNativeInvokeApi, ClientSubsta
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ProofError {
     /// Error produced by a resource container.
     ResourceOperationError(ResourceOperationError),

--- a/radix-engine/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager.rs
@@ -30,7 +30,7 @@ use radix_engine_interface::data::ScryptoValue;
 use radix_engine_interface::math::Decimal;
 use radix_engine_interface::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResourceManagerSubstate {
     pub resource_address: ResourceAddress, // TODO: Figure out a way to remove?
     pub resource_type: ResourceType,
@@ -73,7 +73,7 @@ impl ResourceManagerSubstate {
 }
 
 /// Represents an error when accessing a bucket.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ResourceManagerError {
     InvalidAmount(Decimal, u8),
     MaxMintAmountExceeded,

--- a/radix-engine/src/blueprints/resource/substates/non_fungible.rs
+++ b/radix-engine/src/blueprints/resource/substates/non_fungible.rs
@@ -1,5 +1,5 @@
 use crate::blueprints::resource::*;
 use crate::types::*;
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct NonFungibleSubstate(pub Option<NonFungible>);

--- a/radix-engine/src/blueprints/resource/vault.rs
+++ b/radix-engine/src/blueprints/resource/vault.rs
@@ -14,7 +14,7 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::ScryptoValue;
 use sbor::rust::ops::Deref;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct VaultSubstate(pub Resource);
 
 impl VaultSubstate {
@@ -200,7 +200,7 @@ impl VaultRuntimeSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum VaultError {
     InvalidRequestData(DecodeError),
     ResourceOperationError(ResourceOperationError),

--- a/radix-engine/src/blueprints/resource/worktop.rs
+++ b/radix-engine/src/blueprints/resource/worktop.rs
@@ -23,7 +23,7 @@ impl WorktopSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum WorktopError {
     AssertionFailed,
 }

--- a/radix-engine/src/blueprints/transaction_processor/executables.rs
+++ b/radix-engine/src/blueprints/transaction_processor/executables.rs
@@ -27,7 +27,7 @@ use transaction::errors::ManifestIdAllocationError;
 use transaction::model::*;
 use transaction::validation::*;
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, ScryptoSbor)]
 pub struct TransactionProcessorRunInvocation<'a> {
     pub transaction_hash: Hash,
     pub runtime_validations: Cow<'a, [RuntimeValidationRequest]>,
@@ -35,7 +35,7 @@ pub struct TransactionProcessorRunInvocation<'a> {
     pub blobs: Cow<'a, [Vec<u8>]>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TransactionProcessorError {
     TransactionEpochNotYetValid {
         valid_from: u64,

--- a/radix-engine/src/blueprints/transaction_runtime/package.rs
+++ b/radix-engine/src/blueprints/transaction_runtime/package.rs
@@ -7,12 +7,12 @@ use radix_engine_interface::api::ClientApi;
 use radix_engine_interface::blueprints::transaction_runtime::*;
 use radix_engine_interface::data::ScryptoValue;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum TransactionRuntimeError {
     OutOfUUid,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct TransactionRuntimeSubstate {
     pub hash: Hash,
     pub next_id: u32,

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -23,7 +23,7 @@ use sbor::*;
 use crate::types::*;
 use crate::wasm::WasmRuntimeError;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum IdAllocationError {
     RENodeIdWasNotAllocated(RENodeId),
     AllocatedIDsNotEmpty,
@@ -35,7 +35,7 @@ pub trait CanBeAbortion {
 }
 
 /// Represents an error which causes a tranasction to be rejected.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum RejectionError {
     SuccessButFeeLoanNotRepaid,
     ErrorBeforeFeeLoanRepaid(RuntimeError),
@@ -56,7 +56,7 @@ impl fmt::Display for RejectionError {
 }
 
 /// Represents an error when executing a transaction.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum RuntimeError {
     /// An error occurred within the kernel.
     KernelError(KernelError),
@@ -116,7 +116,7 @@ impl CanBeAbortion for RuntimeError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum KernelError {
     InvalidModeTransition(ExecutionMode, ExecutionMode),
 
@@ -180,7 +180,7 @@ impl CanBeAbortion for KernelError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum CallFrameError {
     OffsetDoesNotExist(RENodeId, SubstateOffset),
     RENodeNotVisible(RENodeId),
@@ -188,14 +188,14 @@ pub enum CallFrameError {
     MovingLockedRENode(RENodeId),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum ScryptoFnResolvingError {
     BlueprintNotFound,
     MethodNotFound,
     InvalidInput,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum InterpreterError {
     NativeUnexpectedReceiver(String),
     NativeExpectedReceiver(String),
@@ -209,7 +209,7 @@ pub enum InterpreterError {
     InvalidScryptoReturn(DecodeError),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ModuleError {
     NodeMoveError(NodeMoveError),
     AuthError(AuthError),
@@ -296,7 +296,7 @@ impl<E: SelfError> From<InvokeError<E>> for RuntimeError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ApplicationError {
     TransactionProcessorError(TransactionProcessorError),
 

--- a/radix-engine/src/kernel/actor.rs
+++ b/radix-engine/src/kernel/actor.rs
@@ -3,7 +3,7 @@ use radix_engine_interface::api::types::RENodeId;
 
 /// Resolved receiver including info whether receiver was derefed
 /// or not
-#[derive(Debug, Copy, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct ResolvedReceiver {
     pub derefed_from: Option<(RENodeId, LockHandle)>,
     pub receiver: RENodeId,
@@ -25,7 +25,7 @@ impl ResolvedReceiver {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResolvedActor {
     pub identifier: FnIdentifier,
     pub receiver: Option<ResolvedReceiver>,
@@ -48,7 +48,7 @@ impl ResolvedActor {
 }
 
 /// Execution mode
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Sbor)]
 pub enum ExecutionMode {
     Kernel,
     Resolver,

--- a/radix-engine/src/kernel/event.rs
+++ b/radix-engine/src/kernel/event.rs
@@ -1,7 +1,7 @@
 use crate::system::kernel_modules::execution_trace::KernelCallTrace;
 use crate::types::*;
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub enum TrackedEvent {
     KernelCallTrace(KernelCallTrace),
 }

--- a/radix-engine/src/kernel/kernel_api.rs
+++ b/radix-engine/src/kernel/kernel_api.rs
@@ -25,7 +25,7 @@ use super::interpreters::ScryptoInterpreter;
 use super::module_mixer::KernelModuleMixer;
 
 bitflags! {
-    #[derive(Encode, Decode, Categorize)]
+    #[derive(Sbor)]
     pub struct LockFlags: u32 {
         /// Allows the locked substate to be mutated
         const MUTABLE = 0b00000001;

--- a/radix-engine/src/kernel/track.rs
+++ b/radix-engine/src/kernel/track.rs
@@ -29,7 +29,7 @@ use sbor::rust::collections::*;
 use super::actor::ResolvedActor;
 use super::event::TrackedEvent;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Sbor)]
 pub enum LockState {
     Read(usize),
     Write,
@@ -71,7 +71,7 @@ pub struct Track<'s> {
     new_global_addresses: Vec<GlobalAddress>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TrackError {
     NotFound(SubstateId),
     SubstateLocked(SubstateId, LockState),

--- a/radix-engine/src/ledger/traits.rs
+++ b/radix-engine/src/ledger/traits.rs
@@ -8,25 +8,14 @@ pub trait QueryableSubstateStore {
     ) -> HashMap<Vec<u8>, PersistedSubstate>;
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, ScryptoSbor)]
 pub struct OutputId {
     pub substate_id: SubstateId,
     pub substate_hash: Hash,
     pub version: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct OutputValue {
     pub substate: PersistedSubstate,
     pub version: u32,

--- a/radix-engine/src/state_manager/state_diff.rs
+++ b/radix-engine/src/state_manager/state_diff.rs
@@ -4,7 +4,7 @@ use crate::types::*;
 use radix_engine_interface::api::types::SubstateId;
 use radix_engine_interface::crypto::hash;
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct StateDiff {
     pub up_substates: BTreeMap<SubstateId, OutputValue>,
     pub down_substates: BTreeSet<OutputId>,

--- a/radix-engine/src/system/global/substates.rs
+++ b/radix-engine/src/system/global/substates.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 
 // TODO: clean up after `Owned(RENodeId)`?
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum GlobalAddressSubstate {
     Component(ComponentId),
     Resource(ResourceManagerId),

--- a/radix-engine/src/system/kernel_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/kernel_modules/auth/auth_module.rs
@@ -30,7 +30,7 @@ use super::HardAuthRule;
 use super::HardProofRule;
 use super::HardResourceOrNonFungible;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum AuthError {
     VisibilityError(RENodeId),
     Unauthorized {

--- a/radix-engine/src/system/kernel_modules/auth/method_authorization.rs
+++ b/radix-engine/src/system/kernel_modules/auth/method_authorization.rs
@@ -3,27 +3,27 @@ use radix_engine_interface::math::Decimal;
 use radix_engine_interface::*;
 use sbor::rust::vec::Vec;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Sbor)]
 pub enum MethodAuthorizationError {
     NotAuthorized,
     UnsupportedMethod,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum HardDecimal {
     Amount(Decimal),
     InvalidSchemaPath,
     DisallowdValueType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Sbor)]
 pub enum HardCount {
     Count(u8),
     InvalidSchemaPath,
     DisallowdValueType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum HardResourceOrNonFungible {
     NonFungible(NonFungibleGlobalId),
     Resource(ResourceAddress),
@@ -31,14 +31,14 @@ pub enum HardResourceOrNonFungible {
     DisallowdValueType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum HardProofRuleResourceList {
     List(Vec<HardResourceOrNonFungible>),
     InvalidSchemaPath,
     DisallowdValueType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum HardProofRule {
     Require(HardResourceOrNonFungible),
     AmountOf(HardDecimal, HardResourceOrNonFungible),
@@ -47,7 +47,7 @@ pub enum HardProofRule {
     CountOf(HardCount, HardProofRuleResourceList),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum HardAuthRule {
     ProofRule(HardProofRule),
     AnyOf(Vec<HardAuthRule>),
@@ -55,7 +55,7 @@ pub enum HardAuthRule {
 }
 
 /// Authorization of a method call
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum MethodAuthorization {
     Protected(HardAuthRule),
     AllowAll,

--- a/radix-engine/src/system/kernel_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/kernel_modules/costing/costing_module.rs
@@ -20,7 +20,7 @@ use radix_engine_interface::constants::*;
 use radix_engine_interface::{api::types::RENodeId, *};
 use sbor::rust::collections::BTreeMap;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum CostingError {
     FeeReserveError(FeeReserveError),
     MaxCallDepthLimitReached,

--- a/radix-engine/src/system/kernel_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/kernel_modules/costing/fee_reserve.rs
@@ -9,7 +9,7 @@ use strum::EnumCount;
 
 // Note: for performance reason, `u128` is used to represent decimal in this file.
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum FeeReserveError {
     InsufficientBalance,
     Overflow,
@@ -73,18 +73,7 @@ pub trait FinalizingFeeReserve {
 
 pub trait FeeReserve: PreExecutionFeeReserve + ExecutionFeeReserve + FinalizingFeeReserve {}
 
-#[derive(
-    Debug,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, ScryptoSbor)]
 pub enum RoyaltyReceiver {
     Package(PackageAddress, PackageId),
     Component(ComponentAddress, ComponentId),
@@ -99,9 +88,7 @@ pub enum RoyaltyReceiver {
     Hash,
     PartialOrd,
     Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
+    ScryptoSbor,
     IntoStaticStr,
     EnumCount,
     Display,
@@ -123,7 +110,7 @@ pub enum CostingReason {
     RunNative,
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct SystemLoanFeeReserve {
     /// The price of cost unit
     cost_unit_price: u128,

--- a/radix-engine/src/system/kernel_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/kernel_modules/costing/fee_summary.rs
@@ -4,7 +4,7 @@ use radix_engine_interface::api::types::VaultId;
 use radix_engine_interface::blueprints::resource::Resource;
 use sbor::rust::collections::*;
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct FeeSummary {
     /// The cost unit price in XRD.
     pub cost_unit_price: Decimal,

--- a/radix-engine/src/system/kernel_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/kernel_modules/costing/fee_table.rs
@@ -26,7 +26,7 @@ pub enum CostingEntry {
     // TODO: more costing after API becomes stable.
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct FeeTable {
     tx_base_fee: u32,
     tx_payload_cost_per_byte: u32,

--- a/radix-engine/src/system/kernel_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/kernel_modules/execution_trace/module.rs
@@ -41,7 +41,7 @@ pub struct ExecutionTraceModule {
     vault_ops: Vec<(ResolvedActor, VaultId, VaultOp)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResourceChange {
     pub resource_address: ResourceAddress,
     pub component_id: ComponentId, // TODO: support non component actor
@@ -62,7 +62,7 @@ pub enum VaultOp {
     LockFee,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Clone, Debug, PartialEq, Eq, ScryptoSbor)]
 pub struct ProofSnapshot {
     pub resource_address: ResourceAddress,
     pub resource_type: ResourceType,
@@ -70,13 +70,13 @@ pub struct ProofSnapshot {
     pub total_locked: LockedAmountOrIds,
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct ResourceSummary {
     pub buckets: HashMap<BucketId, Resource>,
     pub proofs: HashMap<ProofId, ProofSnapshot>,
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct KernelCallTrace {
     pub origin: KernelCallOrigin,
     pub kernel_call_depth: usize,
@@ -88,7 +88,7 @@ pub struct KernelCallTrace {
     pub children: Vec<KernelCallTrace>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum KernelCallOrigin {
     ScryptoFunction(ScryptoFnIdentifier),
     ScryptoMethod(ScryptoFnIdentifier),

--- a/radix-engine/src/system/kernel_modules/node_move/node_move_module.rs
+++ b/radix-engine/src/system/kernel_modules/node_move/node_move_module.rs
@@ -7,7 +7,7 @@ use crate::types::*;
 use radix_engine_interface::api::types::{BucketOffset, ProofOffset, RENodeId, SubstateOffset};
 use radix_engine_interface::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum NodeMoveError {
     CantMoveDownstream(RENodeId),
     CantMoveUpstream(RENodeId),

--- a/radix-engine/src/system/kernel_modules/transaction_limits/module.rs
+++ b/radix-engine/src/system/kernel_modules/transaction_limits/module.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use radix_engine_interface::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TransactionLimitsError {
     /// Used when WASM memory consumed during transaction execution exceeds defined limit,
     /// as parameter current memory value is returned.

--- a/radix-engine/src/system/node_modules/auth/access_rules/executables.rs
+++ b/radix-engine/src/system/node_modules/auth/access_rules/executables.rs
@@ -14,7 +14,7 @@ use radix_engine_interface::api::types::{
 use radix_engine_interface::api::{ClientApi, ClientDerefApi};
 use radix_engine_interface::blueprints::resource::*;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum AccessRulesChainError {
     BlueprintFunctionNotFound(String),
     InvalidIndex(u32),

--- a/radix-engine/src/system/node_modules/auth/access_rules/substates.rs
+++ b/radix-engine/src/system/node_modules/auth/access_rules/substates.rs
@@ -7,7 +7,7 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::IndexedScryptoValue;
 
 /// A transient resource container.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct AccessRulesChainSubstate {
     pub access_rules_chain: Vec<AccessRules>,
 }

--- a/radix-engine/src/system/node_modules/metadata/substates.rs
+++ b/radix-engine/src/system/node_modules/metadata/substates.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 
 /// A transient resource container.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct MetadataSubstate {
     pub metadata: BTreeMap<String, String>,
 }

--- a/radix-engine/src/system/node_substates.rs
+++ b/radix-engine/src/system/node_substates.rs
@@ -28,7 +28,7 @@ use radix_engine_interface::api::types::{
 };
 use radix_engine_interface::data::IndexedScryptoValue;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum PersistedSubstate {
     Global(GlobalAddressSubstate),
     TypeInfo(TypeInfoSubstate),

--- a/radix-engine/src/system/package/abi_extractor.rs
+++ b/radix-engine/src/system/package/abi_extractor.rs
@@ -6,7 +6,7 @@ use radix_engine_interface::api::types::{
     GlobalAddress, GlobalOffset, PackageOffset, RENodeId, SubstateId, SubstateOffset,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ExportError {
     ComponentNotFound(ComponentAddress),
     PackageNotFound(PackageAddress),

--- a/radix-engine/src/system/package/executables.rs
+++ b/radix-engine/src/system/package/executables.rs
@@ -23,7 +23,7 @@ use radix_engine_interface::blueprints::resource::Bucket;
 
 pub struct Package;
 
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum PackageError {
     InvalidRequestData(DecodeError),
     InvalidAbi(DecodeError),

--- a/radix-engine/src/system/type_info/substates.rs
+++ b/radix-engine/src/system/type_info/substates.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 use sbor::rust::fmt::Debug;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TypeInfoSubstate {
     WasmPackage,
     NativePackage,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -14,14 +14,14 @@ use radix_engine_interface::data::{IndexedScryptoValue, ScryptoDecode};
 use transaction::manifest::decompiler::DecompilationContext;
 use utils::ContextualDisplay;
 
-#[derive(Debug, Clone, Default, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Default, ScryptoSbor)]
 pub struct ResourcesUsage {
     pub heap_allocations_sum: usize,
     pub heap_peak_memory: usize,
     pub cpu_cycles: u64,
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct TransactionExecution {
     pub fee_summary: FeeSummary,
     pub events: Vec<TrackedEvent>,
@@ -82,7 +82,7 @@ impl TransactionOutcome {
     }
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct EntityChanges {
     pub new_package_addresses: Vec<PackageAddress>,
     pub new_component_addresses: Vec<ComponentAddress>,
@@ -115,17 +115,17 @@ impl EntityChanges {
     }
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct RejectResult {
     pub error: RejectionError,
 }
 
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct AbortResult {
     pub reason: AbortReason,
 }
 
-#[derive(Debug, Clone, Display, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Clone, Display, PartialEq, Eq, Sbor)]
 pub enum AbortReason {
     ConfiguredAbortTriggeredOnFeeLoanRepayment,
 }

--- a/radix-engine/src/types.rs
+++ b/radix-engine/src/types.rs
@@ -6,7 +6,7 @@ pub use radix_engine_interface::crypto::*;
 pub use radix_engine_interface::data::types::*;
 pub use radix_engine_interface::data::{
     scrypto_decode, scrypto_encode, IndexedScryptoValue, ScryptoCategorize, ScryptoDecode,
-    ScryptoEncode,
+    ScryptoEncode, ScryptoSbor,
 };
 pub use radix_engine_interface::dec;
 pub use radix_engine_interface::math::{BnumI256, Decimal, RoundingMode};

--- a/radix-engine/src/wasm/cost_rules.rs
+++ b/radix-engine/src/wasm/cost_rules.rs
@@ -4,7 +4,7 @@ use wasm_instrument::gas_metering::Rules;
 
 use crate::types::*;
 
-#[derive(Debug, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Sbor)]
 pub struct InstructionCostRules {
     tier_1_cost: u32,
     tier_2_cost: u32,

--- a/radix-engine/src/wasm/errors.rs
+++ b/radix-engine/src/wasm/errors.rs
@@ -6,7 +6,7 @@ use crate::transaction::AbortReason;
 use crate::types::*;
 
 /// Represents an error when validating a WASM file.
-#[derive(Debug, PartialEq, Eq, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Sbor)]
 pub enum PrepareError {
     /// Failed to deserialize.
     /// See <https://webassembly.github.io/spec/core/syntax/index.html>
@@ -50,13 +50,13 @@ pub enum PrepareError {
     NotCompilable,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Sbor)]
 pub enum InvalidImport {
     /// The import is not allowed
     ImportNotAllowed,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Sbor)]
 pub enum InvalidMemory {
     /// The wasm module has no memory section.
     NoMemorySection,
@@ -70,7 +70,7 @@ pub enum InvalidMemory {
     MemoryNotExported,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Sbor)]
 pub enum InvalidTable {
     /// More than one table defined, against WebAssembly MVP spec
     MoreThanOneTable,
@@ -79,7 +79,7 @@ pub enum InvalidTable {
 }
 
 /// Represents an error when invoking an export of a Scrypto module.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum WasmRuntimeError {
     /// Error when reading wasm memory.
     MemoryAccessError,

--- a/radix-engine/src/wasm/wasm_metering_config.rs
+++ b/radix-engine/src/wasm/wasm_metering_config.rs
@@ -1,19 +1,7 @@
 use super::InstructionCostRules;
 use crate::types::*;
 
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, ScryptoSbor)]
 pub enum WasmMeteringConfig {
     V0,
 }
@@ -32,7 +20,7 @@ impl WasmMeteringConfig {
     }
 }
 
-#[derive(Debug, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Sbor)]
 pub struct WasmMeteringParams {
     instruction_cost_rules: InstructionCostRules,
     max_stack_size: u32,

--- a/sbor-tests/benches/data/simple.rs
+++ b/sbor-tests/benches/data/simple.rs
@@ -1,14 +1,14 @@
-use sbor::{Categorize, Decode, Encode};
+use sbor::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Categorize, Encode, Decode, bincode::Encode, bincode::Decode, Serialize, Deserialize)]
+#[derive(Sbor, bincode::Encode, bincode::Decode, Serialize, Deserialize)]
 pub enum SimpleEnum {
     Unit,
     Unamed(u32),
     Named { x: u32, y: u32 },
 }
 
-#[derive(Categorize, Encode, Decode, bincode::Encode, bincode::Decode, Serialize, Deserialize)]
+#[derive(Sbor, bincode::Encode, bincode::Decode, Serialize, Deserialize)]
 pub struct SimpleStruct {
     pub number: u64,
     pub string: String,

--- a/sbor-tests/tests/schema.rs
+++ b/sbor-tests/tests/schema.rs
@@ -7,16 +7,16 @@ use sbor::rust::string::String;
 use sbor::rust::vec::Vec;
 use sbor::*;
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub struct UnitStruct;
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub struct BasicSample {
     pub a: (),
     pub b: UnitStruct,
 }
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 #[sbor(categorize_types = "S, T")]
 pub struct AdvancedSample<T, S> {
     pub a: (),
@@ -32,23 +32,23 @@ pub struct AdvancedSample<T, S> {
     pub k: HashMap<[u8; 3], BTreeMap<i64, BTreeSet<i32>>>,
 }
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub struct Recursive<T> {
     pub hello: Option<Box<Recursive<T>>>,
     pub what: T,
 }
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub struct IndirectRecursive1(
     Vec<IndirectRecursive2<Recursive<u8>>>,
     Recursive<String>,
     Box<IndirectRecursiveEnum3>,
 );
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub struct IndirectRecursive2<T>(Recursive<T>, IndirectRecursive1);
 
-#[derive(Categorize, Encode, Decode, Describe)]
+#[derive(Sbor)]
 pub enum IndirectRecursiveEnum3 {
     Variant1,
     Variant2(Box<IndirectRecursive1>),

--- a/sbor-tests/tests/skip.rs
+++ b/sbor-tests/tests/skip.rs
@@ -4,7 +4,7 @@ use sbor::rust::vec;
 use sbor::rust::vec::Vec;
 use sbor::*;
 
-#[derive(Debug, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Sbor)]
 pub struct TestStructNamed {
     #[allow(unused_variables)]
     #[sbor(skip)]
@@ -12,13 +12,13 @@ pub struct TestStructNamed {
     pub y: u32,
 }
 
-#[derive(Debug, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Sbor)]
 pub struct TestStructUnnamed(#[sbor(skip)] u32, u32);
 
-#[derive(Debug, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Sbor)]
 pub struct TestStructUnit;
 
-#[derive(Debug, PartialEq, Categorize, Encode, Decode)]
+#[derive(Debug, PartialEq, Sbor)]
 pub enum TestEnum {
     A {
         #[sbor(skip)]

--- a/sbor-tests/tests/value.rs
+++ b/sbor-tests/tests/value.rs
@@ -8,7 +8,7 @@ use sbor::*;
 use serde::Serialize;
 use serde_json::{json, to_string, to_value, Value};
 
-#[derive(Categorize, Encode, Decode)]
+#[derive(Sbor)]
 pub struct Sample {
     pub a: (),
     pub b: u32,

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -50,6 +50,9 @@ impl<T: for<'a> Encode<NoCustomValueKind, BasicEncoder<'a>> + ?Sized> BasicEncod
 pub trait BasicDescribe: for<'a> Describe<NoCustomTypeKind> {}
 impl<T: Describe<NoCustomTypeKind> + ?Sized> BasicDescribe for T {}
 
+pub trait BasicSbor: BasicCategorize + BasicDecode + BasicEncode + BasicDescribe {}
+impl<T: BasicCategorize + BasicDecode + BasicEncode + BasicDescribe> BasicSbor for T {}
+
 /// Encode a `T` into byte array.
 pub fn basic_encode<T: BasicEncode + ?Sized>(v: &T) -> Result<Vec<u8>, EncodeError> {
     let mut buf = Vec::with_capacity(512);

--- a/sbor/src/decoder.rs
+++ b/sbor/src/decoder.rs
@@ -3,7 +3,7 @@ use crate::value_kind::*;
 use crate::*;
 
 /// Represents an error ocurred during decoding.
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum DecodeError {
     ExtraTrailingBytes(usize),
 

--- a/sbor/src/encoder.rs
+++ b/sbor/src/encoder.rs
@@ -3,7 +3,7 @@ use crate::rust::vec::Vec;
 use crate::*;
 
 /// Represents an error occurred during encoding.
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum EncodeError {
     MaxDepthExceeded(u8),
     SizeTooLarge { actual: usize, max_allowed: usize },

--- a/scrypto-abi/src/blueprint_abi.rs
+++ b/scrypto-abi/src/blueprint_abi.rs
@@ -1,11 +1,10 @@
 use crate::schema_type::Type;
-use sbor::rust::string::String;
-use sbor::rust::vec::Vec;
-use sbor::{Categorize, Decode, Encode};
+use sbor::rust::prelude::{String, Vec};
+use sbor::*;
 
 /// Represents a blueprint.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, Sbor)]
 pub struct Blueprint {
     pub package_address: String,
     pub blueprint_name: String,
@@ -14,7 +13,7 @@ pub struct Blueprint {
 
 /// Represents the ABI of a blueprint.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct BlueprintAbi {
     pub structure: Type,
     pub fns: Vec<Fn>,
@@ -37,7 +36,7 @@ impl BlueprintAbi {
 
 /// Represents a method/function.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct Fn {
     pub ident: String,
     pub mutability: Option<SelfMutability>,
@@ -48,7 +47,7 @@ pub struct Fn {
 
 /// Whether a method is going to change the component state.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub enum SelfMutability {
     /// An immutable method requires an immutable reference to component state.
     Immutable,

--- a/scrypto-abi/src/lib.rs
+++ b/scrypto-abi/src/lib.rs
@@ -10,5 +10,3 @@ mod schema_type;
 
 pub use blueprint_abi::*;
 pub use schema_type::*;
-
-pub mod scrypto_schema {}

--- a/scrypto-abi/src/schema_type.rs
+++ b/scrypto-abi/src/schema_type.rs
@@ -11,7 +11,7 @@ use sbor::*;
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")  // See https://serde.rs/enum-representations.html
 )]
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Decode, Encode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum Type {
     Bool,
     I8,
@@ -101,7 +101,7 @@ pub enum Type {
 
 /// Represents the type info of an enum variant.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Decode, Encode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub struct Variant {
     pub name: String,
     pub fields: Fields,
@@ -113,7 +113,7 @@ pub struct Variant {
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")
 )]
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Decode, Encode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum Fields {
     Named { named: Vec<(String, Type)> },
 

--- a/scrypto/src/component/component_access_rules.rs
+++ b/scrypto/src/component/component_access_rules.rs
@@ -12,9 +12,7 @@ use radix_engine_interface::blueprints::resource::{AccessRule, AccessRuleEntry, 
 
 // TODO: Should `Encode` and `Decode` be removed so that `ComponentAccessRules` can not be passed
 // between components?
-#[derive(
-    Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, LegacyDescribe)]
 pub struct ComponentAccessRules {
     component: ComponentIdentifier,
     index: u32,
@@ -61,9 +59,7 @@ impl ComponentAccessRules {
     }
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, LegacyDescribe)]
 pub enum ComponentIdentifier {
     RENodeId(ComponentId),
     GlobalAddress(ComponentAddress),
@@ -92,17 +88,7 @@ impl From<ComponentIdentifier> for RENodeId {
     }
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    ScryptoCategorize,
-    ScryptoEncode,
-    ScryptoDecode,
-    LegacyDescribe,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor, LegacyDescribe)]
 pub enum Mutability {
     LOCKED,
     MUTABLE(AccessRule),

--- a/scrypto/src/engine/scrypto_env.rs
+++ b/scrypto/src/engine/scrypto_env.rs
@@ -10,7 +10,7 @@ use sbor::rust::collections::*;
 use sbor::rust::fmt::Debug;
 use sbor::rust::vec::Vec;
 
-#[derive(Debug, Categorize, Encode, Decode)]
+#[derive(Debug, Sbor)]
 pub enum ClientApiError {
     DecodeError(DecodeError),
 }

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -58,7 +58,7 @@ pub use macros::*;
 // Re-export radix engine derives
 pub extern crate radix_engine_derive;
 pub use radix_engine_derive::{
-    LegacyDescribe, NonFungibleData, ScryptoCategorize, ScryptoDecode, ScryptoEncode,
+    LegacyDescribe, NonFungibleData, ScryptoCategorize, ScryptoDecode, ScryptoEncode, ScryptoSbor,
 };
 
 // Re-export Scrypto derive.

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -167,7 +167,7 @@ macro_rules! include_abi {
 ///     }
 /// }
 ///
-/// #[derive(Categorize, Encode, Decode, LegacyDescribe)]
+/// #[derive(Sbor, LegacyDescribe)]
 /// enum DepositResult {
 ///     Success,
 ///     Failure
@@ -203,7 +203,7 @@ macro_rules! external_blueprint {
         }
     ) => {
 
-        #[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+        #[derive(ScryptoSbor, LegacyDescribe)]
         struct $blueprint_ident {
             package_address: ::scrypto::model::PackageAddress,
             blueprint_name: ::sbor::rust::string::String,
@@ -312,7 +312,7 @@ macro_rules! external_blueprint_members {
 /// ```no_run
 /// use scrypto::prelude::*;
 ///
-/// #[derive(Categorize, Encode, Decode, LegacyDescribe)]
+/// #[derive(Sbor, LegacyDescribe)]
 /// enum DepositResult {
 ///     Success,
 ///     Failure
@@ -343,7 +343,7 @@ macro_rules! external_component {
             $($component_methods:tt)*
         }
     ) => {
-        #[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode, LegacyDescribe)]
+        #[derive(ScryptoSbor, LegacyDescribe)]
         struct $component_ident {
             component_address: ::scrypto::model::ComponentAddress,
         }

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -8,7 +8,7 @@ pub use crate::{
     blueprint, borrow_component, borrow_package, borrow_resource_manager, debug, error,
     external_blueprint, external_component, import, include_abi, include_code, info, resource_list,
     this_package, trace, warn, LegacyDescribe, NonFungibleData, ScryptoCategorize, ScryptoDecode,
-    ScryptoEncode,
+    ScryptoEncode, ScryptoSbor,
 };
 pub use num_traits::{
     cast::FromPrimitive, cast::ToPrimitive, identities::One, identities::Zero, pow::Pow,

--- a/simulator/src/resim/cmd_new_simple_badge.rs
+++ b/simulator/src/resim/cmd_new_simple_badge.rs
@@ -14,7 +14,7 @@ use transaction::model::BasicInstruction;
 
 use crate::resim::*;
 
-#[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(ScryptoSbor)]
 struct EmptyStruct;
 
 /// Create a non-fungible badge with fixed supply

--- a/simulator/src/resim/config.rs
+++ b/simulator/src/resim/config.rs
@@ -8,7 +8,7 @@ use crate::resim::*;
 use std::env;
 
 /// Simulator configurations.
-#[derive(Debug, Clone, Default, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Default, ScryptoSbor)]
 pub struct Configs {
     pub default_account: Option<ComponentAddress>,
     pub default_private_key: Option<String>,

--- a/transaction/src/errors.rs
+++ b/transaction/src/errors.rs
@@ -26,7 +26,7 @@ impl From<EncodeError> for SignatureValidationError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Categorize)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum ManifestIdAllocationError {
     OutOfID,
 }

--- a/transaction/src/model/executable.rs
+++ b/transaction/src/model/executable.rs
@@ -3,17 +3,16 @@ use radix_engine_interface::crypto::Hash;
 use radix_engine_interface::*;
 use sbor::rust::collections::BTreeSet;
 use sbor::rust::vec::Vec;
-use sbor::{Categorize, Decode, Encode};
 
 use crate::model::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct AuthZoneParams {
     pub initial_proofs: Vec<NonFungibleGlobalId>,
     pub virtualizable_proofs_resource_addresses: BTreeSet<ResourceAddress>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ExecutionContext {
     pub transaction_hash: Hash,
     pub pre_allocated_ids: BTreeSet<RENodeId>,
@@ -23,7 +22,7 @@ pub struct ExecutionContext {
     pub runtime_validations: Vec<RuntimeValidationRequest>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Categorize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum FeePayment {
     User {
         cost_unit_limit: u32,
@@ -46,7 +45,7 @@ pub struct Executable<'a> {
     pub context: ExecutionContext,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct RuntimeValidationRequest {
     /// The validation to perform
     pub validation: RuntimeValidation,
@@ -55,7 +54,7 @@ pub struct RuntimeValidationRequest {
     pub skip_assertion: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum RuntimeValidation {
     /// To ensure we don't commit a duplicate intent hash
     IntentHashUniqueness { intent_hash: Hash },

--- a/transaction/src/model/instruction.rs
+++ b/transaction/src/model/instruction.rs
@@ -7,7 +7,7 @@ use sbor::rust::collections::BTreeMap;
 use sbor::rust::collections::BTreeSet;
 use sbor::rust::vec::Vec;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum BasicInstruction {
     /// Takes resource from worktop.
     TakeFromWorktop {
@@ -189,7 +189,7 @@ pub enum BasicInstruction {
     },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum Instruction {
     Basic(BasicInstruction),
     System(NativeInvocation),

--- a/transaction/src/model/manifest.rs
+++ b/transaction/src/model/manifest.rs
@@ -1,7 +1,7 @@
 use crate::model::BasicInstruction;
 use radix_engine_interface::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct TransactionManifest {
     pub instructions: Vec<BasicInstruction>,
     pub blobs: Vec<Vec<u8>>,

--- a/transaction/src/model/notarized_transaction.rs
+++ b/transaction/src/model/notarized_transaction.rs
@@ -10,7 +10,7 @@ use crate::model::TransactionManifest;
 // TODO: add versioning of transaction schema
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct TransactionHeader {
     pub version: u8,
     pub network_id: u8,
@@ -23,19 +23,19 @@ pub struct TransactionHeader {
     pub tip_percentage: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct TransactionIntent {
     pub header: TransactionHeader,
     pub manifest: TransactionManifest,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct SignedTransactionIntent {
     pub intent: TransactionIntent,
     pub intent_signatures: Vec<SignatureWithPublicKey>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct NotarizedTransaction {
     pub signed_intent: SignedTransactionIntent,
     pub notary_signature: Signature,
@@ -47,9 +47,7 @@ pub struct NotarizedTransaction {
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type", content = "signature")
 )]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum Signature {
     EcdsaSecp256k1(EcdsaSecp256k1Signature),
     EddsaEd25519(EddsaEd25519Signature),
@@ -61,9 +59,7 @@ pub enum Signature {
     derive(serde::Serialize, serde::Deserialize),
     serde(tag = "type")
 )]
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum SignatureWithPublicKey {
     EcdsaSecp256k1 {
         signature: EcdsaSecp256k1Signature,

--- a/transaction/src/model/preview_transaction.rs
+++ b/transaction/src/model/preview_transaction.rs
@@ -5,7 +5,7 @@ use sbor::*;
 
 use crate::model::TransactionIntent;
 
-#[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Sbor, PartialEq, Eq)]
 pub struct PreviewFlags {
     pub unlimited_loan: bool,
     pub assume_all_signature_proofs: bool,
@@ -13,7 +13,7 @@ pub struct PreviewFlags {
     pub permit_invalid_header_epoch: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct PreviewIntent {
     pub intent: TransactionIntent,
     pub signer_public_keys: Vec<PublicKey>,

--- a/transaction/src/model/system_transaction.rs
+++ b/transaction/src/model/system_transaction.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::crypto::hash;
 use radix_engine_interface::*;
 use std::collections::BTreeSet;
 
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct SystemTransaction {
     pub instructions: Vec<Instruction>,
     pub pre_allocated_ids: BTreeSet<RENodeId>,

--- a/transaction/src/model/test_transaction.rs
+++ b/transaction/src/model/test_transaction.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 
 use crate::model::*;
 
-#[derive(ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(ScryptoSbor)]
 pub struct TestTransaction {
     nonce: u64,
     cost_unit_limit: u32,


### PR DESCRIPTION
## Summary
* Fixes a few issues with Describe implementations
* Main change: Change all derive impls in the engine to use `Sbor` / `ScryptoSbor` instead of their separate types.

## Details
This replaces the separate derives with a single derive `Sbor` / `ScryptoSbor` across the codebase. This proves out that the Categorize implementation is stable across a large range of use cases.

After this change, I'm slightly worried that the Describe impls may cause lag in the IDE on load/edit. We should be on the look-out for this, and report issues in case we wish to slow down / stop changes - but at least to me, it doesn't appear to be a minor cause of slow-down on my machine after this change.

## Testing
It compiling is the main test.

## Update Recommendations

### For Dapp Developers
Deriving `ScryptoEncode`, `ScryptoDecode`, `ScryptoCategorize` and `ScryptoDescribe` can be replaced with deriving `ScryptoSbor`. Similarly, `Encode`, `Decode`, `Categorize` and `Descrive` can be replaced with deriving `Sbor`.

### For Internal Integrators
As for Dapp Developers.
