### PR TITLE
Fix/schema validation fixes

### DIFF
--- a/sbor/src/schema/schema_validation/mod.rs
+++ b/sbor/src/schema/schema_validation/mod.rs
@@ -24,6 +24,7 @@ pub enum SchemaValidationError {
     TypeMetadataContainedWrongNumberOfVariants,
     TypeMetadataForEnumIsNotEnumVariantChildNames,
     TypeMetadataHasMismatchingEnumDiscriminator,
+    TypeMetadataContainedDuplicateEnumVariantNames,
     InvalidIdentName { message: String },
     TypeValidationMismatch,
     TypeValidationNumericValidationInvalid,

--- a/sbor/src/schema/schema_validation/mod.rs
+++ b/sbor/src/schema/schema_validation/mod.rs
@@ -71,7 +71,6 @@ pub struct TypeValidationContext {
 mod tests {
     use super::*;
     use crate::rust::prelude::*;
-    use sbor::*;
 
     fn create_schema(type_data: Vec<TypeData<NoCustomTypeKind, LocalTypeIndex>>) -> BasicSchema {
         let mut type_kinds = vec![];

--- a/sbor/src/schema/schema_validation/mod.rs
+++ b/sbor/src/schema/schema_validation/mod.rs
@@ -66,3 +66,47 @@ pub fn validate_schema<E: CustomTypeExtension>(
 pub struct TypeValidationContext {
     pub local_types_len: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rust::prelude::*;
+    use sbor::*;
+
+    fn create_schema(type_data: Vec<TypeData<NoCustomTypeKind, LocalTypeIndex>>) -> BasicSchema {
+        let mut type_kinds = vec![];
+        let mut type_metadata = vec![];
+        let mut type_validations = vec![];
+        for type_data in type_data {
+            let TypeData {
+                kind,
+                metadata,
+                validation,
+            } = type_data;
+            type_kinds.push(kind);
+            type_metadata.push(metadata);
+            type_validations.push(validation);
+        }
+        BasicSchema {
+            type_kinds,
+            type_metadata,
+            type_validations,
+        }
+    }
+
+    #[test]
+    pub fn duplicate_enum_variant_names_not_allowed() {
+        let schema = create_schema(vec![TypeData::enum_variants(
+            "TestEnum",
+            btreemap![
+                0 => TypeData::struct_with_unit_fields("VariantA"),
+                1 => TypeData::struct_with_unit_fields("VariantB"),
+                2 => TypeData::struct_with_unit_fields("VariantA"), // Repeat!
+            ],
+        )]);
+        assert_eq!(
+            validate_schema(&schema),
+            Err(SchemaValidationError::TypeMetadataContainedDuplicateEnumVariantNames)
+        );
+    }
+}

--- a/sbor/src/schema/schema_validation/type_metadata_validation.rs
+++ b/sbor/src/schema/schema_validation/type_metadata_validation.rs
@@ -100,7 +100,7 @@ pub fn validate_enum_metadata(
             if variants_metadata.len() != variants.len() {
                 return Err(SchemaValidationError::TypeMetadataContainedWrongNumberOfVariants);
             }
-            let mut unique_variant_names = IndexSet::new();
+            let mut unique_variant_names = index_set::new();
             for (discriminator, variant_metadata) in variants_metadata.iter() {
                 let Some(child_types) = variants.get(discriminator) else {
                     return Err(SchemaValidationError::TypeMetadataHasMismatchingEnumDiscriminator)

--- a/sbor/src/traversal/traverser.rs
+++ b/sbor/src/traversal/traverser.rs
@@ -24,19 +24,6 @@ pub trait CustomTerminalValueRef: Debug + Clone + PartialEq + Eq {
     fn custom_value_kind(&self) -> Self::CustomValueKind;
 }
 
-pub trait CustomTerminalValueBatchRef: Debug + Clone + PartialEq + Eq {
-    type CustomValueKind: CustomValueKind;
-
-    fn custom_value_kind(&self) -> Self::CustomValueKind;
-}
-
-pub trait CustomContainerHeader: Copy + Debug + Clone + PartialEq + Eq {
-    type CustomValueKind: CustomValueKind;
-    fn get_child_count(&self) -> u32;
-    fn get_implicit_child_value_kind(&self, index: u32)
-        -> Option<ValueKind<Self::CustomValueKind>>;
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContainerState<C: CustomTraversal> {
     pub container_header: ContainerHeader<C>,


### PR DESCRIPTION
## Summary
Some small tweaks / fixes for schema validation. Notably:
* Enum Variant names can't repeat
* Enums can't specify "None" for children (ie Enum Variant) names

## Testing
Added test for duplicate enum variant names failing validation. More tests should be added in due course for schema validation.