### PR TITLE
Feature/SCRY-294 jemalloc

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -10,7 +10,7 @@ cargo clean
 
 # clean this and other workspaces folders
 (
-    find "." -mindepth 2 -maxdepth 2 -type f \( -name Cargo.toml \) -print \
+    find "." -mindepth 2 -maxdepth 4 -type f \( -name Cargo.toml \) -print \
     | awk '{print substr($1, 1, length($1)-length("Cargo.toml"))}' \
     | xargs -I '{}' bash -c "echo cleaning '{}'; cd '{}'; cargo clean"
 )

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -17,6 +17,7 @@ lru = { version = "0.8.1", default-features = false, optional = true}
 moka = { version = "0.9.4", features = ["sync"], default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 perfcnt = { version = "0.8.0", optional = true }
+tikv-jemallocator = { version = "0.5" }
 
 # WASM de-/serialization
 parity-wasm = { version = "0.42.2" }

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use tikv_jemallocator::Jemalloc;
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 extern crate core;
 #[cfg(not(any(feature = "std", feature = "alloc")))]
 compile_error!("Either feature `std` or `alloc` must be enabled for this crate.");

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-
 // Jemalloc disabled for wasmer builds due to issue with handling of stack overflow.
 #[cfg(not(feature = "wasmer"))]
 use tikv_jemallocator::Jemalloc;

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+
+// Jemalloc disabled for wasmer builds due to issue with handling of stack overflow.
+#[cfg(not(feature = "wasmer"))]
 use tikv_jemallocator::Jemalloc;
+#[cfg(not(feature = "wasmer"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
## Summary

Added use of `jemalloc` library http://jemalloc.net/ as main heap allocator.

## Details

Jemalloc allocator was developed by Jason Evans for FreeBSD OS, later used by Mozilla Firefox 3 and Facebook (website servers) which still maintain this project. List of major users of jemalloc: https://github.com/jemalloc/jemalloc/wiki/Background#adoption 
Also used by `rustc` compiler: https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs

Bench `transfer` improvements:
- on AWS ec2 instance: 1.4751 ms -> 1.3406 ms (~9%)
- on Apple M1: 931 μs -> 812 μs (~13%)

Jemalloc is disabled for `wasmer` build because of failing `test_recursion_stack_overflow` test on Linux. After analysis it looks that stack overflows inside `_rjem_je_edata_heap_remove_first()` function which causes unhandled SIGSEGV exception because of wrong memory pointer passed to be freed. Adding 124 bytes to wasm function (as local const in wasm source) used in recursion calls moves place of the stack overflow occurrence and causes proper handling of the stack overflow exception. After updating `wasmer` to the latest version this issue can be verified. 

Also I added small fix to `clean.sh` script which cleans tests build files.
