### PR TITLE
Fuzzing workflow improvements

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,4 +1,5 @@
 name: Fuzzing
+run-name: Fuzzing input=${{ github.event.inputs.fuzz_input_mode }} duration=${{ github.event.inputs.duration_hours }}h branch=${{ github.ref_name }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   transaction:
     name: Fuzz transaction (AFL)
-    runs-on: k8s-linux-runner
+    runs-on: fuzzing
     env:
       # Temporarily set below flags to workaround lack of RW access /proc filesystem,
       # which is required by below command

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -27,6 +27,8 @@ jobs:
   transaction:
     name: Fuzz transaction (AFL)
     runs-on: fuzzing
+    # set timeout to 7days
+    timeout-minutes: 10080
     env:
       # Temporarily set below flags to workaround lack of RW access /proc filesystem,
       # which is required by below command

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -44,7 +44,7 @@ jobs:
 
     - run: |
         sudo apt-get update -qq
-        sudo apt-get install parallel screen -y
+        sudo apt-get install parallel screen build-essential llvm cmake -y
 
     - name: Install nextest
       uses: taiki-e/install-action@nextest

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -19,6 +19,10 @@ on:
           - raw
           - unique
           - minimize
+      watch_interval:
+        description: 'Check fuzzing status interval [s]'
+        required: true
+        default: 300
 
 env:
   CARGO_TERM_COLOR: always
@@ -73,7 +77,7 @@ jobs:
     - name: Watch AFL
       working-directory: fuzz-tests
       run: |
-        ./afl.sh watch 60
+        ./afl.sh watch ${{ github.event.inputs.watch_interval }}
 
     - name: Generate summary
       working-directory: fuzz-tests

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -29,12 +29,6 @@ jobs:
     runs-on: fuzzing
     # set timeout to 7days
     timeout-minutes: 10080
-    env:
-      # Temporarily set below flags to workaround lack of RW access /proc filesystem,
-      # which is required by below command
-      #   ./fuzz.sh afl machine-init
-      AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES: 1
-      AFL_SKIP_CPUFREQ: 1
 
     steps:
     - uses: actions/checkout@v2
@@ -59,7 +53,7 @@ jobs:
       working-directory: fuzz-tests
       run: |
         ./install_afl.sh
-        #./fuzz.sh afl machine-init
+        ./fuzz.sh afl machine-init
 
     - name: Build AFL
       working-directory: fuzz-tests

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -3,10 +3,10 @@ name: Fuzzing
 on:
   workflow_dispatch:
     inputs:
-      duration:
-        description: 'Fuzzing duration [s]'
+      duration_hours:
+        description: 'Fuzzing duration [h]'
         required: true
-        default: 3600
+        default: 6
       timeout:
         description: 'AFL timeout [ms]'
         required: true
@@ -16,9 +16,9 @@ on:
         description: 'Fuzz input data generation mode'
         required: true
         options:
-          - raw
-          - unique
           - minimize
+          - unique
+          - raw
       watch_interval:
         description: 'Check fuzzing status interval [s]'
         required: true
@@ -72,7 +72,11 @@ jobs:
     - name: Start AFL
       working-directory: fuzz-tests
       run: |
-        ./afl.sh run ${{ github.event.inputs.duration }} all ${{ github.event.inputs.timeout }}
+        # scale=0 - get rid of fractional part
+        # dividing by 1 because 'scale' works only for division ;)
+        # Using floating arithmetics to allow providing fractions of hours (for test purposes)
+        SECONDS=$(echo "scale=0; ${{ github.event.inputs.duration_hours }} * 60 * 60 / 1" | bc)
+        ./afl.sh run $SECONDS all ${{ github.event.inputs.timeout }}
 
     - name: Watch AFL
       working-directory: fuzz-tests

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -84,7 +84,9 @@ jobs:
       run: |
         COMMIT=$(git rev-parse --short HEAD)
         echo -e \
-        "## Repo:\n \
+        "## Input params:\n \
+        ${{ toJSON(github.event.inputs) }}\n \
+        ## Repo:\n \
         revision: [${{ github.repository }} - $COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)\n \
         ## Status:\n \
         \n\`\`\`\n \

--- a/fuzz-tests/afl.sh
+++ b/fuzz-tests/afl.sh
@@ -86,6 +86,10 @@ if [ $cmd = "run" ] ; then
     echo "Running $cpus AFL instances for $duration seconds"
     mkdir -p afl
 
+    # Remove dead screen sessions.
+    # Such sessions might remain if the previous run was cancelled.
+    screen -wipe || true
+
     for (( i=0; i<$cpus; i++ )) ; do
         if [ $i -eq 0 ] ; then
             name=${target}_main_$i

--- a/fuzz-tests/install_afl.sh
+++ b/fuzz-tests/install_afl.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-# this is to install a 'cargo afl' fuzzer with a flag, which prevents setting 'fuzzing' flag
+# This is to install a 'cargo afl' fuzzer with a flag, which prevents setting 'fuzzing' flag
 # when compiling fuzzed targets.
-
-if cargo afl help 1>/dev/null 2>&1 ; then
-    echo -e "cargo afl already installed. Remove it first with \ncargo uninstall afl"
-    exit 1
-fi
-
+# Installing it forcefully to make sure AFL is built wit the current rustc version
 echo "Installing cargo-afl"
-cargo install afl --features no_cfg_fuzzing
+cargo install --force afl --features no_cfg_fuzzing
 

--- a/fuzz-tests/process_fuzz_results.sh
+++ b/fuzz-tests/process_fuzz_results.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -e
+set -u
+
+ARTIFACT_NAME=fuzz_transaction.tgz
+url=$1
+run_id=${url##*/}
+
+dir=run_${run_id}
+
+function usage() {
+    echo "$0 <run-id>"
+    echo "Command speeds up processing fuzzing results."
+    echo "The script gets Github run id or URL and checks fuzzing status."
+    echo "It also tries to reproduce the crashes if this is the case."
+    echo "This is to classify crashes and filter out duplicates."
+    echo "  <run-id>  - Github action run id or url"
+    echo "  <run-id>  - Github action run id or url"
+    exit
+}
+
+function validate_run() {
+    local view=
+    view=$(gh run view $run_id --json status,conclusion,url,workflowName,headBranch,headSha,displayTitle)
+    status=$(jq -r '.status' <<< $view)
+    conclusion=$(jq -r '.conclusion' <<< $view)
+    url=$(jq -r '.url' <<< $view)
+    name=$(jq -r '.workflowName' <<< $view)
+    branch=$(jq -r '.headBranch' <<< $view)
+    sha=$(jq -r '.headSha' <<< $view)
+
+    title="$(jq -r '.displayTitle' <<< $view)"
+    if [ $status = "in_progress" ] ; then
+        echo "run $run_id still in progress - come back later. Details: $url"
+        exit 1
+    fi
+    if [ $conclusion = "failure" ] ; then
+        echo "run $run_id failed - nothing to process. Details: $url"
+        exit 1
+    fi
+    if [ $name != "Fuzzing" ] ; then
+        echo "run $run_id is a '$name' not 'Fuzzing' run. Details: $url"
+        exit 1
+    fi
+
+    echo "Found run:"
+    echo "  title : $title"
+    echo "  branch: $branch"
+    echo "  sha   : $sha"
+}
+
+function get_artifacs() {
+    echo "Seting up a work dir: $dir"
+    mkdir -p $dir
+
+    echo "Downloading $ARTIFACT_NAME"
+    gh run download $run_id -n $ARTIFACT_NAME -D $dir
+
+    tar xf $dir/$ARTIFACT_NAME -C $dir
+    rm $dir/$ARTIFACT_NAME
+}
+
+function get_summary() {
+    cat $dir/afl/summary | awk '/Summary stats/,/Time without/'
+
+    echo "Fuzzing:"
+    echo "  summary: $dir/afl/summary"
+    echo "  crash/hang files:"
+    find $dir/afl/*/*/* -name "id*" | xargs -n1 -I {} echo "    "{}
+}
+
+prefixoutput() {
+    local prefix="    "
+    "$@" > >(sed "s/^/$prefix (stdout): /") 2> >(sed "s/^/$prefix (stderr): /" >&2)
+}
+
+function inspect_crashes() {
+    echo "Inspecting found crashes"
+    pushd $dir
+    work_dir=$(pwd)
+    #files=$(find $work_dir/afl/*/*/* -name "id*")
+    files=$(find afl/*/*/* -name "id*")
+
+    if [ ! -d radixdlt-scrypto ] ; then
+        echo "Checking out the repository"
+        git clone git@github.com:radixdlt/radixdlt-scrypto.git radixdlt-scrypto
+    fi
+    git -C radixdlt-scrypto checkout $sha
+
+    pushd radixdlt-scrypto/fuzz-tests
+    echo "Building simple fuzzer"
+    ./fuzz.sh simple build
+    popd
+    echo "Checking crash/hangs files"
+    for f in $files ; do
+        # calling target directly to get rid of unnecessary debugs
+        #./fuzz.sh simple run ../../$f >/dev/null || true
+        cmd="radixdlt-scrypto/fuzz-tests/target/release/transaction $f"
+        echo
+        echo "file    : $f"
+        echo "command : $cmd"
+#        echo "output  :"
+#        prefixoutput $cmd || true
+        $cmd >output.log 2>&1 || true
+        panic=$(grep panic output.log || true)
+        echo "panic   : $panic"
+    done | tee summary.txt
+    rm output.log
+
+    popd
+    echo
+    echo "work dir: $dir"
+    echo "summary : $dir/summary.txt"
+}
+
+if [ $url = "help" -o $url = "h" ] ; then
+    usage
+fi
+validate_run
+get_artifacs
+get_summary
+inspect_crashes


### PR DESCRIPTION
## Summary

Changes:
- Use dedicated `fuzzing` runner
- Set default transaction job timeout to 7 days
- Install additional packets at `fuzzing` runner
- Install `cargo afl` forcefully to make sure it is built with the current `rustc` version
- Add AFL status check interval parameter
- Display input params in summary
- Show current duration and time left 

