### PR TITLE
Fix/integer overflow in check amount

### DIFF
--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -1,7 +1,9 @@
 use radix_engine::blueprints::resource::ResourceManagerError;
 use radix_engine::errors::{ApplicationError, RuntimeError};
+use radix_engine::types::blueprints::resource::ResourceMethodAuthKey;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use scrypto::prelude::Mutability::LOCKED;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
@@ -104,6 +106,39 @@ fn mint_with_bad_granularity_should_fail() {
         )) = e
         {
             amount.eq(&dec!("0.1")) && *granularity == 0
+        } else {
+            false
+        }
+    });
+}
+
+#[test]
+fn create_fungible_too_high_granularity_should_fail() {
+    // Arrange
+    let mut test_runner = TestRunner::builder().build();
+    let (public_key, _, _) = test_runner.new_allocated_account();
+    let _package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let mut access_rules = BTreeMap::new();
+    access_rules.insert(ResourceMethodAuthKey::Withdraw, (rule!(allow_all), LOCKED));
+    access_rules.insert(ResourceMethodAuthKey::Deposit, (rule!(allow_all), LOCKED));
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .lock_fee(FAUCET_COMPONENT, 10.into())
+        .create_fungible_resource(23u8, BTreeMap::new(), access_rules, Some(dec!("100")))
+        .build();
+    let receipt = test_runner.execute_manifest(
+        manifest,
+        vec![NonFungibleGlobalId::from_public_key(&public_key)],
+    );
+
+    // Assert
+    receipt.expect_specific_failure(|e| {
+        if let RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(
+            ResourceManagerError::InvalidDivisibility(granularity),
+        )) = e
+        {
+            *granularity == 23u8
         } else {
             false
         }

--- a/radix-engine/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager.rs
@@ -144,7 +144,11 @@ where
     Y: KernelNodeApi + KernelSubstateApi + ClientApi<RuntimeError>,
 {
     if divisibility > DIVISIBILITY_MAXIMUM {
-        return Err(RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(divisibility,))));
+        return Err(RuntimeError::ApplicationError(
+            ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(
+                divisibility,
+            )),
+        ));
     }
 
     let mut resource_manager = ResourceManagerSubstate::new(
@@ -1463,7 +1467,11 @@ where
     let resource_address: ResourceAddress = global_node_id.into();
 
     if divisibility > DIVISIBILITY_MAXIMUM {
-        return Err(RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(divisibility,))));
+        return Err(RuntimeError::ApplicationError(
+            ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(
+                divisibility,
+            )),
+        ));
     }
 
     let resource_manager_substate = ResourceManagerSubstate::new(

--- a/radix-engine/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager.rs
@@ -22,6 +22,8 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::math::Decimal;
 use radix_engine_interface::*;
 
+const DIVISIBILITY_MAXIMUM: u8 = 18;
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResourceManagerSubstate {
     pub resource_address: ResourceAddress, // TODO: Figure out a way to remove?
@@ -57,6 +59,7 @@ pub enum ResourceManagerError {
     NonFungibleIdTypeDoesNotMatch(NonFungibleIdType, NonFungibleIdType),
     ResourceTypeDoesNotMatch,
     InvalidNonFungibleIdType,
+    InvalidDivisibility(u8),
 }
 
 fn build_non_fungible_resource_manager_substate_with_initial_supply<Y>(
@@ -140,6 +143,10 @@ fn build_fungible_resource_manager_substate_with_initial_supply<Y>(
 where
     Y: KernelNodeApi + KernelSubstateApi + ClientApi<RuntimeError>,
 {
+    if divisibility > DIVISIBILITY_MAXIMUM {
+        return Err(RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(divisibility,))));
+    }
+
     let mut resource_manager = ResourceManagerSubstate::new(
         ResourceType::Fungible { divisibility },
         None,
@@ -1454,6 +1461,10 @@ where
     Y: KernelNodeApi + KernelSubstateApi + ClientApi<RuntimeError>,
 {
     let resource_address: ResourceAddress = global_node_id.into();
+
+    if divisibility > DIVISIBILITY_MAXIMUM {
+        return Err(RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(ResourceManagerError::InvalidDivisibility(divisibility,))));
+    }
 
     let resource_manager_substate = ResourceManagerSubstate::new(
         ResourceType::Fungible { divisibility },


### PR DESCRIPTION
## Summary

Fix potential integer overflow in ResourceType implementation

## Details

ResourceType check_amount() method was not checking if divisibility is not greater than 18, which could have eventually led to crashes:
- in debug mode:
  `thread '<name>' panicked at 'attempt to subtract with overflow', radix-engine-interface/src/blueprints/resource/resource_type.rs:42:53`
- in release mode:
`thread '<name> panicked at '(bnum) attempt to calculate remainder with a divisor of zero', <home>/.cargo/registry/src/github.com-1ecc6299db9ec823/bnum-0.4.0/src/bint/ops.rs:134:1`

## Testing
A test `create_fungible_too_high_granularity_should_fail()` has been added.

