### PR TITLE
Feature: manifest decompiler command (rtmd)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,8 @@ jobs:
     - name: Run tests
       run: cargo test
       working-directory: transaction
-  cli-resim-rtmc:
-    name: Run CLI tests (resim & rtmc)
+  cli-resim-rtmc-rtmd:
+    name: Run CLI tests (resim & rtmc & rtmd)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -41,6 +41,11 @@ name = "rtmc"
 path = "src/bin/rtmc.rs"
 bench = false
 
+[[bin]]
+name = "rtmd"
+path = "src/bin/rtmd.rs"
+bench = false
+
 [lib]
 bench = false
 

--- a/simulator/src/bin/rtmd.rs
+++ b/simulator/src/bin/rtmd.rs
@@ -1,0 +1,9 @@
+#[cfg(windows)]
+use colored::*;
+use simulator::rtmd;
+
+pub fn main() -> Result<(), rtmd::Error> {
+    #[cfg(windows)]
+    control::set_virtual_terminal(true).unwrap();
+    rtmd::run()
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -4,6 +4,8 @@ pub mod ledger;
 pub mod resim;
 /// Radix transaction manifest compiler CLI.
 pub mod rtmc;
+/// Radix transaction manifest decompiler CLI.
+pub mod rtmd;
 /// Scrypto CLI.
 pub mod scrypto;
 /// Utility functions.

--- a/simulator/src/rtmd/mod.rs
+++ b/simulator/src/rtmd/mod.rs
@@ -1,0 +1,61 @@
+use clap::Parser;
+use radix_engine::types::*;
+use radix_engine_interface::crypto::hash;
+use radix_engine_interface::data::manifest::manifest_decode;
+use std::path::PathBuf;
+use std::str::FromStr;
+use transaction::manifest::decompile;
+use transaction::model::TransactionManifest;
+
+/// Radix transaction manifest decompiler
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None, name = "rtmd")]
+pub struct Args {
+    /// Path to the output file
+    #[clap(short, long)]
+    output: PathBuf,
+
+    /// Network to Use [Simulator | Alphanet | Mainnet]
+    #[clap(short, long)]
+    network: Option<String>,
+
+    /// Extract blobls
+    #[clap(short, long, action)]
+    blobs: bool,
+
+    /// Input file
+    #[clap(required = true)]
+    input: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    IoError(std::io::Error),
+    DecodeError(sbor::DecodeError),
+    DecompileError(transaction::manifest::DecompileError),
+    ParseNetworkError(ParseNetworkError),
+}
+
+pub fn run() -> Result<(), Error> {
+    let args = Args::parse();
+
+    let content = std::fs::read(&args.input).map_err(Error::IoError)?;
+    let network = match args.network {
+        Some(n) => NetworkDefinition::from_str(&n).map_err(Error::ParseNetworkError)?,
+        None => NetworkDefinition::simulator(),
+    };
+    let manifest = manifest_decode::<TransactionManifest>(&content).map_err(Error::DecodeError)?;
+    let result = decompile(&manifest.instructions, &network).map_err(Error::DecompileError)?;
+    std::fs::write(&args.output, &result).map_err(Error::IoError)?;
+
+    if args.blobs {
+        let directory = args.output.parent().unwrap();
+        for blob in manifest.blobs {
+            let blob_hash = hash(&blob);
+            std::fs::write(directory.join(format!("{}.blob", blob_hash)), &blob)
+                .map_err(Error::IoError)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This pull request adds new command line utility `rtmd` which allows to easily decompile binary manifest file. I added this command because it is very useful when working with fuzzing.

Usage:
```bash
Radix transaction manifest decompiler

USAGE:
    rtmd [OPTIONS] --output <OUTPUT> <INPUT>

ARGS:
    <INPUT>    Input file

OPTIONS:
    -b, --blobs                Extract blobls
    -h, --help                 Print help information
    -n, --network <NETWORK>    Network to Use [Simulator | Alphanet | Mainnet]
    -o, --output <OUTPUT>      Path to the output file
    -V, --version              Print version information
```
