### PR TITLE
feat: Improved schema validation error message

### DIFF
--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -214,11 +214,11 @@ pub enum InterpreterError {
     ScryptoBlueprintNotFound(PackageAddress, String),
     ScryptoFunctionNotFound(String),
     ScryptoReceiverNotMatch(String),
-    ScryptoInputSchemaNotMatch(String),
+    ScryptoInputSchemaNotMatch(String, String),
     ScryptoInputDecodeError(DecodeError),
 
     ScryptoOutputDecodeError(DecodeError),
-    ScryptoOutputSchemaNotMatch(String),
+    ScryptoOutputSchemaNotMatch(String, String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]

--- a/radix-engine/src/kernel/interpreters/scrypto_interpreter.rs
+++ b/radix-engine/src/kernel/interpreters/scrypto_interpreter.rs
@@ -56,9 +56,10 @@ fn validate_input(
         &blueprint_schema.schema,
         function_schema.input,
     )
-    .map_err(|_| {
+    .map_err(|err| {
         RuntimeError::InterpreterError(InterpreterError::ScryptoInputSchemaNotMatch(
             fn_ident.to_string(),
+            err.error_message(&blueprint_schema.schema),
         ))
     })?;
 
@@ -84,9 +85,10 @@ fn validate_output(
         &blueprint_schema.schema,
         function_schema.output,
     )
-    .map_err(|_| {
+    .map_err(|err| {
         RuntimeError::InterpreterError(InterpreterError::ScryptoOutputSchemaNotMatch(
             fn_ident.to_string(),
+            err.error_message(&blueprint_schema.schema),
         ))
     })?;
 

--- a/radix-engine/src/system/client_api_impl.rs
+++ b/radix-engine/src/system/client_api_impl.rs
@@ -235,12 +235,11 @@ where
         }
         for i in 0..app_states.len() {
             validate_payload_against_schema(&app_states[i], &schema.schema, schema.substates[i])
-                .map_err(|e| {
-                    // TODO: make `LocatedValidationError` encodable
+                .map_err(|err| {
                     RuntimeError::SystemError(SystemError::SubstateValidationError(
                         SubstateValidationError::SchemaValidationError(
                             blueprint_ident.to_string(),
-                            format!("{:?}", e),
+                            err.error_message(&schema.schema),
                         ),
                     ))
                 })?;
@@ -707,9 +706,9 @@ where
         };
 
         // Validating the event data against the event schema
-        validate_payload_against_schema(&event_data, &schema, local_type_index).map_err(|_| {
+        validate_payload_against_schema(&event_data, &schema, local_type_index).map_err(|err| {
             RuntimeError::ApplicationError(ApplicationError::EventError(
-                EventError::InvalidEventSchema,
+                EventError::EventSchemaNotMatch(err.error_message(&schema)),
             ))
         })?;
 

--- a/radix-engine/src/system/kernel_modules/events/error.rs
+++ b/radix-engine/src/system/kernel_modules/events/error.rs
@@ -10,6 +10,7 @@ pub enum EventError {
         event_name: String,
     },
     InvalidEventSchema,
+    EventSchemaNotMatch(String),
     NoAssociatedPackage,
     DuplicateEventNamesFound,
     FailedToSborEncodeEventSchema,

--- a/sbor/src/schema/typed_traversal/events.rs
+++ b/sbor/src/schema/typed_traversal/events.rs
@@ -8,6 +8,24 @@ pub struct TypedLocatedTraversalEvent<'t, 's, 'de, C: CustomTraversal> {
     pub event: TypedTraversalEvent<'de, C>,
 }
 
+impl<'t, 's, 'de, C: CustomTraversal> TypedLocatedTraversalEvent<'t, 's, 'de, C> {
+    pub fn full_location(&self) -> FullLocation<'s, C> {
+        FullLocation {
+            start_offset: self.location.location.start_offset,
+            end_offset: self.location.location.end_offset,
+            ancestor_path: self
+                .location
+                .location
+                .ancestor_path
+                .iter()
+                .cloned()
+                .zip(self.location.typed_ancestor_path.iter().cloned())
+                .collect(),
+            current_value_info: self.event.current_value_info(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypedTraversalEvent<'de, C: CustomTraversal> {
     PayloadPrefix,
@@ -17,6 +35,99 @@ pub enum TypedTraversalEvent<'de, C: CustomTraversal> {
     TerminalValueBatch(LocalTypeIndex, TerminalValueBatchRef<'de>),
     End,
     Error(TypedTraversalError<C::CustomValueKind>),
+}
+
+impl<'de, C: CustomTraversal> TypedTraversalEvent<'de, C> {
+    pub fn current_value_info(&self) -> Option<CurrentValueInfo<C::CustomValueKind>> {
+        match self {
+            TypedTraversalEvent::PayloadPrefix => None,
+            TypedTraversalEvent::ContainerStart(type_index, header) => {
+                Some(CurrentValueInfo::for_container(*type_index, header))
+            }
+            TypedTraversalEvent::ContainerEnd(type_index, header) => {
+                Some(CurrentValueInfo::for_container(*type_index, header))
+            }
+            TypedTraversalEvent::TerminalValue(type_index, value_ref) => Some(
+                CurrentValueInfo::for_value(*type_index, value_ref.value_kind()),
+            ),
+            TypedTraversalEvent::TerminalValueBatch(type_index, value_batch_ref) => Some(
+                CurrentValueInfo::for_value(*type_index, value_batch_ref.value_kind()),
+            ),
+            TypedTraversalEvent::End => None,
+            TypedTraversalEvent::Error(TypedTraversalError::DecodeError(_)) => None,
+            TypedTraversalEvent::Error(TypedTraversalError::TypeIndexNotFound(_)) => None,
+            TypedTraversalEvent::Error(TypedTraversalError::ValueMismatchWithType(
+                type_mismatch_error,
+            )) => match type_mismatch_error {
+                TypeMismatchError::MismatchingType { expected, actual } => {
+                    Some(CurrentValueInfo::for_value(*expected, *actual))
+                }
+                TypeMismatchError::MismatchingChildElementType { expected, actual } => {
+                    Some(CurrentValueInfo::for_value(*expected, *actual))
+                }
+                TypeMismatchError::MismatchingChildKeyType { expected, actual } => {
+                    Some(CurrentValueInfo::for_value(*expected, *actual))
+                }
+                TypeMismatchError::MismatchingChildValueType { expected, actual } => {
+                    Some(CurrentValueInfo::for_value(*expected, *actual))
+                }
+                TypeMismatchError::MismatchingTupleLength { type_index, .. } => {
+                    Some(CurrentValueInfo::for_value(*type_index, ValueKind::Tuple))
+                }
+                TypeMismatchError::MismatchingEnumVariantLength {
+                    variant,
+                    type_index,
+                    ..
+                } => Some(CurrentValueInfo::for_enum_variant(*type_index, *variant)),
+                TypeMismatchError::UnknownEnumVariant {
+                    type_index,
+                    variant,
+                } => Some(CurrentValueInfo::for_enum_variant(*type_index, *variant)),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentValueInfo<X: CustomValueKind> {
+    pub type_index: LocalTypeIndex,
+    pub value_kind: ValueKind<X>,
+    pub variant: Option<u8>,
+}
+
+impl<X: CustomValueKind> CurrentValueInfo<X> {
+    pub fn for_value(type_index: LocalTypeIndex, value_kind: ValueKind<X>) -> Self {
+        Self {
+            type_index,
+            value_kind,
+            variant: None,
+        }
+    }
+
+    pub fn for_container<C: CustomTraversal>(
+        type_index: LocalTypeIndex,
+        container_header: &ContainerHeader<C>,
+    ) -> Self {
+        let (value_kind, variant) = match container_header {
+            ContainerHeader::Tuple(_) => (ValueKind::Tuple, None),
+            ContainerHeader::EnumVariant(header) => (ValueKind::Enum, Some(header.variant)),
+            ContainerHeader::Array(_) => (ValueKind::Array, None),
+            ContainerHeader::Map(_) => (ValueKind::Map, None),
+        };
+        Self {
+            type_index,
+            value_kind,
+            variant,
+        }
+    }
+
+    pub fn for_enum_variant(type_index: LocalTypeIndex, variant: u8) -> Self {
+        Self {
+            type_index,
+            value_kind: ValueKind::Enum,
+            variant: Some(variant),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/sbor/src/schema/typed_traversal/full_location.rs
+++ b/sbor/src/schema/typed_traversal/full_location.rs
@@ -1,0 +1,122 @@
+use super::*;
+use crate::traversal::*;
+use crate::*;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullLocation<'s, C: CustomTraversal> {
+    pub start_offset: usize,
+    pub end_offset: usize,
+    pub ancestor_path: Vec<(ContainerState<C>, ContainerType<'s>)>,
+    pub current_value_info: Option<CurrentValueInfo<C::CustomValueKind>>,
+}
+
+impl<'s, C: CustomTraversal> FullLocation<'s, C> {
+    /// This enables a full path to be provided in an error message, which can have a debug such as:
+    /// EG: `MyStruct.hello[0]->MyEnum::Option2{1}.inner[0]->MyEnum::Option1{0}.[0]->Map[0].Value->Array[0]->Tuple.[0]->Enum::{6}.[0]->Tuple.[1]->Map[0].Key`
+    ///
+    /// As much information is extracted from the Type as possible, falling back to data from the value model
+    /// if the Type is Any.
+    pub fn path_to_string<E: CustomTypeExtension>(&self, schema: &Schema<E>) -> String {
+        use crate::rust::fmt::*;
+
+        let mut buf = String::new();
+        let mut is_first = true;
+        for (container_state, container_type) in self.ancestor_path.iter() {
+            if is_first {
+                is_first = false;
+            } else {
+                write!(buf, "->").unwrap();
+            }
+            let type_index = container_type.self_type();
+            let type_kind = schema
+                .resolve_type_kind(type_index)
+                .expect("Type index not found in given schema");
+            let metadata = if !matches!(type_kind, TypeKind::Any) {
+                schema.resolve_type_metadata(type_index)
+            } else {
+                None
+            };
+            let type_name = metadata
+                .map(|m| m.type_name.as_ref())
+                .unwrap_or_else(|| container_state.container_header.value_kind_name());
+            let current_index = container_state.current_child_index();
+            let header = container_state.container_header;
+            match header {
+                ContainerHeader::EnumVariant(variant_header) => {
+                    let variant_data = metadata.and_then(|v| match &v.child_names {
+                        Some(ChildNames::EnumVariants(variants)) => {
+                            variants.get(&variant_header.variant)
+                        }
+                        _ => None,
+                    });
+                    let variant_part = variant_data
+                        .map(|d| format!("::{}{{{}}}", d.type_name, variant_header.variant))
+                        .unwrap_or_else(|| format!("::{{{}}}", variant_header.variant));
+                    let index = variant_data.and_then(|d| match &d.child_names {
+                        Some(ChildNames::NamedFields(fields)) => {
+                            fields.get(container_state.current_child_index())
+                        }
+                        _ => None,
+                    });
+                    let field_part = index
+                        .map(|i| format!(".{}[{}]", i, current_index))
+                        .unwrap_or_else(|| format!(".[{}]", current_index));
+                    write!(buf, "{}{}{}", type_name, variant_part, field_part).unwrap();
+                }
+                ContainerHeader::Tuple(_) => {
+                    let index = metadata.and_then(|d| match &d.child_names {
+                        Some(ChildNames::NamedFields(fields)) => {
+                            fields.get(container_state.current_child_index())
+                        }
+                        _ => None,
+                    });
+                    let field_part = index
+                        .map(|i| format!(".{}[{}]", i, current_index))
+                        .unwrap_or_else(|| format!(".[{}]", current_index));
+                    write!(buf, "{}{}", type_name, field_part).unwrap();
+                }
+                ContainerHeader::Array(_) => {
+                    write!(buf, "{}[{}]", type_name, current_index).unwrap();
+                }
+                ContainerHeader::Map(_) => {
+                    let child_index = container_state.current_child_index() / 2;
+                    let key_or_value = if container_state.current_child_index() % 2 == 0 {
+                        "Key"
+                    } else {
+                        "Value"
+                    };
+                    write!(buf, "{}[{}].{}", type_name, child_index, key_or_value).unwrap();
+                }
+            }
+        }
+        if let Some(current_value_info) = &self.current_value_info {
+            if !is_first {
+                write!(buf, "->").unwrap();
+            }
+            let type_kind = schema
+                .resolve_type_kind(current_value_info.type_index)
+                .expect("Type index not found in given schema");
+            let metadata = if !matches!(type_kind, TypeKind::Any) {
+                schema.resolve_type_metadata(current_value_info.type_index)
+            } else {
+                None
+            };
+            let type_name = metadata
+                .map(|m| m.type_name.to_string())
+                .unwrap_or_else(|| current_value_info.value_kind.to_string());
+            if let Some(variant) = current_value_info.variant {
+                let variant_data = metadata.and_then(|v| match &v.child_names {
+                    Some(ChildNames::EnumVariants(variants)) => variants.get(&variant),
+                    _ => None,
+                });
+                let variant_part = variant_data
+                    .map(|d| format!("::{}{{{}}}", d.type_name, variant))
+                    .unwrap_or_else(|| format!("::{{{}}}", variant));
+                write!(buf, "{}{}", type_name, variant_part).unwrap();
+            } else {
+                write!(buf, "{}", type_name).unwrap();
+            }
+        }
+        buf
+    }
+}

--- a/sbor/src/schema/typed_traversal/full_location.rs
+++ b/sbor/src/schema/typed_traversal/full_location.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::rust::fmt::*;
+use crate::rust::format;
+use crate::rust::prelude::*;
 use crate::traversal::*;
 use crate::*;
 
@@ -17,8 +20,6 @@ impl<'s, C: CustomTraversal> FullLocation<'s, C> {
     /// As much information is extracted from the Type as possible, falling back to data from the value model
     /// if the Type is Any.
     pub fn path_to_string<E: CustomTypeExtension>(&self, schema: &Schema<E>) -> String {
-        use crate::rust::fmt::*;
-
         let mut buf = String::new();
         let mut is_first = true;
         for (container_state, container_type) in self.ancestor_path.iter() {

--- a/sbor/src/schema/typed_traversal/mod.rs
+++ b/sbor/src/schema/typed_traversal/mod.rs
@@ -1,5 +1,7 @@
 mod events;
+mod full_location;
 mod typed_traverser;
 
 pub use events::*;
+pub use full_location::*;
 pub use typed_traverser::*;

--- a/sbor/src/traversal/events.rs
+++ b/sbor/src/traversal/events.rs
@@ -83,6 +83,24 @@ pub struct MapHeader<X: CustomValueKind> {
 }
 
 impl<C: CustomTraversal> ContainerHeader<C> {
+    pub fn get_own_value_kind(&self) -> ValueKind<C::CustomValueKind> {
+        match self {
+            ContainerHeader::Tuple(_) => ValueKind::Tuple,
+            ContainerHeader::EnumVariant(_) => ValueKind::Enum,
+            ContainerHeader::Array(_) => ValueKind::Array,
+            ContainerHeader::Map(_) => ValueKind::Map,
+        }
+    }
+
+    pub fn value_kind_name(&self) -> &'static str {
+        match self {
+            ContainerHeader::Tuple(_) => "Tuple",
+            ContainerHeader::EnumVariant(_) => "Enum",
+            ContainerHeader::Array(_) => "Array",
+            ContainerHeader::Map(_) => "Map",
+        }
+    }
+
     pub fn get_child_count(&self) -> usize {
         match self {
             ContainerHeader::Tuple(TupleHeader { length }) => *length,

--- a/sbor/src/traversal/traverser.rs
+++ b/sbor/src/traversal/traverser.rs
@@ -45,6 +45,12 @@ pub struct ContainerState<C: CustomTraversal> {
     pub next_child_index: usize,
 }
 
+impl<C: CustomTraversal> ContainerState<C> {
+    pub fn current_child_index(&self) -> usize {
+        self.next_child_index - 1
+    }
+}
+
 /// The `VecTraverser` is for streamed decoding of a payload.
 /// It turns payload decoding into a pull-based event stream.
 ///

--- a/sbor/src/value_kind.rs
+++ b/sbor/src/value_kind.rs
@@ -27,6 +27,15 @@ pub enum ValueKind<X: CustomValueKind> {
     Custom(X),
 }
 
+impl<X: CustomValueKind> crate::rust::fmt::Display for ValueKind<X> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Custom(x) => write!(f, "{:?}", x),
+            _ => write!(f, "{:?}", self),
+        }
+    }
+}
+
 impl<X: CustomValueKind> ValueKind<X> {
     pub fn as_u8(&self) -> u8 {
         match self {


### PR DESCRIPTION
## Summary
Adds a more detailed error message when schema validation fails, which includes the value path (including logical type names, where we have them!) to where the error occurred.

## Details
Example path:

"MyStruct.hello[0]->MyEnum::Option2{1}.inner[0]->MyEnum::Option1{0}.[0]->Map[0].Value->Array[0]->Tuple.[0]->Enum::{6}.[0]->Tuple.[1]->Map[0].Key"

## Testing
Have added a test in `payload_validator.rs`