### PR TITLE
Fix/fix scrypto categorize with generic parameters

### DIFF
--- a/radix-engine-derive/src/describe.rs
+++ b/radix-engine-derive/src/describe.rs
@@ -103,7 +103,7 @@ mod tests {
                     ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> > for MyEnum<T>
                 where
                     T: ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >,
-                    T: ::sbor::Categorize<<
+                    T: ::sbor::Categorize< <
                         radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>
                         as ::sbor::CustomTypeKind<::sbor::GlobalTypeId>
                     >::CustomValueKind >

--- a/radix-engine-derive/src/describe.rs
+++ b/radix-engine-derive/src/describe.rs
@@ -48,6 +48,48 @@ mod tests {
     }
 
     #[test]
+    fn test_describe_generic_struct() {
+        let input = TokenStream::from_str("pub struct Thing<T> { field: T }").unwrap();
+        let code_hash = get_code_hash_const_array_token_stream(&input);
+        let output = handle_describe(input).unwrap();
+
+        assert_code_eq(
+            output,
+            quote! {
+                impl<T> ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> > for Thing<T>
+                where
+                    T: ::sbor::Describe<
+                        radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>
+                    >,
+                    T: ::sbor::Categorize<
+                        <
+                            radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>
+                            as ::sbor::CustomTypeKind<::sbor::GlobalTypeId>
+                        >::CustomValueKind
+                    >
+                {
+                    const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
+                        stringify!(Thing),
+                        &[<T>::TYPE_ID,],
+                        &#code_hash
+                    );
+                    fn type_data() -> Option<::sbor::TypeData<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>, ::sbor::GlobalTypeId>> {
+                        Some(::sbor::TypeData::named_fields_tuple(
+                            stringify!(Thing),
+                            ::sbor::rust::vec![
+                                ("field", <T as ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >>::TYPE_ID),
+                            ],
+                        ))
+                    }
+                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >) {
+                        aggregator.add_child_type_and_descendents::<T>();
+                    }
+                }
+            },
+        );
+    }
+
+    #[test]
     fn test_describe_enum() {
         let input = TokenStream::from_str("enum MyEnum<T: Bound> { A { named: T }, B(String), C }")
             .unwrap();
@@ -61,7 +103,10 @@ mod tests {
                     ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> > for MyEnum<T>
                 where
                     T: ::sbor::Describe<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId> >,
-                    T: ::sbor::Categorize<radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>::CustomValueKind >
+                    T: ::sbor::Categorize<<
+                        radix_engine_interface::data::ScryptoCustomTypeKind<::sbor::GlobalTypeId>
+                        as ::sbor::CustomTypeKind<::sbor::GlobalTypeId>
+                    >::CustomValueKind >
                 {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(MyEnum),

--- a/radix-engine-tests/tests/scrypto_sbor.rs
+++ b/radix-engine-tests/tests/scrypto_sbor.rs
@@ -1,0 +1,8 @@
+use radix_engine::types::*;
+
+// The test is ensuring the below compiles, to avoid regression of an issue where
+// Sbor works with generic parameters but ScryptoSbor doesn't
+#[derive(Clone, PartialEq, Eq, Hash, Debug, ScryptoSbor)]
+pub struct Thing<T> {
+    pub field: T,
+}

--- a/sbor-derive-common/src/describe.rs
+++ b/sbor-derive-common/src/describe.rs
@@ -486,7 +486,7 @@ mod tests {
                 where
                     T: ::sbor::Describe<C>,
                     T2: ::sbor::Describe<C>,
-                    T2: ::sbor::Categorize<C::CustomValueKind>
+                    T2: ::sbor::Categorize< <C as ::sbor::CustomTypeKind<::sbor::GlobalTypeId> >::CustomValueKind>
                 {
                     const TYPE_ID: ::sbor::GlobalTypeId = ::sbor::GlobalTypeId::novel_with_code(
                         stringify!(Test),

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -483,7 +483,9 @@ pub fn build_describe_generics<'a>(
         for categorize_type in categorize_types {
             new_where_clause
                 .predicates
-                .push(parse_quote!(#categorize_type: ::sbor::Categorize<#custom_type_kind_generic::CustomValueKind>));
+                .push(parse_quote!(#categorize_type: ::sbor::Categorize<<
+                    #custom_type_kind_generic as::sbor::CustomTypeKind<::sbor::GlobalTypeId>
+                >::CustomValueKind>));
         }
         where_clause = Some(new_where_clause);
     }


### PR DESCRIPTION
## Summary
Fixes an issue spotted by @jakrawcz-rdx 

## Details
We needed to make sure that the use of the associated type was fully qualified, because otherwise the compiler complains :(

## Testing
Added tested that this code now compiles:
```
#[derive(Clone, PartialEq, Eq, Hash, Debug, ScryptoSbor)]
pub struct Thing<T> {
    pub field: T,
}
```