### PR TITLE
Feature: Access Controller badge withdraw

### DIFF
--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -88,7 +88,7 @@ pub type AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput = ();
 // Access Controller Initiate Badge Withdraw Attempt As Recovery
 //===============================================================
 
-pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_BADGE_WITHDRAW_IDENT: &str =
+pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_RECOVERY_IDENT: &str =
     "initiate_badge_withdraw_attempt_as_recovery";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
@@ -264,7 +264,7 @@ pub type AccessControllerStopTimedRecoveryOutput = ();
 // Access Controller Stop Timed Badge Withdraw Attempt
 //=====================================================
 
-pub const ACCESS_CONTROLLER_STOP_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+pub const ACCESS_CONTROLLER_STOP_TIMED_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
     "stop_timed_badge_withdraw_attempt";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -164,18 +164,6 @@ pub struct AccessControllerTimedConfirmRecoveryInput {
 
 pub type AccessControllerTimedConfirmRecoveryOutput = ();
 
-//========================================================
-// Access Controller Timed Confirm Badge Withdraw Attempt
-//========================================================
-
-pub const ACCESS_CONTROLLER_TIMED_CONFIRM_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
-    "timed_confirm_badge_withdraw_attempt";
-
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
-pub struct AccessControllerTimedConfirmBadgeWithdrawAttemptInput;
-
-pub type AccessControllerTimedConfirmBadgeWithdrawAttemptOutput = Bucket;
-
 //=========================================================
 // Access Controller Cancel Primary Role Recovery Proposal
 //=========================================================
@@ -259,15 +247,3 @@ pub struct AccessControllerStopTimedRecoveryInput {
 }
 
 pub type AccessControllerStopTimedRecoveryOutput = ();
-
-//=====================================================
-// Access Controller Stop Timed Badge Withdraw Attempt
-//=====================================================
-
-pub const ACCESS_CONTROLLER_STOP_TIMED_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
-    "stop_timed_badge_withdraw_attempt";
-
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
-pub struct AccessControllerStopTimedBadgeWithdrawAttemptInput;
-
-pub type AccessControllerStopTimedBadgeWithdrawAttemptOutput = ();

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -76,7 +76,7 @@ pub type AccessControllerInitiateRecoveryAsRecoveryOutput = ();
 // Access Controller Initiate Badge Withdraw Attempt As Primary
 //==============================================================
 
-pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT: &str =
+pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_PRIMARY_IDENT: &str =
     "initiate_badge_withdraw_attempt_as_primary";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
@@ -88,7 +88,7 @@ pub type AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput = ();
 // Access Controller Initiate Badge Withdraw Attempt As Recovery
 //===============================================================
 
-pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_RECOVERY_IDENT: &str =
+pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_RECOVERY_IDENT: &str =
     "initiate_badge_withdraw_attempt_as_recovery";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -72,6 +72,30 @@ pub struct AccessControllerInitiateRecoveryAsRecoveryInput {
 
 pub type AccessControllerInitiateRecoveryAsRecoveryOutput = ();
 
+//==============================================================
+// Access Controller Initiate Badge Withdraw Attempt As Primary
+//==============================================================
+
+pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT: &str =
+    "initiate_badge_withdraw_attempt_as_primary";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput;
+
+pub type AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput = ();
+
+//===============================================================
+// Access Controller Initiate Badge Withdraw Attempt As Recovery
+//===============================================================
+
+pub const ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_BADGE_WITHDRAW_IDENT: &str =
+    "initiate_badge_withdraw_attempt_as_recovery";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryInput;
+
+pub type AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput = ();
+
 //=======================================================
 // Access Controller Quick Confirm Primary Role Recovery
 //=======================================================
@@ -102,9 +126,33 @@ pub struct AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput {
 
 pub type AccessControllerQuickConfirmRecoveryRoleRecoveryProposalOutput = ();
 
-//=================================
-// Access Controller Timed Confirm
-//=================================
+//=====================================================================
+// Access Controller Quick Confirm Primary Role Badge Withdraw Attempt
+//=====================================================================
+
+pub const ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "quick_confirm_primary_role_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptInput;
+
+pub type AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptOutput = Bucket;
+
+//======================================================================
+// Access Controller Quick Confirm Recovery Role Badge Withdraw Attempt
+//======================================================================
+
+pub const ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "quick_confirm_recovery_role_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptInput;
+
+pub type AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptOutput = Bucket;
+
+//=========================================
+// Access Controller Timed Confirm Recovery
+//=========================================
 
 pub const ACCESS_CONTROLLER_TIMED_CONFIRM_RECOVERY_IDENT: &str = "timed_confirm_recovery";
 
@@ -115,6 +163,18 @@ pub struct AccessControllerTimedConfirmRecoveryInput {
 }
 
 pub type AccessControllerTimedConfirmRecoveryOutput = ();
+
+//========================================================
+// Access Controller Timed Confirm Badge Withdraw Attempt
+//========================================================
+
+pub const ACCESS_CONTROLLER_TIMED_CONFIRM_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "timed_confirm_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerTimedConfirmBadgeWithdrawAttemptInput;
+
+pub type AccessControllerTimedConfirmBadgeWithdrawAttemptOutput = Bucket;
 
 //=========================================================
 // Access Controller Cancel Primary Role Recovery Proposal
@@ -139,6 +199,30 @@ pub const ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_RECOVERY_PROPOSAL_IDENT: &str =
 pub struct AccessControllerCancelRecoveryRoleRecoveryProposalInput;
 
 pub type AccessControllerCancelRecoveryRoleRecoveryProposalOutput = ();
+
+//==============================================================
+// Access Controller Cancel Primary Role Badge Withdraw Attempt
+//==============================================================
+
+pub const ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "cancel_primary_role_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput;
+
+pub type AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput = ();
+
+//===============================================================
+// Access Controller Cancel Recovery Role Badge Withdraw Attempt
+//===============================================================
+
+pub const ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "cancel_recovery_role_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput;
+
+pub type AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput = ();
 
 //=====================================
 // Access Controller Lock Primary Role
@@ -175,3 +259,15 @@ pub struct AccessControllerStopTimedRecoveryInput {
 }
 
 pub type AccessControllerStopTimedRecoveryOutput = ();
+
+//=====================================================
+// Access Controller Stop Timed Badge Withdraw Attempt
+//=====================================================
+
+pub const ACCESS_CONTROLLER_STOP_BADGE_WITHDRAW_ATTEMPT_IDENT: &str =
+    "stop_timed_badge_withdraw_attempt";
+
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+pub struct AccessControllerStopTimedBadgeWithdrawAttemptInput;
+
+pub type AccessControllerStopTimedBadgeWithdrawAttemptOutput = ();

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -134,9 +134,9 @@ pub const ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_ID
     "quick_confirm_primary_role_badge_withdraw_attempt";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
-pub struct AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptInput;
+pub struct AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptInput;
 
-pub type AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptOutput = Bucket;
+pub type AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptOutput = Bucket;
 
 //======================================================================
 // Access Controller Quick Confirm Recovery Role Badge Withdraw Attempt
@@ -146,9 +146,9 @@ pub const ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_I
     "quick_confirm_recovery_role_badge_withdraw_attempt";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
-pub struct AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptInput;
+pub struct AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptInput;
 
-pub type AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptOutput = Bucket;
+pub type AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptOutput = Bucket;
 
 //=========================================
 // Access Controller Timed Confirm Recovery

--- a/radix-engine-tests/tests/access_controller.rs
+++ b/radix-engine-tests/tests/access_controller.rs
@@ -1,4 +1,5 @@
 use radix_engine::blueprints::access_controller::AccessControllerError;
+use radix_engine::blueprints::resource::FungibleResourceManagerError;
 use radix_engine::errors::ApplicationError;
 use radix_engine::errors::ModuleError;
 use radix_engine::errors::RuntimeError;
@@ -360,6 +361,104 @@ pub fn confirmation_role_cant_initiate_a_badge_withdraw_attempt_as_primary_or_re
 
         // Assert
         receipt.expect_specific_failure(is_auth_unauthorized_error);
+    }
+}
+
+#[test]
+pub fn badge_withdraw_only_succeeds_when_confirmation_is_performed_by_allowed_roles() {
+    // Arrange
+    let test_vectors: [(Role, Role, Option<ErrorCheckFunction>); 4] = [
+        // Proposer: Primary Role
+        (
+            Role::Primary,                        // Initiator
+            Role::Recovery,                       // Confirm
+            Some(is_drop_non_empty_bucket_error), // Expected Error
+        ),
+        (
+            Role::Primary,
+            Role::Primary,
+            Some(is_auth_unauthorized_error),
+        ),
+        // Proposer: Recovery Role
+        (
+            Role::Recovery,
+            Role::Primary,
+            Some(is_drop_non_empty_bucket_error),
+        ),
+        (
+            Role::Recovery,
+            Role::Recovery,
+            Some(is_auth_unauthorized_error),
+        ),
+    ];
+
+    for (proposer, confirmor, expected_error) in test_vectors {
+        let mut test_runner = AccessControllerTestRunner::new(Some(10));
+        test_runner
+            .initiate_badge_withdraw_attempt(proposer, true)
+            .expect_commit_success();
+
+        // Act
+        let receipt = test_runner.quick_confirm_badge_withdraw_attempt(confirmor, proposer);
+
+        // Assert
+        if let Some(error_check_fn) = expected_error {
+            receipt.expect_specific_failure(error_check_fn);
+        } else {
+            receipt.expect_commit_success();
+        }
+    }
+}
+
+#[test]
+pub fn primary_can_cancel_their_badge_withdraw_attempt() {
+    // Arrange
+    let mut test_runner = AccessControllerTestRunner::new(Some(10));
+    test_runner
+        .initiate_badge_withdraw_attempt(Role::Primary, true)
+        .expect_commit_success();
+
+    {
+        // Act
+        let receipt = test_runner.cancel_badge_withdraw_attempt(Role::Primary);
+
+        // Assert
+        receipt.expect_commit_success();
+    }
+
+    {
+        // Act
+        let receipt =
+            test_runner.quick_confirm_badge_withdraw_attempt(Role::Recovery, Role::Primary);
+
+        // Assert
+        receipt.expect_specific_failure(is_no_badge_withdraw_attempts_exists_for_proposer_error);
+    }
+}
+
+#[test]
+pub fn recovery_can_cancel_their_badge_withdraw_attempt() {
+    // Arrange
+    let mut test_runner = AccessControllerTestRunner::new(Some(10));
+    test_runner
+        .initiate_badge_withdraw_attempt(Role::Recovery, true)
+        .expect_commit_success();
+
+    {
+        // Act
+        let receipt = test_runner.cancel_badge_withdraw_attempt(Role::Recovery);
+
+        // Assert
+        receipt.expect_commit_success();
+    }
+
+    {
+        // Act
+        let receipt =
+            test_runner.quick_confirm_badge_withdraw_attempt(Role::Confirmation, Role::Recovery);
+
+        // Assert
+        receipt.expect_specific_failure(is_no_badge_withdraw_attempts_exists_for_proposer_error);
     }
 }
 
@@ -1442,6 +1541,15 @@ fn is_no_recovery_exists_for_proposer_error(error: &RuntimeError) -> bool {
     )
 }
 
+fn is_no_badge_withdraw_attempts_exists_for_proposer_error(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::AccessControllerError(
+            AccessControllerError::NoBadgeWithdrawAttemptExistsForProposer { .. }
+        ))
+    )
+}
+
 fn is_no_timed_recoveries_found_error(error: &RuntimeError) -> bool {
     matches!(
         error,
@@ -1465,6 +1573,15 @@ fn is_recovery_proposal_mismatch_error(error: &RuntimeError) -> bool {
         error,
         RuntimeError::ApplicationError(ApplicationError::AccessControllerError(
             AccessControllerError::RecoveryProposalMismatch { .. }
+        ))
+    )
+}
+
+fn is_drop_non_empty_bucket_error(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::ResourceManagerError(
+            FungibleResourceManagerError::DropNonEmptyBucket
         ))
     )
 }
@@ -1650,6 +1767,39 @@ impl AccessControllerTestRunner {
         self.execute_manifest(manifest)
     }
 
+    pub fn quick_confirm_badge_withdraw_attempt(
+        &mut self,
+        as_role: Role,
+        proposer: Role,
+    ) -> TransactionReceipt {
+        let proposer = match proposer {
+            Role::Primary => Proposer::Primary,
+            Role::Recovery => Proposer::Recovery,
+            Role::Confirmation => panic!("Confirmation is not a valid proposer"),
+        };
+
+        let method_name = match proposer {
+            Proposer::Primary => {
+                ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT
+            }
+            Proposer::Recovery => {
+                ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT
+            }
+        };
+
+        let manifest = self
+            .manifest_builder(as_role)
+            .call_method(
+                self.access_controller_address,
+                method_name,
+                to_manifest_value(
+                    &AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptInput {},
+                ),
+            )
+            .build();
+        self.execute_manifest(manifest)
+    }
+
     pub fn timed_confirm_recovery(
         &mut self,
         as_role: Role,
@@ -1689,6 +1839,24 @@ impl AccessControllerTestRunner {
                 self.access_controller_address,
                 method_name,
                 to_manifest_value(&AccessControllerCancelPrimaryRoleRecoveryProposalInput),
+            )
+            .build();
+        self.execute_manifest(manifest)
+    }
+
+    pub fn cancel_badge_withdraw_attempt(&mut self, as_role: Role) -> TransactionReceipt {
+        let method_name = match as_role {
+            Role::Primary => ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
+            Role::Recovery => ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
+            Role::Confirmation => panic!("No method for the given role"),
+        };
+
+        let manifest = self
+            .manifest_builder(as_role)
+            .call_method(
+                self.access_controller_address,
+                method_name,
+                to_manifest_value(&AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput),
             )
             .build();
         self.execute_manifest(manifest)

--- a/radix-engine/src/blueprints/access_controller/events.rs
+++ b/radix-engine/src/blueprints/access_controller/events.rs
@@ -8,13 +8,28 @@ pub struct InitiateRecoveryEvent {
 }
 
 #[derive(ScryptoSbor, ScryptoEvent)]
+pub struct InitiateBadgeWithdrawAttemptEvent {
+    pub proposer: Proposer,
+}
+
+#[derive(ScryptoSbor, ScryptoEvent)]
 pub struct RuleSetUpdateEvent {
     pub proposer: Proposer,
     pub proposal: RecoveryProposal,
 }
 
 #[derive(ScryptoSbor, ScryptoEvent)]
+pub struct BadgeWithdrawEvent {
+    pub proposer: Proposer,
+}
+
+#[derive(ScryptoSbor, ScryptoEvent)]
 pub struct CancelRecoveryProposalEvent {
+    pub proposer: Proposer,
+}
+
+#[derive(ScryptoSbor, ScryptoEvent)]
+pub struct CancelBadgeWithdrawAttemptEvent {
     pub proposer: Proposer,
 }
 
@@ -26,3 +41,6 @@ pub struct UnlockPrimaryRoleEvent;
 
 #[derive(ScryptoSbor, ScryptoEvent)]
 pub struct StopTimedRecoveryEvent;
+
+#[derive(ScryptoSbor, ScryptoEvent)]
+pub struct StopTimedBadgeWithdrawAttemptEvent;

--- a/radix-engine/src/blueprints/access_controller/events.rs
+++ b/radix-engine/src/blueprints/access_controller/events.rs
@@ -41,6 +41,3 @@ pub struct UnlockPrimaryRoleEvent;
 
 #[derive(ScryptoSbor, ScryptoEvent)]
 pub struct StopTimedRecoveryEvent;
-
-#[derive(ScryptoSbor, ScryptoEvent)]
-pub struct StopTimedBadgeWithdrawAttemptEvent;

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -304,25 +304,25 @@ impl AccessControllerNativePackage {
             },
         );
         functions.insert(
-            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT.to_string(),
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_PRIMARY_IDENT.to_string(),
             FunctionSchema {
                 receiver: Some(Receiver::SelfRefMut),
                 input: aggregator
                     .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput>(),
                 output: aggregator
                     .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput>(),
-                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT.to_string(),
+                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_PRIMARY_IDENT.to_string(),
             },
         );
         functions.insert(
-            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_RECOVERY_IDENT.to_string(),
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_RECOVERY_IDENT.to_string(),
             FunctionSchema {
                 receiver: Some(Receiver::SelfRefMut),
                 input: aggregator
                     .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryInput>(),
                 output: aggregator
                     .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput>(),
-                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_RECOVERY_IDENT.to_string(),
+                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_RECOVERY_IDENT.to_string(),
             },
         );
         functions.insert(
@@ -503,6 +503,55 @@ impl AccessControllerNativePackage {
                 api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
 
                 Self::stop_timed_recovery(input, api)
+            }
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_PRIMARY_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                Self::initiate_badge_withdraw_attempt_as_primary(input, api)
+            }
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_RECOVERY_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                Self::initiate_badge_withdraw_attempt_as_recovery(input, api)
+            }
+            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                let receiver = receiver.ok_or(RuntimeError::SystemUpstreamError(
+                    SystemUpstreamError::NativeExpectedReceiver(export_name.to_string()),
+                ))?;
+                Self::quick_confirm_primary_role_badge_withdraw_attempt(receiver, input, api)
+            }
+            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                let receiver = receiver.ok_or(RuntimeError::SystemUpstreamError(
+                    SystemUpstreamError::NativeExpectedReceiver(export_name.to_string()),
+                ))?;
+                Self::quick_confirm_recovery_role_badge_withdraw_attempt(receiver, input, api)
+            }
+            ACCESS_CONTROLLER_TIMED_CONFIRM_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                let receiver = receiver.ok_or(RuntimeError::SystemUpstreamError(
+                    SystemUpstreamError::NativeExpectedReceiver(export_name.to_string()),
+                ))?;
+                Self::timed_confirm_badge_withdraw_attempt(receiver, input, api)
+            }
+            ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                Self::cancel_primary_role_badge_withdraw_attempt(input, api)
+            }
+            ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                Self::cancel_recovery_role_badge_withdraw_attempt(input, api)
+            }
+            ACCESS_CONTROLLER_STOP_TIMED_BADGE_WITHDRAW_ATTEMPT_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                Self::stop_timed_badge_withdraw_attempt(input, api)
             }
             _ => Err(RuntimeError::SystemUpstreamError(
                 SystemUpstreamError::NativeExportDoesNotExist(export_name.to_string()),
@@ -1160,7 +1209,7 @@ fn access_rules_from_rule_set(rule_set: RuleSet) -> AccessRulesConfig {
     access_rules.set_method_access_rule_to_group(
         MethodKey::new(
             ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT,
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_PRIMARY_IDENT,
         ),
         primary_group.into(),
     );
@@ -1185,7 +1234,7 @@ fn access_rules_from_rule_set(rule_set: RuleSet) -> AccessRulesConfig {
     access_rules.set_method_access_rule_to_group(
         MethodKey::new(
             ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_RECOVERY_IDENT,
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_ATTEMPT_AS_RECOVERY_IDENT,
         ),
         recovery_group.into(),
     );

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -400,7 +400,11 @@ impl AccessControllerNativePackage {
                 CancelRecoveryProposalEvent,
                 LockPrimaryRoleEvent,
                 UnlockPrimaryRoleEvent,
-                StopTimedRecoveryEvent
+                StopTimedRecoveryEvent,
+                InitiateBadgeWithdrawAttemptEvent,
+                BadgeWithdrawEvent,
+                CancelBadgeWithdrawAttemptEvent,
+                StopTimedBadgeWithdrawAttemptEvent
             ]
         };
 

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -303,6 +303,94 @@ impl AccessControllerNativePackage {
                 export_name: ACCESS_CONTROLLER_STOP_TIMED_RECOVERY_IDENT.to_string(),
             },
         );
+        functions.insert(
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput>(),
+                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_PRIMARY_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_BADGE_WITHDRAW_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput>(),
+                export_name: ACCESS_CONTROLLER_INITIATE_BADGE_WITHDRAW_AS_BADGE_WITHDRAW_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerQuickConfirmPrimaryRoleBadgeRecoveryAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerQuickConfirmRecoveryRoleBadgeRecoveryAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_TIMED_CONFIRM_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerTimedConfirmBadgeWithdrawAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerTimedConfirmBadgeWithdrawAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_TIMED_CONFIRM_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_CANCEL_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_CANCEL_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
+        functions.insert(
+            ACCESS_CONTROLLER_STOP_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator
+                    .add_child_type_and_descendents::<AccessControllerStopTimedBadgeWithdrawAttemptInput>(),
+                output: aggregator
+                    .add_child_type_and_descendents::<AccessControllerStopTimedBadgeWithdrawAttemptOutput>(),
+                export_name: ACCESS_CONTROLLER_STOP_BADGE_WITHDRAW_ATTEMPT_IDENT.to_string(),
+            },
+        );
 
         let event_schema = event_schema! {
             aggregator,

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -1173,11 +1173,52 @@ fn access_rules_from_rule_set(rule_set: RuleSet) -> AccessRulesConfig {
         recovery_group.into(),
     );
 
-    // Confirmation Role Rules
-    let confirmation_group = "confirmation";
+    // Recovery || Confirmation Role Rules
+    let recovery_or_confirmation_group = "recovery_or_confirmation";
     access_rules.set_group_access_rule(
-        confirmation_group.into(),
-        rule_set.confirmation_role.clone(),
+        recovery_or_confirmation_group.into(),
+        access_rule_or(vec![
+            rule_set.recovery_role.clone(),
+            rule_set.confirmation_role.clone(),
+        ]),
+    );
+    access_rules.set_method_access_rule_to_group(
+        MethodKey::new(
+            ObjectModuleId::SELF,
+            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_RECOVERY_PROPOSAL_IDENT,
+        ),
+        recovery_or_confirmation_group.into(),
+    );
+    access_rules.set_method_access_rule_to_group(
+        MethodKey::new(
+            ObjectModuleId::SELF,
+            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
+        ),
+        recovery_or_confirmation_group.into(),
+    );
+
+    // Primary || Confirmation Role Rules
+    let primary_or_confirmation_group = "primary_or_confirmation";
+    access_rules.set_group_access_rule(
+        primary_or_confirmation_group.into(),
+        access_rule_or(vec![
+            rule_set.primary_role.clone(),
+            rule_set.confirmation_role.clone(),
+        ]),
+    );
+    access_rules.set_method_access_rule_to_group(
+        MethodKey::new(
+            ObjectModuleId::SELF,
+            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_RECOVERY_PROPOSAL_IDENT,
+        ),
+        primary_or_confirmation_group.into(),
+    );
+    access_rules.set_method_access_rule_to_group(
+        MethodKey::new(
+            ObjectModuleId::SELF,
+            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
+        ),
+        primary_or_confirmation_group.into(),
     );
 
     // Other methods
@@ -1194,46 +1235,6 @@ fn access_rules_from_rule_set(rule_set: RuleSet) -> AccessRulesConfig {
             ]
             .into(),
         ),
-    );
-    access_rules.set_method_access_rule(
-        MethodKey::new(
-            ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_RECOVERY_PROPOSAL_IDENT,
-        ),
-        access_rule_or(
-            [
-                rule_set.recovery_role.clone(),
-                rule_set.confirmation_role.clone(),
-            ]
-            .into(),
-        ),
-    );
-    access_rules.set_method_access_rule(
-        MethodKey::new(
-            ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_QUICK_CONFIRM_PRIMARY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
-        ),
-        access_rule_or([rule_set.recovery_role, rule_set.confirmation_role.clone()].into()),
-    );
-    access_rules.set_method_access_rule(
-        MethodKey::new(
-            ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_RECOVERY_PROPOSAL_IDENT,
-        ),
-        access_rule_or(
-            [
-                rule_set.primary_role.clone(),
-                rule_set.confirmation_role.clone(),
-            ]
-            .into(),
-        ),
-    );
-    access_rules.set_method_access_rule(
-        MethodKey::new(
-            ObjectModuleId::SELF,
-            ACCESS_CONTROLLER_QUICK_CONFIRM_RECOVERY_ROLE_BADGE_WITHDRAW_ATTEMPT_IDENT,
-        ),
-        access_rule_or([rule_set.primary_role, rule_set.confirmation_role].into()),
     );
 
     let non_fungible_local_id =

--- a/radix-engine/src/blueprints/access_controller/state_machine.rs
+++ b/radix-engine/src/blueprints/access_controller/state_machine.rs
@@ -9,9 +9,12 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::time::TimeComparisonOperator;
 use sbor::rust::boxed::Box;
 
+use super::PrimaryRoleBadgeWithdrawAttemptState;
+use super::RecoveryRoleBadgeWithdrawAttemptState;
+use super::RecoveryRoleWithdrawBadgeState;
 use super::{
-    AccessControllerError, AccessControllerSubstate, PrimaryOperationState, PrimaryRoleState,
-    RecoveryOperationState, RecoveryRecoveryState,
+    AccessControllerError, AccessControllerSubstate, PrimaryRoleLockingState,
+    PrimaryRoleRecoveryAttemptState, RecoveryRoleRecoveryAttemptState, RecoveryRoleRecoveryState,
 };
 
 /// A trait which defines the interface for an access controller transition for a given trigger or
@@ -59,10 +62,10 @@ impl Transition<AccessControllerCreateProofStateMachineInput> for AccessControll
     where
         Y: ClientApi<RuntimeError>,
     {
-        // Proofs can only be created when the primary role is unlocked - regardless of whether the
-        // controller is in recovery or normal operations.
+        // Proofs can only be created when the primary role is unlocked - regardless of any pending
+        // recovery or withdraw attempts.
         match self.state {
-            (PrimaryRoleState::Unlocked, _, _) => {
+            (PrimaryRoleLockingState::Unlocked, _, _, _, _) => {
                 Vault(self.controlled_asset).sys_create_proof(api)
             }
             _ => access_controller_runtime_error!(OperationRequiresUnlockedPrimaryRole),
@@ -88,9 +91,17 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsPrimaryStateMachineInput>
         Y: ClientApi<RuntimeError>,
     {
         match self.state {
-            (_, ref mut primary_operations_state @ PrimaryOperationState::Normal, _) => {
-                // Transition the primary operations state from normal to recovery
-                *primary_operations_state = PrimaryOperationState::Recovery(input.proposal);
+            (
+                _,
+                ref mut
+                primary_role_recovery_attempt_state @ PrimaryRoleRecoveryAttemptState::NoRecoveryAttempt,
+                _,
+                _,
+                _,
+            ) => {
+                // Transition the primary recovery attempt state from normal to recovery
+                *primary_role_recovery_attempt_state =
+                    PrimaryRoleRecoveryAttemptState::RecoveryAttempt(input.proposal);
                 Ok(())
             }
             _ => Err(RuntimeError::ApplicationError(
@@ -122,31 +133,131 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsRecoveryStateMachineInput>
         Y: ClientApi<RuntimeError>,
     {
         match self.state {
-            (_, _, ref mut recovery_operations_state @ RecoveryOperationState::Normal) => {
-                match self.timed_recovery_delay_in_minutes {
-                    Some(delay_in_minutes) => {
-                        let current_time = Runtime::sys_current_time(api, TimePrecision::Minute)?;
-                        let timed_recovery_allowed_after = current_time
-                            .add_minutes(delay_in_minutes as i64)
-                            .map_or(access_controller_runtime_error!(TimeOverflow), |instant| {
-                                Ok(instant)
-                            })?;
+            (
+                _,
+                _,
+                _,
+                ref mut recovery_role_recovery_attempt_state @ RecoveryRoleRecoveryAttemptState::NoRecoveryAttempt,
+                _,
+            ) => match self.timed_recovery_delay_in_minutes {
+                Some(delay_in_minutes) => {
+                    let current_time = Runtime::sys_current_time(api, TimePrecision::Minute)?;
+                    let timed_recovery_allowed_after = current_time
+                        .add_minutes(delay_in_minutes as i64)
+                        .map_or(access_controller_runtime_error!(TimeOverflow), |instant| {
+                            Ok(instant)
+                        })?;
 
-                        *recovery_operations_state =
-                            RecoveryOperationState::Recovery(RecoveryRecoveryState::Timed {
-                                proposal: input.proposal,
-                                timed_recovery_allowed_after,
-                            });
-                        Ok(())
-                    }
-                    None => {
-                        *recovery_operations_state = RecoveryOperationState::Recovery(
-                            RecoveryRecoveryState::Untimed(input.proposal),
-                        );
-                        Ok(())
-                    }
+                    *recovery_role_recovery_attempt_state = RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                        RecoveryRoleRecoveryState::TimedRecovery {
+                            proposal: input.proposal,
+                            timed_recovery_allowed_after,
+                        },
+                    );
+                    Ok(())
                 }
+                None => {
+                    *recovery_role_recovery_attempt_state = RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                        RecoveryRoleRecoveryState::UntimedRecovery(input.proposal),
+                    );
+                    Ok(())
+                }
+            },
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::RecoveryAlreadyExistsForProposer {
+                        proposer: Proposer::Recovery,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput;
+
+impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        match self.state {
+            (
+                _,
+                _,
+                ref mut
+                primary_role_withdraw_badge_attempt_state @ PrimaryRoleBadgeWithdrawAttemptState::NoBadgeWithdrawAttempt,
+                _,
+                _,
+            ) => {
+                // Transition the primary role withdraw attempt state to withdraw attempt
+                *primary_role_withdraw_badge_attempt_state = PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt;
+                Ok(())
             }
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::BadgeWithdrawAttemptAlreadyExistsForProposer {
+                        proposer: Proposer::Primary,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput;
+
+impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        api: &mut Y,
+        _input: AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        match self.state {
+            (
+                _,
+                _,
+                _,
+                _,
+                ref mut recovery_role_badge_withdraw_attempt_state @ RecoveryRoleBadgeWithdrawAttemptState::NoBadgeWithdrawAttempt,
+            ) => match self.timed_recovery_delay_in_minutes {
+                Some(delay_in_minutes) => {
+                    let current_time = Runtime::sys_current_time(api, TimePrecision::Minute)?;
+                    let timed_recovery_allowed_after = current_time
+                        .add_minutes(delay_in_minutes as i64)
+                        .map_or(access_controller_runtime_error!(TimeOverflow), |instant| {
+                            Ok(instant)
+                        })?;
+
+                    *recovery_role_badge_withdraw_attempt_state = RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                        RecoveryRoleWithdrawBadgeState::TimedWithdraw {
+                            timed_recovery_allowed_after,
+                        },
+                    );
+                    Ok(())
+                }
+                None => {
+                    *recovery_role_badge_withdraw_attempt_state = RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                        RecoveryRoleWithdrawBadgeState::UntimedWithdraw,
+                    );
+                    Ok(())
+                }
+            },
             _ => Err(RuntimeError::ApplicationError(
                 ApplicationError::AccessControllerError(
                     AccessControllerError::RecoveryAlreadyExistsForProposer {
@@ -176,7 +287,7 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalStateM
         Y: ClientApi<RuntimeError>,
     {
         match self.state {
-            (_, PrimaryOperationState::Recovery(ref proposal), _) => {
+            (_, PrimaryRoleRecoveryAttemptState::RecoveryAttempt(ref proposal), _, _, _) => {
                 let proposal = proposal.clone();
 
                 // Ensure that the caller has passed in the expected proposal
@@ -218,10 +329,12 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalState
             (
                 _,
                 _,
-                RecoveryOperationState::Recovery(
-                    RecoveryRecoveryState::Untimed(ref proposal)
-                    | RecoveryRecoveryState::Timed { ref proposal, .. },
+                _,
+                RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                    RecoveryRoleRecoveryState::UntimedRecovery(ref proposal)
+                    | RecoveryRoleRecoveryState::TimedRecovery { ref proposal, .. },
                 ),
+                _,
             ) => {
                 let proposal = proposal.clone();
 
@@ -235,6 +348,79 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalState
             _ => Err(RuntimeError::ApplicationError(
                 ApplicationError::AccessControllerError(
                     AccessControllerError::NoRecoveryExistsForProposer {
+                        proposer: Proposer::Recovery,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        match self.state {
+            (_, _, PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt, _, _) => {
+                // Transition back to the initial state of the state machine
+                self.state = Default::default();
+                Ok(())
+            }
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::NoBadgeWithdrawAttemptExistsForProposer {
+                        proposer: Proposer::Primary,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        match self.state {
+            (
+                _,
+                _,
+                _,
+                _,
+                RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                    RecoveryRoleWithdrawBadgeState::UntimedWithdraw
+                    | RecoveryRoleWithdrawBadgeState::TimedWithdraw { .. },
+                ),
+            ) => {
+                // Transition back to the initial state of the state machine
+                self.state = Default::default();
+                Ok(())
+            }
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::NoBadgeWithdrawAttemptExistsForProposer {
                         proposer: Proposer::Recovery,
                     },
                 ),
@@ -267,10 +453,14 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
             (
                 _,
                 _,
-                RecoveryOperationState::Recovery(RecoveryRecoveryState::Timed {
-                    ref proposal,
-                    ref timed_recovery_allowed_after,
-                }),
+                _,
+                RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                    RecoveryRoleRecoveryState::TimedRecovery {
+                        ref proposal,
+                        ref timed_recovery_allowed_after,
+                    },
+                ),
+                _,
             ) => {
                 let proposal = proposal.clone();
 
@@ -299,6 +489,58 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
     }
 }
 
+pub(super) struct AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        api: &mut Y,
+        _input: AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        // Timed confirm recovery can only be performed by the recovery role (this is checked
+        // through access rules on the invocation itself) and can be performed in recovery mode
+        // regardless of whether primary is locked or unlocked.
+        match self.state {
+            (
+                _,
+                _,
+                _,
+                _,
+                RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                    RecoveryRoleWithdrawBadgeState::TimedWithdraw {
+                        ref timed_recovery_allowed_after,
+                    },
+                ),
+            ) => {
+                let recovery_time_has_elapsed = Runtime::sys_compare_against_current_time(
+                    api,
+                    timed_recovery_allowed_after.clone(),
+                    TimePrecision::Minute,
+                    TimeComparisonOperator::Gte,
+                )?;
+
+                // If the timed recovery delay has elapsed, then we transition into normal
+                // operations mode with primary unlocked and return the ruleset that was found.
+                if !recovery_time_has_elapsed {
+                    access_controller_runtime_error!(TimedRecoveryDelayHasNotElapsed)
+                } else {
+                    self.state = Default::default();
+
+                    Ok(())
+                }
+            }
+            _ => access_controller_runtime_error!(NoTimedBadgeWithdrawAttemptsFound),
+        }
+    }
+}
+
 pub(super) struct AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput;
 
 impl TransitionMut<AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput>
@@ -317,9 +559,9 @@ impl TransitionMut<AccessControllerCancelPrimaryRoleRecoveryProposalStateMachine
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
-            (_, PrimaryOperationState::Recovery(..), _) => {
+            (_, PrimaryRoleRecoveryAttemptState::RecoveryAttempt(..), _, _, _) => {
                 // Transition from the recovery state to the normal operations state
-                self.state.1 = PrimaryOperationState::Normal;
+                self.state.1 = PrimaryRoleRecoveryAttemptState::NoRecoveryAttempt;
                 Ok(())
             }
             _ => Err(RuntimeError::ApplicationError(
@@ -351,14 +593,82 @@ impl TransitionMut<AccessControllerCancelRecoveryRoleRecoveryProposalStateMachin
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
-            (_, _, RecoveryOperationState::Recovery(..)) => {
+            (_, _, _, RecoveryRoleRecoveryAttemptState::RecoveryAttempt(..), _) => {
                 // Transition from the recovery state to the normal operations state
-                self.state.2 = RecoveryOperationState::Normal;
+                self.state.3 = RecoveryRoleRecoveryAttemptState::NoRecoveryAttempt;
                 Ok(())
             }
             _ => Err(RuntimeError::ApplicationError(
                 ApplicationError::AccessControllerError(
                     AccessControllerError::NoRecoveryExistsForProposer {
+                        proposer: Proposer::Recovery,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        // A badge withdraw attempt can only be canceled when it exists regardless of whether
+        // primary is locked or unlocked
+        match self.state {
+            (_, _, PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt, _, _) => {
+                // Transition from the recovery state to the normal operations state
+                self.state.2 = PrimaryRoleBadgeWithdrawAttemptState::NoBadgeWithdrawAttempt;
+                Ok(())
+            }
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::NoBadgeWithdrawAttemptExistsForProposer {
+                        proposer: Proposer::Primary,
+                    },
+                ),
+            )),
+        }
+    }
+}
+
+pub(super) struct AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        // A badge withdraw attempt can only be canceled when it exists regardless of whether
+        // primary is locked or unlocked
+        match self.state {
+            (_, _, _, _, RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(..)) => {
+                // Transition from the recovery state to the normal operations state
+                self.state.4 = RecoveryRoleBadgeWithdrawAttemptState::NoBadgeWithdrawAttempt;
+                Ok(())
+            }
+            _ => Err(RuntimeError::ApplicationError(
+                ApplicationError::AccessControllerError(
+                    AccessControllerError::NoBadgeWithdrawAttemptExistsForProposer {
                         proposer: Proposer::Recovery,
                     },
                 ),
@@ -382,8 +692,8 @@ impl TransitionMut<AccessControllerLockPrimaryRoleStateMachineInput> for AccessC
     {
         // Primary can only be locked when it's unlocked
         match self.state {
-            (ref mut primary_state @ PrimaryRoleState::Unlocked, _, _) => {
-                *primary_state = PrimaryRoleState::Locked;
+            (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Unlocked, ..) => {
+                *primary_role_locking_state = PrimaryRoleLockingState::Locked;
                 Ok(())
             }
             _ => Ok(()),
@@ -408,8 +718,8 @@ impl TransitionMut<AccessControllerUnlockPrimaryRoleStateMachineInput>
     {
         // Primary can only be unlocked when it's locked
         match self.state {
-            (ref mut primary_state @ PrimaryRoleState::Locked, _, _) => {
-                *primary_state = PrimaryRoleState::Unlocked;
+            (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Locked, ..) => {
+                *primary_role_locking_state = PrimaryRoleLockingState::Unlocked;
                 Ok(())
             }
             _ => Ok(()),
@@ -440,22 +750,64 @@ impl TransitionMut<AccessControllerStopTimedRecoveryStateMachineInput>
             (
                 _,
                 _,
-                RecoveryOperationState::Recovery(RecoveryRecoveryState::Timed {
-                    ref proposal, ..
-                }),
+                _,
+                RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                    RecoveryRoleRecoveryState::TimedRecovery { ref proposal, .. },
+                ),
+                _,
             ) => {
                 // Ensure that the caller has passed in the expected proposal
                 validate_recovery_proposal(&proposal, &input.proposal)?;
 
                 // Transition from timed recovery to untimed recovery
-                self.state.2 = RecoveryOperationState::Recovery(RecoveryRecoveryState::Untimed(
-                    proposal.clone(),
-                ));
+                self.state.3 = RecoveryRoleRecoveryAttemptState::RecoveryAttempt(
+                    RecoveryRoleRecoveryState::UntimedRecovery(proposal.clone()),
+                );
 
                 Ok(())
             }
             // TODO: A more descriptive error is needed here.
             _ => access_controller_runtime_error!(NoTimedRecoveriesFound),
+        }
+    }
+}
+
+pub(super) struct AccessControllerStopBadgeWithdrawAttemptStateMachineInput;
+
+impl TransitionMut<AccessControllerStopBadgeWithdrawAttemptStateMachineInput>
+    for AccessControllerSubstate
+{
+    type Output = ();
+
+    fn transition_mut<Y>(
+        &mut self,
+        _api: &mut Y,
+        _input: AccessControllerStopBadgeWithdrawAttemptStateMachineInput,
+    ) -> Result<Self::Output, RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        // We can only stop the timed recovery timer if we're in recovery mode. It doesn't matter
+        // if primary is locked or unlocked
+        match self.state {
+            (
+                _,
+                _,
+                _,
+                _,
+                RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                    RecoveryRoleWithdrawBadgeState::TimedWithdraw { .. },
+                ),
+            ) => {
+                // Transition from timed recovery to untimed recovery
+                self.state.4 = RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt(
+                    RecoveryRoleWithdrawBadgeState::UntimedWithdraw,
+                );
+
+                Ok(())
+            }
+            // TODO: A more descriptive error is needed here.
+            _ => access_controller_runtime_error!(NoTimedBadgeWithdrawAttemptsFound),
         }
     }
 }

--- a/radix-engine/src/blueprints/access_controller/state_machine.rs
+++ b/radix-engine/src/blueprints/access_controller/state_machine.rs
@@ -361,11 +361,11 @@ pub(super) struct AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptSta
 impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput>
     for AccessControllerSubstate
 {
-    type Output = ();
+    type Output = Bucket;
 
     fn transition_mut<Y>(
         &mut self,
-        _api: &mut Y,
+        api: &mut Y,
         _input: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
     ) -> Result<Self::Output, RuntimeError>
     where
@@ -375,7 +375,7 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptSt
             (_, _, PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt, _, _) => {
                 // Transition back to the initial state of the state machine
                 self.state = Default::default();
-                Ok(())
+                Vault(self.controlled_asset).sys_take_all(api)
             }
             _ => Err(RuntimeError::ApplicationError(
                 ApplicationError::AccessControllerError(
@@ -393,11 +393,11 @@ pub(super) struct AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptSt
 impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput>
     for AccessControllerSubstate
 {
-    type Output = ();
+    type Output = Bucket;
 
     fn transition_mut<Y>(
         &mut self,
-        _api: &mut Y,
+        api: &mut Y,
         _input: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
     ) -> Result<Self::Output, RuntimeError>
     where
@@ -416,7 +416,7 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptS
             ) => {
                 // Transition back to the initial state of the state machine
                 self.state = Default::default();
-                Ok(())
+                Vault(self.controlled_asset).sys_take_all(api)
             }
             _ => Err(RuntimeError::ApplicationError(
                 ApplicationError::AccessControllerError(
@@ -494,7 +494,7 @@ pub(super) struct AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineIn
 impl TransitionMut<AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineInput>
     for AccessControllerSubstate
 {
-    type Output = ();
+    type Output = Bucket;
 
     fn transition_mut<Y>(
         &mut self,
@@ -533,7 +533,7 @@ impl TransitionMut<AccessControllerTimedConfirmBadgeWithdrawAttemptStateMachineI
                 } else {
                     self.state = Default::default();
 
-                    Ok(())
+                    Vault(self.controlled_asset).sys_take_all(api)
                 }
             }
             _ => access_controller_runtime_error!(NoTimedBadgeWithdrawAttemptsFound),
@@ -772,9 +772,9 @@ impl TransitionMut<AccessControllerStopTimedRecoveryStateMachineInput>
     }
 }
 
-pub(super) struct AccessControllerStopBadgeWithdrawAttemptStateMachineInput;
+pub(super) struct AccessControllerStopTimedBadgeWithdrawAttemptStateMachineInput;
 
-impl TransitionMut<AccessControllerStopBadgeWithdrawAttemptStateMachineInput>
+impl TransitionMut<AccessControllerStopTimedBadgeWithdrawAttemptStateMachineInput>
     for AccessControllerSubstate
 {
     type Output = ();
@@ -782,7 +782,7 @@ impl TransitionMut<AccessControllerStopBadgeWithdrawAttemptStateMachineInput>
     fn transition_mut<Y>(
         &mut self,
         _api: &mut Y,
-        _input: AccessControllerStopBadgeWithdrawAttemptStateMachineInput,
+        _input: AccessControllerStopTimedBadgeWithdrawAttemptStateMachineInput,
     ) -> Result<Self::Output, RuntimeError>
     where
         Y: ClientApi<RuntimeError>,


### PR DESCRIPTION
## Summary

This PR adds the ability for the badge(s) stored in the access controller to be withdrawn. The process of withdrawing it is the same as the recovery process: it must be initiated by one role and confirmed by another role. A difference between badge withdraw and recovery is that badge withdraw can't be "timed" confirmed (i.e., can't just be confirmed after some amount of time has passed)