### PR TITLE
Fix/fix fee reserve

### DIFF
--- a/radix-engine/src/system/kernel_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/kernel_modules/costing/fee_reserve.rs
@@ -251,6 +251,7 @@ impl SystemLoanFeeReserve {
         if self.xrd_balance < amount {
             return Err(FeeReserveError::InsufficientBalance);
         } else {
+            self.xrd_balance -= amount;
             self.royalty_committed
                 .entry(recipient)
                 .or_insert((recipient_vault_id, 0))


### PR DESCRIPTION
## Summary

- Fixed running `xrd_balance` not updated for royalty
- Updated `cost_unit_limit` to be applicable to both execution and royalty