### PR TITLE
Resource changes per instruction

### DIFF
--- a/radix-engine-tests/tests/account.rs
+++ b/radix-engine-tests/tests/account.rs
@@ -185,7 +185,7 @@ fn assert_resource_changes_for_transfer(
 fn aggregate_resource_changes(
     resource_changes: IndexMap<usize, Vec<ResourceChange>>,
 ) -> Vec<ResourceChange> {
-    let mut aggregate = IndexMap::<(RENodeId, ObjectId, ResourceAddress), Decimal>::new();
+    let mut aggregate = index_map_new::<(RENodeId, ObjectId, ResourceAddress), Decimal>();
     for ResourceChange {
         node_id,
         vault_id,

--- a/radix-engine-tests/tests/account.rs
+++ b/radix-engine-tests/tests/account.rs
@@ -32,7 +32,13 @@ fn can_withdraw_from_my_account_internal(use_virtual: bool) {
     let transfer_amount = other_account_balance - 10000 /* initial balance */;
 
     assert_resource_changes_for_transfer(
-        &receipt.expect_commit().resource_changes,
+        &receipt
+            .expect_commit()
+            .resource_changes
+            .iter()
+            .flat_map(|(_, rc)| rc)
+            .cloned()
+            .collect(),
         RADIX_TOKEN,
         other_account,
         transfer_amount,
@@ -144,7 +150,10 @@ fn account_to_bucket_to_account_internal(use_virtual: bool) {
 
     // Assert
     receipt.expect_commit_success();
-    assert_eq!(1, receipt.expect_commit().resource_changes.len()); // Just the fee payment
+    assert_eq!(
+        1,
+        aggregate_resource_changes(receipt.expect_commit().resource_changes.clone()).len()
+    ); // Just the lock fee
 }
 
 #[test]
@@ -171,4 +180,35 @@ fn assert_resource_changes_for_transfer(
         .any(|r| r.resource_address == resource_address
             && r.node_id == RENodeId::GlobalComponent(target_account)
             && r.amount == Decimal::from(transfer_amount)));
+}
+
+fn aggregate_resource_changes(
+    resource_changes: IndexMap<usize, Vec<ResourceChange>>,
+) -> Vec<ResourceChange> {
+    let mut aggregate = IndexMap::<(RENodeId, ObjectId, ResourceAddress), Decimal>::new();
+    for ResourceChange {
+        node_id,
+        vault_id,
+        amount,
+        resource_address,
+    } in resource_changes
+        .into_iter()
+        .flat_map(|(_, rc)| rc)
+        .into_iter()
+    {
+        *aggregate
+            .entry((node_id, vault_id, resource_address))
+            .or_default() += amount;
+    }
+    aggregate
+        .into_iter()
+        .map(
+            |((node_id, vault_id, resource_address), amount)| ResourceChange {
+                node_id,
+                vault_id,
+                resource_address,
+                amount,
+            },
+        )
+        .collect()
 }

--- a/radix-engine-tests/tests/execution_trace.rs
+++ b/radix-engine-tests/tests/execution_trace.rs
@@ -567,7 +567,6 @@ fn test_worktop_changes() {
         assert_eq!(
             worktop_changes.get(&13),
             Some(&vec![
-                WorktopChange::Put(ResourceSpecifier::Amount(fungible_resource, 100.into())),
                 WorktopChange::Take(ResourceSpecifier::Ids(
                     non_fungible_resource,
                     [
@@ -576,7 +575,8 @@ fn test_worktop_changes() {
                         NonFungibleLocalId::integer(3),
                     ]
                     .into()
-                ))
+                )),
+                WorktopChange::Take(ResourceSpecifier::Amount(fungible_resource, 100.into()))
             ])
         );
     }

--- a/radix-engine/src/kernel/track.rs
+++ b/radix-engine/src/kernel/track.rs
@@ -459,7 +459,7 @@ impl<'s> Track<'s> {
         self,
         mut invoke_result: Result<Vec<InstructionOutput>, RuntimeError>,
         mut fee_reserve: SystemLoanFeeReserve,
-        vault_ops: Vec<(TraceActor, ObjectId, VaultOp)>,
+        vault_ops: Vec<(TraceActor, ObjectId, VaultOp, usize)>,
         events: Vec<TrackedEvent>,
         application_events: Vec<(EventTypeIdentifier, Vec<u8>)>,
         application_logs: Vec<(Level, String)>,
@@ -586,7 +586,7 @@ impl<'s> FinalizingTrack<'s> {
         self,
         invoke_result: Result<Vec<InstructionOutput>, RuntimeError>,
         fee_summary: &mut FeeSummary,
-        vault_ops: Vec<(TraceActor, ObjectId, VaultOp)>,
+        vault_ops: Vec<(TraceActor, ObjectId, VaultOp, usize)>,
         application_events: Vec<(EventTypeIdentifier, Vec<u8>)>,
         application_logs: Vec<(Level, String)>,
     ) -> TransactionResult {

--- a/radix-engine/src/ledger/bootstrap.rs
+++ b/radix-engine/src/ledger/bootstrap.rs
@@ -690,6 +690,7 @@ mod tests {
         assert!(commit_result
             .resource_changes
             .iter()
+            .flat_map(|(_, rc)| rc)
             .any(|rc| rc.amount == allocation_amount
                 && rc.node_id == RENodeId::GlobalComponent(account_component_address)));
     }

--- a/radix-engine/src/system/kernel_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/kernel_modules/execution_trace/module.rs
@@ -613,10 +613,10 @@ impl ExecutionTraceReceipt {
         actual_fee_payments: &BTreeMap<ObjectId, Decimal>,
         is_commit_success: bool,
     ) -> Self {
-        let mut vault_changes = IndexMap::<
+        let mut vault_changes = index_map_new::<
             usize,
             IndexMap<RENodeId, IndexMap<ObjectId, (ResourceAddress, Decimal)>>,
-        >::new();
+        >();
         let mut vault_locked_by = index_map_new::<ObjectId, RENodeId>();
         for (actor, vault_id, vault_op, instruction_index) in ops {
             if let TraceActor::Actor(Actor {
@@ -666,7 +666,7 @@ impl ExecutionTraceReceipt {
             }
         }
 
-        let mut resource_changes = IndexMap::<usize, Vec<ResourceChange>>::new();
+        let mut resource_changes = index_map_new::<usize, Vec<ResourceChange>>();
         for (instruction_index, instruction_resource_changes) in vault_changes {
             for (node_id, map) in instruction_resource_changes {
                 for (vault_id, (resource_address, delta)) in map {

--- a/radix-engine/src/system/kernel_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/kernel_modules/execution_trace/module.rs
@@ -22,7 +22,7 @@ pub struct ExecutionTraceModule {
     max_kernel_call_depth_traced: usize,
 
     /// Current transaction index
-    current_transaction_index: usize,
+    current_instruction_index: usize,
 
     /// Current kernel calls depth. Note that this doesn't necessarily correspond to the
     /// call frame depth, as there can be nested kernel calls within a single call frame
@@ -35,8 +35,8 @@ pub struct ExecutionTraceModule {
     /// A mapping of complete KernelCallTrace stacks (\w both inputs and outputs), indexed by depth.
     kernel_call_traces_stacks: IndexMap<usize, Vec<KernelCallTrace>>,
 
-    /// Vault operations: (Caller, Vault ID, operation)
-    vault_ops: Vec<(TraceActor, ObjectId, VaultOp)>,
+    /// Vault operations: (Caller, Vault ID, operation, instruction index)
+    vault_ops: Vec<(TraceActor, ObjectId, VaultOp, usize)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
@@ -49,7 +49,7 @@ pub struct ResourceChange {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionTraceReceipt {
-    pub resource_changes: Vec<ResourceChange>,
+    pub resource_changes: IndexMap<usize, Vec<ResourceChange>>,
 }
 
 #[derive(Debug, Clone)]
@@ -293,7 +293,7 @@ impl KernelModule for ExecutionTraceModule {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_module_state()
             .execution_trace
-            .current_transaction_index = new_index;
+            .current_instruction_index = new_index;
         Ok(())
     }
 }
@@ -302,7 +302,7 @@ impl ExecutionTraceModule {
     pub fn new(max_kernel_call_depth_traced: usize) -> ExecutionTraceModule {
         Self {
             max_kernel_call_depth_traced,
-            current_transaction_index: 0,
+            current_instruction_index: 0,
             current_kernel_call_depth: 0,
             traced_kernel_call_inputs_stack: vec![],
             kernel_call_traces_stacks: index_map_new(),
@@ -529,7 +529,12 @@ impl ExecutionTraceModule {
         }
     }
 
-    pub fn collect_events(mut self) -> (Vec<(TraceActor, ObjectId, VaultOp)>, Vec<TrackedEvent>) {
+    pub fn collect_events(
+        mut self,
+    ) -> (
+        Vec<(TraceActor, ObjectId, VaultOp, usize)>,
+        Vec<TrackedEvent>,
+    ) {
         let mut events = Vec::new();
         for (_, traces) in self.kernel_call_traces_stacks.drain(..) {
             // Emit an output event for each "root" kernel call trace
@@ -542,7 +547,7 @@ impl ExecutionTraceModule {
     }
 
     fn instruction_index(&self) -> usize {
-        self.current_transaction_index
+        self.current_instruction_index
     }
 
     fn handle_vault_put_input<'s>(
@@ -560,6 +565,7 @@ impl ExecutionTraceModule {
                 actor.clone(),
                 vault_id.clone(),
                 VaultOp::Put(resource.resource_address(), resource.amount()),
+                self.instruction_index(),
             ));
         }
     }
@@ -569,8 +575,12 @@ impl ExecutionTraceModule {
             .clone()
             .map(|a| TraceActor::Actor(a))
             .unwrap_or(TraceActor::Root);
-        self.vault_ops
-            .push((actor, vault_id.clone(), VaultOp::LockFee));
+        self.vault_ops.push((
+            actor,
+            vault_id.clone(),
+            VaultOp::LockFee,
+            self.instruction_index(),
+        ));
     }
 
     fn handle_vault_take_output<'s>(
@@ -588,6 +598,7 @@ impl ExecutionTraceModule {
                 actor.clone(),
                 vault_id.clone(),
                 VaultOp::Take(resource.resource_address(), resource.amount()),
+                self.instruction_index(),
             ));
         }
     }
@@ -598,18 +609,18 @@ impl ExecutionTraceReceipt {
     // The current approach relies on various runtime invariants.
 
     pub fn new(
-        ops: Vec<(TraceActor, ObjectId, VaultOp)>,
+        ops: Vec<(TraceActor, ObjectId, VaultOp, usize)>,
         actual_fee_payments: &BTreeMap<ObjectId, Decimal>,
         is_commit_success: bool,
     ) -> Self {
-        // TODO: Might want to change the key from being a ComponentId to being an enum to
-        //       accommodate for accounts
-        let mut vault_changes =
-            index_map_new::<RENodeId, IndexMap<ObjectId, (ResourceAddress, Decimal)>>();
+        let mut vault_changes = IndexMap::<
+            usize,
+            IndexMap<RENodeId, IndexMap<ObjectId, (ResourceAddress, Decimal)>>,
+        >::new();
         let mut vault_locked_by = index_map_new::<ObjectId, RENodeId>();
-        for (actor, vault_id, vault_op) in ops {
+        for (actor, vault_id, vault_op, instruction_index) in ops {
             if let TraceActor::Actor(Actor {
-                identifier: ActorIdentifier::Method(method),
+                identifier: ActorIdentifier::Method(MethodIdentifier(node_id, ..)),
                 ..
             }) = actor
             {
@@ -617,7 +628,9 @@ impl ExecutionTraceReceipt {
                     VaultOp::Create(_) => todo!("Not supported yet!"),
                     VaultOp::Put(resource_address, amount) => {
                         vault_changes
-                            .entry(method.0)
+                            .entry(instruction_index)
+                            .or_default()
+                            .entry(node_id)
                             .or_default()
                             .entry(vault_id)
                             .or_insert((resource_address, Decimal::zero()))
@@ -625,7 +638,9 @@ impl ExecutionTraceReceipt {
                     }
                     VaultOp::Take(resource_address, amount) => {
                         vault_changes
-                            .entry(method.0)
+                            .entry(instruction_index)
+                            .or_default()
+                            .entry(node_id)
                             .or_default()
                             .entry(vault_id)
                             .or_insert((resource_address, Decimal::zero()))
@@ -633,7 +648,9 @@ impl ExecutionTraceReceipt {
                     }
                     VaultOp::LockFee => {
                         vault_changes
-                            .entry(method.0)
+                            .entry(instruction_index)
+                            .or_default()
+                            .entry(node_id)
                             .or_default()
                             .entry(vault_id)
                             .or_insert((RADIX_TOKEN, Decimal::zero()))
@@ -642,35 +659,39 @@ impl ExecutionTraceReceipt {
                         // Hack: Additional check to avoid second `lock_fee` attempts (runtime failure) from
                         // polluting the `vault_locked_by` index.
                         if !vault_locked_by.contains_key(&vault_id) {
-                            vault_locked_by.insert(vault_id, method.0);
+                            vault_locked_by.insert(vault_id, node_id);
                         }
                     }
                 }
             }
         }
 
-        let mut resource_changes = Vec::<ResourceChange>::new();
-        for (node_id, map) in vault_changes {
-            for (vault_id, (resource_address, delta)) in map {
-                // Amount = put/take amount - fee_amount
-                let fee_amount = actual_fee_payments
-                    .get(&vault_id)
-                    .cloned()
-                    .unwrap_or_default();
-                let amount = if is_commit_success {
-                    delta
-                } else {
-                    Decimal::zero()
-                } - fee_amount;
+        let mut resource_changes = IndexMap::<usize, Vec<ResourceChange>>::new();
+        for (instruction_index, instruction_resource_changes) in vault_changes {
+            for (node_id, map) in instruction_resource_changes {
+                for (vault_id, (resource_address, delta)) in map {
+                    // Amount = put/take amount - fee_amount
+                    let fee_amount = actual_fee_payments
+                        .get(&vault_id)
+                        .cloned()
+                        .unwrap_or_default();
+                    let amount = if is_commit_success {
+                        delta
+                    } else {
+                        Decimal::zero()
+                    } - fee_amount;
 
-                // Add a resource change log if non-zero
-                if !amount.is_zero() {
-                    resource_changes.push(ResourceChange {
-                        resource_address,
-                        node_id,
-                        vault_id,
-                        amount,
-                    });
+                    // Add a resource change log if non-zero
+                    if !amount.is_zero() {
+                        resource_changes.entry(instruction_index).or_default().push(
+                            ResourceChange {
+                                resource_address,
+                                node_id,
+                                vault_id,
+                                amount,
+                            },
+                        );
+                    }
                 }
             }
         }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -52,7 +52,7 @@ pub struct CommitResult {
     pub outcome: TransactionOutcome,
     pub state_updates: StateDiff,
     pub entity_changes: EntityChanges,
-    pub resource_changes: Vec<ResourceChange>,
+    pub resource_changes: IndexMap<usize, Vec<ResourceChange>>,
     pub application_logs: Vec<(Level, String)>,
     pub application_events: Vec<(EventTypeIdentifier, Vec<u8>)>,
     pub next_epoch: Option<(BTreeMap<ComponentAddress, Validator>, u64)>,


### PR DESCRIPTION
## Summary

Previously, resource changes exposed the changes that happened throughout the transaction as a whole which lead to some lost resolution when trying to use the resource changes to determine how a specific instruction impacted it.

This PR changes the resource changes from being a flat vector of changes to being a map where the key is the instruction index and the value is a vector of resource changes that happened as a result of this instruction. 

