### PR TITLE
Fix 'resim show' non-fungibles

### DIFF
--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -13,6 +13,12 @@ temp=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 account=`echo $temp | cut -d " " -f1`
 account2=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 
+# Dump each entity in the ledger
+addresses=`$resim show-ledger | grep -e "─ " | awk '{print $2}'`
+for addr in $addresses ; do
+    $resim show $addr
+done
+
 # Test - set epoch & time
 $resim set-current-epoch 858585
 $resim set-current-time 2023-01-27T13:01:16Z


### PR DESCRIPTION
## Summary

Let `resim show` dump both fungible and non-fungible resources.
This is to fix regression introduced in PR #900 - panic when dumping non-fungible resources:
```
thread 'main' panicked at 'Not a resource manager', ../radixdlt-scrypto/radix-engine/src/system/node_substates.rs:826:13
```
## Testing
`test/resim.sh` modified to dump all entities in the ledger.
