### PR TITLE
Dump each entity in the ledger in resim.sh

### DIFF
--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -13,6 +13,12 @@ temp=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 account=`echo $temp | cut -d " " -f1`
 account2=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 
+# Dump each entity in the ledger
+addresses=`$resim show-ledger | grep -e "─ " | awk '{print $2}'`
+for addr in $addresses ; do
+    $resim show $addr
+done
+
 # Test - set epoch & time
 $resim set-current-epoch 858585
 $resim set-current-time 2023-01-27T13:01:16Z


### PR DESCRIPTION
## Summary
This PR ports changes from [#952 - Let `resim show` dump both fungible and non-fungible resources.](https://github.com/radixdlt/radixdlt-scrypto/pull/952)

In fact the `resim` issue has been indirectly fixed on develop by #930, but here we also introduce the test for the issue.

## Testing
`test/resim.sh` modified to dump all entities in the ledger.