### PR TITLE
Fix typo that prevented no_std testing

### DIFF
--- a/test_extra.sh
+++ b/test_extra.sh
@@ -26,8 +26,8 @@ test_crates_features \
     scrypto-schema \
     scrypto-tests \
     radix-engine \
-    radix-engine-tests" \
-    "scrypto" \
+    radix-engine-tests \
+    scrypto" \
     "--no-default-features --features alloc"
 
 echo "Congrats! All extra tests passed."


### PR DESCRIPTION
## Summary

Fixed typo that prevented testing with `no_std` feature
