### PR TITLE
Fix manifest SET_METHOD_ACCESS_RULE references

### DIFF
--- a/radix-engine/src/transaction/reference_extractor.rs
+++ b/radix-engine/src/transaction/reference_extractor.rs
@@ -79,9 +79,18 @@ pub fn extract_refs_from_instruction(
             let value: ManifestValue = manifest_decode(&manifest_encode(value).unwrap()).unwrap();
             extract_refs_from_value(&value, global_references, local_references);
         }
-        Instruction::RemoveMetadata { entity_address, .. }
-        | Instruction::SetMethodAccessRule { entity_address, .. } => {
+        Instruction::RemoveMetadata { entity_address, .. } => {
             global_references.insert(to_address(entity_address.clone()).into());
+        }
+        Instruction::SetMethodAccessRule {
+            entity_address,
+            rule,
+            ..
+        } => {
+            global_references.insert(to_address(entity_address.clone()).into());
+            // TODO: Remove and cleanup
+            let value: ManifestValue = manifest_decode(&manifest_encode(rule).unwrap()).unwrap();
+            extract_refs_from_value(&value, global_references, local_references);
         }
         Instruction::RecallResource { vault_id, .. } => {
             // TODO: This needs to be cleaned up


### PR DESCRIPTION
## Summary
Fix bug in manifest instruction SET_METHOD_ACCESS_RULE where references in AccessRules was not being properly handled.