### PR TITLE
Drop support for PackageAddress, ComponentAddress and ResourceAddress in Manifest

### DIFF
--- a/simulator/tests/m1.rtm
+++ b/simulator/tests/m1.rtm
@@ -1,7 +1,7 @@
-CALL_METHOD ComponentAddress("${account}") "lock_fee" Decimal("10");
+CALL_METHOD Address("${account}") "lock_fee" Decimal("10");
 
 # Prepare - instantiate a `Hello` component
-CALL_FUNCTION PackageAddress("${package}") "Hello" "instantiate_hello";
+CALL_FUNCTION Address("${package}") "Hello" "instantiate_hello";
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");
+CALL_METHOD Address("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/simulator/tests/m2.rtm
+++ b/simulator/tests/m2.rtm
@@ -1,31 +1,31 @@
-CALL_METHOD ComponentAddress("${account}") "lock_fee" Decimal("10");
+CALL_METHOD Address("${account}") "lock_fee" Decimal("10");
 
 # Prepare - grab token from the `Hello` component
-CALL_METHOD ComponentAddress("${component}") "free_token";
+CALL_METHOD Address("${component}") "free_token";
 
 # Test - assertions
-ASSERT_WORKTOP_CONTAINS ResourceAddress("${resource}");
-ASSERT_WORKTOP_CONTAINS_BY_AMOUNT Decimal("1.0") ResourceAddress("${resource}");
+ASSERT_WORKTOP_CONTAINS Address("${resource}");
+ASSERT_WORKTOP_CONTAINS_BY_AMOUNT Decimal("1.0") Address("${resource}");
 
 # Test - worktop
-TAKE_FROM_WORKTOP ResourceAddress("${resource}") Bucket("bucket1");
+TAKE_FROM_WORKTOP Address("${resource}") Bucket("bucket1");
 RETURN_TO_WORKTOP Bucket("bucket1");
-TAKE_FROM_WORKTOP_BY_AMOUNT Decimal("1.0") ResourceAddress("${resource}") Bucket("bucket2");
+TAKE_FROM_WORKTOP_BY_AMOUNT Decimal("1.0") Address("${resource}") Bucket("bucket2");
 RETURN_TO_WORKTOP Bucket("bucket2");
 
 # Test - auth zone
-CALL_METHOD ComponentAddress("${account}") "create_proof_by_amount" ResourceAddress("${xrd}") Decimal("5.0");
-CREATE_PROOF_FROM_AUTH_ZONE ResourceAddress("${xrd}") Proof("proof1");
-CREATE_PROOF_FROM_AUTH_ZONE_BY_AMOUNT Decimal("2.0") ResourceAddress("${xrd}") Proof("proof2");
+CALL_METHOD Address("${account}") "create_proof_by_amount" Address("${xrd}") Decimal("5.0");
+CREATE_PROOF_FROM_AUTH_ZONE Address("${xrd}") Proof("proof1");
+CREATE_PROOF_FROM_AUTH_ZONE_BY_AMOUNT Decimal("2.0") Address("${xrd}") Proof("proof2");
 CLONE_PROOF Proof("proof2") Proof("proof3");
 DROP_PROOF Proof("proof1");
 DROP_PROOF Proof("proof2");
 DROP_PROOF Proof("proof3");
 
 # Test - bucket proof
-CALL_METHOD ComponentAddress("${account}") "withdraw" ResourceAddress("${xrd}") Decimal("5.0");
+CALL_METHOD Address("${account}") "withdraw" Address("${xrd}") Decimal("5.0");
 CLEAR_AUTH_ZONE;
-TAKE_FROM_WORKTOP ResourceAddress("${xrd}") Bucket("xrd");
+TAKE_FROM_WORKTOP Address("${xrd}") Bucket("xrd");
 CREATE_PROOF_FROM_BUCKET Bucket("xrd") Proof("proof4");
 CLONE_PROOF Proof("proof4") Proof("proof5");
 DROP_PROOF Proof("proof4");
@@ -33,4 +33,4 @@ DROP_PROOF Proof("proof5");
 RETURN_TO_WORKTOP Bucket("xrd");
 
 # Clean up - deposit resources
-CALL_METHOD ComponentAddress("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");
+CALL_METHOD Address("${account}") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/access_controller/new.rtm
+++ b/transaction/examples/access_controller/new.rtm
@@ -1,2 +1,2 @@
-TAKE_FROM_WORKTOP ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
+TAKE_FROM_WORKTOP Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
 CREATE_ACCESS_CONTROLLER Bucket("some_xrd") Tuple(Enum(0u8), Enum(0u8), Enum(0u8)) Enum(0u8);

--- a/transaction/examples/access_rule/access_rule.rtm
+++ b/transaction/examples/access_rule/access_rule.rtm
@@ -1,4 +1,4 @@
 SET_METHOD_ACCESS_RULE
-    ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
+    Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
     Tuple(Enum("NodeModuleId::SELF"), "test")
     Enum("AccessRule::AllowAll");

--- a/transaction/examples/access_rule/assert_access_rule.rtm
+++ b/transaction/examples/access_rule/assert_access_rule.rtm
@@ -1,5 +1,5 @@
 CALL_METHOD
-    ComponentAddress("account_sim1qwskd4q5jdywfw6f7jlwmcyp2xxq48uuwruc003x2kcskxh3na")
+    Address("account_sim1qwskd4q5jdywfw6f7jlwmcyp2xxq48uuwruc003x2kcskxh3na")
     "lock_fee"
     Decimal("10");
 

--- a/transaction/examples/account/multi_account_resource_transfer.rtm
+++ b/transaction/examples/account/multi_account_resource_transfer.rtm
@@ -12,43 +12,43 @@
 # that you are using is resim then you can safely ignore this warning.
 # ==================================================================================================
 CALL_METHOD 
-    ComponentAddress("${this_account_component_address}") 
+    Address("${this_account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Withdrawing 330 XRD from the account component
 CALL_METHOD 
-    ComponentAddress("${this_account_component_address}") 
+    Address("${this_account_component_address}") 
     "withdraw"
-    ResourceAddress("${xrd_resource_address}")
+    Address("${xrd_resource_address}")
     Decimal("330");
 
 # Taking 150 XRD from the worktop and depositing them into Account A
 TAKE_FROM_WORKTOP_BY_AMOUNT
     Decimal("150")
-    ResourceAddress("${xrd_resource_address}")
+    Address("${xrd_resource_address}")
     Bucket("account_a_bucket");
 CALL_METHOD
-    ComponentAddress("${account_a_component_address}")
+    Address("${account_a_component_address}")
     "deposit"
     Bucket("account_a_bucket");
 
 # Taking 130 XRD from the worktop and depositing them into Account B
 TAKE_FROM_WORKTOP_BY_AMOUNT
     Decimal("130")
-    ResourceAddress("${xrd_resource_address}")
+    Address("${xrd_resource_address}")
     Bucket("account_b_bucket");
 CALL_METHOD
-    ComponentAddress("${account_b_component_address}")
+    Address("${account_b_component_address}")
     "deposit"
     Bucket("account_b_bucket");
 
 # Taking 50 XRD from the worktop and depositing them into Account C
 TAKE_FROM_WORKTOP_BY_AMOUNT
     Decimal("50")
-    ResourceAddress("${xrd_resource_address}")
+    Address("${xrd_resource_address}")
     Bucket("account_c_bucket");
 CALL_METHOD
-    ComponentAddress("${account_c_component_address}")
+    Address("${account_c_component_address}")
     "deposit"
     Bucket("account_c_bucket");

--- a/transaction/examples/account/resource_transfer.rtm
+++ b/transaction/examples/account/resource_transfer.rtm
@@ -8,19 +8,19 @@
 # that you are using is resim then you can safely ignore this warning.
 # ==================================================================================================
 CALL_METHOD 
-    ComponentAddress("${this_account_component_address}") 
+    Address("${this_account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Withdrawing 100 XRD from the account component
 CALL_METHOD 
-    ComponentAddress("${this_account_component_address}") 
+    Address("${this_account_component_address}") 
     "withdraw"
-    ResourceAddress("${xrd_resource_address}")
+    Address("${xrd_resource_address}")
     Decimal("100");
 
 # Depositing all of the XRD withdrawn from the account into the other account
 CALL_METHOD
-    ComponentAddress("${other_account_component_address}") 
+    Address("${other_account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/call/call_function.rtm
+++ b/transaction/examples/call/call_function.rtm
@@ -1,5 +1,5 @@
 CALL_FUNCTION
-    PackageAddress("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
+    Address("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
     "BlueprintName"
     "f"
     "string";

--- a/transaction/examples/call/call_method.rtm
+++ b/transaction/examples/call/call_method.rtm
@@ -1,5 +1,5 @@
 CALL_METHOD
-    ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
+    Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
     "complicated_method"
     Decimal("1")
     PreciseDecimal("2");

--- a/transaction/examples/faucet/free_funds.rtm
+++ b/transaction/examples/faucet/free_funds.rtm
@@ -10,18 +10,18 @@
 # account component. However, since this example hows how to get free funds from the faucet, then 
 # we can assume that our account component probably has no funds in the first place. 
 CALL_METHOD 
-    ComponentAddress("${faucet_component_address}") 
+    Address("${faucet_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Calling the "free" method on the faucet component which is the method responsible for dispensing 
 # XRD from the faucet.
 CALL_METHOD 
-    ComponentAddress("${faucet_component_address}") 
+    Address("${faucet_component_address}") 
     "free";
 
 # Depositing all of the XRD dispensed from the faucet into our account component.
 CALL_METHOD
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/metadata/metadata.rtm
+++ b/transaction/examples/metadata/metadata.rtm
@@ -1,26 +1,26 @@
 SET_METADATA
-    PackageAddress("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
+    Address("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
     "k"
     Enum(0u8, Enum(0u8, "v"));
 
 SET_METADATA
-    ComponentAddress("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
+    Address("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
     "k"
     Enum(0u8, Enum(0u8, "v"));
 
 SET_METADATA
-    ResourceAddress("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
+    Address("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
     "k"
     Enum(0u8, Enum(0u8, "v"));
 
 REMOVE_METADATA
-    PackageAddress("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
+    Address("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
     "k";
 
 REMOVE_METADATA
-    ComponentAddress("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
+    Address("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
     "k";
 
 REMOVE_METADATA
-    ResourceAddress("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
+    Address("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
     "k";

--- a/transaction/examples/package/publish.rtm
+++ b/transaction/examples/package/publish.rtm
@@ -8,7 +8,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 

--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
@@ -57,6 +57,6 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
 # Depositing the entirety of the initial supply of the newly created resource into our account 
 # component.
 CALL_METHOD
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
@@ -61,6 +61,6 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
 # Depositing the entirety of the initial supply of the newly created resource into our account 
 # component.
 CALL_METHOD
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/resources/mint/fungible/mint.rtm
+++ b/transaction/examples/resources/mint/fungible/mint.rtm
@@ -13,25 +13,25 @@
 # a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
 # its own method call and creating a proof will be its own method call.
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource
 CALL_METHOD
-    ComponentAddress("${account_component_address}")
+    Address("${account_component_address}")
     "create_proof_by_amount"
-    ResourceAddress("${minter_badge_resource_address}")
+    Address("${minter_badge_resource_address}")
     Decimal("1");
 
 # Minting some amount of tokens from the mintable fungible resource
 MINT_FUNGIBLE 
-    ResourceAddress("${mintable_resource_address}")
+    Address("${mintable_resource_address}")
     Decimal("${mint_amount}");
 
 # Depositing the entirety of the newly minted tokens into out account
 CALL_METHOD
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/resources/mint/non_fungible/mint.rtm
+++ b/transaction/examples/resources/mint/non_fungible/mint.rtm
@@ -13,23 +13,23 @@
 # a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
 # its own method call and creating a proof will be its own method call.
 CALL_METHOD 
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # We have a badge in our account component which allows us to mint this resource. So, we create a 
 # proof from this badge which will allow us to mint the resource
 CALL_METHOD
-    ComponentAddress("${account_component_address}")
+    Address("${account_component_address}")
     "create_proof_by_amount"
-    ResourceAddress("${minter_badge_resource_address}")
+    Address("${minter_badge_resource_address}")
     Decimal("1");
 
 # Minting a single non-fungible token from the resource. This non-fungible token has no data (this
 # is what the 5c2100 bit means, it's the SBOR representation of an empty struct) and has an id that
 # is user specified.
 MINT_NON_FUNGIBLE
-    ResourceAddress("${mintable_resource_address}") 
+    Address("${mintable_resource_address}") 
     Map<NonFungibleLocalId, Tuple>(
         NonFungibleLocalId("${non_fungible_local_id}"), 
         Tuple(
@@ -40,6 +40,6 @@ MINT_NON_FUNGIBLE
 
 # Depositing the entirety of the newly minted tokens into out account
 CALL_METHOD
-    ComponentAddress("${account_component_address}") 
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/resources/worktop.rtm
+++ b/transaction/examples/resources/worktop.rtm
@@ -1,28 +1,28 @@
 # Withdraw XRD from account
-CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "withdraw" ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "withdraw" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
 
 # Buy GUM with XRD
-TAKE_FROM_WORKTOP_BY_AMOUNT Decimal("2.0") ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("xrd");
-CALL_METHOD ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum") "buy_gumball" Bucket("xrd");
-ASSERT_WORKTOP_CONTAINS_BY_AMOUNT Decimal("3.0") ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag");
-ASSERT_WORKTOP_CONTAINS ResourceAddress("resource_sim1qzhdk7tq68u8msj38r6v6yqa5myc64ejx3ud20zlh9gseqtux6");
+TAKE_FROM_WORKTOP_BY_AMOUNT Decimal("2.0") Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("xrd");
+CALL_METHOD Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum") "buy_gumball" Bucket("xrd");
+ASSERT_WORKTOP_CONTAINS_BY_AMOUNT Decimal("3.0") Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag");
+ASSERT_WORKTOP_CONTAINS Address("resource_sim1qzhdk7tq68u8msj38r6v6yqa5myc64ejx3ud20zlh9gseqtux6");
 
 # Create a proof from bucket, clone it and drop both
-TAKE_FROM_WORKTOP ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
+TAKE_FROM_WORKTOP Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
 CREATE_PROOF_FROM_BUCKET Bucket("some_xrd") Proof("proof1");
 CLONE_PROOF Proof("proof1") Proof("proof2");
 DROP_PROOF Proof("proof1");
 DROP_PROOF Proof("proof2");
 
 # Create a proof from account and drop it
-CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "create_proof_by_amount" ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "create_proof_by_amount" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
 POP_FROM_AUTH_ZONE Proof("proof3");
 DROP_PROOF Proof("proof3");
 
 # Return a bucket to worktop
 RETURN_TO_WORKTOP Bucket("some_xrd");
-TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleLocalId>(NonFungibleLocalId("#1#")) ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
+TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleLocalId>(NonFungibleLocalId("#1#")) Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
 
 # Drop all proofs, cancel all buckets and move resources to account
 DROP_ALL_PROOFS;
-CALL_METHOD ComponentAddress("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/transaction/examples/royalty/royalty.rtm
+++ b/transaction/examples/royalty/royalty.rtm
@@ -1,5 +1,5 @@
 SET_PACKAGE_ROYALTY_CONFIG
-    PackageAddress("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
+    Address("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe")
     Map<String, Tuple>(
         "Blueprint",
         Tuple(
@@ -11,7 +11,7 @@ SET_PACKAGE_ROYALTY_CONFIG
     );
 
 SET_COMPONENT_ROYALTY_CONFIG
-    ComponentAddress("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
+    Address("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt")
     Tuple(
         Map<String, U32>(
             "method", 1u32
@@ -20,7 +20,7 @@ SET_COMPONENT_ROYALTY_CONFIG
     );
 
 CLAIM_PACKAGE_ROYALTY
-    PackageAddress("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe");
+    Address("package_sim1qy4hrp8a9apxldp5cazvxgwdj80cxad4u8cpkaqqnhlsa3lfpe");
 
 CLAIM_COMPONENT_ROYALTY
-    ComponentAddress("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt");
+    Address("component_sim1qg2jwzl3hxnkqye8tfj5v3p2wp7cv9xdcjv4nl63refs785pvt");

--- a/transaction/examples/values/values.rtm
+++ b/transaction/examples/values/values.rtm
@@ -1,12 +1,12 @@
 TAKE_FROM_WORKTOP
-    ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag")
+    Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag")
     Bucket("temp1");
 CREATE_PROOF_FROM_AUTH_ZONE
-    ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag")
+    Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag")
     Proof("temp2");
 
 CALL_METHOD 
-    ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
+    Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
     "aliases"
 
     # enum
@@ -33,27 +33,27 @@ CALL_METHOD
     NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:#456#")
     NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:[031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f]")
     NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:#1234567890#")
-    Tuple(ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#"))
+    Tuple(Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#"))
 
     # array
     Array<Bytes>(Bytes("dead"), Array<U8>(5u8, 10u8, 255u8))
     Array<Array>(Bytes("dead"), Array<U8>(5u8, 10u8, 255u8))
-    Array<NonFungibleGlobalId>(NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:<value>"), Tuple(ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#")))
-    Array<Tuple>(NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:<value>"), Tuple(ResourceAddress("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#")));
+    Array<NonFungibleGlobalId>(NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:<value>"), Tuple(Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#")))
+    Array<Tuple>(NonFungibleGlobalId("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag:<value>"), Tuple(Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"), NonFungibleLocalId("#1#")));
 
 CALL_METHOD 
-    ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
+    Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")
     "custom_types"
 
     # Address
     Address("package_sim1qyqzcexvnyg60z7lnlwauh66nhzg3m8tch2j8wc0e70qkydk8r")
-    PackageAddress("package_sim1qyqzcexvnyg60z7lnlwauh66nhzg3m8tch2j8wc0e70qkydk8r")
-    ComponentAddress("account_sim1q0u9gxewjxj8nhxuaschth2mgencma2hpkgwz30s9wlslthace")
-    ComponentAddress("epochmanager_sim1qsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvygtcq")
-    ComponentAddress("clock_sim1qcqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqagpd30")
-    ComponentAddress("validator_sim1q5qszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsvkh36j")
-    ComponentAddress("accesscontroller_sim1pspqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqq397jz")
-    ResourceAddress("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
+    Address("package_sim1qyqzcexvnyg60z7lnlwauh66nhzg3m8tch2j8wc0e70qkydk8r")
+    Address("account_sim1q0u9gxewjxj8nhxuaschth2mgencma2hpkgwz30s9wlslthace")
+    Address("epochmanager_sim1qsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvygtcq")
+    Address("clock_sim1qcqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqagpd30")
+    Address("validator_sim1q5qszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsvkh36j")
+    Address("accesscontroller_sim1pspqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqq397jz")
+    Address("resource_sim1qq8cays25704xdyap2vhgmshkkfyr023uxdtk59ddd4qs8cr5v")
 
     Bucket("temp1")
     Proof("temp2")

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -333,9 +333,6 @@ pub enum Value {
     Err(Box<Value>),
     Bytes(Box<Value>),
     NonFungibleGlobalId(Box<Value>),
-    PackageAddress(Box<Value>),
-    ComponentAddress(Box<Value>),
-    ResourceAddress(Box<Value>),
 
     // ==============
     // Custom Types
@@ -382,13 +379,6 @@ impl Value {
             Value::Err(_) => ManifestValueKind::Enum,
             Value::Bytes(_) => ManifestValueKind::Array,
             Value::NonFungibleGlobalId(_) => ManifestValueKind::Tuple,
-            Value::PackageAddress(_) => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
-            Value::ComponentAddress(_) => {
-                ManifestValueKind::Custom(ManifestCustomValueKind::Address)
-            }
-            Value::ResourceAddress(_) => {
-                ManifestValueKind::Custom(ManifestCustomValueKind::Address)
-            }
 
             // ==============
             // Custom Types

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -715,12 +715,6 @@ fn generate_package_address(
     bech32_decoder: &Bech32Decoder,
 ) -> Result<PackageAddress, GeneratorError> {
     match value {
-        ast::Value::PackageAddress(inner) => match &**inner {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_package_address(s)
-                .map_err(|_| GeneratorError::InvalidPackageAddress(s.into())),
-            v => invalid_type!(v, ast::Type::String),
-        },
         ast::Value::Address(inner) => match &**inner {
             ast::Value::String(s) => bech32_decoder
                 .validate_and_decode_package_address(s)
@@ -736,12 +730,6 @@ fn generate_component_address(
     bech32_decoder: &Bech32Decoder,
 ) -> Result<ComponentAddress, GeneratorError> {
     match value {
-        ast::Value::ComponentAddress(inner) => match &**inner {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_component_address(s)
-                .map_err(|_| GeneratorError::InvalidComponentAddress(s.into())),
-            v => invalid_type!(v, ast::Type::String),
-        },
         ast::Value::Address(inner) => match &**inner {
             ast::Value::String(s) => bech32_decoder
                 .validate_and_decode_component_address(s)
@@ -757,12 +745,6 @@ fn generate_resource_address(
     bech32_decoder: &Bech32Decoder,
 ) -> Result<ResourceAddress, GeneratorError> {
     match value {
-        ast::Value::ResourceAddress(inner) => match inner.borrow() {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_resource_address(s)
-                .map_err(|_| GeneratorError::InvalidResourceAddress(s.into())),
-            v => invalid_type!(v, ast::Type::String),
-        },
         ast::Value::Address(inner) => match inner.borrow() {
             ast::Value::String(s) => bech32_decoder
                 .validate_and_decode_resource_address(s)
@@ -788,30 +770,6 @@ fn generate_address(
                 .or(bech32_decoder
                     .validate_and_decode_resource_address(s)
                     .map(|a| Address::Resource(a)))
-                .map_err(|_| GeneratorError::InvalidAddress(s.into()))
-                .map(from_address),
-            v => return invalid_type!(v, ast::Type::String),
-        },
-        ast::Value::PackageAddress(value) => match value.borrow() {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_package_address(s)
-                .map(|a| Address::Package(a))
-                .map_err(|_| GeneratorError::InvalidAddress(s.into()))
-                .map(from_address),
-            v => return invalid_type!(v, ast::Type::String),
-        },
-        ast::Value::ComponentAddress(value) => match value.borrow() {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_component_address(s)
-                .map(|a| Address::Component(a))
-                .map_err(|_| GeneratorError::InvalidAddress(s.into()))
-                .map(from_address),
-            v => return invalid_type!(v, ast::Type::String),
-        },
-        ast::Value::ResourceAddress(value) => match value.borrow() {
-            ast::Value::String(s) => bech32_decoder
-                .validate_and_decode_resource_address(s)
-                .map(|a| Address::Resource(a))
                 .map_err(|_| GeneratorError::InvalidAddress(s.into()))
                 .map(from_address),
             v => return invalid_type!(v, ast::Type::String),
@@ -1245,21 +1203,6 @@ pub fn generate_value(
                 ],
             })
         }
-        ast::Value::PackageAddress(_) => {
-            generate_package_address(value, bech32_decoder).map(|v| Value::Custom {
-                value: ManifestCustomValue::Address(from_address(Address::Package(v))),
-            })
-        }
-        ast::Value::ComponentAddress(_) => {
-            generate_component_address(value, bech32_decoder).map(|v| Value::Custom {
-                value: ManifestCustomValue::Address(from_address(Address::Component(v))),
-            })
-        }
-        ast::Value::ResourceAddress(_) => {
-            generate_resource_address(value, bech32_decoder).map(|v| Value::Custom {
-                value: ManifestCustomValue::Address(from_address(Address::Resource(v))),
-            })
-        }
         // ==============
         // Custom Types
         // ==============
@@ -1494,15 +1437,15 @@ mod tests {
     #[test]
     fn test_failures() {
         generate_value_error!(
-            r#"ComponentAddress(100u32)"#,
+            r#"Address(100u32)"#,
             GeneratorError::InvalidAstValue {
                 expected_type: vec![ast::Type::String],
                 actual: ast::Value::U32(100),
             }
         );
         generate_value_error!(
-            r#"PackageAddress("invalid_package_address")"#,
-            GeneratorError::InvalidPackageAddress("invalid_package_address".into())
+            r#"Address("invalid_package_address")"#,
+            GeneratorError::InvalidAddress("invalid_package_address".into())
         );
         generate_value_error!(
             r#"Decimal("invalid_decimal")"#,
@@ -1525,27 +1468,27 @@ mod tests {
             .unwrap();
 
         generate_instruction_ok!(
-            r#"TAKE_FROM_WORKTOP_BY_AMOUNT  Decimal("1")  ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")  Bucket("xrd_bucket");"#,
+            r#"TAKE_FROM_WORKTOP_BY_AMOUNT  Decimal("1")  Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")  Bucket("xrd_bucket");"#,
             Instruction::TakeFromWorktopByAmount {
                 amount: Decimal::from(1),
                 resource_address: resource,
             },
         );
         generate_instruction_ok!(
-            r#"TAKE_FROM_WORKTOP  ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")  Bucket("xrd_bucket");"#,
+            r#"TAKE_FROM_WORKTOP  Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")  Bucket("xrd_bucket");"#,
             Instruction::TakeFromWorktop {
                 resource_address: resource
             },
         );
         generate_instruction_ok!(
-            r#"ASSERT_WORKTOP_CONTAINS_BY_AMOUNT  Decimal("1")  ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak");"#,
+            r#"ASSERT_WORKTOP_CONTAINS_BY_AMOUNT  Decimal("1")  Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak");"#,
             Instruction::AssertWorktopContainsByAmount {
                 amount: Decimal::from(1),
                 resource_address: resource,
             },
         );
         generate_instruction_ok!(
-            r#"CALL_FUNCTION  PackageAddress("package_sim1q8gl2qqsusgzmz92es68wy2fr7zjc523xj57eanm597qrz3dx7")  "Airdrop"  "new"  500u32  PreciseDecimal("120");"#,
+            r#"CALL_FUNCTION  Address("package_sim1q8gl2qqsusgzmz92es68wy2fr7zjc523xj57eanm597qrz3dx7")  "Airdrop"  "new"  500u32  PreciseDecimal("120");"#,
             Instruction::CallFunction {
                 package_address: Bech32Decoder::for_simulator()
                     .validate_and_decode_package_address(
@@ -1558,7 +1501,7 @@ mod tests {
             },
         );
         generate_instruction_ok!(
-            r#"CALL_METHOD  ComponentAddress("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")  "refill";"#,
+            r#"CALL_METHOD  Address("component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum")  "refill";"#,
             Instruction::CallMethod {
                 component_address: component,
                 method_name: "refill".to_string(),
@@ -1566,14 +1509,14 @@ mod tests {
             },
         );
         generate_instruction_ok!(
-            r#"MINT_FUNGIBLE ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak") Decimal("100");"#,
+            r#"MINT_FUNGIBLE Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak") Decimal("100");"#,
             Instruction::MintFungible {
                 resource_address: resource,
                 amount: dec!("100")
             },
         );
         generate_instruction_ok!(
-            r##"MINT_NON_FUNGIBLE ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak") Map<NonFungibleLocalId, Tuple>(NonFungibleLocalId("#1#"), Tuple(Tuple("Hello World", Decimal("12")), Tuple(12u8, 19u128)));"##,
+            r##"MINT_NON_FUNGIBLE Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak") Map<NonFungibleLocalId, Tuple>(NonFungibleLocalId("#1#"), Tuple(Tuple("Hello World", Decimal("12")), Tuple(12u8, 19u128)));"##,
             Instruction::MintNonFungible {
                 resource_address: resource,
                 entries: BTreeMap::from([(
@@ -1742,7 +1685,7 @@ mod tests {
         generate_instruction_ok!(
             r#"
             MINT_UUID_NON_FUNGIBLE
-                ResourceAddress("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")
+                Address("resource_sim1qr9alp6h38ggejqvjl3fzkujpqj2d84gmqy72zuluzwsykwvak")
                 Array<Tuple>(
                     Tuple(
                         Tuple("Hello World", Decimal("12")),

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -55,9 +55,6 @@ pub enum TokenKind {
     Err,
     Bytes,
     NonFungibleGlobalId,
-    PackageAddress,
-    ComponentAddress,
-    ResourceAddress,
 
     // ==============
     // SBOR custom types
@@ -401,9 +398,6 @@ impl Lexer {
             "Err" => Ok(TokenKind::Err),
             "Bytes" => Ok(TokenKind::Bytes),
             "NonFungibleGlobalId" => Ok(TokenKind::NonFungibleGlobalId),
-            "PackageAddress" => Ok(TokenKind::PackageAddress),
-            "ComponentAddress" => Ok(TokenKind::ComponentAddress),
-            "ResourceAddress" => Ok(TokenKind::ResourceAddress),
 
             "Address" => Ok(TokenKind::Address),
             "Bucket" => Ok(TokenKind::Bucket),

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -298,10 +298,7 @@ impl Parser {
             | TokenKind::Ok
             | TokenKind::Err
             | TokenKind::Bytes
-            | TokenKind::NonFungibleGlobalId
-            | TokenKind::PackageAddress
-            | TokenKind::ComponentAddress
-            | TokenKind::ResourceAddress => self.parse_alias(),
+            | TokenKind::NonFungibleGlobalId => self.parse_alias(),
 
             // ==============
             // Custom Types
@@ -373,13 +370,6 @@ impl Parser {
             TokenKind::NonFungibleGlobalId => Ok(Value::NonFungibleGlobalId(Box::new(
                 self.parse_values_one()?,
             ))),
-            TokenKind::PackageAddress => Ok(Value::PackageAddress(self.parse_values_one()?.into())),
-            TokenKind::ComponentAddress => {
-                Ok(Value::ComponentAddress(self.parse_values_one()?.into()))
-            }
-            TokenKind::ResourceAddress => {
-                Ok(Value::ResourceAddress(self.parse_values_one()?.into()))
-            }
             _ => Err(ParserError::UnexpectedToken(token)),
         }
     }
@@ -476,9 +466,6 @@ impl Parser {
             // Alias
             TokenKind::Bytes => Ok(Type::Bytes),
             TokenKind::NonFungibleGlobalId => Ok(Type::NonFungibleGlobalId),
-            TokenKind::PackageAddress => Ok(Type::PackageAddress),
-            TokenKind::ComponentAddress => Ok(Type::ComponentAddress),
-            TokenKind::ResourceAddress => Ok(Type::ResourceAddress),
 
             // Custom types
             TokenKind::Address => Ok(Type::Address),
@@ -606,7 +593,7 @@ mod tests {
             })
         );
         parse_value_error!(
-            r#"PackageAddress("abc", "def")"#,
+            r#"Address("abc", "def")"#,
             ParserError::InvalidNumberOfValues {
                 actual: 2,
                 expected: 1


### PR DESCRIPTION
## Summary

Drop support of PackageAddress, ComponentAddress and ResourceAddress in Manifest

## Update Recommendations

### For Dapp Developers

You can use `Address("bech32_address")` instead.
