### PR TITLE
Feature/SCRY-424 First substate read db costing

### DIFF
--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -377,7 +377,7 @@ fn substate_id(
     module_id: SysModuleId,
     substate_offset_seed: u8,
 ) -> (NodeId, ModuleId, SubstateKey) {
-    let fake_pkg_address = PackageAddress::new_unchecked([node_id_seed; 27]);
+    let fake_pkg_address = PackageAddress::new_unchecked([node_id_seed; 30]);
     let fake_kvs_entry_id = vec![substate_offset_seed; substate_offset_seed as usize];
     (
         NodeId(fake_pkg_address.into()),

--- a/radix-engine-stores/src/interface.rs
+++ b/radix-engine-stores/src/interface.rs
@@ -117,13 +117,15 @@ pub trait SubstateStore {
     ) -> Vec<(SubstateKey, IndexedScryptoValue)>;
 
     /// Acquires a lock over a substate.
+    /// Returns tuple of lock handle id and information if particular substate
+    /// is locked for the first time during transaction execution.
     fn acquire_lock(
         &mut self,
         node_id: &NodeId,
         module_id: ModuleId,
         substate_key: &SubstateKey,
         flags: LockFlags,
-    ) -> Result<u32, AcquireLockError> {
+    ) -> Result<(u32, bool), AcquireLockError> {
         self.acquire_lock_virtualize(node_id, module_id, substate_key, flags, || None)
     }
 
@@ -134,7 +136,7 @@ pub trait SubstateStore {
         substate_key: &SubstateKey,
         flags: LockFlags,
         virtualize: F,
-    ) -> Result<u32, AcquireLockError>;
+    ) -> Result<(u32, bool), AcquireLockError>;
 
     /// Releases a lock.
     ///

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -73,6 +73,7 @@ fn test_basic_transfer() {
         + 1680 /* DropNode */
         + 719200 /* Invoke */
         + 16327 /* LockSubstate */
+        + 864 /* LockSubstateFirstTime */
         + 111754 /* ReadSubstate */
         + 62500 /* RunNative */
         + 7500 /* RunSystem */
@@ -208,6 +209,7 @@ fn test_radiswap() {
         + 3675 /* DropNode */
         + 2368287 /* Invoke */
         + 38277 /* LockSubstate */
+        + 1472 /* LockSubstateFirstTime */
         + 350706 /* ReadSubstate */
         + 135000 /* RunNative */
         + 15000 /* RunSystem */
@@ -319,6 +321,7 @@ fn test_flash_loan() {
         + 6195 /* DropNode */
         + 2478055 /* Invoke */
         + 58854 /* LockSubstate */
+        + 1280 /* LockSubstateFirstTime */
         + 450122 /* ReadSubstate */
         + 215000 /* RunNative */
         + 40000 /* RunSystem */

--- a/radix-engine/src/kernel/call_frame.rs
+++ b/radix-engine/src/kernel/call_frame.rs
@@ -178,7 +178,7 @@ impl CallFrame {
         ) {
             let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
             Some(type_info)
-        } else if let Ok(handle) = store.acquire_lock(
+        } else if let Ok((handle, _)) = store.acquire_lock(
             node_id,
             SysModuleId::TypeInfo.into(),
             &TypeInfoOffset::TypeInfo.into(),
@@ -200,13 +200,14 @@ impl CallFrame {
         module_id: ModuleId,
         substate_key: &SubstateKey,
         flags: LockFlags,
-    ) -> Result<LockHandle, LockSubstateError> {
+    ) -> Result<(LockHandle, bool), LockSubstateError> {
         // Check node visibility
         self.get_node_visibility(node_id)
             .ok_or_else(|| LockSubstateError::NodeNotInCallFrame(node_id.clone()))?;
 
         // Lock and read the substate
         let mut store_handle = None;
+        let mut first_time_lock = false;
         let substate_value = if heap.contains_node(node_id) {
             // TODO: make Heap more like Store?
             if flags.contains(LockFlags::UNMODIFIED_BASE) {
@@ -230,7 +231,7 @@ impl CallFrame {
                 }
             }
         } else {
-            let handle = store
+            let (handle, first_time) = store
                 .acquire_lock_virtualize(node_id, module_id.into(), substate_key, flags, || {
                     if module_id.virtualize_substates() {
                         let value = IndexedScryptoValue::from_typed(&Option::<ScryptoValue>::None);
@@ -241,6 +242,7 @@ impl CallFrame {
                 })
                 .map_err(|x| LockSubstateError::TrackError(Box::new(x)))?;
             store_handle = Some(handle);
+            first_time_lock = first_time;
             store.read_substate(handle)
         };
 
@@ -294,7 +296,7 @@ impl CallFrame {
             *counter += 1;
         }
 
-        Ok(lock_handle)
+        Ok((lock_handle, first_time_lock))
     }
 
     pub fn drop_lock<S: SubstateStore>(

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -51,6 +51,7 @@ pub trait KernelCallbackObject: Sized {
     fn after_lock_substate<Y>(
         handle: LockHandle,
         size: usize,
+        first_time_lock: bool,
         api: &mut Y,
     ) -> Result<(), RuntimeError>
     where

--- a/radix-engine/src/system/module.rs
+++ b/radix-engine/src/system/module.rs
@@ -145,6 +145,7 @@ pub trait SystemModule<M: KernelCallbackObject> {
     fn after_lock_substate<Y: KernelApi<M>>(
         _api: &mut Y,
         _lock_handle: LockHandle,
+        _first_time_lock: bool,
         _size: usize,
     ) -> Result<(), RuntimeError> {
         Ok(())

--- a/radix-engine/src/system/module_mixer.rs
+++ b/radix-engine/src/system/module_mixer.rs
@@ -675,35 +675,36 @@ impl<V: SystemCallbackObject> SystemModule<SystemCallback<V>> for SystemModuleMi
     fn after_lock_substate<Y: KernelApi<SystemCallback<V>>>(
         api: &mut Y,
         handle: LockHandle,
+        first_time_lock: bool,
         size: usize,
     ) -> Result<(), RuntimeError> {
         let modules: EnabledModules = api.kernel_get_callback().modules.enabled_modules;
         if modules.contains(EnabledModules::KERNEL_DEBUG) {
-            KernelTraceModule::after_lock_substate(api, handle, size)?;
+            KernelTraceModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::COSTING) {
-            CostingModule::after_lock_substate(api, handle, size)?;
+            CostingModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::NODE_MOVE) {
-            NodeMoveModule::after_lock_substate(api, handle, size)?;
+            NodeMoveModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::AUTH) {
-            AuthModule::after_lock_substate(api, handle, size)?;
+            AuthModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::LOGGER) {
-            LoggerModule::after_lock_substate(api, handle, size)?;
+            LoggerModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::TRANSACTION_RUNTIME) {
-            TransactionRuntimeModule::after_lock_substate(api, handle, size)?;
+            TransactionRuntimeModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::EXECUTION_TRACE) {
-            ExecutionTraceModule::after_lock_substate(api, handle, size)?;
+            ExecutionTraceModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::TRANSACTION_LIMITS) {
-            TransactionLimitsModule::after_lock_substate(api, handle, size)?;
+            TransactionLimitsModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         if modules.contains(EnabledModules::EVENTS) {
-            EventsModule::after_lock_substate(api, handle, size)?;
+            EventsModule::after_lock_substate(api, handle, first_time_lock, size)?;
         }
         Ok(())
     }

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -149,12 +149,13 @@ impl<C: SystemCallbackObject> KernelCallbackObject for SystemCallback<C> {
     fn after_lock_substate<Y>(
         handle: LockHandle,
         size: usize,
+        first_time_lock: bool,
         api: &mut Y,
     ) -> Result<(), RuntimeError>
     where
         Y: KernelApi<Self>,
     {
-        SystemModuleMixer::after_lock_substate(api, handle, size)
+        SystemModuleMixer::after_lock_substate(api, handle, first_time_lock, size)
     }
 
     fn on_drop_lock<Y>(lock_handle: LockHandle, api: &mut Y) -> Result<(), RuntimeError>

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -329,6 +329,25 @@ impl<V: SystemCallbackObject> SystemModule<SystemCallback<V>> for CostingModule 
         Ok(())
     }
 
+    fn after_lock_substate<Y: KernelApi<SystemCallback<V>>>(
+        api: &mut Y,
+        _handle: LockHandle,
+        first_time_lock: bool,
+        _size: usize,
+    ) -> Result<(), RuntimeError> {
+        if first_time_lock {
+            api.kernel_get_callback()
+                .modules
+                .costing
+                .apply_execution_cost(
+                    CostingReason::LockSubstateFirstTime,
+                    |fee_table| fee_table.kernel_api_cost(CostingEntry::LockSubstateFirstTime),
+                    1,
+                )?;
+        }
+        Ok(())
+    }
+
     fn on_read_substate<Y: KernelApi<SystemCallback<V>>>(
         api: &mut Y,
         _lock_handle: LockHandle,

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -101,6 +101,7 @@ pub enum CostingReason {
     CreateNode,
     AllocateNodeId,
     LockSubstate,
+    LockSubstateFirstTime,
     ReadSubstate,
     WriteSubstate,
     DropLock,

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -34,6 +34,7 @@ pub enum CostingEntry<'a> {
         module_id: &'a SysModuleId,
         substate_key: &'a SubstateKey,
     },
+    LockSubstateFirstTime,
     ReadSubstate {
         size: u32,
     },
@@ -346,6 +347,7 @@ impl FeeTable {
                 (SysModuleId::TypeInfo, Some(EntityType::InternalNonFungibleVault)) => 207,
                 _ => 632, // average of above values
             },
+            CostingEntry::LockSubstateFirstTime => 100, // todo
             CostingEntry::ReadSubstate { size: _ } => 174,
             CostingEntry::WriteSubstate { size: _ } => 126,
         }) as u64

--- a/radix-engine/src/system/system_modules/kernel_trace/module.rs
+++ b/radix-engine/src/system/system_modules/kernel_trace/module.rs
@@ -130,9 +130,15 @@ impl<V: SystemCallbackObject> SystemModule<SystemCallback<V>> for KernelTraceMod
     fn after_lock_substate<Y: KernelApi<SystemCallback<V>>>(
         api: &mut Y,
         handle: LockHandle,
+        first_time_lock: bool,
         size: usize,
     ) -> Result<(), RuntimeError> {
-        log!(api, "Substate locked: handle = {:?}", handle);
+        log!(
+            api,
+            "Substate locked: handle = {:?}, first_time_lock = {:?}",
+            handle,
+            first_time_lock
+        );
         Ok(())
     }
 

--- a/radix-engine/src/track/track.rs
+++ b/radix-engine/src/track/track.rs
@@ -200,7 +200,8 @@ pub struct Track<'s, S: SubstateDatabase> {
     locks: IndexMap<u32, (NodeId, ModuleId, SubstateKey, LockFlags)>,
     next_lock_id: u32,
 
-    substate_already_read: HashSet<(NodeId, ModuleId, SubstateKey)>,
+    /// Stores list of substates locked at leaset once during transaction execution
+    substate_already_locked: HashSet<(NodeId, ModuleId, SubstateKey)>,
 }
 
 impl<'s, S: SubstateDatabase> Track<'s, S> {
@@ -211,7 +212,7 @@ impl<'s, S: SubstateDatabase> Track<'s, S> {
             updates: index_map_new(),
             locks: index_map_new(),
             next_lock_id: 0,
-            substate_already_read: HashSet::with_capacity(32),
+            substate_already_locked: HashSet::with_capacity(32),
         }
     }
 
@@ -545,7 +546,7 @@ impl<'s, S: SubstateDatabase> SubstateStore for Track<'s, S> {
         })?;
 
         let first_time_lock =
-            self.substate_already_read
+            self.substate_already_locked
                 .insert((*node_id, module_id, substate_key.clone()));
 
         let handle_id = self.new_lock_handle(node_id, module_id, substate_key, flags);

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -470,7 +470,7 @@ fn distribute_fees<S: SubstateDatabase>(
         let node_id = recipient_vault_id;
         let module_id = SysModuleId::Object;
         let substate_key = FungibleVaultOffset::LiquidFungible.into();
-        let handle = track
+        let (handle, _) = track
             .acquire_lock(
                 &node_id,
                 module_id.into(),
@@ -505,7 +505,7 @@ fn distribute_fees<S: SubstateDatabase>(
         required -= amount;
 
         // Refund overpayment
-        let handle = track
+        let (handle, _) = track
             .acquire_lock(
                 &vault_id,
                 SysModuleId::Object.into(),


### PR DESCRIPTION
## Summary
Added mechanism for 1st substate lock costing.

## Details
Extended return value of `acquire_lock` substate store interface to return also information if lock of particular substate (defined as node id, module id and substate key) has been called for the first time. This information is propagated to the Costing module to apply additional fee for the first time substate lock, as this may be a high cost operation due to database loading.

Logic which handles information if substate was locked for the first time is implemented in Kernel `Track` module.

## Testing
Updated costing of tests: `test_basic_transfer`, `test_flash_loan`, `test_radiswap`.
