### PR TITLE
Fuzzing workfow summary tweaks

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -91,6 +91,7 @@ jobs:
         ./process_fuzz_results.sh afl/transaction
 
     - name: Generate summary
+      if: success() || failure() || cancelled()
       working-directory: fuzz-tests
       run: |
         COMMIT=$(git rev-parse --short HEAD)
@@ -115,6 +116,7 @@ jobs:
         tar -cvzf fuzz_transaction.tgz -T list
 
     - name: Upload artifacts
+      if: success() || failure() || cancelled()
       uses: actions/upload-artifact@v3
       with:
         name: fuzz_transaction.tgz

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Generate input for AFL
       working-directory: fuzz-tests
       run: |
-        ./fuzz.sh generate-input ${{ github.event.inputs.fuzz_input_mode }}
+        ./fuzz.sh generate-input ${{ github.event.inputs.fuzz_input_mode }} ${{ github.event.inputs.timeout }}
 
     - name: Start AFL
       working-directory: fuzz-tests

--- a/fuzz-tests/afl.sh
+++ b/fuzz-tests/afl.sh
@@ -153,8 +153,12 @@ elif [ $cmd = "watch" ] ; then
             echo "Fuzzing ends in  : $(humanize_seconds $time_left)"
         fi
     done
+    echo "AFL instances stdout:"
+    find afl -name "${target}_*.log"  | sort | xargs tail -n50
+    echo "AFL instances stderr:"
+    find afl -name "${target}_*.err"  | sort | xargs tail -n50
     echo "AFL instances status (0 means 'ok'):"
-    find afl -name "${target}_*.status" | xargs grep -H -v "*"
+    find afl -name "${target}_*.status" | sort | xargs cat
 else
     error "Command '$cmd' not supported"
 fi

--- a/fuzz-tests/afl.sh
+++ b/fuzz-tests/afl.sh
@@ -110,7 +110,7 @@ if [ $cmd = "run" ] ; then
             # secondary fuzzer
             fuzz_args="-S $name "
         fi
-        fuzzer+="-p $power_schedule "
+        fuzz_args+="-p $power_schedule "
         # TODO: use different fuzzing variants per instance
         fuzz_cmd="./fuzz.sh afl run -V $duration $fuzz_args -T $name -t $timeout"
         echo -e "Starting screen session with:\n  $fuzz_cmd"

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -12,6 +12,7 @@ DFLT_COMMAND=simple
 DFLT_SUBCOMMAND=run
 DFLT_RUN_CMD_ARG=inf
 DFLT_TARGET=transaction
+DFLT_TIMEOUT=1000
 
 function usage() {
     echo "$0 [FUZZER/COMMAND] [SUBCOMMAND] [COMMAND-ARGS]"
@@ -41,6 +42,8 @@ function usage() {
     echo "        raw         - Do not process generated data"
     echo "        unique      - Make the input data unique"
     echo "        minimize    - Minimize the input data"
+    echo "  Args:"
+    echo "        timeout     - timeout in ms"
     echo "Examples:"
     echo "  - build AFL fuzz tests"
     echo "    $0 afl build"
@@ -146,6 +149,8 @@ function fuzzer_simple() {
 function generate_input() {
     # available modes: raw, unique, minimize
     local mode=${1:-minimize}
+    local timeout=${2:-$DFLT_TIMEOUT}
+
     if [ $target = "transaction" ] ; then
         if [ ! -f target-afl/release/${target} ] ; then
             echo "target binary 'target-afl/release/${target}' not built. Call below command to build it"
@@ -171,7 +176,7 @@ function generate_input() {
         mv ../radix-engine-tests/manifest_*.raw ${curr_path}/${raw_dir}
 
         # Make the input corpus unique
-        cargo afl cmin -i $raw_dir -o $cmin_dir -- target-afl/release/${target} 2>&1 | tee afl_cmin.log
+        cargo afl cmin -t $timeout -i $raw_dir -o $cmin_dir -- target-afl/release/${target} 2>&1 | tee afl_cmin.log
         if [ $mode = "unique" ] ; then
             mv $cmin_dir/* $final_dir
             return
@@ -184,12 +189,13 @@ function generate_input() {
         pushd $cmin_dir
         # Filter out the files not greater than 100k to reduce minimizing duration
         if which parallel && parallel --version | grep -q 'GNU parallel' ; then
-            # parallel is nicer because is serializes output from commands in parallel
-            find . -type f -size -100k | parallel -- \
-                cargo afl tmin -i "{}" -o "${curr_path}/${final_dir}/{/}" -- ${curr_path}/target-afl/release/${target}
+            # parallel is nicer because is serializes output from commands in parallel.
+            # "halt now,fail=1" - exit when any job has failed. Kill other running jobs
+            find . -type f -size -100k | parallel --halt now,fail=1 -- \
+                cargo afl tmin -t $timeout -i "{}" -o "${curr_path}/${final_dir}/{/}" -- ${curr_path}/target-afl/release/${target}
         else
             find . -type f -size -100k | xargs -P 8 -I {} \
-                cargo afl tmin -i "{}" -o "${curr_path}/${final_dir}/{}" -- ${curr_path}/target-afl/release/${target}
+                cargo afl tmin -t $timeout -i "{}" -o "${curr_path}/${final_dir}/{}" -- ${curr_path}/target-afl/release/${target}
         fi
         popd
     else

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -169,7 +169,7 @@ function generate_input() {
             echo "raw dir is not empty, skipping generation"
             popd
             if [ $mode = "raw" ] ; then
-                mv ${curr_path}/${raw_dir}/* ${curr_path}/${final_dir}
+                find ${curr_path}/${raw_dir} -type f -name "*" | xargs  -I {} mv {} ${curr_path}/${final_dir}
                 return
             fi
 

--- a/fuzz-tests/process_fuzz_results.sh
+++ b/fuzz-tests/process_fuzz_results.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#set -x
 set -e
 set -u
 
@@ -158,6 +159,7 @@ if [ -d $url_or_dir ] ; then
         work_dir=local_$(date -u  +%Y%m%d%H%M%S)
     else
         echo "This is not AFL output directory"
+        exit 1
     fi
 else
     gh_run_id=${url_or_dir##*/}


### PR DESCRIPTION
## Summary

Few changes to  make fuzzing summary more useful.

## Details
* Print fuzzing sessions log tails in summary (especially useful when workflow fails)
* Attempt to generate summary and upload artifacts even if job failed or cancelled
eg. to not loose long-term fuzzing results
* Option to setup timeout when generating fuzz input data
* Fix power schedules setting

