### PR TITLE
Getting rid of HashSet from prod code

### DIFF
--- a/radix-engine/src/kernel/call_frame.rs
+++ b/radix-engine/src/kernel/call_frame.rs
@@ -15,26 +15,26 @@ use super::track::{Track, TrackError};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallFrameUpdate {
     pub nodes_to_move: Vec<RENodeId>,
-    pub node_refs_to_copy: HashSet<RENodeId>,
+    pub node_refs_to_copy: IndexSet<RENodeId>,
 }
 
 impl CallFrameUpdate {
     pub fn empty() -> Self {
         CallFrameUpdate {
             nodes_to_move: Vec::new(),
-            node_refs_to_copy: HashSet::new(),
+            node_refs_to_copy: index_set_new(),
         }
     }
 
     pub fn move_node(node_id: RENodeId) -> Self {
         CallFrameUpdate {
             nodes_to_move: vec![node_id],
-            node_refs_to_copy: HashSet::new(),
+            node_refs_to_copy: index_set_new(),
         }
     }
 
     pub fn copy_ref(node_id: RENodeId) -> Self {
-        let mut node_refs_to_copy = HashSet::new();
+        let mut node_refs_to_copy = index_set_new();
         node_refs_to_copy.insert(node_id);
         CallFrameUpdate {
             nodes_to_move: vec![],
@@ -65,7 +65,7 @@ pub struct SubstateLock {
     pub node_id: RENodeId,
     pub module_id: NodeModuleId,
     pub offset: SubstateOffset,
-    pub temp_references: HashSet<RENodeId>,
+    pub temp_references: IndexSet<RENodeId>,
     pub substate_owned_nodes: Vec<RENodeId>,
     pub flags: LockFlags,
 }
@@ -139,7 +139,7 @@ impl CallFrame {
         let (references, substate_owned_nodes) = substate_ref.references_and_owned_nodes();
 
         // Expand references
-        let mut temp_references = HashSet::new();
+        let mut temp_references = index_set_new();
         for node_id in references {
             // TODO: fix this ugly condition
             if matches!(node_id, RENodeId::GlobalObject(_)) {

--- a/radix-engine/src/kernel/track.rs
+++ b/radix-engine/src/kernel/track.rs
@@ -949,10 +949,7 @@ impl<'a, 'b> BalanceChangeAccounting<'a, 'b> {
                 };
                 let mut new_balance = substate.vault_liquid_non_fungible().ids().clone();
 
-                let intersection: HashSet<NonFungibleLocalId> =
-                    new_balance.intersection(&old_balance).cloned().collect();
-                new_balance.retain(|x| !intersection.contains(x));
-                old_balance.retain(|x| !intersection.contains(x));
+                remove_intersection(&mut new_balance, &mut old_balance);
 
                 Some(BalanceChange::NonFungible {
                     added: new_balance,
@@ -991,4 +988,15 @@ impl<'a, 'b> BalanceChangeAccounting<'a, 'b> {
             .unwrap_or_else(|| panic!("Substate store corrupted - missing {:?}", substate_id))
             .substate
     }
+}
+
+/// Removes the `left.intersection(right)` from both `left` and `right`, in place, without
+/// computing (or allocating) the intersection itself.
+/// Implementation note: since Rust has no "iterator with delete" capabilities, the implementation
+/// uses a (normally frowned-upon) side-effect of a lambda inside `.retain()`.
+/// Performance note: since the `BTreeSet`s are inherently sorted, the implementation _could_ have
+/// an `O(n+m)` runtime (i.e. traversing 2 iterators). However, it would then contain significantly
+/// more bugs than the `O(n * log(m))` one-liner below.
+fn remove_intersection<T: Ord>(left: &mut BTreeSet<T>, right: &mut BTreeSet<T>) {
+    left.retain(|id| !right.remove(id));
 }

--- a/radix-engine/src/system/node_substates.rs
+++ b/radix-engine/src/system/node_substates.rs
@@ -1298,7 +1298,7 @@ impl<'a> SubstateRef<'a> {
     }
 
     // TODO: remove this method
-    pub fn references_and_owned_nodes(&self) -> (HashSet<RENodeId>, Vec<RENodeId>) {
+    pub fn references_and_owned_nodes(&self) -> (IndexSet<RENodeId>, Vec<RENodeId>) {
         match self {
             SubstateRef::Worktop(worktop) => {
                 let nodes = worktop
@@ -1306,39 +1306,39 @@ impl<'a> SubstateRef<'a> {
                     .values()
                     .map(|o| RENodeId::Object(o.bucket_id()))
                     .collect();
-                (HashSet::new(), nodes)
+                (index_set_new(), nodes)
             }
             SubstateRef::VaultInfo(vault) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 references.insert(RENodeId::GlobalObject(vault.resource_address.into()));
                 (references, Vec::new())
             }
             SubstateRef::ProofInfo(proof) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 references.insert(RENodeId::GlobalObject(proof.resource_address.into()));
                 (references, Vec::new())
             }
             SubstateRef::FungibleProof(proof) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 for r in proof.evidence.keys() {
                     references.insert(r.to_re_node_id());
                 }
                 (references, Vec::new())
             }
             SubstateRef::NonFungibleProof(proof) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 for r in proof.evidence.keys() {
                     references.insert(r.to_re_node_id());
                 }
                 (references, Vec::new())
             }
             SubstateRef::BucketInfo(bucket) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 references.insert(RENodeId::GlobalObject(bucket.resource_address.into()));
                 (references, Vec::new())
             }
             SubstateRef::PackageInfo(substate) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 for component_ref in &substate.dependent_components {
                     references.insert(RENodeId::GlobalObject(component_ref.clone().into()));
                 }
@@ -1352,10 +1352,10 @@ impl<'a> SubstateRef<'a> {
                 if let Some(vault) = substate.royalty_vault {
                     owns.push(RENodeId::Object(vault.id()));
                 }
-                (HashSet::new(), owns)
+                (index_set_new(), owns)
             }
             SubstateRef::TypeInfo(substate) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 match substate {
                     TypeInfoSubstate::Object {
                         package_address, ..
@@ -1366,12 +1366,12 @@ impl<'a> SubstateRef<'a> {
                 }
                 (references, Vec::new())
             }
-            SubstateRef::FungibleResourceManager(..) => (HashSet::new(), Vec::new()),
+            SubstateRef::FungibleResourceManager(..) => (index_set_new(), Vec::new()),
             SubstateRef::NonFungibleResourceManager(substate) => {
                 let mut owned_nodes = Vec::new();
                 owned_nodes.push(RENodeId::KeyValueStore(substate.non_fungible_table));
 
-                (HashSet::new(), owned_nodes)
+                (index_set_new(), owned_nodes)
             }
             SubstateRef::EpochManager(substate) => {
                 let (_, owns, refs) = IndexedScryptoValue::from_typed(&substate).unpack();
@@ -1388,7 +1388,7 @@ impl<'a> SubstateRef<'a> {
             SubstateRef::AccessController(substate) => {
                 let mut owned_nodes = Vec::new();
                 owned_nodes.push(RENodeId::Object(substate.controlled_asset));
-                (HashSet::new(), owned_nodes)
+                (index_set_new(), owned_nodes)
             }
             SubstateRef::ComponentState(substate) => {
                 let (_, owns, refs) =
@@ -1400,7 +1400,7 @@ impl<'a> SubstateRef<'a> {
                 if let Some(vault) = substate.royalty_vault {
                     owned_nodes.push(RENodeId::Object(vault.vault_id()));
                 }
-                (HashSet::new(), owned_nodes)
+                (index_set_new(), owned_nodes)
             }
             SubstateRef::KeyValueStoreEntry(substate) => {
                 if let Some(substate) = substate {
@@ -1408,7 +1408,7 @@ impl<'a> SubstateRef<'a> {
                         IndexedScryptoValue::from_scrypto_value(substate.clone()).unpack();
                     (refs, own)
                 } else {
-                    (HashSet::new(), Vec::new())
+                    (index_set_new(), Vec::new())
                 }
             }
             SubstateRef::Account(substate) => {
@@ -1416,10 +1416,10 @@ impl<'a> SubstateRef<'a> {
                 owned_nodes.push(RENodeId::KeyValueStore(
                     substate.vaults.key_value_store_id(),
                 ));
-                (HashSet::new(), owned_nodes)
+                (index_set_new(), owned_nodes)
             }
             SubstateRef::AuthZone(substate) => {
-                let mut references = HashSet::new();
+                let mut references = index_set_new();
                 let mut owned_nodes = Vec::new();
                 for proof in &substate.proofs {
                     owned_nodes.push(RENodeId::Object(proof.0));
@@ -1429,7 +1429,7 @@ impl<'a> SubstateRef<'a> {
                 }
                 (references, owned_nodes)
             }
-            _ => (HashSet::new(), Vec::new()),
+            _ => (index_set_new(), Vec::new()),
         }
     }
 }

--- a/sbor-derive-common/Cargo.toml
+++ b/sbor-derive-common/Cargo.toml
@@ -8,6 +8,7 @@ proc-macro2 = { version = "1.0.38" }
 syn = { version = "1.0.93", features = ["full", "extra-traits"] }
 quote = { version = "1.0.18" }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
+itertools = { version = "0.10.3" }
 
 [features]
 trace = []

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -1,5 +1,5 @@
+use itertools::Itertools;
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 use std::io::Write;
 use std::process::Command;
 use std::process::Stdio;
@@ -192,16 +192,7 @@ pub fn get_hash_of_code(input: &TokenStream) -> [u8; 20] {
 }
 
 pub fn get_unique_types<'a>(types: &[&'a syn::Type]) -> Vec<&'a syn::Type> {
-    let mut seen = HashSet::<&syn::Type>::new();
-    let mut out = Vec::<&syn::Type>::new();
-    for t in types {
-        if seen.contains(t) {
-            continue;
-        }
-        seen.insert(t);
-        out.push(t);
-    }
-    out
+    types.into_iter().unique().cloned().collect()
 }
 
 pub(crate) struct FieldsData {

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -1111,6 +1111,7 @@ name = "sbor-derive-common"
 version = "0.9.0"
 dependencies = [
  "const-sha1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -62,7 +62,7 @@ pub fn dump_package<T: ReadableSubstateStore, O: std::io::Write>(
 
 struct ComponentStateDump {
     pub raw_state: Option<IndexedScryptoValue>,
-    pub owned_vaults: Option<HashSet<ObjectId>>,
+    pub owned_vaults: Option<IndexSet<ObjectId>>,
     pub package_address: Option<PackageAddress>, // Native components have no package address.
     pub blueprint_name: String,                  // All components have a blueprint, native or not.
     pub access_rules: Option<AccessRulesConfig>, // Virtual Components don't have access rules.
@@ -120,7 +120,7 @@ pub fn dump_component<T: ReadableSubstateStore + QueryableSubstateStore, O: std:
             let access_rules = access_rules_chain_substate.access_rules;
 
             // Find all vaults owned by the component, assuming a tree structure.
-            let mut vaults_found: HashSet<ObjectId> = raw_state
+            let mut vaults_found: IndexSet<ObjectId> = raw_state
                 .owned_node_ids()
                 .iter()
                 .cloned()
@@ -160,7 +160,7 @@ pub fn dump_component<T: ReadableSubstateStore + QueryableSubstateStore, O: std:
             // Just an account with no vaults.
             ComponentStateDump {
                 raw_state: None,
-                owned_vaults: Some(HashSet::new()),
+                owned_vaults: Some(index_set_new()),
                 package_address: None, // No package address for native components (yet).
                 blueprint_name: "Account".into(),
                 access_rules: None,
@@ -209,7 +209,7 @@ pub fn dump_component<T: ReadableSubstateStore + QueryableSubstateStore, O: std:
         | ComponentAddress::EddsaEd25519VirtualIdentity(..) => {
             ComponentStateDump {
                 raw_state: None,
-                owned_vaults: Some(HashSet::new()),
+                owned_vaults: Some(index_set_new()),
                 package_address: None, // No package address for native components (yet).
                 blueprint_name: "Identity".into(),
                 access_rules: None,
@@ -375,7 +375,7 @@ fn dump_kv_store<T: ReadableSubstateStore + QueryableSubstateStore, O: std::io::
 }
 
 fn dump_resources<T: ReadableSubstateStore, O: std::io::Write>(
-    vaults: &HashSet<ObjectId>,
+    vaults: &IndexSet<ObjectId>,
     substate_store: &T,
     output: &mut O,
 ) -> Result<(), DisplayError> {

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -4,7 +4,7 @@ use radix_engine_interface::blueprints::transaction_processor::RuntimeValidation
 use radix_engine_interface::constants::*;
 use radix_engine_interface::crypto::{Hash, PublicKey};
 use radix_engine_interface::network::NetworkDefinition;
-use sbor::rust::collections::{BTreeSet, HashSet};
+use sbor::rust::collections::*;
 
 use crate::errors::{SignatureValidationError, *};
 use crate::model::*;
@@ -350,7 +350,7 @@ impl NotarizedTransactionValidator {
         }
 
         // verify intent signature
-        let mut signers = HashSet::new();
+        let mut signers = index_set_new();
         let intent_payload = transaction.signed_intent.intent.to_bytes()?;
         for sig in &transaction.signed_intent.intent_signatures {
             let public_key = recover(&intent_payload, sig)


### PR DESCRIPTION
A follow-up to https://github.com/radixdlt/radixdlt-scrypto/pull/931.

In the Set's case, we literally have no occurrence of "I need a HashSet but promise to not iterate over it".
Hence, I did not have to introduce `NonIterSet<>`.
I simply either migrated to `IndexSet<>`, or removed the need for allocating a set altogether.