### PR TITLE
Feature/no std stable

### DIFF
--- a/examples/no-std/rust-toolchain
+++ b/examples/no-std/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
## Summary

Uses `stable` toolchain for our no-std example.

## Update Recommendations

Requires Rust `v1.68.0` or above.