### PR TITLE
fix: Fix compilation of value serializer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
           -p radix-engine-derive \
           -p radix-engine-interface \
           -p radix-engine \
-          -p radix-engine-tests
+          -p radix-engine-tests \
+          --features serde
   radix-engine-no-std:
     name: Run Radix Engine tests (no_std)
     runs-on: ${{ matrix.os }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
         "Cargo.toml",
         "simulator/Cargo.toml",
     ],
+    "rust-analyzer.cargo.features": [
+        "serde",
+    ],
     "cSpell.words": [
         "bech",
         "bincode",

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ set -e
 
 cd "$(dirname "$0")"
 
-echo "Building the workspace packages..."
+echo "Building the workspace packages (with all extended features)..."
 
-(set -x; cargo build)
-(set -x; cargo test --no-run)
-(set -x; cargo bench --no-run)
+(set -x; cargo build --features serde)
+(set -x; cargo test --no-run --features serde)
+(set -x; cargo bench --no-run --features serde)
 
 echo "Building the engine in different configurations..."
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -43,3 +43,7 @@ bench = false
 
 [lib]
 bench = false
+
+[features]
+# This feature is unused and is only added as  a workaround for https://github.com/rust-lang/rust-analyzer/issues/8521
+serde = []


### PR DESCRIPTION
## Summary
So... `value_serializer` wasn't actually building(!) - and the code didn't compile... it must have been broken in the last week or so since the last merge of the node.

To fix this I've:
* Ensured the serde feature is on in VSCode, so VSCode users don't miss it ;). This has required a minor workaround to make Rust Analyzer happy...
* Ensure the serde feature is turned on in CI
* Actually fixed the compilation errors

Oh and also I've changed Own to encode the ObjectId.
