### PR TITLE
Use full git commit hash for resettable 'lazy_static' repo

### DIFF
--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -29,7 +29,7 @@ scrypto-unit = { path = "../scrypto-unit", default-features = false }
 # - warnings such as "Instrumentation output varies across runs"
 # - low stability reports
 # More details: https://github.com/rust-fuzz/afl.rs#lazy_static-variables
-lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs", rev = "c5eb91f" }
+lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs", rev = "c5eb91f2bde4c2f70092d1574f7145cb33ff0922" }
 
 [workspace]
 members = ["."]


### PR DESCRIPTION
This is to prevent potential collision.


