### PR TITLE
Expose access rules fields; add resolve_entry helper method

### DIFF
--- a/radix-engine-interface/src/blueprints/resource/access_rules.rs
+++ b/radix-engine-interface/src/blueprints/resource/access_rules.rs
@@ -120,12 +120,7 @@ impl AccessRulesConfig {
     pub fn get_access_rule(&self, key: &MethodKey) -> AccessRule {
         match self.method_auth.get(key) {
             None => self.get_default(),
-            Some(AccessRuleEntry::AccessRule(access_rule)) => access_rule.clone(),
-            Some(AccessRuleEntry::Group(group_key)) => self
-                .grouped_auth
-                .get(group_key)
-                .cloned()
-                .unwrap_or(AccessRule::DenyAll),
+            Some(entry) => self.resolve_entry(entry),
         }
     }
 
@@ -137,18 +132,21 @@ impl AccessRulesConfig {
             .unwrap_or(AccessRule::DenyAll)
     }
 
+    fn resolve_entry(&self, entry: &AccessRuleEntry) -> AccessRule {
+        match entry {
+            AccessRuleEntry::AccessRule(access_rule) => access_rule.clone(),
+            AccessRuleEntry::Group(name) => match self.grouped_auth.get(name) {
+                Some(access_rule) => access_rule.clone(),
+                None => AccessRule::DenyAll,
+            },
+        }
+    }
+
     pub fn get_mutability(&self, key: &MethodKey) -> AccessRule {
         self.method_auth_mutability
             .get(key)
             .cloned()
-            .map(|e| match e {
-                AccessRuleEntry::AccessRule(access_rule) => access_rule,
-                AccessRuleEntry::Group(name) => self
-                    .grouped_auth
-                    .get(&name)
-                    .cloned()
-                    .unwrap_or(AccessRule::DenyAll),
-            })
+            .map(|e| self.resolve_entry(&e))
             .unwrap_or_else(|| self.get_default_mutability())
     }
 
@@ -159,14 +157,8 @@ impl AccessRulesConfig {
             .unwrap_or_else(|| self.get_default_mutability())
     }
 
-    fn get_default_mutability(&self) -> AccessRule {
-        match &self.default_auth_mutability {
-            AccessRuleEntry::AccessRule(access_rule) => access_rule.clone(),
-            AccessRuleEntry::Group(name) => match self.grouped_auth.get(name) {
-                Some(access_rule) => access_rule.clone(),
-                None => AccessRule::DenyAll,
-            },
-        }
+    pub fn get_default_mutability(&self) -> AccessRule {
+        self.resolve_entry(&self.default_auth_mutability)
     }
 
     pub fn set_mutability<A: Into<AccessRuleEntry>>(&mut self, key: MethodKey, method_auth: A) {
@@ -178,13 +170,7 @@ impl AccessRulesConfig {
     }
 
     pub fn get_default(&self) -> AccessRule {
-        match &self.default_auth {
-            AccessRuleEntry::AccessRule(access_rule) => access_rule.clone(),
-            AccessRuleEntry::Group(name) => match self.grouped_auth.get(name) {
-                Some(access_rule) => access_rule.clone(),
-                None => AccessRule::DenyAll,
-            },
-        }
+        self.resolve_entry(&self.default_auth)
     }
 
     pub fn set_method_access_rule<E: Into<AccessRuleEntry>>(
@@ -245,6 +231,14 @@ impl AccessRulesConfig {
 
     pub fn get_all_grouped_auth(&self) -> &BTreeMap<String, AccessRule> {
         &self.grouped_auth
+    }
+
+    pub fn get_all_method_mutability(&self) -> &BTreeMap<MethodKey, AccessRuleEntry> {
+        &self.method_auth_mutability
+    }
+
+    pub fn get_all_grouped_auth_mutability(&self) -> &BTreeMap<String, AccessRule> {
+        &self.grouped_auth_mutability
     }
 }
 


### PR DESCRIPTION
Makes `get_default_mutability` public and re-adds pub `get_all_method_mutability` and `get_all_grouped_auth_mutability`.
Also adds a helper method `resolve_entry` which removes some duplication.