### PR TITLE
Fight non-deterministic instrumentation output when fuzzing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -108,22 +108,22 @@ jobs:
         ## Repo:\n \
         revision: [${{ github.repository }} - $COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)\n \
         ## Status:\n \
-        \n\`\`\`\n \
-         $(cat afl/sessions_info) \
+        \n\`\`\`\n\
+        $(cat afl/sessions_info) \
         \n\`\`\`\n \
         ## Details:\n \
         <details>\n
           <summary>More details</summary>\n
-        \n\`\`\`\n \
+        \n\`\`\`\n\
         $(cargo afl whatsup -d afl/transaction) \
         \n\`\`\`\n
         </details>\n" > afl/summary
         cat afl/summary >> $GITHUB_STEP_SUMMARY
 
         echo -e \
-        "## Crash summary:\n \
-        \n\`\`\`\n \
-         $(cat afl/crash_summary.txt) \
+        "## Crash summary:\n\
+        \n\`\`\`\n\
+        $(cat afl/crash_summary.txt) \
         \n\`\`\`\n" >> $GITHUB_STEP_SUMMARY
 
         find afl -type f ! -path "*/queue/*" | tee list

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -102,8 +102,15 @@ jobs:
         revision: [${{ github.repository }} - $COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)\n \
         ## Status:\n \
         \n\`\`\`\n \
-         $(cargo afl whatsup -d afl/transaction) \
-        \n\`\`\`\n" > afl/summary
+         $(cat afl/sessions_info) \
+        \n\`\`\`\n \
+        ## Details:\n \
+        <details>\n
+          <summary>More details</summary>\n
+        \n\`\`\`\n \
+        $(cargo afl whatsup -d afl/transaction) \
+        \n\`\`\`\n
+        </details>\n" > afl/summary
         cat afl/summary >> $GITHUB_STEP_SUMMARY
 
         echo -e \

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -85,6 +85,7 @@ jobs:
         ./afl.sh watch ${{ github.event.inputs.watch_interval }}
 
     - name: Process AFL results
+      if: success() || failure() || cancelled()
       working-directory: fuzz-tests
       run: |
         # it is expected to generate afl/crash_summary.txt

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -84,6 +84,12 @@ jobs:
       run: |
         ./afl.sh watch ${{ github.event.inputs.watch_interval }}
 
+    - name: Quit AFL
+      if: failure() || cancelled()
+      working-directory: fuzz-tests
+      run: |
+        ./afl.sh quit
+
     - name: Process AFL results
       if: success() || failure() || cancelled()
       working-directory: fuzz-tests

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -29,7 +29,7 @@ scrypto-unit = { path = "../scrypto-unit", default-features = false }
 # - warnings such as "Instrumentation output varies across runs"
 # - low stability reports
 # More details: https://github.com/rust-fuzz/afl.rs#lazy_static-variables
-lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs" }
+lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs", rev = "c5eb91f" }
 
 [workspace]
 members = ["."]

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -35,7 +35,11 @@ members = ["."]
 
 [profile.release]
 # TODO: check if really this required
-debug = 1
+# Commented out out since due to following error, when building AFLplusplus
+#  - in debug mode (see GNUmakefile:142 - Werror is set)
+#  - with some modern gcc toolchain: clang 16.0, llvm-gcc 14
+# src/afl-fuzz-redqueen.c:1603:20: warning: variable 'cons_0' set but not used [-Wunused-but-set-variable]
+#debug = 1
 
 [[bin]]
 name = "transaction"

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -19,6 +19,7 @@ sbor = { path = "../sbor", default-features = false }
 radix-engine = { path = "../radix-engine", default-features = false, features = ["radix_engine_fuzzing"] }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
+radix-engine-stores = { path = "../radix-engine-stores", default-features = false }
 transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false, features = ["radix_engine_fuzzing"] }
 scrypto-unit = { path = "../scrypto-unit", default-features = false }

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -20,7 +20,7 @@ radix-engine = { path = "../radix-engine", default-features = false }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
 transaction = { path = "../transaction", default-features = false }
-utils = { path = "../utils", default-features = false }
+utils = { path = "../utils", default-features = false, features = ["radix_engine_fuzzing"] }
 scrypto-unit = { path = "../scrypto-unit", default-features = false }
 
 [workspace]

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -16,7 +16,7 @@ rand_chacha = { version = "0.3.1", optional = true }
 log = { version = "0.4.17", optional = true }
 once_cell = { version = "1.17.1"}
 sbor = { path = "../sbor", default-features = false }
-radix-engine = { path = "../radix-engine", default-features = false }
+radix-engine = { path = "../radix-engine", default-features = false, features = ["radix_engine_fuzzing"] }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
 transaction = { path = "../transaction", default-features = false }

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -9,7 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { version = "0.4", optional = true }
-afl = { version = "0.12.16", optional = true }
+afl = { version = "0.12.16", features = ["reset_lazy_static"], optional = true }
 clap = { version = "4.1.7", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
@@ -22,6 +22,13 @@ radix-engine-interface = { path = "../radix-engine-interface", default-features 
 transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false, features = ["radix_engine_fuzzing"] }
 scrypto-unit = { path = "../scrypto-unit", default-features = false }
+
+[patch.crates-io]
+# Use "resettable" `lazy_static` version to prevent incorrect AFL behaviour, eg.
+# - warnings such as "Instrumentation output varies across runs"
+# - low stability reports
+# More details: https://github.com/rust-fuzz/afl.rs#lazy_static-variables
+lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs" }
 
 [workspace]
 members = ["."]

--- a/fuzz-tests/afl.sh
+++ b/fuzz-tests/afl.sh
@@ -23,6 +23,7 @@ function usage() {
     echo "    watch <interval>"
     echo "            Monitor AFL instances until they are finished."
     echo "            One can specify interval (default: $DFLT_INTERVAL) to output the status"
+    echo "    quit    Quit all AFL instances"
 }
 
 function error() {
@@ -175,6 +176,18 @@ elif [ $cmd = "watch" ] ; then
         printf "  %-20s: %s\n" "coverage" $coverage
         printf "  %-20s: %s\n" "stability" $stability
     done | tee afl/sessions_info
+elif [ $cmd = "quit" ] ; then
+    list=$(find afl/${target} -name fuzzer_stats | sort)
+    if [ "$list" != "" ] ; then
+        for stats_file in $list ; do
+            name=$(grep afl_banner $stats_file | awk '{print $3}')
+            pid=$(grep fuzzer_pid $stats_file | awk '{print $3}')
+            echo "killing session $name"
+            kill -9 $pid
+        done
+    else
+        echo "nothing to be done"
+    fi
 else
     error "Command '$cmd' not supported"
 fi

--- a/fuzz-tests/src/transaction.rs
+++ b/fuzz-tests/src/transaction.rs
@@ -53,7 +53,7 @@ impl Fuzzer {
             runner.create_non_fungible_resource(accounts[0].address),
         ];
 
-        let snapshot = runner.get_snapshot();
+        let snapshot = runner.create_snapshot();
 
         println!("resources = {:?}", resources);
 

--- a/fuzz-tests/src/transaction.rs
+++ b/fuzz-tests/src/transaction.rs
@@ -206,9 +206,9 @@ fn init_statics() {
 #[cfg(feature = "libfuzzer-sys")]
 fuzz_target!(|data: &[u8]| {
     unsafe {
-        static mut FUZZER: Lazy<Fuzzer> = Lazy::new(|| Fuzzer::new());
+        let mut fuzzer = Fuzzer::new();
 
-        FUZZER.fuzz_tx_manifest(data);
+        fuzzer.fuzz_tx_manifest(data);
     }
 });
 
@@ -216,12 +216,12 @@ fuzz_target!(|data: &[u8]| {
 fn main() {
     init_statics();
 
-    // fuzz! uses `catch_unwind` and it requires RefUnwindSafe trait, which is not auto-implemented by
-    // Fuzzer members (TestRunner mainly). `AssertUnwindSafe` annotates the variable is indeed
-    // unwind safe
-    let mut fuzzer = AssertUnwindSafe(Fuzzer::new());
-
     fuzz!(|data: &[u8]| {
+        // fuzz! uses `catch_unwind` and it requires RefUnwindSafe trait, which is not auto-implemented by
+        // Fuzzer members (TestRunner mainly). `AssertUnwindSafe` annotates the variable is indeed
+        // unwind safe
+        let mut fuzzer = AssertUnwindSafe(Fuzzer::new());
+
         fuzzer.fuzz_tx_manifest(data);
     });
 }
@@ -230,7 +230,8 @@ fn main() {
 fn main() {
     init_statics();
 
-    let mut fuzzer = Fuzzer::new();
-
-    simple_fuzzer::fuzz(|data: &[u8]| -> TxStatus { fuzzer.fuzz_tx_manifest(data) });
+    simple_fuzzer::fuzz(|data: &[u8]| -> TxStatus {
+        let mut fuzzer = Fuzzer::new();
+        fuzzer.fuzz_tx_manifest(data)
+    });
 }

--- a/fuzz-tests/src/transaction.rs
+++ b/fuzz-tests/src/transaction.rs
@@ -16,7 +16,7 @@ mod simple_fuzzer;
 use radix_engine::types::{ComponentAddress, EcdsaSecp256k1PublicKey, ResourceAddress};
 use radix_engine_interface::blueprints::resource::{FromPublicKey, NonFungibleGlobalId};
 use radix_engine_interface::data::manifest::manifest_decode;
-use scrypto_unit::TestRunner;
+use scrypto_unit::{TestRunner, TestRunnerSnapshot};
 use transaction::ecdsa_secp256k1::EcdsaSecp256k1PrivateKey;
 use transaction::model::Instruction;
 use transaction::model::TransactionManifest;
@@ -29,6 +29,7 @@ struct Account {
 
 struct Fuzzer {
     runner: TestRunner,
+    snapshot: TestRunnerSnapshot,
     accounts: Vec<Account>,
     resources: Vec<ResourceAddress>,
 }
@@ -52,13 +53,20 @@ impl Fuzzer {
             runner.create_non_fungible_resource(accounts[0].address),
         ];
 
+        let snapshot = runner.get_snapshot();
+
         println!("resources = {:?}", resources);
 
         Self {
             runner,
+            snapshot,
             accounts,
             resources,
         }
+    }
+
+    fn reset_runner(&mut self) {
+        self.runner.restore_snapshot(self.snapshot.clone());
     }
 
     // pick account from the preallocated pool basing on the input data
@@ -208,6 +216,7 @@ fuzz_target!(|data: &[u8]| {
     unsafe {
         static mut FUZZER: Lazy<Fuzzer> = Lazy::new(|| Fuzzer::new());
 
+        FUZZER.reset_runner();
         FUZZER.fuzz_tx_manifest(data);
     }
 });
@@ -222,6 +231,7 @@ fn main() {
     let mut fuzzer = AssertUnwindSafe(Fuzzer::new());
 
     fuzz!(|data: &[u8]| {
+        fuzzer.reset_runner();
         fuzzer.fuzz_tx_manifest(data);
     });
 }
@@ -232,5 +242,8 @@ fn main() {
 
     let mut fuzzer = Fuzzer::new();
 
-    simple_fuzzer::fuzz(|data: &[u8]| -> TxStatus { fuzzer.fuzz_tx_manifest(data) });
+    simple_fuzzer::fuzz(|data: &[u8]| -> TxStatus {
+        fuzzer.reset_runner();
+        fuzzer.fuzz_tx_manifest(data)
+    });
 }

--- a/radix-engine-common/tests/scrypto_codec.rs
+++ b/radix-engine-common/tests/scrypto_codec.rs
@@ -5,8 +5,8 @@ use sbor::rust::boxed::Box;
 use sbor::rust::cell::RefCell;
 use sbor::rust::collections::BTreeMap;
 use sbor::rust::collections::BTreeSet;
-use sbor::rust::collections::HashMap;
-use sbor::rust::collections::HashSet;
+use sbor::rust::collections::{hash_map_new, HashMap};
+use sbor::rust::collections::{hash_set_new, HashSet};
 use sbor::rust::hash::Hash;
 use sbor::rust::rc::Rc;
 use sbor::rust::string::String;
@@ -383,13 +383,13 @@ fn wrap_in_4_collections<T: Eq + Ord + Eq>(inner: Option<T>) -> FourDeepCollecti
 }
 
 fn wrap_in_hashmap<T>(inner: T) -> HashMap<u8, T> {
-    let mut value = HashMap::new();
+    let mut value = hash_map_new();
     value.insert(1, inner);
     value
 }
 
 fn wrap_in_hashset<T: Hash + Eq>(inner: T) -> HashSet<T> {
-    let mut value = HashSet::new();
+    let mut value = hash_set_new();
     value.insert(inner);
     value
 }

--- a/radix-engine-stores/src/hash_tree/jellyfish.rs
+++ b/radix-engine-stores/src/hash_tree/jellyfish.rs
@@ -86,8 +86,8 @@ use super::types::{
 };
 use crate::hash_tree::types::StorageError;
 use radix_engine_interface::crypto::Hash;
-use sbor::rust::collections::hash_map::HashMap;
 use sbor::rust::collections::BTreeMap;
+use sbor::rust::collections::{hash_map_new, HashMap};
 use sbor::rust::marker::PhantomData;
 use sbor::rust::vec;
 use sbor::rust::vec::Vec;
@@ -252,7 +252,7 @@ impl<'a, R: 'a + TreeReader<K>, K: Clone> JellyfishMerkleTree<'a, R, K> {
 
                 // Reuse the current `InternalNode` in memory to create a new internal node.
                 let mut old_children: Children = internal_node.into();
-                let mut new_created_children: HashMap<Nibble, Node<K>> = HashMap::new();
+                let mut new_created_children: HashMap<Nibble, Node<K>> = hash_map_new();
                 for (child_nibble, child_option) in new_children {
                     if let Some(child) = child_option {
                         new_created_children.insert(child_nibble, child);

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -99,7 +99,7 @@ pub trait TreeStore<P: Payload>: ReadableTreeStore<P> + WriteableTreeStore<P> {}
 impl<S: ReadableTreeStore<P> + WriteableTreeStore<P>, P: Payload> TreeStore<P> for S {}
 
 /// A `TreeStore` based on memory object copies (i.e. no serialization).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedInMemoryTreeStore {
     pub root_tree_nodes: HashMap<NodeKey, TreeNode<ReNodeModulePayload>>,
     pub sub_tree_nodes: HashMap<NodeKey, TreeNode<SubstateKey>>,

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::crypto::Hash;
 use radix_engine_interface::data::scrypto::{scrypto_decode, scrypto_encode, ScryptoSbor};
 use radix_engine_interface::types::{ModuleId, NodeId, SubstateKey};
 use radix_engine_interface::*;
-use sbor::rust::collections::HashMap;
+use sbor::rust::collections::{hash_map_new, HashMap};
 use sbor::rust::vec::Vec;
 use sbor::*;
 
@@ -110,8 +110,8 @@ impl TypedInMemoryTreeStore {
     /// A constructor of a newly-initialized, empty store.
     pub fn new() -> TypedInMemoryTreeStore {
         TypedInMemoryTreeStore {
-            root_tree_nodes: HashMap::new(),
-            sub_tree_nodes: HashMap::new(),
+            root_tree_nodes: hash_map_new(),
+            sub_tree_nodes: hash_map_new(),
             stale_key_buffer: Vec::new(),
         }
     }
@@ -160,7 +160,7 @@ impl SerializedInMemoryTreeStore {
     /// A constructor of a newly-initialized, empty store.
     pub fn new() -> Self {
         Self {
-            memory: HashMap::new(),
+            memory: hash_map_new(),
             stale_key_buffer: Vec::new(),
         }
     }

--- a/radix-engine-stores/src/memory_db.rs
+++ b/radix-engine-stores/src/memory_db.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::types::*;
 use sbor::rust::ops::Bound::Included;
 use sbor::rust::prelude::*;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct InMemorySubstateDatabase {
     substates: BTreeMap<Vec<u8>, Vec<u8>>,
 }

--- a/radix-engine-stores/src/query/accounter.rs
+++ b/radix-engine-stores/src/query/accounter.rs
@@ -41,8 +41,8 @@ pub struct Accounting {
 impl Accounting {
     pub fn new() -> Self {
         Accounting {
-            fungibles: HashMap::new(),
-            non_fungibles: HashMap::new(),
+            fungibles: hash_map_new(),
+            non_fungibles: hash_map_new(),
         }
     }
 

--- a/radix-engine-tests/tests/arguments.rs
+++ b/radix-engine-tests/tests/arguments.rs
@@ -95,7 +95,7 @@ fn hashmap_of_strings_and_buckets_argument_should_succeed() {
         .lock_fee(test_runner.faucet_component(), 10.into())
         .take_from_worktop(RADIX_TOKEN, |builder, bucket_id1| {
             builder.take_from_worktop(RADIX_TOKEN, |builder, bucket_id2| {
-                let mut map = HashMap::new();
+                let mut map = hash_map_new();
                 map.insert("first".to_string(), bucket_id1);
                 map.insert("second".to_string(), bucket_id2);
 

--- a/radix-engine-tests/tests/package_schema.rs
+++ b/radix-engine-tests/tests/package_schema.rs
@@ -160,7 +160,7 @@ fn test_invalid_input_arg_tree_map_fails() {
 
 #[test]
 fn test_input_arg_hash_set_succeeds() {
-    let mut hash_set = HashSet::new();
+    let mut hash_set = hash_set_new();
     hash_set.insert(());
     test_arg("hash_set", to_manifest_value(&hash_set), Success);
 }

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -53,7 +53,7 @@ alloc = ["sbor/alloc", "native-sdk/alloc", "transaction/alloc", "radix-engine-in
 
 # Enables heap memory and CPU cycles resource tracing - available only for Linux OS on x86 arch.
 # Requires CAP_PERFMON capability for the process (sudo setcap cap_perfmon=eip <exec_file>).
-cpu_ram_metrics = ["std", "dep:perfcnt"] 
+cpu_ram_metrics = ["std", "dep:perfcnt"]
 
 # Use `wasmer` as WASM engine, otherwise `wasmi`
 wasmer = ["dep:wasmer", "dep:wasmer-compiler-singlepass"]
@@ -62,6 +62,10 @@ wasmer = ["dep:wasmer", "dep:wasmer-compiler-singlepass"]
 moka = ["dep:moka"]
 
 resource_tracker = ["dep:radix-engine-utils", "resources-tracker-macro/resource_tracker"]
+
+# This flag is set by fuzz-tests framework and it disables cache in wasm_instrumenter/wasmi/wasmer
+# to prevent non-determinism when fuzzing
+radix_engine_fuzzing = []
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]

--- a/radix-engine/src/vm/wasm/wasm_instrumenter.rs
+++ b/radix-engine/src/vm/wasm/wasm_instrumenter.rs
@@ -4,6 +4,7 @@ use crate::vm::wasm::{WasmMeteringConfig, WasmModule};
 use sbor::rust::sync::Arc;
 
 pub struct WasmInstrumenter {
+    // This flag disables cache in wasm_instrumenter/wasmi/wasmer to prevent non-determinism when fuzzing
     #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<Vec<u8>>>>,
     #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]

--- a/radix-engine/src/vm/wasm/wasm_instrumenter.rs
+++ b/radix-engine/src/vm/wasm/wasm_instrumenter.rs
@@ -4,10 +4,13 @@ use crate::vm::wasm::{WasmMeteringConfig, WasmModule};
 use sbor::rust::sync::Arc;
 
 pub struct WasmInstrumenter {
-    #[cfg(not(feature = "moka"))]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<Vec<u8>>>>,
-    #[cfg(feature = "moka")]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
     cache: moka::sync::Cache<MeteredCodeKey, Arc<Vec<u8>>>,
+    #[cfg(feature = "radix_engine_fuzzing")]
+    #[allow(dead_code)]
+    cache: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -30,17 +33,19 @@ pub struct InstrumentedCode {
 
 impl WasmInstrumenter {
     pub fn new(options: InstrumenterOptions) -> Self {
-        #[cfg(not(feature = "moka"))]
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
         let cache = RefCell::new(lru::LruCache::new(
             NonZeroUsize::new(options.max_cache_size_bytes / (1024 * 1024)).unwrap(),
         ));
-        #[cfg(feature = "moka")]
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
         let cache = moka::sync::Cache::builder()
             .weigher(|_key: &MeteredCodeKey, value: &Arc<Vec<u8>>| -> u32 {
                 value.len().try_into().unwrap_or(u32::MAX)
             })
             .max_capacity(options.max_cache_size_bytes as u64)
             .build();
+        #[cfg(feature = "radix_engine_fuzzing")]
+        let cache = options.max_cache_size_bytes;
 
         Self { cache }
     }
@@ -53,33 +58,39 @@ impl WasmInstrumenter {
     ) -> InstrumentedCode {
         let metered_code_key = (code_key, wasm_metering_config);
 
-        #[cfg(not(feature = "moka"))]
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
         {
-            if let Some(cached) = self.cache.borrow_mut().get(&metered_code_key) {
+            #[cfg(not(feature = "moka"))]
+            {
+                if let Some(cached) = self.cache.borrow_mut().get(&metered_code_key) {
+                    return InstrumentedCode {
+                        metered_code_key,
+                        code: cached.clone(),
+                    };
+                }
+            }
+            #[cfg(feature = "moka")]
+            if let Some(cached) = self.cache.get(&metered_code_key) {
                 return InstrumentedCode {
                     metered_code_key,
                     code: cached.clone(),
                 };
             }
         }
-        #[cfg(feature = "moka")]
-        if let Some(cached) = self.cache.get(&metered_code_key) {
-            return InstrumentedCode {
-                metered_code_key,
-                code: cached.clone(),
-            };
-        }
 
         let instrumented_ref =
             Arc::new(self.instrument_no_cache(code, wasm_metering_config.parameters()));
 
-        #[cfg(not(feature = "moka"))]
-        self.cache
-            .borrow_mut()
-            .put(metered_code_key, instrumented_ref.clone());
-        #[cfg(feature = "moka")]
-        self.cache
-            .insert(metered_code_key, instrumented_ref.clone());
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
+        {
+            #[cfg(not(feature = "moka"))]
+            self.cache
+                .borrow_mut()
+                .put(metered_code_key, instrumented_ref.clone());
+            #[cfg(feature = "moka")]
+            self.cache
+                .insert(metered_code_key, instrumented_ref.clone());
+        }
 
         InstrumentedCode {
             metered_code_key,

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -77,6 +77,7 @@ pub struct WasmerInstanceEnv {
 
 pub struct WasmerEngine {
     store: Store,
+    // This flag disables cache in wasm_instrumenter/wasmi/wasmer to prevent non-determinism when fuzzing
     #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmerModule>>>,
     #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -1,4 +1,5 @@
 use super::InstrumentedCode;
+#[cfg(not(feature = "radix_engine_fuzzing"))]
 use super::MeteredCodeKey;
 use crate::errors::InvokeError;
 use crate::types::*;
@@ -76,10 +77,12 @@ pub struct WasmerInstanceEnv {
 
 pub struct WasmerEngine {
     store: Store,
-    #[cfg(not(feature = "moka"))]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmerModule>>>,
-    #[cfg(feature = "moka")]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
     modules_cache: moka::sync::Cache<MeteredCodeKey, Arc<WasmerModule>>,
+    #[cfg(feature = "radix_engine_fuzzing")]
+    modules_cache: usize,
 }
 
 pub fn read_memory(instance: &Instance, ptr: u32, len: u32) -> Result<Vec<u8>, WasmRuntimeError> {
@@ -590,11 +593,12 @@ impl Default for WasmerEngine {
 impl WasmerEngine {
     pub fn new(options: EngineOptions) -> Self {
         let compiler = Singlepass::new();
-        #[cfg(not(feature = "moka"))]
+
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
         let modules_cache = RefCell::new(lru::LruCache::new(
             NonZeroUsize::new(options.max_cache_size_bytes / (1024 * 1024)).unwrap(),
         ));
-        #[cfg(feature = "moka")]
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
         let modules_cache = moka::sync::Cache::builder()
             .weigher(
                 |_metered_code_key: &MeteredCodeKey, value: &Arc<WasmerModule>| -> u32 {
@@ -604,6 +608,9 @@ impl WasmerEngine {
             )
             .max_capacity(options.max_cache_size_bytes as u64)
             .build();
+        #[cfg(feature = "radix_engine_fuzzing")]
+        let modules_cache = options.max_cache_size_bytes;
+
         Self {
             store: Store::new(&Universal::new(compiler).engine()),
             modules_cache,
@@ -615,16 +622,21 @@ impl WasmEngine for WasmerEngine {
     type WasmInstance = WasmerInstance;
 
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmerInstance {
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
         let metered_code_key = &instrumented_code.metered_code_key;
-        #[cfg(not(feature = "moka"))]
+
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
         {
-            if let Some(cached_module) = self.modules_cache.borrow_mut().get(key) {
+            #[cfg(not(feature = "moka"))]
+            {
+                if let Some(cached_module) = self.modules_cache.borrow_mut().get(key) {
+                    return cached_module.instantiate();
+                }
+            }
+            #[cfg(feature = "moka")]
+            if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
                 return cached_module.instantiate();
             }
-        }
-        #[cfg(feature = "moka")]
-        if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
-            return cached_module.instantiate();
         }
 
         let code = instrumented_code.code.as_ref();
@@ -634,13 +646,16 @@ impl WasmEngine for WasmerEngine {
             code_size_bytes: code.len(),
         });
 
-        #[cfg(not(feature = "moka"))]
-        self.modules_cache
-            .borrow_mut()
-            .put(*metered_code_key, new_module.clone());
-        #[cfg(feature = "moka")]
-        self.modules_cache
-            .insert(*metered_code_key, new_module.clone());
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
+        {
+            #[cfg(not(feature = "moka"))]
+            self.modules_cache
+                .borrow_mut()
+                .put(*metered_code_key, new_module.clone());
+            #[cfg(feature = "moka")]
+            self.modules_cache
+                .insert(*metered_code_key, new_module.clone());
+        }
 
         new_module.instantiate()
     }

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -885,6 +885,7 @@ pub struct EngineOptions {
 }
 
 pub struct WasmiEngine {
+    // This flag disables cache in wasm_instrumenter/wasmi/wasmer to prevent non-determinism when fuzzing
     #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmiModule>>>,
     #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -1,11 +1,13 @@
 use sbor::rust::mem::transmute;
 use sbor::rust::mem::MaybeUninit;
+#[cfg(not(feature = "radix_engine_fuzzing"))]
 use sbor::rust::sync::Arc;
 use wasmi::core::Value;
 use wasmi::core::{HostError, Trap};
 use wasmi::*;
 
 use super::InstrumentedCode;
+#[cfg(not(feature = "radix_engine_fuzzing"))]
 use super::MeteredCodeKey;
 use crate::errors::InvokeError;
 use crate::types::*;
@@ -883,10 +885,13 @@ pub struct EngineOptions {
 }
 
 pub struct WasmiEngine {
-    #[cfg(not(feature = "moka"))]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
     modules_cache: RefCell<lru::LruCache<MeteredCodeKey, Arc<WasmiModule>>>,
-    #[cfg(feature = "moka")]
+    #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
     modules_cache: moka::sync::Cache<MeteredCodeKey, Arc<WasmiModule>>,
+    #[cfg(feature = "radix_engine_fuzzing")]
+    #[allow(dead_code)]
+    modules_cache: usize,
 }
 
 impl Default for WasmiEngine {
@@ -899,11 +904,11 @@ impl Default for WasmiEngine {
 
 impl WasmiEngine {
     pub fn new(options: EngineOptions) -> Self {
-        #[cfg(not(feature = "moka"))]
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
         let modules_cache = RefCell::new(lru::LruCache::new(
             NonZeroUsize::new(options.max_cache_size_bytes / (1024 * 1024)).unwrap(),
         ));
-        #[cfg(feature = "moka")]
+        #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
         let modules_cache = moka::sync::Cache::builder()
             .weigher(|_key: &MeteredCodeKey, value: &Arc<WasmiModule>| -> u32 {
                 // Approximate the module entry size by the code size
@@ -911,6 +916,9 @@ impl WasmiEngine {
             })
             .max_capacity(options.max_cache_size_bytes as u64)
             .build();
+        #[cfg(feature = "radix_engine_fuzzing")]
+        let modules_cache = options.max_cache_size_bytes;
+
         Self { modules_cache }
     }
 }
@@ -919,31 +927,37 @@ impl WasmEngine for WasmiEngine {
     type WasmInstance = WasmiInstance;
 
     fn instantiate(&self, instrumented_code: &InstrumentedCode) -> WasmiInstance {
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
         let metered_code_key = &instrumented_code.metered_code_key;
 
-        #[cfg(not(feature = "moka"))]
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
         {
-            if let Some(cached_module) = self.modules_cache.borrow_mut().get(metered_code_key) {
-                return cached_module.instantiate();
+            #[cfg(not(feature = "moka"))]
+            {
+                if let Some(cached_module) = self.modules_cache.borrow_mut().get(metered_code_key) {
+                    return cached_module.instantiate();
+                }
             }
-        }
-        #[cfg(feature = "moka")]
-        if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
-            return cached_module.as_ref().instantiate();
+            #[cfg(feature = "moka")]
+            if let Some(cached_module) = self.modules_cache.get(metered_code_key) {
+                return cached_module.as_ref().instantiate();
+            }
         }
 
         let code = &instrumented_code.code.as_ref()[..];
         let module = WasmiModule::new(code).unwrap();
         let instance = module.instantiate();
 
-        #[cfg(not(feature = "moka"))]
-        self.modules_cache
-            .borrow_mut()
-            .put(*metered_code_key, Arc::new(module));
-        #[cfg(feature = "moka")]
-        self.modules_cache
-            .insert(*metered_code_key, Arc::new(module));
-
+        #[cfg(not(feature = "radix_engine_fuzzing"))]
+        {
+            #[cfg(not(feature = "moka"))]
+            self.modules_cache
+                .borrow_mut()
+                .put(*metered_code_key, Arc::new(module));
+            #[cfg(feature = "moka")]
+            self.modules_cache
+                .insert(*metered_code_key, Arc::new(module));
+        }
         instance
     }
 }

--- a/sbor-tests/tests/deterministic.rs
+++ b/sbor-tests/tests/deterministic.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sbor::rust::collections::{HashMap, HashSet};
+use sbor::rust::collections::{hash_map_new, hash_set_new};
 use sbor::rust::vec::Vec;
 use sbor::*;
 
 fn encode_new_hash_set(forward: bool) -> Vec<u8> {
-    let mut set = HashSet::new();
+    let mut set = hash_set_new();
     if forward {
         for i in 0u32..100u32 {
             set.insert(i);
@@ -27,7 +27,7 @@ fn encoding_of_hash_set_should_be_deterministic() {
 }
 
 fn encode_new_hash_map(forward: bool) -> Vec<u8> {
-    let mut set = HashMap::new();
+    let mut set = hash_map_new();
     if forward {
         for i in 0u32..100u32 {
             set.insert(i, i);

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -10,6 +10,7 @@ sbor-derive = { path = "../sbor-derive" }
 serde = { version = "1.0.137", default-features = false, optional = true, features=["derive"] }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
 lazy_static = "1.4.0"
+paste = { version = "1.0.7" }
 
 [dev-dependencies]
 serde_json = { version = "1.0.81", default-features = false }

--- a/sbor/src/codec/collection.rs
+++ b/sbor/src/codec/collection.rs
@@ -280,7 +280,7 @@ impl<
         let key_value_kind = decoder.read_and_check_value_kind(K::value_kind())?;
         let value_value_kind = decoder.read_and_check_value_kind(V::value_kind())?;
         let size = decoder.read_size()?;
-        let mut map = HashMap::with_capacity(if size <= 1024 { size } else { 1024 });
+        let mut map = hash_map_with_capacity(if size <= 1024 { size } else { 1024 });
         for _ in 0..size {
             map.insert(
                 decoder.decode_deeper_body_with_value_kind(key_value_kind)?,

--- a/sbor/src/schema/well_known_types.rs
+++ b/sbor/src/schema/well_known_types.rs
@@ -24,54 +24,47 @@ pub mod basic_well_known_types {
 #[macro_export]
 macro_rules! create_well_known_lookup {
     ($lookup_name: ident, $custom_type_kind: ty, [$(($id: path, $type_data: expr),)*]) => {
-        lazy_static::lazy_static! {
-            static ref $lookup_name: [Option<TypeData<$custom_type_kind, LocalTypeIndex>>; 256] = {
-                let mut lookup = {
-                    // Initialize the array with None, following the example here:
-                    // https://github.com/rust-lang/rust/issues/54542#issuecomment-505789992
-                    let mut lookup: [sbor::rust::mem::MaybeUninit<Option<TypeData<$custom_type_kind, LocalTypeIndex>>>; 256] = unsafe {
-                        sbor::rust::mem::MaybeUninit::uninit().assume_init()
-                    };
+        paste::paste! {
+            const [<$lookup_name:upper _INIT>]: Option<TypeData<$custom_type_kind, LocalTypeIndex>> = None;
 
-                    for elem in &mut lookup[..] {
-                        unsafe { sbor::rust::ptr::write(elem.as_mut_ptr(), None); }
-                    }
+            lazy_static::lazy_static! {
+                static ref $lookup_name: [Option<TypeData<$custom_type_kind, LocalTypeIndex>>; 256] = {
+                    let mut lookup: [Option<TypeData<$custom_type_kind, LocalTypeIndex>>; 256] = [ [<$lookup_name:upper _INIT>]; 256 ];
 
-                    unsafe { sbor::rust::mem::transmute::<_, [Option<TypeData<$custom_type_kind, LocalTypeIndex>>; 256]>(lookup) }
+                    // Now add in the basic types
+                    lookup[sbor::basic_well_known_types::BOOL_ID as usize] = Some(TypeData::unnamed(TypeKind::Bool));
+                    lookup[sbor::basic_well_known_types::I8_ID as usize] = Some(TypeData::unnamed(TypeKind::I8));
+                    lookup[sbor::basic_well_known_types::I16_ID as usize] = Some(TypeData::unnamed(TypeKind::I16));
+                    lookup[sbor::basic_well_known_types::I32_ID as usize] = Some(TypeData::unnamed(TypeKind::I32));
+                    lookup[sbor::basic_well_known_types::I64_ID as usize] = Some(TypeData::unnamed(TypeKind::I64));
+                    lookup[sbor::basic_well_known_types::I128_ID as usize] = Some(TypeData::unnamed(TypeKind::I128));
+                    lookup[sbor::basic_well_known_types::U8_ID as usize] = Some(TypeData::unnamed(TypeKind::U8));
+                    lookup[sbor::basic_well_known_types::U16_ID as usize] = Some(TypeData::unnamed(TypeKind::U16));
+                    lookup[sbor::basic_well_known_types::U32_ID as usize] = Some(TypeData::unnamed(TypeKind::U32));
+                    lookup[sbor::basic_well_known_types::U64_ID as usize] = Some(TypeData::unnamed(TypeKind::U64));
+                    lookup[sbor::basic_well_known_types::U128_ID as usize] = Some(TypeData::unnamed(TypeKind::U128));
+                    lookup[sbor::basic_well_known_types::STRING_ID as usize] = Some(TypeData::unnamed(TypeKind::String));
+                    lookup[sbor::basic_well_known_types::ANY_ID as usize] = Some(TypeData::unnamed(TypeKind::Any));
+                    lookup[sbor::basic_well_known_types::UNIT_ID as usize] = Some(TypeData::no_child_names(
+                        TypeKind::Tuple {
+                            field_types: sbor::rust::prelude::vec![],
+                        },
+                        "None"
+                    ));
+                    lookup[sbor::basic_well_known_types::BYTES_ID as usize] = Some(TypeData::no_child_names(
+                        TypeKind::Array {
+                            element_type: LocalTypeIndex::WellKnown(sbor::basic_well_known_types::U8_ID),
+                        },
+                        "Bytes"
+                    ));
+                    // And now add in the custom types
+                    $(lookup[$id as usize] = Some($type_data);)*
+
+                    // And return the lookup
+                    lookup
                 };
-                // Now add in the basic types
-                lookup[sbor::basic_well_known_types::BOOL_ID as usize] = Some(TypeData::unnamed(TypeKind::Bool));
-                lookup[sbor::basic_well_known_types::I8_ID as usize] = Some(TypeData::unnamed(TypeKind::I8));
-                lookup[sbor::basic_well_known_types::I16_ID as usize] = Some(TypeData::unnamed(TypeKind::I16));
-                lookup[sbor::basic_well_known_types::I32_ID as usize] = Some(TypeData::unnamed(TypeKind::I32));
-                lookup[sbor::basic_well_known_types::I64_ID as usize] = Some(TypeData::unnamed(TypeKind::I64));
-                lookup[sbor::basic_well_known_types::I128_ID as usize] = Some(TypeData::unnamed(TypeKind::I128));
-                lookup[sbor::basic_well_known_types::U8_ID as usize] = Some(TypeData::unnamed(TypeKind::U8));
-                lookup[sbor::basic_well_known_types::U16_ID as usize] = Some(TypeData::unnamed(TypeKind::U16));
-                lookup[sbor::basic_well_known_types::U32_ID as usize] = Some(TypeData::unnamed(TypeKind::U32));
-                lookup[sbor::basic_well_known_types::U64_ID as usize] = Some(TypeData::unnamed(TypeKind::U64));
-                lookup[sbor::basic_well_known_types::U128_ID as usize] = Some(TypeData::unnamed(TypeKind::U128));
-                lookup[sbor::basic_well_known_types::STRING_ID as usize] = Some(TypeData::unnamed(TypeKind::String));
-                lookup[sbor::basic_well_known_types::ANY_ID as usize] = Some(TypeData::unnamed(TypeKind::Any));
-                lookup[sbor::basic_well_known_types::UNIT_ID as usize] = Some(TypeData::no_child_names(
-                    TypeKind::Tuple {
-                        field_types: sbor::rust::prelude::vec![],
-                    },
-                    "None"
-                ));
-                lookup[sbor::basic_well_known_types::BYTES_ID as usize] = Some(TypeData::no_child_names(
-                    TypeKind::Array {
-                        element_type: LocalTypeIndex::WellKnown(sbor::basic_well_known_types::U8_ID),
-                    },
-                    "Bytes"
-                ));
-                // And now add in the custom types
-                $(lookup[$id as usize] = Some($type_data);)*
 
-                // And return the lookup
-                lookup
-            };
-
+            }
         }
     };
 }

--- a/sbor/src/value.rs
+++ b/sbor/src/value.rs
@@ -450,11 +450,11 @@ mod tests {
     pub fn test_parse_normal() {
         let mut set1 = BTreeSet::new();
         set1.insert(1);
-        let mut set2 = HashSet::new();
+        let mut set2 = hash_set_new();
         set2.insert(2);
         let mut map1 = BTreeMap::new();
         map1.insert(1, 2);
-        let mut map2 = HashMap::new();
+        let mut map2 = hash_map_new();
         map2.insert(3, 4);
 
         let data = TestData {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -235,7 +235,7 @@ impl TestRunner {
         }
     }
 
-    pub fn get_snapshot(&self) -> TestRunnerSnapshot {
+    pub fn create_snapshot(&self) -> TestRunnerSnapshot {
         TestRunnerSnapshot {
             substate_db: self.substate_db.clone(),
             next_private_key: self.next_private_key,

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -215,6 +215,14 @@ pub struct TestRunner {
     faucet_component: ComponentAddress,
 }
 
+#[derive(Clone)]
+pub struct TestRunnerSnapshot {
+    substate_db: InMemorySubstateDatabase,
+    next_private_key: u64,
+    next_transaction_nonce: u64,
+    state_hash_support: Option<StateHashSupport>,
+}
+
 impl TestRunner {
     pub fn builder() -> TestRunnerBuilder {
         TestRunnerBuilder {
@@ -225,6 +233,22 @@ impl TestRunner {
             trace: false,
             state_hashing: false,
         }
+    }
+
+    pub fn get_snapshot(&self) -> TestRunnerSnapshot {
+        TestRunnerSnapshot {
+            substate_db: self.substate_db.clone(),
+            next_private_key: self.next_private_key,
+            next_transaction_nonce: self.next_transaction_nonce,
+            state_hash_support: self.state_hash_support.clone(),
+        }
+    }
+
+    pub fn restore_snapshot(&mut self, snapshot: TestRunnerSnapshot) {
+        self.substate_db = snapshot.substate_db;
+        self.next_private_key = snapshot.next_private_key;
+        self.next_transaction_nonce = snapshot.next_transaction_nonce;
+        self.state_hash_support = snapshot.state_hash_support;
     }
 
     pub fn faucet_component(&self) -> ComponentAddress {
@@ -1340,6 +1364,7 @@ impl TestRunner {
     }
 }
 
+#[derive(Clone)]
 pub struct StateHashSupport {
     tree_store: TypedInMemoryTreeStore,
     current_version: Version,

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,6 +17,9 @@ default = ["std"]
 std = ["indexmap/std"]
 alloc = ["hashbrown"]
 serde = ["serde/derive"]
+# This flag is set by fuzz-tests framework and it enables StubHasher (instead of RandomHasher) for
+# Map and Set structs to prevent non-determinism when fuzzing.
+radix_engine_fuzzing= []
 
 [lib]
 bench = false


### PR DESCRIPTION
## Summary

Introduced few changes to improve consistency across runs for the same input data.

## Details

Following changes introduced to increase the consistency:
* Use stub hasher (instead of random one) for hash and index maps/sets
* disabled cache in VM-related stuff (most likely the cache uses some hashing inside)
* initialize static objects outside fuzzing loop
* save TestRunner state before fuzzing loop and restore it upon each fuzzing loop step
* use "resettable" lazy_static when fuzzing

Above changes increased the stability to `~99.5%`, which is good enough (for more info see _Nerd details_ below)

Additionally:
* got rid of `unsafe` when initializing well_known_lookup
It was suspected to impact consistency, but it turned out it does not. But it is always good to get rid of `unsafe` if possible.
* reformat Fuzzing summary (include coverage and stability)
* improve Fuzzing processing
  * process even if failed or cancelled
  * quit AFL instances before processing

## Nerd details

Inconsistency is indicated with following:
* warning message `WARNING: Instrumentation output varies across runs` when AFL starts and calibrates itself using provided input data
The more messages like that the less stable is the fuzzing process.
![image](https://user-images.githubusercontent.com/117115317/233289811-834836d5-bf4a-4524-89fd-f6e767688664.png)
* stability field in AFL UI (more details [Path geometry](https://github.com/AFLplusplus/AFLplusplus/blob/3b6fcd911a860a8c823c912c4b08b423734e4cfe/docs/afl-fuzz_approach.md#path-geometry)
before changes:
![image](https://user-images.githubusercontent.com/117115317/233311504-88ca81f5-7abc-4561-b8d7-1ac34560d650.png)
after changes:
![image](https://user-images.githubusercontent.com/117115317/233314895-5967ea7e-88d5-4362-8590-f837bdbfbefe.png)

According to the linked above stability description as long as the stability is 

> shown in purple the fuzzing process is unlikely to be negatively affected

