### PR TITLE
Temporarily skip machine-init step in Fuzzing workflow

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -27,6 +27,13 @@ jobs:
   transaction:
     name: Fuzz transaction (AFL)
     runs-on: k8s-linux-runner
+    env:
+      # Temporarily set below flags to workaround lack of RW access /proc filesystem,
+      # which is required by below command
+      #   ./fuzz.sh afl machine-init
+      AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
+      AFL_SKIP_CPUFREQ: 1
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -46,7 +53,7 @@ jobs:
       working-directory: fuzz-tests
       run: |
         ./install_afl.sh
-        ./fuzz.sh afl machine-init
+        #./fuzz.sh afl machine-init
 
     - name: Build AFL
       working-directory: fuzz-tests


### PR DESCRIPTION
## Summary
Do not attempt to write to /proc filesystem, since k8s-linux-runner does not allow it.

