### PR TITLE
Fuzz transaction in Github Actions

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   transaction:
     name: Fuzz transaction (AFL)
-    runs-on: ubuntu-latest
+    runs-on: k8s-linux-runner
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,91 @@
+name: Fuzzing
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Fuzzing duration [s]'
+        required: true
+        default: 3600
+      timeout:
+        description: 'AFL timeout [ms]'
+        required: true
+        default: 1000
+      fuzz_input_mode:
+        type: choice
+        description: 'Fuzz input data generation mode'
+        required: true
+        options:
+          - raw
+          - unique
+          - minimize
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  transaction:
+    name: Fuzz transaction (AFL)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Add wasm target
+      run: rustup target add wasm32-unknown-unknown
+
+    - name: Add wasm target (nightly)
+      run: rustup +nightly target add wasm32-unknown-unknown
+
+    - name: Setup AFL
+      working-directory: fuzz-tests
+      run: |
+        ./install_afl.sh
+        ./fuzz.sh afl machine-init
+
+    - name: Build AFL
+      working-directory: fuzz-tests
+      run: |
+        ./fuzz.sh afl build
+
+    - name: Generate input for AFL
+      working-directory: fuzz-tests
+      run: |
+        ./fuzz.sh generate-input ${{ github.event.inputs.fuzz_input_mode }}
+
+    - name: Start AFL
+      working-directory: fuzz-tests
+      run: |
+        ./afl.sh run ${{ github.event.inputs.duration }} all ${{ github.event.inputs.timeout }}
+
+    - name: Watch AFL
+      working-directory: fuzz-tests
+      run: |
+        ./afl.sh watch 60
+
+    - name: Generate summary
+      working-directory: fuzz-tests
+      run: |
+        COMMIT=$(git rev-parse --short HEAD)
+        echo -e \
+        "## Repo:\n \
+        revision: [${{ github.repository }} - $COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)\n \
+        ## Status:\n \
+        \n\`\`\`\n \
+         $(cargo afl whatsup -d afl/transaction) \
+        \n\`\`\`\n" > afl/summary
+        cat afl/summary >> $GITHUB_STEP_SUMMARY
+        find afl -type f ! -path "*/queue/*" | tee list
+        tar -cvzf fuzz_transaction.tgz -T list
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: fuzz_transaction.tgz
+        path: |
+          fuzz-tests/fuzz_transaction.tgz

--- a/fuzz-tests/afl.sh
+++ b/fuzz-tests/afl.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -x
+set -e
+set -u
+
+DFLT_CPUS=1
+DFLT_INTERVAL=60
+# At the moment this is the only supported test
+DFLT_TARGET=transaction
+DFLT_AFL_TIMEOUT=1000
+
+function usage() {
+    echo "$0 [COMMAND] [COMMAND-ARGS]"
+    echo "Commands:"
+    echo "    run <duration> <instances> [timeout]"
+    echo "            Run given number of AFL instances (default: $DFLT_CPUS) in screen sessions"
+    echo "            for a given number of seconds."
+    echo "            For 'instances' one can specify"
+    echo "              all      - to run as many instances as CPU cores available"
+    echo "              <number> - to run <number> of instances"
+    echo "            'timeout' is an AFL timeout in ms"
+    echo "    watch - Monitor AFL instances until they are finished."
+    echo "            One can specify interval (default: $DFLT_INTERVAL) to output the status"
+}
+
+function get_cpus() {
+    local uname="$(uname -s)"
+    if [ $uname = "Linux" ] ; then
+        cat /proc/cpuinfo  | grep processor | wc -l
+    elif [ $uname = "Darwin" ] ; then
+        sysctl -n hw.ncpu
+    else
+        echo "OS $uname not supported"
+        exit 1
+    fi
+}
+
+target=$DFLT_TARGET
+cmd=${1:-watch}
+shift
+
+if [ $cmd = "run" ] ; then
+    duration=${1}
+    cpus=${2:-1}
+    timeout=${3:-$DFLT_AFL_TIMEOUT}
+    if [ $cpus = "all" ] ; then
+        cpus=$(get_cpus)
+        echo "CPU cores available: $cpus"
+    fi
+    echo "Running $cpus AFL instances"
+    mkdir -p afl
+
+    for (( i=0; i<$cpus; i++ )) ; do
+        if [ $i -eq 0 ] ; then
+            name=main_$i
+            # main fuzzer
+            fuzzer="-M $name"
+        else
+            name=secondary_$i
+            # secondary fuzzer
+            fuzzer="-S $name"
+        fi
+        # TODO: use different fuzzing variants per instance
+        screen -dmS afl_$name \
+            bash -c "{ ./fuzz.sh afl run -V $duration $fuzzer -T $target -t $timeout >afl/$name.log 2>afl/$name.err ; echo \$? > afl/$name.status; }"
+    done
+elif [ $cmd = "watch" ] ; then
+    interval=${1:-$DFLT_INTERVAL}
+    while ! screen -ls afl | grep "No Sockets found" ; do
+        sleep $interval
+        # afl folder structure created with some delay after fuzz startup
+        if [ -d afl/$target ] ; then
+            cargo afl whatsup -d afl/$target
+        fi
+    done
+    echo "AFL instances status (0 means 'ok'):"
+    find afl -name "*.status" | xargs grep -H -v "*"
+else
+    echo "Command '$cmd' not supported"
+    exit 1
+fi
+
+

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -161,7 +161,7 @@ function generate_input() {
 
         pushd ..
         # Collect input data
-        cargo nextest run -p radix-engine-tests --features dump_manifest_to_file can_withdraw_from_my_allocated_account
+        cargo nextest run -p radix-engine-tests --features dump_manifest_to_file
         popd
         if [ $mode = "raw" ] ; then
             mv ../radix-engine-tests/manifest_*.raw ${curr_path}/${final_dir}

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -161,7 +161,7 @@ function generate_input() {
 
         pushd ..
         # Collect input data
-        cargo nextest run -p radix-engine-tests --features dump_manifest_to_file
+        cargo nextest run -p radix-engine-tests --features dump_manifest_to_file can_withdraw_from_my_allocated_account
         popd
         if [ $mode = "raw" ] ; then
             mv ../radix-engine-tests/manifest_*.raw ${curr_path}/${final_dir}


### PR DESCRIPTION
## Summary

This PR introduces a "Fuzzing" workflow in Github Actions, which includes Transaction Fuzz job.

## Details

Workflow runs transaction fuzzing test for a given time.
Fuzz input parameters are:
- Fuzzing duration [s] - duration of the fuzzing test
- AFL timeout [ms] - maximal test case duration, above which AFL reports timeout
- Transaction fuzz input data generation mode
  - `raw`  - do not process the generated raw manifest files.
  - `unique` - reduce the input data by making it unique (it is processed with `cargo afl cmin`)
  - `minimize` - minimize the unique input data (it is processed with `cargo afl tmin`)

Job is configured to auto-scale (start AFL instances on all available CPU cores).
As a result it should produce a `fuzz_transaction.tgz` artifact, which includes transaction fuzzing stats and data that caused some issues (crashes, hangs, etc).