### PR TITLE
Bug fix: Events emitted by transient nodes

### DIFF
--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -1399,6 +1399,30 @@ fn setting_metadata_emits_correct_events() {
 }
 
 //=========
+// Account
+//=========
+
+#[test]
+fn create_account_events_can_be_looked_up() {
+    // Arrange
+    let mut test_runner = TestRunner::builder().without_trace().build();
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .new_account_advanced(AccessRulesConfig::new())
+        .build();
+    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+
+    // Assert
+    {
+        let events = receipt.expect_commit(true).clone().application_events;
+        for (event_id, _) in events {
+            let _name = test_runner.event_name(&event_id);
+        }
+    }
+}
+
+//=========
 // Helpers
 //=========
 

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -396,6 +396,7 @@ where
 
         let global_node_id = self.api.kernel_allocate_node_id(entity_type)?;
         let global_address = GlobalAddress::new_or_panic(global_node_id.into());
+
         self.globalize_with_address(modules, global_address)?;
         Ok(global_address)
     }
@@ -429,6 +430,10 @@ where
             .ok_or(RuntimeError::SystemError(SystemError::MissingModule(
                 ObjectModuleId::SELF,
             )))?;
+        self.api.kernel_get_callback().modules.events.replace_key(
+            (node_id, ObjectModuleId::SELF),
+            (*address.as_node_id(), ObjectModuleId::SELF),
+        );
         let mut node_substates = self.api.kernel_drop_node(&node_id)?;
 
         // Update the `global` flag of the type info substate.
@@ -468,6 +473,11 @@ where
                         )));
                     }
 
+                    self.api.kernel_get_callback().modules.events.replace_key(
+                        (node_id, ObjectModuleId::SELF),
+                        (*address.as_node_id(), ObjectModuleId::AccessRules),
+                    );
+
                     let mut access_rule_substates = self.api.kernel_drop_node(&node_id)?;
                     let access_rules = access_rule_substates
                         .remove(&SysModuleId::Object.into())
@@ -486,6 +496,11 @@ where
                         )));
                     }
 
+                    self.api.kernel_get_callback().modules.events.replace_key(
+                        (node_id, ObjectModuleId::SELF),
+                        (*address.as_node_id(), ObjectModuleId::Metadata),
+                    );
+
                     let mut metadata_substates = self.api.kernel_drop_node(&node_id)?;
                     let metadata = metadata_substates
                         .remove(&SysModuleId::Virtualized.into())
@@ -503,6 +518,11 @@ where
                             }),
                         )));
                     }
+
+                    self.api.kernel_get_callback().modules.events.replace_key(
+                        (node_id, ObjectModuleId::SELF),
+                        (*address.as_node_id(), ObjectModuleId::Royalty),
+                    );
 
                     let mut royalty_substates = self.api.kernel_drop_node(&node_id)?;
                     let royalty = royalty_substates

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -430,10 +430,14 @@ where
             .ok_or(RuntimeError::SystemError(SystemError::MissingModule(
                 ObjectModuleId::SELF,
             )))?;
-        self.api.kernel_get_callback().modules.events.replace_key(
-            (node_id, ObjectModuleId::SELF),
-            (*address.as_node_id(), ObjectModuleId::SELF),
-        );
+        self.api
+            .kernel_get_callback()
+            .modules
+            .events
+            .add_replacement(
+                (node_id, ObjectModuleId::SELF),
+                (*address.as_node_id(), ObjectModuleId::SELF),
+            );
         let mut node_substates = self.api.kernel_drop_node(&node_id)?;
 
         // Update the `global` flag of the type info substate.
@@ -473,10 +477,14 @@ where
                         )));
                     }
 
-                    self.api.kernel_get_callback().modules.events.replace_key(
-                        (node_id, ObjectModuleId::SELF),
-                        (*address.as_node_id(), ObjectModuleId::AccessRules),
-                    );
+                    self.api
+                        .kernel_get_callback()
+                        .modules
+                        .events
+                        .add_replacement(
+                            (node_id, ObjectModuleId::SELF),
+                            (*address.as_node_id(), ObjectModuleId::AccessRules),
+                        );
 
                     let mut access_rule_substates = self.api.kernel_drop_node(&node_id)?;
                     let access_rules = access_rule_substates
@@ -496,10 +504,14 @@ where
                         )));
                     }
 
-                    self.api.kernel_get_callback().modules.events.replace_key(
-                        (node_id, ObjectModuleId::SELF),
-                        (*address.as_node_id(), ObjectModuleId::Metadata),
-                    );
+                    self.api
+                        .kernel_get_callback()
+                        .modules
+                        .events
+                        .add_replacement(
+                            (node_id, ObjectModuleId::SELF),
+                            (*address.as_node_id(), ObjectModuleId::Metadata),
+                        );
 
                     let mut metadata_substates = self.api.kernel_drop_node(&node_id)?;
                     let metadata = metadata_substates
@@ -519,10 +531,14 @@ where
                         )));
                     }
 
-                    self.api.kernel_get_callback().modules.events.replace_key(
-                        (node_id, ObjectModuleId::SELF),
-                        (*address.as_node_id(), ObjectModuleId::Royalty),
-                    );
+                    self.api
+                        .kernel_get_callback()
+                        .modules
+                        .events
+                        .add_replacement(
+                            (node_id, ObjectModuleId::SELF),
+                            (*address.as_node_id(), ObjectModuleId::Royalty),
+                        );
 
                     let mut royalty_substates = self.api.kernel_drop_node(&node_id)?;
                     let royalty = royalty_substates

--- a/radix-engine/src/system/system_modules/events/module.rs
+++ b/radix-engine/src/system/system_modules/events/module.rs
@@ -6,73 +6,43 @@ use radix_engine_interface::types::*;
 
 #[derive(Debug, Default, Clone)]
 pub struct EventsModule {
-    index: u32,
-    event_store:
-        IndexMap<(NodeId, ObjectModuleId), Vec<(Option<String>, LocalTypeIndex, Vec<u8>, u32)>>,
+    events: Vec<(EventTypeIdentifier, Vec<u8>)>,
+    replacements: IndexMap<(NodeId, ObjectModuleId), (NodeId, ObjectModuleId)>,
 }
 
 impl EventsModule {
     pub fn add_event(&mut self, identifier: EventTypeIdentifier, data: Vec<u8>) {
-        let (node_id, module_id, blueprint_name, local_type_index) = match identifier {
-            EventTypeIdentifier(Emitter::Method(node_id, module_id), local_type_index) => {
-                (node_id, module_id, None, local_type_index)
-            }
-            EventTypeIdentifier(
-                Emitter::Function(node_id, module_id, blueprint_name),
-                local_type_index,
-            ) => (node_id, module_id, Some(blueprint_name), local_type_index),
-        };
-        self.event_store
-            .entry((node_id, module_id))
-            .or_default()
-            .push((blueprint_name, local_type_index, data, self.index));
-        self.index += 1;
+        self.events.push((identifier, data))
     }
 
-    pub fn replace_key(&mut self, old: (NodeId, ObjectModuleId), new: (NodeId, ObjectModuleId)) {
-        if let Some(value) = self.event_store.remove(&old) {
-            self.event_store.insert(new, value);
-        }
+    pub fn add_replacement(
+        &mut self,
+        old: (NodeId, ObjectModuleId),
+        new: (NodeId, ObjectModuleId),
+    ) {
+        self.replacements.insert(old, new);
     }
 
     pub fn events(self) -> Vec<(EventTypeIdentifier, Vec<u8>)> {
-        let mut events = self
-            .event_store
-            .into_iter()
-            .flat_map(|((node_id, module_id), events)| {
-                let mut resolved_events = Vec::new();
-                for (blueprint_name, local_type_index, data, index) in events {
-                    let event = if let Some(blueprint_name) = blueprint_name {
-                        (
-                            EventTypeIdentifier(
-                                Emitter::Function(node_id, module_id, blueprint_name),
-                                local_type_index,
-                            ),
-                            data,
-                            index,
-                        )
-                    } else {
-                        (
-                            EventTypeIdentifier(
-                                Emitter::Method(node_id, module_id),
-                                local_type_index,
-                            ),
-                            data,
-                            index,
-                        )
-                    };
-                    resolved_events.push(event);
-                }
+        let mut events = self.events;
 
-                resolved_events
-            })
-            .collect::<Vec<(EventTypeIdentifier, Vec<u8>, u32)>>();
-        events.sort_by(|(_, _, a), (_, _, b)| a.cmp(b));
+        for (event_identifier, _) in events.iter_mut() {
+            // Apply replacements
+            let (node_id, module_id) = match event_identifier {
+                EventTypeIdentifier(Emitter::Method(node_id, module_id), _) => (node_id, module_id),
+                EventTypeIdentifier(Emitter::Function(node_id, module_id, _), _) => {
+                    (node_id, module_id)
+                }
+            };
+            if let Some((new_node_id, new_module_id)) =
+                self.replacements.get(&(*node_id, *module_id))
+            {
+                *node_id = *new_node_id;
+                *module_id = *new_module_id;
+            }
+        }
 
         events
-            .into_iter()
-            .map(|(identifier, data, _)| (identifier, data))
-            .collect()
     }
 }
 

--- a/radix-engine/src/system/system_modules/events/module.rs
+++ b/radix-engine/src/system/system_modules/events/module.rs
@@ -1,18 +1,78 @@
 use crate::kernel::kernel_callback_api::KernelCallbackObject;
 use crate::system::module::SystemModule;
 use crate::types::*;
+use radix_engine_interface::api::ObjectModuleId;
 use radix_engine_interface::types::*;
 
 #[derive(Debug, Default, Clone)]
-pub struct EventsModule(Vec<(EventTypeIdentifier, Vec<u8>)>);
+pub struct EventsModule {
+    index: u32,
+    event_store:
+        IndexMap<(NodeId, ObjectModuleId), Vec<(Option<String>, LocalTypeIndex, Vec<u8>, u32)>>,
+}
 
 impl EventsModule {
     pub fn add_event(&mut self, identifier: EventTypeIdentifier, data: Vec<u8>) {
-        self.0.push((identifier, data))
+        let (node_id, module_id, blueprint_name, local_type_index) = match identifier {
+            EventTypeIdentifier(Emitter::Method(node_id, module_id), local_type_index) => {
+                (node_id, module_id, None, local_type_index)
+            }
+            EventTypeIdentifier(
+                Emitter::Function(node_id, module_id, blueprint_name),
+                local_type_index,
+            ) => (node_id, module_id, Some(blueprint_name), local_type_index),
+        };
+        self.event_store
+            .entry((node_id, module_id))
+            .or_default()
+            .push((blueprint_name, local_type_index, data, self.index));
+        self.index += 1;
+    }
+
+    pub fn replace_key(&mut self, old: (NodeId, ObjectModuleId), new: (NodeId, ObjectModuleId)) {
+        if let Some(value) = self.event_store.remove(&old) {
+            self.event_store.insert(new, value);
+        }
     }
 
     pub fn events(self) -> Vec<(EventTypeIdentifier, Vec<u8>)> {
-        self.0
+        let mut events = self
+            .event_store
+            .into_iter()
+            .flat_map(|((node_id, module_id), events)| {
+                let mut resolved_events = Vec::new();
+                for (blueprint_name, local_type_index, data, index) in events {
+                    let event = if let Some(blueprint_name) = blueprint_name {
+                        (
+                            EventTypeIdentifier(
+                                Emitter::Function(node_id, module_id, blueprint_name),
+                                local_type_index,
+                            ),
+                            data,
+                            index,
+                        )
+                    } else {
+                        (
+                            EventTypeIdentifier(
+                                Emitter::Method(node_id, module_id),
+                                local_type_index,
+                            ),
+                            data,
+                            index,
+                        )
+                    };
+                    resolved_events.push(event);
+                }
+
+                resolved_events
+            })
+            .collect::<Vec<(EventTypeIdentifier, Vec<u8>, u32)>>();
+        events.sort_by(|(_, _, a), (_, _, b)| a.cmp(b));
+
+        events
+            .into_iter()
+            .map(|(identifier, data, _)| (identifier, data))
+            .collect()
     }
 }
 

--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -85,10 +85,7 @@ files=`ls target/*.blob`
 blobs=`echo $files | sed 's/ / --blobs /g'`
 $resim run ./target/temp2.rtm --blobs $blobs
 $resim new-account --manifest ./target/temp3.rtm
-# FIXME: temporarily commenting below call since it causes following panic.
-#  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/resim/mod.rs:395:26
-#  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-echo "FIXME: reenable this call: " $resim run ./target/temp3.rtm
+$resim run ./target/temp3.rtm
 
 # Test - run manifest with a given set of signing keys
 $resim generate-key-pair


### PR DESCRIPTION
## Summary

This PR fixes a bug in the events implementation where the event schema of events emitted by NodeModules prior to globalization could not be looked up. This is fixed by doing the appropriate replacements to the events in the event store when a node is globalized.