### PR TITLE
Feature: Add Scrypto KVStoreEntry lifetime

### DIFF
--- a/radix-engine-tests/tests/blueprints/kv_store/src/basic.rs
+++ b/radix-engine-tests/tests/blueprints/kv_store/src/basic.rs
@@ -36,8 +36,10 @@ mod basic {
             map.insert("hello".to_owned(), "hello".to_owned());
             let removed = map.remove(&"hello".to_owned());
             assert_eq!(removed, Option::Some("hello".to_owned()));
-            let maybe_entry = map.get(&"hello2".to_owned());
-            assert!(maybe_entry.is_none());
+            {
+                let maybe_entry = map.get(&"hello2".to_owned());
+                assert!(maybe_entry.is_none());
+            }
 
             Self { map }.instantiate().globalize()
         }

--- a/radix-engine-tests/tests/blueprints/kv_store/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/kv_store/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod basic;
 pub mod cyclic_map;
 pub mod kv_store;
+pub mod nested_kv_stores;
 pub mod precommitted;
 pub mod ref_check;
 pub mod super_kv_store;

--- a/radix-engine-tests/tests/blueprints/kv_store/src/nested_kv_stores.rs
+++ b/radix-engine-tests/tests/blueprints/kv_store/src/nested_kv_stores.rs
@@ -1,0 +1,27 @@
+use scrypto::prelude::*;
+
+#[blueprint]
+mod nested_kv_stores {
+    struct NestedKvStores {
+        counters: KeyValueStore<String, KeyValueStore<String, u64>>,
+    }
+
+    impl NestedKvStores {
+        pub fn instantiate() -> ComponentAddress {
+            let mut counters = KeyValueStore::<String, KeyValueStore<String, u64>>::new();
+            counters.insert("A".into(), {
+                let kv_store = KeyValueStore::new();
+                kv_store.insert("A1".into(), 0);
+                kv_store
+            });
+
+            {
+                let mut inner_map = counters.get_mut(&String::from("A")).unwrap();
+                let mut value = inner_map.get_mut(&"A1".into()).unwrap();
+                *value += 1;
+            }
+
+            Self { counters }.instantiate().globalize()
+        }
+    }
+}

--- a/radix-engine-tests/tests/kv_store.rs
+++ b/radix-engine-tests/tests/kv_store.rs
@@ -499,3 +499,25 @@ fn remove_from_stored_map_when_contain_vault_should_not_work() {
         )
     });
 }
+
+#[test]
+fn nested_kv_stores_works() {
+    // Arrange
+    let mut test_runner = TestRunner::builder().build();
+    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .lock_fee(test_runner.faucet_component(), 10.into())
+        .call_function(
+            package_address,
+            "NestedKvStores",
+            "instantiate",
+            manifest_args!(),
+        )
+        .build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_commit_success();
+}


### PR DESCRIPTION
## Summary
Add lifetimes to scrypto kv_store so that it forces user to drop map entry before moving map

## Details
There currently exists a problem where locked kv entries to an unowned kv_store do not have their lifetime linked with the kv_store so it was possible in Scrypto to move the KVStore before the entries were unlocked. Radix Engine notices this though and causes an error.

This PR adds a lifetime to the kv_entry so that scrypto compilation will complain if the entry is not dropped before moving the KVStore.

## Update Recommendations

### For Dapp Developers
Users of KeyValueStore entries must now drop the entry (e.g. by scoping the entry with brackets) if they would like to move the KeyValueStore afterwards.