### PR TITLE
Replace jemalloc with mimalloc

### DIFF
--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -447,6 +447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -643,6 +662,7 @@ dependencies = [
  "bitflags",
  "colored",
  "hex",
+ "mimalloc",
  "moka",
  "native-sdk",
  "parity-wasm",

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -17,7 +17,7 @@ lru = { version = "0.8.1", default-features = false, optional = true}
 moka = { version = "0.9.4", features = ["sync"], default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 perfcnt = { version = "0.8.0", optional = true }
-tikv-jemallocator = { version = "0.5" }
+mimalloc = { version = "0.1.34", default-features = false }
 
 # WASM de-/serialization
 parity-wasm = { version = "0.42.2" }

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -1,11 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-// Jemalloc disabled for wasmer builds due to issue with handling of stack overflow.
-#[cfg(not(feature = "wasmer"))]
-use tikv_jemallocator::Jemalloc;
-#[cfg(not(feature = "wasmer"))]
+use mimalloc::MiMalloc;
+
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: MiMalloc = MiMalloc;
 
 extern crate core;
 #[cfg(not(any(feature = "std", feature = "alloc")))]

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -583,6 +583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.8.0+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -852,6 +871,7 @@ dependencies = [
  "bitflags",
  "colored",
  "hex",
+ "mimalloc",
  "moka",
  "native-sdk",
  "parity-wasm",
@@ -859,7 +879,6 @@ dependencies = [
  "radix-engine-interface",
  "sbor",
  "strum",
- "tikv-jemallocator",
  "transaction",
  "utils",
  "wasm-instrument",
@@ -1393,26 +1412,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.3+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "radix-engine-interface",
  "sbor",
  "strum",
+ "tikv-jemallocator",
  "transaction",
  "utils",
  "wasm-instrument",
@@ -1392,6 +1393,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR replaces jemalloc with mimalloc for better cross-platform support (the Rust binding).
- [`tikv/jemallocator`](https://github.com/tikv/jemallocator) only supports limited platforms, as stated on the home page;
- [`purpleprotocol/mimalloc_rust`](https://github.com/purpleprotocol/mimalloc_rust) is tested by CI on Ubuntu, MacOS and Windows.
---

Interestingly, contradictory to Microsoft's claim, the performance is slightly worse than jemalloc.

**First CI Run**

Test | Base | PR | %
-- | -- | -- | --
Radiswap::run | 4.9±0.09ms | 5.1±0.09ms | +4.08%
SpinLoop::run | 154.3±5.20ms | 156.9±5.82ms | +1.69%
Transfer::run | 1381.5±21.88µs | 1530.0±55.96µs | +10.75%

**Second CI Run**

Test | Base | PR | %
-- | -- | -- | --
Radiswap::run | 4.9±0.05ms | 5.0±0.02ms | +2.04%
SpinLoop::run | 155.2±2.09ms | 156.1±3.30ms | +0.58%
Transfer::run | 1377.0±13.72µs | 1479.7±25.71µs | +7.46%


**Third CI Run**

Test | Base | PR | %
-- | -- | -- | --
Radiswap::run | 4.9±0.05ms | 5.1±0.05ms | +4.08%
SpinLoop::run | 158.4±2.44ms | 158.3±3.36ms | -0.06%
Transfer::run | 1362.9±9.52µs | 1522.3±15.07µs | +11.70%


