### PR TITLE
SBOR Encodable Receipts

### DIFF
--- a/radix-engine-interface/src/api/types/indexed_value.rs
+++ b/radix-engine-interface/src/api/types/indexed_value.rs
@@ -2,13 +2,16 @@ use crate::api::types::*;
 use core::convert::Infallible;
 use radix_engine_common::data::scrypto::model::*;
 use radix_engine_common::data::scrypto::*;
+use radix_engine_common::ScryptoSbor;
 use sbor::path::SborPathBuf;
 use sbor::rust::fmt;
 use sbor::rust::prelude::*;
 use sbor::*;
 use utils::ContextualDisplay;
 
-#[derive(Clone, PartialEq, Eq)]
+// TODO: Remove the default ScryptoSbor derive and do a custom implementation that encodes and
+// decodes as ScryptoValue.
+#[derive(Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct IndexedScryptoValue {
     bytes: Vec<u8>,
     value: ScryptoValue,

--- a/radix-engine-interface/src/api/types/indexed_value.rs
+++ b/radix-engine-interface/src/api/types/indexed_value.rs
@@ -2,16 +2,13 @@ use crate::api::types::*;
 use core::convert::Infallible;
 use radix_engine_common::data::scrypto::model::*;
 use radix_engine_common::data::scrypto::*;
-use radix_engine_common::ScryptoSbor;
 use sbor::path::SborPathBuf;
 use sbor::rust::fmt;
 use sbor::rust::prelude::*;
 use sbor::*;
 use utils::ContextualDisplay;
 
-// TODO: Remove the default ScryptoSbor derive and do a custom implementation that encodes and
-// decodes as ScryptoValue.
-#[derive(Clone, PartialEq, Eq, ScryptoSbor)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct IndexedScryptoValue {
     bytes: Vec<u8>,
     value: ScryptoValue,

--- a/radix-engine/src/blueprints/transaction_processor/executables.rs
+++ b/radix-engine/src/blueprints/transaction_processor/executables.rs
@@ -65,7 +65,7 @@ impl<T: ScryptoEncode + Debug + Send + Sync> NativeOutput for T {}
 
 #[derive(Debug, Clone, ScryptoSbor)]
 pub enum InstructionOutput {
-    CallReturn(IndexedScryptoValue),
+    CallReturn(Vec<u8>),
     None,
 }
 
@@ -462,7 +462,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::CallMethod {
                     component_address,
@@ -484,7 +484,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::PublishPackage {
                     code,
@@ -523,7 +523,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::BurnResource { bucket_id } => {
                     let bucket = processor.take_bucket(&bucket_id)?;
@@ -538,7 +538,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::MintFungible {
                     resource_address,
@@ -554,7 +554,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::MintNonFungible {
                     resource_address,
@@ -571,7 +571,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::MintUuidNonFungible {
                     resource_address,
@@ -590,7 +590,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::RecallResource { vault_id, amount } => {
                     let rtn = api.call_method(
@@ -603,7 +603,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
                 Instruction::SetMetadata {
                     entity_address,
@@ -629,7 +629,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::SetPackageRoyaltyConfig {
                     package_address,
@@ -651,7 +651,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::SetComponentRoyaltyConfig {
                     component_address,
@@ -673,7 +673,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::ClaimPackageRoyalty { package_address } => {
                     let result = api.call_module_method(
@@ -689,7 +689,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::ClaimComponentRoyalty { component_address } => {
                     let result = api.call_module_method(
@@ -705,7 +705,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::SetMethodAccessRule {
                     entity_address,
@@ -731,7 +731,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                         api,
                     )?;
 
-                    InstructionOutput::CallReturn(result_indexed)
+                    InstructionOutput::CallReturn(result_indexed.into())
                 }
                 Instruction::AssertAccessRule { access_rule } => {
                     let rtn = ComponentAuthZone::sys_assert_access_rule(access_rule, api)?;
@@ -740,7 +740,7 @@ impl<'a> Executor for TransactionProcessorRunInvocation<'a> {
                     TransactionProcessor::move_proofs_to_authzone_and_buckets_to_worktop(
                         &result, api,
                     )?;
-                    InstructionOutput::CallReturn(result)
+                    InstructionOutput::CallReturn(result.into())
                 }
             };
             outputs.push(result);

--- a/radix-engine/src/blueprints/transaction_processor/executables.rs
+++ b/radix-engine/src/blueprints/transaction_processor/executables.rs
@@ -63,7 +63,7 @@ pub enum TransactionProcessorError {
 pub trait NativeOutput: ScryptoEncode + Debug + Send + Sync {}
 impl<T: ScryptoEncode + Debug + Send + Sync> NativeOutput for T {}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub enum InstructionOutput {
     CallReturn(IndexedScryptoValue),
     None,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -44,7 +44,7 @@ impl TransactionExecution {
 }
 
 /// Captures whether a transaction should be committed, and its other results
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub enum TransactionResult {
     Commit(CommitResult),
     Reject(RejectResult),
@@ -61,7 +61,7 @@ impl TransactionResult {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct CommitResult {
     pub outcome: TransactionOutcome,
     pub state_updates: StateDiff,
@@ -73,7 +73,7 @@ pub struct CommitResult {
 }
 
 /// Captures whether a transaction's commit outcome is Success or Failure
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, ScryptoSbor)]
 pub enum TransactionOutcome {
     Success(Vec<InstructionOutput>),
     Failure(RuntimeError),
@@ -147,7 +147,7 @@ pub enum AbortReason {
 }
 
 /// Represents a transaction receipt.
-#[derive(Clone)]
+#[derive(Clone, ScryptoSbor)]
 pub struct TransactionReceipt {
     pub execution: TransactionExecution, // THIS FIELD IS USEFUL FOR DEBUGGING EVEN IF THE TRANSACTION IS REJECTED
     pub result: TransactionResult,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -274,7 +274,7 @@ impl TransactionReceipt {
     pub fn output<T: ScryptoDecode>(&self, nth: usize) -> T {
         match &self.expect_commit_success()[nth] {
             InstructionOutput::CallReturn(value) => {
-                value.as_typed().expect("Output can't be converted")
+                scrypto_decode::<T>(value).expect("Output can't be converted")
             }
             InstructionOutput::None => panic!("No call return from the instruction"),
         }
@@ -409,7 +409,9 @@ impl<'a> ContextualDisplay<AddressDisplayContext<'a>> for TransactionReceipt {
                         "\n{} {}",
                         prefix!(i, outputs),
                         match output {
-                            InstructionOutput::CallReturn(x) => x.to_string(context),
+                            InstructionOutput::CallReturn(x) => IndexedScryptoValue::from_slice(&x)
+                                .expect("Impossible case! Instruction output can't be decoded")
+                                .to_string(context),
                             InstructionOutput::None => "None".to_string(),
                         }
                     )?;


### PR DESCRIPTION
## Summary

This change makes the transaction receipts SBOR encodable which simplifies some of the complexity in the Radix Engine Toolkit. 