### PR TITLE
Feature/SCRY-420-transaction-metrics

### DIFF
--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -445,6 +445,7 @@ impl FinalizingFeeReserve for SystemLoanFeeReserve {
             execution_cost_breakdown,
             execution_cost_sum: self.execution_committed_sum,
             royalty_cost_breakdown,
+            royalty_cost_sum: self.royalty_committed_sum,
         }
     }
 }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -21,10 +21,12 @@ pub struct FeeSummary {
     pub locked_fees: Vec<(NodeId, LiquidFungibleResource, bool)>,
     /// The execution cost breakdown
     pub execution_cost_breakdown: BTreeMap<CostingReason, u32>,
-    /// The total number of cost units consumed.
+    /// The total number of cost units consumed (excluding royalties).
     pub execution_cost_sum: u32,
     /// The royalty cost breakdown
     pub royalty_cost_breakdown: BTreeMap<RoyaltyRecipient, (NodeId, Decimal)>,
+    /// The total number of cost units consumed for royalties.
+    pub royalty_cost_sum: u32,
 }
 
 impl FeeSummary {

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -7,7 +7,7 @@ use crate::kernel::kernel_callback_api::KernelCallbackObject;
 use crate::system::module::SystemModule;
 use crate::system::system_callback::SystemCallback;
 use crate::system::system_callback_api::SystemCallbackObject;
-use crate::transaction::{TransactionExecutionTrace, TransactionResult};
+use crate::transaction::{ExecutionMetrics, TransactionExecutionTrace, TransactionResult};
 use crate::types::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::math::Decimal;
@@ -45,28 +45,6 @@ impl ExecutionTraceModule {
     pub fn update_instruction_index(&mut self, new_index: usize) {
         self.current_instruction_index = new_index;
     }
-}
-
-/// Metrics gathered during transaction execution.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
-pub struct ExecutionMetrics {
-    /// Consumed cost units (excluding royalties)
-    pub execution_cost_units_consumed: usize,
-    /// Consumed royalties cost units
-    pub royalties_cost_units_consumed: usize,
-    /// Total substate read size in bytes.
-    pub substate_read_size: usize,
-    /// Substate read count.
-    pub substate_read_count: usize,
-    /// Total substate write size in bytes.
-    pub substate_write_size: usize,
-    /// Substate write count.
-    pub substate_write_count: usize,
-    /// Peak WASM memory usage during transactino execution.
-    /// This is the highest sum of all nested WASM instances.
-    pub max_wasm_memory_used: usize,
-    /// The highest invoke payload size during transaction execution.
-    pub max_invoke_payload_size: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -7,7 +7,7 @@ use crate::kernel::kernel_callback_api::KernelCallbackObject;
 use crate::system::module::SystemModule;
 use crate::system::system_callback::SystemCallback;
 use crate::system::system_callback_api::SystemCallbackObject;
-use crate::transaction::{ExecutionMetrics, TransactionExecutionTrace, TransactionResult};
+use crate::transaction::{TransactionExecutionTrace, TransactionResult};
 use crate::types::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::math::Decimal;
@@ -576,11 +576,7 @@ impl ExecutionTraceModule {
         }
     }
 
-    pub fn finalize(
-        mut self,
-        transaction_result: &TransactionResult,
-        execution_metrics: &mut ExecutionMetrics,
-    ) -> TransactionExecutionTrace {
+    pub fn finalize(mut self, transaction_result: &TransactionResult) -> TransactionExecutionTrace {
         match transaction_result {
             TransactionResult::Commit(c) => {
                 let mut execution_traces = Vec::new();
@@ -593,11 +589,6 @@ impl ExecutionTraceModule {
                     &c.fee_payments,
                     c.outcome.is_success(),
                 );
-
-                execution_metrics.execution_cost_units_consumed =
-                    c.fee_summary.execution_cost_sum as usize;
-                execution_metrics.royalties_cost_units_consumed =
-                    c.fee_summary.royalty_cost_sum as usize;
 
                 TransactionExecutionTrace {
                     execution_traces,

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -598,7 +598,11 @@ impl ExecutionTraceModule {
         }
     }
 
-    pub fn finalize(mut self, transaction_result: &TransactionResult) -> TransactionExecutionTrace {
+    pub fn finalize(
+        mut self,
+        transaction_result: &TransactionResult,
+        execution_metrics: &mut ExecutionMetrics,
+    ) -> TransactionExecutionTrace {
         match transaction_result {
             TransactionResult::Commit(c) => {
                 let mut execution_traces = Vec::new();
@@ -612,14 +616,14 @@ impl ExecutionTraceModule {
                     c.outcome.is_success(),
                 );
 
+                execution_metrics.execution_cost_units_consumed =
+                    c.fee_summary.execution_cost_sum as usize;
+                execution_metrics.royalties_cost_units_consumed =
+                    c.fee_summary.royalty_cost_sum as usize;
+
                 TransactionExecutionTrace {
                     execution_traces,
                     resource_changes,
-                    execution_metrics: ExecutionMetrics {
-                        execution_cost_units_consumed: c.fee_summary.execution_cost_sum as usize,
-                        royalties_cost_units_consumed: c.fee_summary.royalty_cost_sum as usize,
-                        ..Default::default()
-                    },
                 }
             }
             TransactionResult::Reject(_) | TransactionResult::Abort(_) => {

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -48,42 +48,25 @@ impl ExecutionTraceModule {
 }
 
 /// Metrics gathered during transaction execution.
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
 pub struct ExecutionMetrics {
     /// Consumed cost units (excluding royalties)
     pub execution_cost_units_consumed: usize,
-
     /// Consumed royalties cost units
     pub royalties_cost_units_consumed: usize,
-
     /// Total substate read size in bytes.
     pub substate_read_size: usize,
-
     /// Substate read count.
     pub substate_read_count: usize,
-
     /// Total substate write size in bytes.
     pub substate_write_size: usize,
-
     /// Substate write count.
     pub substate_write_count: usize,
-
-    /// Peak memory usage by WASM.
+    /// Peak WASM memory usage during transactino execution.
+    /// This is the highest sum of all nested WASM instances.
     pub max_wasm_memory_used: usize,
-}
-
-impl Default for ExecutionMetrics {
-    fn default() -> Self {
-        Self {
-            execution_cost_units_consumed: 0,
-            royalties_cost_units_consumed: 0,
-            substate_read_size: 0,
-            substate_read_count: 0,
-            substate_write_size: 0,
-            substate_write_count: 0,
-            max_wasm_memory_used: 0,
-        }
-    }
+    /// The highest invoke payload size during transaction execution.
+    pub max_invoke_payload_size: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -47,6 +47,45 @@ impl ExecutionTraceModule {
     }
 }
 
+/// Metrics gathered during transaction execution.
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
+pub struct ExecutionMetrics {
+    /// Consumed cost units (excluding royalties)
+    pub execution_cost_units_consumed: usize,
+
+    /// Consumed royalties cost units
+    pub royalties_cost_units_consumed: usize,
+
+    /// Total substate read size in bytes.
+    pub substate_read_size: usize,
+
+    /// Substate read count.
+    pub substate_read_count: usize,
+
+    /// Total substate write size in bytes.
+    pub substate_write_size: usize,
+
+    /// Substate write count.
+    pub substate_write_count: usize,
+
+    /// Peak memory usage by WASM.
+    pub max_wasm_memory_used: usize,
+}
+
+impl Default for ExecutionMetrics {
+    fn default() -> Self {
+        Self {
+            execution_cost_units_consumed: 0,
+            royalties_cost_units_consumed: 0,
+            substate_read_size: 0,
+            substate_read_count: 0,
+            substate_write_size: 0,
+            substate_write_count: 0,
+            max_wasm_memory_used: 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResourceChange {
     pub node_id: NodeId,
@@ -593,6 +632,11 @@ impl ExecutionTraceModule {
                 TransactionExecutionTrace {
                     execution_traces,
                     resource_changes,
+                    execution_metrics: ExecutionMetrics {
+                        execution_cost_units_consumed: c.fee_summary.execution_cost_sum as usize,
+                        royalties_cost_units_consumed: c.fee_summary.royalty_cost_sum as usize,
+                        ..Default::default()
+                    },
                 }
             }
             TransactionResult::Reject(_) | TransactionResult::Abort(_) => {

--- a/radix-engine/src/system/system_modules/transaction_limits/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_limits/module.rs
@@ -95,13 +95,16 @@ impl TransactionLimitsModule {
     }
 
     /// Exports metrics to transaction receipt.
-    pub fn finalize(&self, transaction_metrics: &mut ExecutionMetrics) {
-        transaction_metrics.substate_read_count = self.substate_db_read_count;
-        transaction_metrics.substate_write_count = self.substate_db_write_count;
-        transaction_metrics.substate_read_size = self.substate_db_read_size_total;
-        transaction_metrics.substate_write_size = self.substate_db_write_size_total;
-        transaction_metrics.max_wasm_memory_used = self.wasm_max_memory;
-        transaction_metrics.max_invoke_payload_size = self.invoke_payload_max_size;
+    pub fn finalize(&self) -> ExecutionMetrics {
+        ExecutionMetrics {
+            substate_read_count: self.substate_db_read_count,
+            substate_write_count: self.substate_db_write_count,
+            substate_read_size: self.substate_db_read_size_total,
+            substate_write_size: self.substate_db_write_size_total,
+            max_wasm_memory_used: self.wasm_max_memory,
+            max_invoke_payload_size: self.invoke_payload_max_size,
+            ..Default::default()
+        }
     }
 
     /// Checks if maximum WASM memory limit for one instance was exceeded and then

--- a/radix-engine/src/system/system_modules/transaction_limits/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_limits/module.rs
@@ -3,7 +3,7 @@ use crate::kernel::kernel_api::KernelInvocation;
 use crate::system::module::SystemModule;
 use crate::system::system_callback::{SystemCallback, SystemInvocation};
 use crate::system::system_callback_api::SystemCallbackObject;
-use crate::system::system_modules::execution_trace::ExecutionMetrics;
+use crate::transaction::ExecutionMetrics;
 use crate::types::*;
 use crate::{
     errors::ModuleError,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -234,7 +234,6 @@ where
 
         // Finalize
         let result_type = determine_result_type(invoke_result, &mut fee_reserve);
-        let mut execution_metrics = system.modules.transaction_limits.finalize();
         let transaction_result = match result_type {
             TransactionResultType::Commit(outcome) => {
                 let is_success = outcome.is_ok();
@@ -276,10 +275,11 @@ where
                 TransactionResult::Abort(AbortResult { reason: error })
             }
         };
-        let execution_trace = system
+        let execution_trace = system.modules.execution_trace.finalize(&transaction_result);
+        let execution_metrics = system
             .modules
-            .execution_trace
-            .finalize(&transaction_result, &mut execution_metrics);
+            .transaction_limits
+            .finalize(&transaction_result);
 
         // Finish resources usage measurement and get results
         let resources_usage = match () {

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -304,6 +304,7 @@ where
         receipt
     }
 
+    #[cfg(not(feature = "alloc"))]
     fn print_execution_summary(receipt: &TransactionReceipt) {
         match &receipt.result {
             TransactionResult::Commit(commit) => {

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -298,91 +298,111 @@ where
 
         #[cfg(not(feature = "alloc"))]
         if execution_config.kernel_trace {
-            match &receipt.result {
-                TransactionResult::Commit(commit) => {
-                    println!("{:-^80}", "Cost Analysis");
-                    let break_down = commit
-                        .fee_summary
-                        .execution_cost_breakdown
-                        .iter()
-                        .map(|(k, v)| (k.to_string(), v))
-                        .collect::<BTreeMap<String, &u32>>();
-                    for (k, v) in break_down {
-                        println!("{:<30}: {:>10}", k, v);
-                    }
-
-                    println!("{:-^80}", "Cost Totals");
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Total Cost Units Consumed", commit.fee_summary.execution_cost_sum
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Total Royalty Units Consumed", commit.fee_summary.royalty_cost_sum
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Cost Unit Limit", commit.fee_summary.cost_unit_limit
-                    );
-                    // NB - we use "to_string" to ensure they align correctly
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Execution XRD",
-                        commit.fee_summary.total_execution_cost_xrd.to_string()
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Royalty XRD",
-                        commit.fee_summary.total_royalty_cost_xrd.to_string()
-                    );
-                    println!("{:-^80}", "Execution Metrics");
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Total Substate Read Bytes",
-                        receipt.execution_trace.execution_metrics.substate_read_size
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Total Substate Write Bytes",
-                        receipt
-                            .execution_trace
-                            .execution_metrics
-                            .substate_write_size
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Substate Read Count",
-                        receipt
-                            .execution_trace
-                            .execution_metrics
-                            .substate_read_count
-                    );
-                    println!(
-                        "{:<30}: {:>10}",
-                        "Substate Write Count",
-                        receipt
-                            .execution_trace
-                            .execution_metrics
-                            .substate_write_count
-                    );
-                    println!("{:-^80}", "Application Logs");
-                    for (level, message) in &commit.application_logs {
-                        println!("[{}] {}", level, message);
-                    }
-                }
-                TransactionResult::Reject(e) => {
-                    println!("{:-^80}", "Transaction Rejected");
-                    println!("{:?}", e.error);
-                }
-                TransactionResult::Abort(e) => {
-                    println!("{:-^80}", "Transaction Aborted");
-                    println!("{:?}", e);
-                }
-            }
-            println!("{:-^80}", "Finish");
+            TransactionExecutor::<S, W>::print_execution_summary(&receipt);
         }
 
         receipt
+    }
+
+    fn print_execution_summary(receipt: &TransactionReceipt) {
+        match &receipt.result {
+            TransactionResult::Commit(commit) => {
+                println!("{:-^80}", "Cost Analysis");
+                let break_down = commit
+                    .fee_summary
+                    .execution_cost_breakdown
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect::<BTreeMap<String, &u32>>();
+                for (k, v) in break_down {
+                    println!("{:<30}: {:>10}", k, v);
+                }
+
+                println!("{:-^80}", "Cost Totals");
+                println!(
+                    "{:<30}: {:>10}",
+                    "Total Cost Units Consumed", commit.fee_summary.execution_cost_sum
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Total Royalty Units Consumed", commit.fee_summary.royalty_cost_sum
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Cost Unit Limit", commit.fee_summary.cost_unit_limit
+                );
+                // NB - we use "to_string" to ensure they align correctly
+                println!(
+                    "{:<30}: {:>10}",
+                    "Execution XRD",
+                    commit.fee_summary.total_execution_cost_xrd.to_string()
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Royalty XRD",
+                    commit.fee_summary.total_royalty_cost_xrd.to_string()
+                );
+                println!("{:-^80}", "Execution Metrics");
+                println!(
+                    "{:<30}: {:>10}",
+                    "Total Substate Read Bytes",
+                    receipt.execution_trace.execution_metrics.substate_read_size
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Total Substate Write Bytes",
+                    receipt
+                        .execution_trace
+                        .execution_metrics
+                        .substate_write_size
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Substate Read Count",
+                    receipt
+                        .execution_trace
+                        .execution_metrics
+                        .substate_read_count
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Substate Write Count",
+                    receipt
+                        .execution_trace
+                        .execution_metrics
+                        .substate_write_count
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Peak WASM Memory Usage Bytes",
+                    receipt
+                        .execution_trace
+                        .execution_metrics
+                        .max_wasm_memory_used
+                );
+                println!(
+                    "{:<30}: {:>10}",
+                    "Max Invoke Payload Size Bytes",
+                    receipt
+                        .execution_trace
+                        .execution_metrics
+                        .max_invoke_payload_size
+                );
+                println!("{:-^80}", "Application Logs");
+                for (level, message) in &commit.application_logs {
+                    println!("[{}] {}", level, message);
+                }
+            }
+            TransactionResult::Reject(e) => {
+                println!("{:-^80}", "Transaction Rejected");
+                println!("{:?}", e.error);
+            }
+            TransactionResult::Abort(e) => {
+                println!("{:-^80}", "Transaction Aborted");
+                println!("{:?}", e);
+            }
+        }
+        println!("{:-^80}", "Finish");
     }
 }
 

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -275,7 +275,11 @@ where
                 TransactionResult::Abort(AbortResult { reason: error })
             }
         };
-        let execution_trace = system.modules.execution_trace.finalize(&transaction_result);
+        let mut execution_trace = system.modules.execution_trace.finalize(&transaction_result);
+        system
+            .modules
+            .transaction_limits
+            .finalize(&mut execution_trace.execution_metrics);
 
         // Finish resources usage measurement and get results
         let resources_usage = match () {
@@ -314,6 +318,10 @@ where
                     );
                     println!(
                         "{:<30}: {:>10}",
+                        "Total Royalty Units Consumed", commit.fee_summary.royalty_cost_sum
+                    );
+                    println!(
+                        "{:<30}: {:>10}",
                         "Cost Unit Limit", commit.fee_summary.cost_unit_limit
                     );
                     // NB - we use "to_string" to ensure they align correctly
@@ -326,6 +334,36 @@ where
                         "{:<30}: {:>10}",
                         "Royalty XRD",
                         commit.fee_summary.total_royalty_cost_xrd.to_string()
+                    );
+                    println!("{:-^80}", "Execution Metrics");
+                    println!(
+                        "{:<30}: {:>10}",
+                        "Total Substate Read Bytes",
+                        receipt.execution_trace.execution_metrics.substate_read_size
+                    );
+                    println!(
+                        "{:<30}: {:>10}",
+                        "Total Substate Write Bytes",
+                        receipt
+                            .execution_trace
+                            .execution_metrics
+                            .substate_write_size
+                    );
+                    println!(
+                        "{:<30}: {:>10}",
+                        "Substate Read Count",
+                        receipt
+                            .execution_trace
+                            .execution_metrics
+                            .substate_read_count
+                    );
+                    println!(
+                        "{:<30}: {:>10}",
+                        "Substate Write Count",
+                        receipt
+                            .execution_trace
+                            .execution_metrics
+                            .substate_write_count
                     );
                     println!("{:-^80}", "Application Logs");
                     for (level, message) in &commit.application_logs {

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -31,7 +31,6 @@ pub struct ResourcesUsage {
 pub struct TransactionExecutionTrace {
     pub execution_traces: Vec<ExecutionTrace>,
     pub resource_changes: IndexMap<usize, Vec<ResourceChange>>,
-    pub execution_metrics: ExecutionMetrics,
 }
 
 impl TransactionExecutionTrace {
@@ -193,6 +192,8 @@ pub struct TransactionReceipt {
     pub result: TransactionResult,
     /// Optional execution trace, controlled by config `ExecutionConfig::execution_trace`.
     pub execution_trace: TransactionExecutionTrace,
+    /// Metrics gathered during transaction execution.
+    pub execution_metrics: ExecutionMetrics,
     /// Optional resource usage trace, controlled by feature flag `resources_usage`.
     pub resources_usage: ResourcesUsage,
 }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -3,7 +3,7 @@ use crate::blueprints::epoch_manager::{EpochChangeEvent, Validator};
 use crate::errors::*;
 use crate::system::system_modules::costing::FeeSummary;
 use crate::system::system_modules::execution_trace::{
-    ExecutionMetrics, ExecutionTrace, ResourceChange, WorktopChange,
+    ExecutionTrace, ResourceChange, WorktopChange,
 };
 use crate::types::*;
 use colored::*;
@@ -41,6 +41,28 @@ impl TransactionExecutionTrace {
         }
         aggregator
     }
+}
+
+/// Metrics gathered during transaction execution.
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
+pub struct ExecutionMetrics {
+    /// Consumed cost units (excluding royalties)
+    pub execution_cost_units_consumed: usize,
+    /// Consumed royalties cost units
+    pub royalties_cost_units_consumed: usize,
+    /// Total substate read size in bytes.
+    pub substate_read_size: usize,
+    /// Substate read count.
+    pub substate_read_count: usize,
+    /// Total substate write size in bytes.
+    pub substate_write_size: usize,
+    /// Substate write count.
+    pub substate_write_count: usize,
+    /// Peak WASM memory usage during transactino execution.
+    /// This is the highest sum of all nested WASM instances.
+    pub max_wasm_memory_used: usize,
+    /// The highest invoke payload size during transaction execution.
+    pub max_invoke_payload_size: usize,
 }
 
 /// Captures whether a transaction should be committed, and its other results

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -3,7 +3,7 @@ use crate::blueprints::epoch_manager::{EpochChangeEvent, Validator};
 use crate::errors::*;
 use crate::system::system_modules::costing::FeeSummary;
 use crate::system::system_modules::execution_trace::{
-    ExecutionTrace, ResourceChange, WorktopChange,
+    ExecutionMetrics, ExecutionTrace, ResourceChange, WorktopChange,
 };
 use crate::types::*;
 use colored::*;
@@ -31,6 +31,7 @@ pub struct ResourcesUsage {
 pub struct TransactionExecutionTrace {
     pub execution_traces: Vec<ExecutionTrace>,
     pub resource_changes: IndexMap<usize, Vec<ResourceChange>>,
+    pub execution_metrics: ExecutionMetrics,
 }
 
 impl TransactionExecutionTrace {


### PR DESCRIPTION
## Summary
Returning tracked transaction execution limits values in transaction receipt.

## Details
Extended `TransactionReceipt.execution_trace` field with `ExecutionMetrics` struct which contains achieved tracked transaction limits values as following fields:
- Execution cost units consumed (+separate for royalties)
- Substates read/write count
- Substates read/write size
- Invoke maximum payload size
- Peak value of WASM memory usage

Also added printing these values in the transaction summary.