### PR TITLE
Tweak/add conversion to bytes from renodeid

### DIFF
--- a/simulator/src/utils/common_instructions.rs
+++ b/simulator/src/utils/common_instructions.rs
@@ -194,8 +194,9 @@ fn build_call_arguments<'a>(
         _ => panic!("Inconsistent schema"),
     }
 
-    let manifest_value: ManifestValue = to_manifest_value(&ManifestValue::Tuple { fields: built_args })
-        .expect("Failed to transcode ManifestValue");
+    let manifest_value: ManifestValue =
+        to_manifest_value(&ManifestValue::Tuple { fields: built_args })
+            .expect("Failed to transcode ManifestValue");
 
     Ok((builder, manifest_value))
 }


### PR DESCRIPTION
## Summary
Tiny PR which adds a conversion of RENodeId to bytes which we can use for the "EntityId" in Core API / Gateway API.

## Update Recommendations
### For Internal Integrators

We should use this conversion in:
* The Core API for EntityId
* The Gateway API for EntityId

Soon this will be one-to-one convertible to/from Bech32m addresses.
