### PR TITLE
Fix worktop drop vulnerability 

### DIFF
--- a/native-sdk/src/resource/worktop.rs
+++ b/native-sdk/src/resource/worktop.rs
@@ -26,7 +26,10 @@ impl Worktop {
             RESOURCE_MANAGER_PACKAGE,
             WORKTOP_BLUEPRINT,
             WORKTOP_DROP_IDENT,
-            scrypto_encode(&WorktopDropInput { worktop: self.0 }).unwrap(),
+            scrypto_encode(&WorktopDropInput {
+                worktop: OwnedWorktop(self.0),
+            })
+            .unwrap(),
         )?;
 
         Ok(())

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -15,6 +15,7 @@ strum = { version = "0.24", default-features = false, features = ["derive"] }
 bitflags = { version = "1.3" }
 serde_json = { version = "1.0", default-features = false }
 lazy_static = "1.4.0"
+const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
 
 [features]
 # You should enable either `std` or `alloc`

--- a/radix-engine-interface/src/blueprints/resource/worktop.rs
+++ b/radix-engine-interface/src/blueprints/resource/worktop.rs
@@ -1,9 +1,12 @@
 use crate::blueprints::resource::*;
+use crate::constants::RESOURCE_MANAGER_PACKAGE;
 use crate::data::scrypto::model::*;
 use crate::math::Decimal;
 use crate::*;
+use radix_engine_common::data::scrypto::*;
 use radix_engine_common::types::*;
 use sbor::rust::prelude::*;
+use sbor::*;
 
 pub const WORKTOP_BLUEPRINT: &str = "Worktop";
 
@@ -11,7 +14,31 @@ pub const WORKTOP_DROP_IDENT: &str = "Worktop_drop";
 
 #[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct WorktopDropInput {
-    pub worktop: Own,
+    pub worktop: OwnedWorktop,
+}
+
+#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[sbor(transparent)]
+pub struct OwnedWorktop(pub Own);
+
+impl Describe<ScryptoCustomTypeKind> for OwnedWorktop {
+    const TYPE_ID: GlobalTypeId =
+        GlobalTypeId::Novel(const_sha1::sha1("OwnedWorktop".as_bytes()).as_bytes());
+
+    fn type_data() -> Option<TypeData<ScryptoCustomTypeKind, GlobalTypeId>> {
+        Some(TypeData {
+            kind: TypeKind::Custom(ScryptoCustomTypeKind::Own),
+            metadata: TypeMetadata::no_child_names("OwnedWorktop"),
+            validation: TypeValidation::Custom(ScryptoCustomTypeValidation::Own(
+                OwnValidation::IsTypedObject(
+                    RESOURCE_MANAGER_PACKAGE,
+                    WORKTOP_BLUEPRINT.to_string(),
+                ),
+            )),
+        })
+    }
+
+    fn add_all_dependencies(_aggregator: &mut TypeAggregator<ScryptoCustomTypeKind>) {}
 }
 
 pub type WorktopDropOutput = ();

--- a/radix-engine-tests/tests/own.rs
+++ b/radix-engine-tests/tests/own.rs
@@ -1,0 +1,36 @@
+use radix_engine::types::*;
+use radix_engine_interface::blueprints::resource::FromPublicKey;
+use scrypto::prelude::{WORKTOP_BLUEPRINT, WORKTOP_DROP_IDENT};
+use scrypto_unit::*;
+use transaction::builder::ManifestBuilder;
+
+#[test]
+fn mis_typed_own_passed_to_worktop_drop_function() {
+    // Basic setup
+    let mut test_runner = TestRunner::builder().build();
+    let (public_key, _, account) = test_runner.new_allocated_account();
+
+    // Instantiate component
+    let receipt = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee(account, 10u32.into())
+            .take_from_worktop_by_amount(Decimal::ZERO, RADIX_TOKEN, |builder, bucket| {
+                builder.call_function(
+                    RESOURCE_MANAGER_PACKAGE,
+                    WORKTOP_BLUEPRINT,
+                    WORKTOP_DROP_IDENT,
+                    manifest_args!(bucket),
+                )
+            })
+            .build(),
+        vec![NonFungibleGlobalId::from_public_key(&public_key)],
+    );
+
+    // Assert
+    let error_message = receipt
+        .expect_commit_failure()
+        .outcome
+        .expect_failure()
+        .to_string();
+    assert!(error_message.contains("InputSchemaNotMatch"))
+}

--- a/radix-engine/src/blueprints/resource/fungible/fungible_proof.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_proof.rs
@@ -131,8 +131,6 @@ impl FungibleProofBlueprint {
     where
         Y: ClientApi<RuntimeError>,
     {
-        // FIXME: check type before schema check is ready! applicable to all functions!
-
         let parent = api
             .get_object_info(proof.0.as_node_id())?
             .outer_object

--- a/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
@@ -204,8 +204,6 @@ impl FungibleVaultBlueprint {
     // Protected method
     //===================
 
-    // FIXME: set up auth
-
     pub fn lock_amount<Y>(
         receiver: &NodeId,
         amount: Decimal,

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_proof.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_proof.rs
@@ -153,7 +153,6 @@ impl NonFungibleProofBlueprint {
     where
         Y: ClientApi<RuntimeError>,
     {
-        // FIXME: check type before schema check is ready! applicable to all functions!
         let parent = api
             .get_object_info(proof.0.as_node_id())?
             .outer_object

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
@@ -194,8 +194,6 @@ impl NonFungibleVaultBlueprint {
     // Protected method
     //===================
 
-    // FIXME: set up auth
-
     pub fn lock_non_fungibles<Y>(
         receiver: &NodeId,
         local_ids: BTreeSet<NonFungibleLocalId>,

--- a/radix-engine/src/blueprints/resource/worktop.rs
+++ b/radix-engine/src/blueprints/resource/worktop.rs
@@ -44,8 +44,6 @@ impl WorktopBlueprint {
             RuntimeError::SystemUpstreamError(SystemUpstreamError::InputDecodeError(e))
         })?;
 
-        // FIXME we must check the node type, before generic own schema validation is ready.
-
         let mut node_substates = api.kernel_drop_node(input.worktop.as_node_id())?;
         let substate = node_substates
             .remove(&SysModuleId::Object.into())

--- a/radix-engine/src/blueprints/resource/worktop.rs
+++ b/radix-engine/src/blueprints/resource/worktop.rs
@@ -44,7 +44,7 @@ impl WorktopBlueprint {
             RuntimeError::SystemUpstreamError(SystemUpstreamError::InputDecodeError(e))
         })?;
 
-        let mut node_substates = api.kernel_drop_node(input.worktop.as_node_id())?;
+        let mut node_substates = api.kernel_drop_node(input.worktop.0.as_node_id())?;
         let substate = node_substates
             .remove(&SysModuleId::Object.into())
             .unwrap()

--- a/radix-engine/src/track/track.rs
+++ b/radix-engine/src/track/track.rs
@@ -722,10 +722,11 @@ impl<'s, S: SubstateDatabase, M: DatabaseMapper> SubstateStore for Track<'s, S, 
 
                 let value = IndexedScryptoValue::from_vec(substate).unwrap();
 
-                // FIXME: This only works because only NonFungible Vaults use this.
-                // FIXME: Will need to fix this by maintaining the invariant that the value
-                // FIXME: of the index contains the key. Or alternatively, change the abstraction
-                // FIXME: from being a Map to a Set
+                // FIXME
+                // This only works because only NonFungible Vaults use this.
+                // Will need to fix this by maintaining the invariant that the value
+                // of the index contains the key. Or alternatively, change the abstraction
+                // from being a Map to a Set
                 let substate_key = SubstateKey::Map(value.as_slice().to_vec());
 
                 let tracked = TrackedSubstateKey {

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -911,6 +911,7 @@ name = "radix-engine-interface"
 version = "0.10.0"
 dependencies = [
  "bitflags",
+ "const-sha1",
  "hex",
  "lazy_static",
  "radix-engine-common",


### PR DESCRIPTION
## Summary

This PR fixes an issue with `Worktop::drop` function.

Without it, Radix Engine will panic when a mismatched `Own` is passed. 

Also checked how `Own`/`Reference` is used in substates and found no issue.