### PR TITLE
Disable size-based costing for package code loading

### DIFF
--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -207,7 +207,7 @@ fn test_radiswap() {
         + 10000 /* DropNode */
         + 25340 /* Invoke */
         + 231500 /* LockSubstate */
-        + 2638280 /* ReadSubstate */
+        + 165460 /* ReadSubstate */
         + 137500 /* RunNative */
         + 15000 /* RunSystem */
         + 1653645 /* RunWasm */
@@ -317,7 +317,7 @@ fn test_flash_loan() {
         + 20000 /* DropNode */
         + 44790 /* Invoke */
         + 356000 /* LockSubstate */
-        + 6648610 /* ReadSubstate */
+        + 245330 /* ReadSubstate */
         + 215000 /* RunNative */
         + 30000 /* RunSystem */
         + 1310835 /* RunWasm */

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -996,7 +996,13 @@ where
                 .get_ref(lock_handle, &mut self.heap, &mut self.track)?;
         let ret = substate_ref.to_scrypto_value();
 
-        KernelModuleMixer::on_read_substate(self, lock_handle, ret.as_slice().len())?;
+        // TODO: Design special package code loading cost rule
+        let size = match substate_ref {
+            SubstateRef::PackageCode(..) => 0,
+            _ => ret.as_slice().len(),
+        };
+
+        KernelModuleMixer::on_read_substate(self, lock_handle, size)?;
 
         Ok(ret)
     }
@@ -1030,12 +1036,6 @@ where
         &'a mut S: From<SubstateRefMut<'a>>,
         'b: 'a,
     {
-        // A little hacky: this post sys call is called before the sys call happens due to
-        // a mutable borrow conflict for substate ref.
-        // Some modules (specifically: ExecutionTraceModule) require that all
-        // pre/post callbacks are balanced.
-        // TODO: Move post sys call to substate_ref drop() so that it's actually
-        // after the sys call processing, not before.
         KernelModuleMixer::on_write_substate(
             self,
             lock_handle,
@@ -1059,20 +1059,12 @@ where
         package_address: PackageAddress,
         handle: LockHandle,
     ) -> Result<W::WasmInstance, RuntimeError> {
-        let substate_ref = self
-            .current_frame
-            .get_ref(handle, &mut self.heap, &mut self.track)?;
-        let code: &PackageCodeSubstate = substate_ref.into();
-        let code_size = code.code().len();
+        let package_code: &PackageCodeSubstate = self.kernel_get_substate_ref(handle)?;
+        let code = package_code.code.clone();
 
-        let instance = self
+        Ok(self
             .scrypto_interpreter
-            .create_instance(package_address, &code.code);
-
-        // TODO: move before create_instance() call
-        KernelModuleMixer::on_read_substate(self, handle, code_size)?;
-
-        Ok(instance)
+            .create_instance(package_address, &code))
     }
 }
 


### PR DESCRIPTION
## Summary

This PR disables size-based costing for package code loading.

It's a temporary workaround before we fine-tune the fee table and costing rules.
