### PR TITLE
Getting rid of plain HashMap usage from macro code

### DIFF
--- a/sbor-derive-common/Cargo.toml
+++ b/sbor-derive-common/Cargo.toml
@@ -8,8 +8,12 @@ proc-macro2 = { version = "1.0.38" }
 syn = { version = "1.0.93", features = ["full", "extra-traits"] }
 quote = { version = "1.0.18" }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
+utils = { path = "../utils", default-features = false }
 
 [features]
+default = ["std"]
+std = ["utils/std"]
+alloc = ["utils/alloc"]
 trace = []
 
 [lib]


### PR DESCRIPTION
A problematic part extracted from its base PR (see https://github.com/radixdlt/radixdlt-scrypto/pull/931#issue-1644373644).

The build ends with:
```
+ cargo build --no-default-features --features alloc
   Compiling utils v0.9.0 (/Users/jakrawcz/repo1/radixdlt-scrypto/utils)
error: Feature `std` and `alloc` can't be enabled at the same time.
 --> utils/src/lib.rs:6:1
  |
6 | compile_error!("Feature `std` and `alloc` can't be enabled at the same time.");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `utils` (lib) due to previous error
```

Please advice.