### PR TITLE
tweak: Fix up typed_substate_layout for partitions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ You can delete this section if it's not useful.
 INSTRUCTIONS:
 This section is to provide recommendations to consumers of this repo about how they
 should handle breaking changes, or integrate new features. The two key stakeholder
-groups are DApp Developers and Internal Integrators, and there are separate sections
+groups are dApp Developers and Internal Integrators, and there are separate sections
 for each.
 
 In order to allow us to compile aggregated update instructions across PRs, please tag the PR
@@ -44,10 +44,10 @@ If your PR contains no breaking changes or new features or hasn't been tagged, t
 section can be deleted.
 ```
 
-### For Dapp Developers
+### For dApp Developers
 ```
 INSTRUCTIONS:
-Migration recommendations for a Dapp developer to update their Dapp/integrations
+Migration recommendations for a dApp developer to update their dApp/integrations
 due to to the change/s in this PR.
 
 These will be aggregated by the Developer Ecosystem team and included in the next Scrypto migration guide

--- a/radix-engine-common/src/address/hrpset.rs
+++ b/radix-engine-common/src/address/hrpset.rs
@@ -18,8 +18,6 @@ pub struct HrpSet {
     internal_account: String,
     internal_component: String,
     internal_key_value_store: String,
-    internal_index: String,
-    internal_sorted_index: String,
 }
 
 impl HrpSet {
@@ -44,8 +42,6 @@ impl HrpSet {
             EntityType::InternalAccount => &self.internal_account,
             EntityType::InternalGenericComponent => &self.internal_component,
             EntityType::InternalKeyValueStore => &self.internal_key_value_store,
-            EntityType::InternalIndex => &self.internal_index,
-            EntityType::InternalSortedIndex => &self.internal_sorted_index,
         }
     }
 }
@@ -67,8 +63,6 @@ impl From<&NetworkDefinition> for HrpSet {
             internal_account: format!("internal_account_{}", suffix),
             internal_component: format!("internal_component_{}", suffix),
             internal_key_value_store: format!("internal_keyvaluestore_{}", suffix),
-            internal_index: format!("internal_index_{}", suffix),
-            internal_sorted_index: format!("internal_sortedindex_{}", suffix),
         }
     }
 }

--- a/radix-engine-common/src/native_addresses.rs
+++ b/radix-engine-common/src/native_addresses.rs
@@ -62,16 +62,15 @@ pub const GLOBAL_CALLER_VIRTUAL_BADGE: ResourceAddress = ResourceAddress::new_or
 // TRANSACTION BADGES
 //=========================================================================
 
-/// The non-fungible badge resource which is used for virtual proofs representing the fact that the current transaction is a system transaction.
+/// The non-fungible badge resource which is used for virtual proofs representing the fact that the current transaction is
+/// a system transaction.
+///
+/// The following ids have meanings:
+/// * `0` is used to represent a full-authority system transaction such as genesis, or a protocol update
+/// * `1` is used to represent a consensus-authrority transaction, such as a round change
 pub const SYSTEM_TRANSACTION_BADGE: ResourceAddress = ResourceAddress::new_or_panic([
     154, 76, 99, 24, 198, 49, 140, 104, 18, 11, 52, 204, 99, 24, 198, 49, 140, 247, 171, 71, 140,
     85, 71, 199, 198, 49, 140, 99, 24, 198,
-]);
-
-/// The non-fungible badge resource which is used for virtual proofs representing the fact that the current transaction is a consensus/validator transaction.
-pub const CONSENSUS_TRANSACTION_BADGE: ResourceAddress = ResourceAddress::new_or_panic([
-    154, 76, 99, 24, 198, 49, 140, 108, 78, 11, 52, 204, 99, 24, 198, 49, 140, 247, 189, 90, 122,
-    171, 74, 81, 70, 49, 140, 99, 24, 198,
 ]);
 
 //=========================================================================
@@ -266,11 +265,6 @@ mod tests {
             SYSTEM_TRANSACTION_BADGE.as_ref(),
             EntityType::GlobalNonFungibleResource,
             "resource_rdx1nfxxxxxxxxxxsystxnxxxxxxxxx002683325037xxxxxxxxxsystxn",
-        );
-        check_address(
-            CONSENSUS_TRANSACTION_BADGE.as_ref(),
-            EntityType::GlobalNonFungibleResource,
-            "resource_rdx1nfxxxxxxxxxxcnstxnxxxxxxxxx000260245552xxxxxxxxxcnstxn",
         );
 
         // Entity owner badges

--- a/radix-engine-common/src/types/entity_type.rs
+++ b/radix-engine-common/src/types/entity_type.rs
@@ -95,18 +95,6 @@ pub enum EntityType {
     /// A key value store allows access to substates, but not on-ledger iteration.
     /// The substates are considered independent for contention/locking/versioning.
     InternalKeyValueStore = 0b10110000, //----------- 10110 => k, 000xx => qpzr
-
-    /// An internal index entity (177 in decimal). Gives Bech32 prefix: `k` followed by one of `q`, `p`, `z` or `r`.
-    ///
-    /// An index allows access to substates, and on-ledger iteration (ordered by key hash).
-    /// The whole index is considered a single unit for contention/locking/versioning.
-    InternalIndex = 0b10110001, //------------------- 10110 => k, 001xx => y9x8
-
-    /// An internal sorted index entity (178 in decimal). Gives Bech32 prefix: `k` followed by one of `q`, `p`, `z` or `r`.
-    ///
-    /// An index allows access to substates, and on-ledger iteration (ordered by `prefix_u16 || key_hash`).
-    /// The whole index is considered a single unit for contention/locking/versioning.
-    InternalSortedIndex = 0b10110010, //------------- 10110 => k, 010xx => gf2t
 }
 
 impl EntityType {
@@ -130,9 +118,7 @@ impl EntityType {
             | EntityType::InternalNonFungibleVault
             | EntityType::InternalAccount
             | EntityType::InternalGenericComponent
-            | EntityType::InternalKeyValueStore
-            | EntityType::InternalIndex
-            | EntityType::InternalSortedIndex => false,
+            | EntityType::InternalKeyValueStore => false,
         }
     }
 
@@ -160,9 +146,7 @@ impl EntityType {
             | EntityType::InternalNonFungibleVault
             | EntityType::InternalAccount
             | EntityType::InternalGenericComponent
-            | EntityType::InternalKeyValueStore
-            | EntityType::InternalIndex
-            | EntityType::InternalSortedIndex => false,
+            | EntityType::InternalKeyValueStore => false,
         }
     }
 

--- a/radix-engine-interface/src/api/actor_key_value_entry_api.rs
+++ b/radix-engine-interface/src/api/actor_key_value_entry_api.rs
@@ -5,6 +5,7 @@ use sbor::rust::fmt::Debug;
 use sbor::rust::vec::Vec;
 
 pub trait ClientActorKeyValueEntryApi<E: Debug> {
+    /// If the key value entry doesn't exist, it uses the default "Option::None"
     fn actor_lock_key_value_entry(
         &mut self,
         object_handle: ObjectHandle,

--- a/radix-engine-interface/src/types/node_layout.rs
+++ b/radix-engine-interface/src/types/node_layout.rs
@@ -110,7 +110,7 @@ pub enum NonFungibleVaultField {
 #[derive(Debug, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord, FromRepr)]
 pub enum EpochManagerPartitionOffset {
     EpochManager,
-    SecondaryIndex,
+    RegisteredValidatorsByStakeIndex,
 }
 
 impl TryFrom<u8> for EpochManagerPartitionOffset {

--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -20,25 +20,21 @@ pub use radix_engine::system::node_modules::type_info::*;
 // Core API of the node.
 //
 // Specifically:
-// * Every (EntityType, SysModuleId, SubstateKey) should be mappable into a `TypedSubstateKey`
-// * Every (&TypedSubstateKey, Data) should be mappable into a `WellKnownSubstateData`
+// * Every (EntityType, PartitionNumber, SubstateKey) should be mappable into a `TypedSubstateKey`
+// * Every (&TypedSubstateKey, Data) should be mappable into a `TypedSubstateValue`
 //
 // Please keep them these in-line with the well-known objects, and please don't
 // remove these without talking to the Network team.
 //=========================================================================
 
 //=========================================================================
-// TODO - move this to a relevant REP when it's been created
+// A partition can be in one of four types:
 //
-// BACKGROUND:
-// A generic Object SysModule consists of 0 or more DbModules, each with a u8 "ModuleId".
-//
-// These modules are one of four types:
-// - Tuple
+// - Field
 //   => Has key: TupleKey(u8) also known as an offset
 //   => No iteration exposed to engine
 //   => Is versioned / locked substate-by-substate
-// - ConcurrentMap
+// - KeyValue ("ConcurrentMap")
 //   => Has key: MapKey(Vec<u8>)
 //   => No iteration exposed to engine
 //   => Is versioned / locked substate-by-substate
@@ -46,31 +42,31 @@ pub use radix_engine::system::node_modules::type_info::*;
 //   => Has key: MapKey(Vec<u8>)
 //   => Iteration exposed to engine via the MapKey's database key (ie hash of the key)
 //   => Is versioned / locked in its entirety
-// - SortedU16Index(SortedU16Key(U16, Vec<u8>))
-//   => Has key: MapKey(Vec<u8>)
+// - SortedU16Index
+//   => Has key: SortedU16Key(U16, Vec<u8>)
 //   => Iteration exposed to engine via the user-controlled U16 prefix and then the MapKey's database key (ie hash of the key)
 //   => Is versioned / locked in its entirety
 //
 // But in this file, we just handle explicitly supported/possible combinations of things.
 //
-// An entirely generic capturing of a substate type would look something like this:
+// An entirely generic capturing of a substate key for a given node partition would look something like this:
 //
-// pub enum GenericObjectModuleSubstateType {
-//    Tuple(ModuleId, TupleKey),
-//    ConcurrentMap(ModuleId, MapKey),
-//    Index(ModuleId, MapKey),
-//    SortedU16Index(ModuleId, SortedU16Key),
+// pub enum GenericModuleSubstateKey {
+//    Field(TupleKey),
+//    KeyValue(MapKey),
+//    Index(MapKey),
+//    SortedU16Index(SortedU16Key),
 // }
 //=========================================================================
 
 /// By node module (roughly SysModule)
 #[derive(Debug, Clone)]
 pub enum TypedSubstateKey {
-    TypeInfoModule(TypeInfoField),
-    AccessRulesModule(AccessRulesField),
-    RoyaltyModule(RoyaltyField),
-    MetadataModule(String),
-    ObjectModule(TypedObjectModuleSubstateKey),
+    TypeInfoModuleField(TypeInfoField),
+    AccessRulesModuleField(AccessRulesField),
+    RoyaltyModuleField(RoyaltyField),
+    MetadataModuleEntryKey(String),
+    MainModule(TypedMainModuleSubstateKey),
 }
 
 impl TypedSubstateKey {
@@ -79,10 +75,10 @@ impl TypedSubstateKey {
     /// Just a work around for now to filter out "transient" substates we shouldn't really be storing.
     pub fn value_is_mappable(&self) -> bool {
         match self {
-            TypedSubstateKey::ObjectModule(TypedObjectModuleSubstateKey::NonFungibleVault(
+            TypedSubstateKey::MainModule(TypedMainModuleSubstateKey::NonFungibleVaultField(
                 NonFungibleVaultField::LockedNonFungible,
             )) => false,
-            TypedSubstateKey::ObjectModule(TypedObjectModuleSubstateKey::FungibleVault(
+            TypedSubstateKey::MainModule(TypedMainModuleSubstateKey::FungibleVaultField(
                 FungibleVaultField::LockedFungible,
             )) => false,
             _ => true,
@@ -92,25 +88,25 @@ impl TypedSubstateKey {
 
 /// Doesn't include non-object modules, nor transient nodes.
 #[derive(Debug, Clone)]
-pub enum TypedObjectModuleSubstateKey {
+pub enum TypedMainModuleSubstateKey {
     // Objects
-    Package(PackageField),
-    FungibleResource(FungibleResourceManagerField),
+    PackageField(PackageField),
+    FungibleResourceField(FungibleResourceManagerField),
     NonFungibleResourceField(NonFungibleResourceManagerField),
     NonFungibleResourceData(NonFungibleLocalId),
-    FungibleVault(FungibleVaultField),
-    NonFungibleVault(NonFungibleVaultField),
-    NonFungibleVaultContentsIndex(NonFungibleLocalId),
+    FungibleVaultField(FungibleVaultField),
+    NonFungibleVaultField(NonFungibleVaultField),
+    NonFungibleVaultContentsIndexKey(NonFungibleLocalId),
     EpochManagerField(EpochManagerField),
-    EpochManagerRegisteredValidatorsByStakeIndex(ValidatorByStakeKey),
-    Clock(ClockField),
-    Validator(ValidatorField),
-    AccountVaultIndex(ResourceAddress),
-    AccessController(AccessControllerField),
+    EpochManagerRegisteredValidatorsByStakeIndexKey(ValidatorByStakeKey),
+    ClockField(ClockField),
+    ValidatorField(ValidatorField),
+    AccountVaultIndexKey(ResourceAddress),
+    AccessControllerField(AccessControllerField),
     // Generic Scrypto Components
-    GenericScryptoComponent(ComponentField),
+    GenericScryptoComponentField(ComponentField),
     // Substates for Generic KV Stores
-    GenericKeyValueStore(MapKey),
+    GenericKeyValueStoreKey(MapKey),
 }
 
 #[derive(Debug, Clone, ScryptoSbor)]
@@ -141,10 +137,10 @@ pub fn to_typed_substate_key(
     substate_key: &SubstateKey,
 ) -> Result<TypedSubstateKey, String> {
     let substate_type = match partition_num {
-        TYPE_INFO_FIELD_PARTITION => TypedSubstateKey::TypeInfoModule(
+        TYPE_INFO_FIELD_PARTITION => TypedSubstateKey::TypeInfoModuleField(
             TypeInfoField::try_from(substate_key).map_err(|_| error("TypeInfoOffset"))?,
         ),
-        METADATA_KV_STORE_PARTITION => TypedSubstateKey::MetadataModule(
+        METADATA_KV_STORE_PARTITION => TypedSubstateKey::MetadataModuleEntryKey(
             scrypto_decode(
                 substate_key
                     .for_map()
@@ -152,14 +148,14 @@ pub fn to_typed_substate_key(
             )
             .map_err(|_| error("string Metadata key"))?,
         ),
-        ROYALTY_FIELD_PARTITION => TypedSubstateKey::RoyaltyModule(
+        ROYALTY_FIELD_PARTITION => TypedSubstateKey::RoyaltyModuleField(
             RoyaltyField::try_from(substate_key).map_err(|_| error("RoyaltyOffset"))?,
         ),
-        ACCESS_RULES_FIELD_PARTITION => TypedSubstateKey::AccessRulesModule(
+        ACCESS_RULES_FIELD_PARTITION => TypedSubstateKey::AccessRulesModuleField(
             AccessRulesField::try_from(substate_key).map_err(|_| error("AccessRulesOffset"))?,
         ),
         partition_num @ _ if partition_num >= OBJECT_BASE_PARTITION => {
-            TypedSubstateKey::ObjectModule(to_typed_object_module_substate_key(
+            TypedSubstateKey::MainModule(to_typed_object_module_substate_key(
                 entity_type,
                 partition_num.0 - OBJECT_BASE_PARTITION.0,
                 substate_key,
@@ -174,7 +170,7 @@ pub fn to_typed_object_module_substate_key(
     entity_type: EntityType,
     partition_offset: u8,
     substate_key: &SubstateKey,
-) -> Result<TypedObjectModuleSubstateKey, String> {
+) -> Result<TypedMainModuleSubstateKey, String> {
     return to_typed_object_substate_key_internal(entity_type, partition_offset, substate_key)
         .map_err(|_| {
             format!(
@@ -188,17 +184,17 @@ fn to_typed_object_substate_key_internal(
     entity_type: EntityType,
     partition_offset: u8,
     substate_key: &SubstateKey,
-) -> Result<TypedObjectModuleSubstateKey, ()> {
+) -> Result<TypedMainModuleSubstateKey, ()> {
     let substate_type = match entity_type {
         EntityType::InternalGenericComponent | EntityType::GlobalGenericComponent => {
-            TypedObjectModuleSubstateKey::GenericScryptoComponent(ComponentField::try_from(
+            TypedMainModuleSubstateKey::GenericScryptoComponentField(ComponentField::try_from(
                 substate_key,
             )?)
         }
         EntityType::GlobalPackage => {
-            TypedObjectModuleSubstateKey::Package(PackageField::try_from(substate_key)?)
+            TypedMainModuleSubstateKey::PackageField(PackageField::try_from(substate_key)?)
         }
-        EntityType::GlobalFungibleResource => TypedObjectModuleSubstateKey::FungibleResource(
+        EntityType::GlobalFungibleResource => TypedMainModuleSubstateKey::FungibleResourceField(
             FungibleResourceManagerField::try_from(substate_key)?,
         ),
         EntityType::GlobalNonFungibleResource => {
@@ -206,13 +202,13 @@ fn to_typed_object_substate_key_internal(
                 NonFungibleResourceManagerPartitionOffset::try_from(partition_offset)?;
             match partition_offset {
                 NonFungibleResourceManagerPartitionOffset::ResourceManager => {
-                    TypedObjectModuleSubstateKey::NonFungibleResourceField(
+                    TypedMainModuleSubstateKey::NonFungibleResourceField(
                         NonFungibleResourceManagerField::try_from(substate_key)?,
                     )
                 }
                 NonFungibleResourceManagerPartitionOffset::NonFungibleData => {
                     let key = substate_key.for_map().ok_or(())?;
-                    TypedObjectModuleSubstateKey::NonFungibleResourceData(
+                    TypedMainModuleSubstateKey::NonFungibleResourceData(
                         scrypto_decode(&key).map_err(|_| ())?,
                     )
                 }
@@ -222,25 +218,25 @@ fn to_typed_object_substate_key_internal(
             let partition_offset = EpochManagerPartitionOffset::try_from(partition_offset)?;
             match partition_offset {
                 EpochManagerPartitionOffset::EpochManager => {
-                    TypedObjectModuleSubstateKey::EpochManagerField(EpochManagerField::try_from(
+                    TypedMainModuleSubstateKey::EpochManagerField(EpochManagerField::try_from(
                         substate_key,
                     )?)
                 }
                 EpochManagerPartitionOffset::RegisteredValidatorsByStakeIndex => {
                     let key = substate_key.for_sorted().ok_or(())?;
-                    TypedObjectModuleSubstateKey::EpochManagerRegisteredValidatorsByStakeIndex(
+                    TypedMainModuleSubstateKey::EpochManagerRegisteredValidatorsByStakeIndexKey(
                         key.clone().try_into().map_err(|_| ())?,
                     )
                 }
             }
         }
         EntityType::GlobalValidator => {
-            TypedObjectModuleSubstateKey::Validator(ValidatorField::try_from(substate_key)?)
+            TypedMainModuleSubstateKey::ValidatorField(ValidatorField::try_from(substate_key)?)
         }
         EntityType::GlobalClock => {
-            TypedObjectModuleSubstateKey::Clock(ClockField::try_from(substate_key)?)
+            TypedMainModuleSubstateKey::ClockField(ClockField::try_from(substate_key)?)
         }
-        EntityType::GlobalAccessController => TypedObjectModuleSubstateKey::AccessController(
+        EntityType::GlobalAccessController => TypedMainModuleSubstateKey::AccessControllerField(
             AccessControllerField::try_from(substate_key)?,
         ),
         EntityType::GlobalVirtualSecp256k1Account
@@ -248,26 +244,26 @@ fn to_typed_object_substate_key_internal(
         | EntityType::InternalAccount
         | EntityType::GlobalAccount => {
             let key = substate_key.for_map().ok_or(())?;
-            TypedObjectModuleSubstateKey::AccountVaultIndex(scrypto_decode(&key).map_err(|_| ())?)
+            TypedMainModuleSubstateKey::AccountVaultIndexKey(scrypto_decode(&key).map_err(|_| ())?)
         }
         EntityType::GlobalVirtualSecp256k1Identity
         | EntityType::GlobalVirtualEd25519Identity
         | EntityType::GlobalIdentity => Err(())?, // Identity doesn't have any substates
-        EntityType::InternalFungibleVault => {
-            TypedObjectModuleSubstateKey::FungibleVault(FungibleVaultField::try_from(substate_key)?)
-        }
+        EntityType::InternalFungibleVault => TypedMainModuleSubstateKey::FungibleVaultField(
+            FungibleVaultField::try_from(substate_key)?,
+        ),
         EntityType::InternalNonFungibleVault => {
             let partition_offset = NonFungibleVaultPartitionOffset::try_from(partition_offset)?;
 
             match partition_offset {
                 NonFungibleVaultPartitionOffset::Balance => {
-                    TypedObjectModuleSubstateKey::NonFungibleVault(NonFungibleVaultField::try_from(
-                        substate_key,
-                    )?)
+                    TypedMainModuleSubstateKey::NonFungibleVaultField(
+                        NonFungibleVaultField::try_from(substate_key)?,
+                    )
                 }
                 NonFungibleVaultPartitionOffset::NonFungibles => {
                     let key = substate_key.for_map().ok_or(())?;
-                    TypedObjectModuleSubstateKey::NonFungibleVaultContentsIndex(
+                    TypedMainModuleSubstateKey::NonFungibleVaultContentsIndexKey(
                         scrypto_decode(&key).map_err(|_| ())?,
                     )
                 }
@@ -276,7 +272,7 @@ fn to_typed_object_substate_key_internal(
         // These seem to be spread between Object and Virtualized SysModules
         EntityType::InternalKeyValueStore => {
             let key = substate_key.for_map().ok_or(())?;
-            TypedObjectModuleSubstateKey::GenericKeyValueStore(key.clone())
+            TypedMainModuleSubstateKey::GenericKeyValueStoreKey(key.clone())
         }
     };
     Ok(substate_type)
@@ -284,36 +280,32 @@ fn to_typed_object_substate_key_internal(
 
 #[derive(Debug, Clone)]
 pub enum TypedSubstateValue {
-    TypeInfoModule(TypedTypeInfoModuleSubstateValue),
-    AccessRulesModule(TypedAccessRulesModuleSubstateValue),
-    RoyaltyModule(TypedRoyaltyModuleSubstateValue),
-    MetadataModule(TypedMetadataModuleSubstateValue),
-    ObjectModule(TypedObjectModuleSubstateValue),
+    TypeInfoModuleFieldValue(TypedTypeInfoModuleFieldValue),
+    AccessRulesModuleFieldValue(TypedAccessRulesModuleFieldValue),
+    RoyaltyModuleFieldValue(TypedRoyaltyModuleFieldValue),
+    MetadataModuleEntryValue(MetadataValueSubstate),
+    MainModule(TypedMainModuleSubstateValue),
 }
 
 #[derive(Debug, Clone)]
-pub enum TypedTypeInfoModuleSubstateValue {
+pub enum TypedTypeInfoModuleFieldValue {
     TypeInfo(TypeInfoSubstate),
 }
 
 #[derive(Debug, Clone)]
-pub enum TypedAccessRulesModuleSubstateValue {
+pub enum TypedAccessRulesModuleFieldValue {
     MethodAccessRules(MethodAccessRulesSubstate),
 }
 
 #[derive(Debug, Clone)]
-pub enum TypedRoyaltyModuleSubstateValue {
+pub enum TypedRoyaltyModuleFieldValue {
     ComponentRoyaltyConfig(ComponentRoyaltyConfigSubstate),
     ComponentRoyaltyAccumulator(ComponentRoyaltyAccumulatorSubstate),
 }
 
+/// Contains all the main module substate values, by each known partition layout
 #[derive(Debug, Clone)]
-pub enum TypedMetadataModuleSubstateValue {
-    Metadata(MetadataValueSubstate),
-}
-
-#[derive(Debug, Clone)]
-pub enum TypedObjectModuleSubstateValue {
+pub enum TypedMainModuleSubstateValue {
     // Objects
     Package(TypedPackageFieldValue),
     FungibleResource(TypedFungibleResourceManagerFieldValue),
@@ -327,9 +319,9 @@ pub enum TypedObjectModuleSubstateValue {
     Clock(TypedClockFieldValue),
     Validator(TypedValidatorFieldValue),
     AccountVaultIndex(AccountVaultIndexEntry), // (We don't yet have account fields yet)
-    AccessController(TypedAccessControllerSubstateValue),
+    AccessController(TypedAccessControllerFieldValue),
     // Generic Scrypto Components and KV Stores
-    GenericScryptoComponent(GenericScryptoComponentSubstateValue),
+    GenericScryptoComponent(GenericScryptoComponentFieldValue),
     GenericKeyValueStore(GenericScryptoSborPayload),
 }
 
@@ -383,17 +375,12 @@ pub enum TypedValidatorFieldValue {
 }
 
 #[derive(Debug, Clone)]
-pub enum TypedAccountFieldValue {
-    // Not any fields currently
-}
-
-#[derive(Debug, Clone)]
-pub enum TypedAccessControllerSubstateValue {
+pub enum TypedAccessControllerFieldValue {
     AccessController(AccessControllerSubstate),
 }
 
 #[derive(Debug, Clone)]
-pub enum GenericScryptoComponentSubstateValue {
+pub enum GenericScryptoComponentFieldValue {
     State(GenericScryptoSborPayload),
 }
 
@@ -419,36 +406,34 @@ fn to_typed_substate_value_internal(
     data: &[u8],
 ) -> Result<TypedSubstateValue, DecodeError> {
     let substate_value = match substate_key {
-        TypedSubstateKey::TypeInfoModule(type_info_offset) => {
-            TypedSubstateValue::TypeInfoModule(match type_info_offset {
+        TypedSubstateKey::TypeInfoModuleField(type_info_offset) => {
+            TypedSubstateValue::TypeInfoModuleFieldValue(match type_info_offset {
                 TypeInfoField::TypeInfo => {
-                    TypedTypeInfoModuleSubstateValue::TypeInfo(scrypto_decode(data)?)
+                    TypedTypeInfoModuleFieldValue::TypeInfo(scrypto_decode(data)?)
                 }
             })
         }
-        TypedSubstateKey::AccessRulesModule(access_rules_offset) => {
-            TypedSubstateValue::AccessRulesModule(match access_rules_offset {
+        TypedSubstateKey::AccessRulesModuleField(access_rules_offset) => {
+            TypedSubstateValue::AccessRulesModuleFieldValue(match access_rules_offset {
                 AccessRulesField::AccessRules => {
-                    TypedAccessRulesModuleSubstateValue::MethodAccessRules(scrypto_decode(data)?)
+                    TypedAccessRulesModuleFieldValue::MethodAccessRules(scrypto_decode(data)?)
                 }
             })
         }
-        TypedSubstateKey::RoyaltyModule(royalty_offset) => {
-            TypedSubstateValue::RoyaltyModule(match royalty_offset {
+        TypedSubstateKey::RoyaltyModuleField(royalty_offset) => {
+            TypedSubstateValue::RoyaltyModuleFieldValue(match royalty_offset {
                 RoyaltyField::RoyaltyConfig => {
-                    TypedRoyaltyModuleSubstateValue::ComponentRoyaltyConfig(scrypto_decode(data)?)
+                    TypedRoyaltyModuleFieldValue::ComponentRoyaltyConfig(scrypto_decode(data)?)
                 }
                 RoyaltyField::RoyaltyAccumulator => {
-                    TypedRoyaltyModuleSubstateValue::ComponentRoyaltyAccumulator(scrypto_decode(
-                        data,
-                    )?)
+                    TypedRoyaltyModuleFieldValue::ComponentRoyaltyAccumulator(scrypto_decode(data)?)
                 }
             })
         }
-        TypedSubstateKey::MetadataModule(_) => TypedSubstateValue::MetadataModule(
-            TypedMetadataModuleSubstateValue::Metadata(scrypto_decode(data)?),
-        ),
-        TypedSubstateKey::ObjectModule(object_substate_key) => TypedSubstateValue::ObjectModule(
+        TypedSubstateKey::MetadataModuleEntryKey(_) => {
+            TypedSubstateValue::MetadataModuleEntryValue(scrypto_decode(data)?)
+        }
+        TypedSubstateKey::MainModule(object_substate_key) => TypedSubstateValue::MainModule(
             to_typed_object_substate_value(object_substate_key, data)?,
         ),
     };
@@ -456,12 +441,12 @@ fn to_typed_substate_value_internal(
 }
 
 fn to_typed_object_substate_value(
-    substate_key: &TypedObjectModuleSubstateKey,
+    substate_key: &TypedMainModuleSubstateKey,
     data: &[u8],
-) -> Result<TypedObjectModuleSubstateValue, DecodeError> {
+) -> Result<TypedMainModuleSubstateValue, DecodeError> {
     let substate_value = match substate_key {
-        TypedObjectModuleSubstateKey::Package(offset) => {
-            TypedObjectModuleSubstateValue::Package(match offset {
+        TypedMainModuleSubstateKey::PackageField(offset) => {
+            TypedMainModuleSubstateValue::Package(match offset {
                 PackageField::Info => TypedPackageFieldValue::Info(scrypto_decode(data)?),
                 PackageField::CodeType => TypedPackageFieldValue::CodeType(scrypto_decode(data)?),
                 PackageField::Code => TypedPackageFieldValue::Code(scrypto_decode(data)?),
@@ -471,8 +456,8 @@ fn to_typed_object_substate_value(
                 }
             })
         }
-        TypedObjectModuleSubstateKey::FungibleResource(offset) => {
-            TypedObjectModuleSubstateValue::FungibleResource(match offset {
+        TypedMainModuleSubstateKey::FungibleResourceField(offset) => {
+            TypedMainModuleSubstateValue::FungibleResource(match offset {
                 FungibleResourceManagerField::Divisibility => {
                     TypedFungibleResourceManagerFieldValue::Divisibility(scrypto_decode(data)?)
                 }
@@ -481,8 +466,8 @@ fn to_typed_object_substate_value(
                 }
             })
         }
-        TypedObjectModuleSubstateKey::NonFungibleResourceField(offset) => {
-            TypedObjectModuleSubstateValue::NonFungibleResource(match offset {
+        TypedMainModuleSubstateKey::NonFungibleResourceField(offset) => {
+            TypedMainModuleSubstateValue::NonFungibleResource(match offset {
                 NonFungibleResourceManagerField::IdType => {
                     TypedNonFungibleResourceManagerFieldValue::IdType(scrypto_decode(data)?)
                 }
@@ -494,13 +479,13 @@ fn to_typed_object_substate_value(
                 }
             })
         }
-        TypedObjectModuleSubstateKey::NonFungibleResourceData(_) => {
-            TypedObjectModuleSubstateValue::NonFungibleResourceData(GenericScryptoSborPayload {
+        TypedMainModuleSubstateKey::NonFungibleResourceData(_) => {
+            TypedMainModuleSubstateValue::NonFungibleResourceData(GenericScryptoSborPayload {
                 data: data.to_vec(),
             })
         }
-        TypedObjectModuleSubstateKey::FungibleVault(offset) => {
-            TypedObjectModuleSubstateValue::FungibleVault(match offset {
+        TypedMainModuleSubstateKey::FungibleVaultField(offset) => {
+            TypedMainModuleSubstateValue::FungibleVault(match offset {
                 FungibleVaultField::LiquidFungible => {
                     TypedFungibleVaultFieldValue::Balance(scrypto_decode(data)?)
                 }
@@ -508,8 +493,8 @@ fn to_typed_object_substate_value(
                 FungibleVaultField::LockedFungible => Err(DecodeError::InvalidCustomValue)?,
             })
         }
-        TypedObjectModuleSubstateKey::NonFungibleVault(offset) => {
-            TypedObjectModuleSubstateValue::NonFungibleVaultField(match offset {
+        TypedMainModuleSubstateKey::NonFungibleVaultField(offset) => {
+            TypedMainModuleSubstateValue::NonFungibleVaultField(match offset {
                 NonFungibleVaultField::LiquidNonFungible => {
                     TypedNonFungibleVaultFieldValue::Balance(scrypto_decode(data)?)
                 }
@@ -517,13 +502,11 @@ fn to_typed_object_substate_value(
                 NonFungibleVaultField::LockedNonFungible => Err(DecodeError::InvalidCustomValue)?,
             })
         }
-        TypedObjectModuleSubstateKey::NonFungibleVaultContentsIndex(_) => {
-            TypedObjectModuleSubstateValue::NonFungibleVaultContentsIndexEntry(scrypto_decode(
-                data,
-            )?)
+        TypedMainModuleSubstateKey::NonFungibleVaultContentsIndexKey(_) => {
+            TypedMainModuleSubstateValue::NonFungibleVaultContentsIndexEntry(scrypto_decode(data)?)
         }
-        TypedObjectModuleSubstateKey::EpochManagerField(offset) => {
-            TypedObjectModuleSubstateValue::EpochManagerField(match offset {
+        TypedMainModuleSubstateKey::EpochManagerField(offset) => {
+            TypedMainModuleSubstateValue::EpochManagerField(match offset {
                 EpochManagerField::Config => {
                     TypedEpochManagerFieldValue::Config(scrypto_decode(data)?)
                 }
@@ -535,46 +518,46 @@ fn to_typed_object_substate_value(
                 }
             })
         }
-        TypedObjectModuleSubstateKey::EpochManagerRegisteredValidatorsByStakeIndex(_) => {
-            TypedObjectModuleSubstateValue::EpochManagerRegisteredValidatorsByStakeIndexEntry(
+        TypedMainModuleSubstateKey::EpochManagerRegisteredValidatorsByStakeIndexKey(_) => {
+            TypedMainModuleSubstateValue::EpochManagerRegisteredValidatorsByStakeIndexEntry(
                 scrypto_decode(data)?,
             )
         }
-        TypedObjectModuleSubstateKey::Clock(offset) => {
-            TypedObjectModuleSubstateValue::Clock(match offset {
+        TypedMainModuleSubstateKey::ClockField(offset) => {
+            TypedMainModuleSubstateValue::Clock(match offset {
                 ClockField::CurrentTimeRoundedToMinutes => {
                     TypedClockFieldValue::CurrentTimeRoundedToMinutes(scrypto_decode(data)?)
                 }
             })
         }
-        TypedObjectModuleSubstateKey::Validator(offset) => {
-            TypedObjectModuleSubstateValue::Validator(match offset {
+        TypedMainModuleSubstateKey::ValidatorField(offset) => {
+            TypedMainModuleSubstateValue::Validator(match offset {
                 ValidatorField::Validator => {
                     TypedValidatorFieldValue::Validator(scrypto_decode(data)?)
                 }
             })
         }
-        TypedObjectModuleSubstateKey::AccountVaultIndex(_) => {
-            TypedObjectModuleSubstateValue::AccountVaultIndex(scrypto_decode(data)?)
+        TypedMainModuleSubstateKey::AccountVaultIndexKey(_) => {
+            TypedMainModuleSubstateValue::AccountVaultIndex(scrypto_decode(data)?)
         }
-        TypedObjectModuleSubstateKey::AccessController(offset) => {
-            TypedObjectModuleSubstateValue::AccessController(match offset {
+        TypedMainModuleSubstateKey::AccessControllerField(offset) => {
+            TypedMainModuleSubstateValue::AccessController(match offset {
                 AccessControllerField::AccessController => {
-                    TypedAccessControllerSubstateValue::AccessController(scrypto_decode(data)?)
+                    TypedAccessControllerFieldValue::AccessController(scrypto_decode(data)?)
                 }
             })
         }
-        TypedObjectModuleSubstateKey::GenericScryptoComponent(offset) => {
-            TypedObjectModuleSubstateValue::GenericScryptoComponent(match offset {
+        TypedMainModuleSubstateKey::GenericScryptoComponentField(offset) => {
+            TypedMainModuleSubstateValue::GenericScryptoComponent(match offset {
                 ComponentField::State0 => {
-                    GenericScryptoComponentSubstateValue::State(GenericScryptoSborPayload {
+                    GenericScryptoComponentFieldValue::State(GenericScryptoSborPayload {
                         data: data.to_vec(),
                     })
                 }
             })
         }
-        TypedObjectModuleSubstateKey::GenericKeyValueStore(_) => {
-            TypedObjectModuleSubstateValue::GenericKeyValueStore(GenericScryptoSborPayload {
+        TypedMainModuleSubstateKey::GenericKeyValueStoreKey(_) => {
+            TypedMainModuleSubstateValue::GenericKeyValueStore(GenericScryptoSborPayload {
                 data: data.to_vec(),
             })
         }

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
@@ -16,7 +16,9 @@ pub enum NonFungibleVaultError {
 
 pub use radix_engine_interface::blueprints::resource::LiquidNonFungibleVault as NonFungibleVaultBalanceSubstate;
 
-pub const NON_FUNGIBLE_VAULT_NON_FUNGIBLES: CollectionIndex = 0u8;
+pub const NON_FUNGIBLE_VAULT_CONTENTS_INDEX: CollectionIndex = 0u8;
+
+pub use crate::types::NonFungibleLocalId as NonFungibleVaultContentsEntry;
 
 pub struct NonFungibleVaultBlueprint;
 
@@ -263,7 +265,7 @@ impl NonFungibleVault {
         // TODO: only allow a certain amount to be returned
         let items: Vec<NonFungibleLocalId> = api.actor_index_scan_typed(
             OBJECT_HANDLE_SELF,
-            NON_FUNGIBLE_VAULT_NON_FUNGIBLES,
+            NON_FUNGIBLE_VAULT_CONTENTS_INDEX,
             u32::MAX,
         )?;
         let ids = items.into_iter().collect();
@@ -324,7 +326,7 @@ impl NonFungibleVault {
         let taken = {
             let ids: Vec<NonFungibleLocalId> = api.actor_index_take_typed(
                 OBJECT_HANDLE_SELF,
-                NON_FUNGIBLE_VAULT_NON_FUNGIBLES,
+                NON_FUNGIBLE_VAULT_CONTENTS_INDEX,
                 amount_to_take,
             )?;
             LiquidNonFungibleResource {
@@ -360,7 +362,7 @@ impl NonFungibleVault {
         for id in ids {
             let removed = api.actor_index_remove(
                 OBJECT_HANDLE_SELF,
-                NON_FUNGIBLE_VAULT_NON_FUNGIBLES,
+                NON_FUNGIBLE_VAULT_CONTENTS_INDEX,
                 scrypto_encode(id).unwrap(),
             )?;
 
@@ -404,7 +406,7 @@ impl NonFungibleVault {
         for id in resource.ids {
             api.actor_index_insert_typed(
                 OBJECT_HANDLE_SELF,
-                NON_FUNGIBLE_VAULT_NON_FUNGIBLES,
+                NON_FUNGIBLE_VAULT_CONTENTS_INDEX,
                 scrypto_encode(&id).unwrap(),
                 id,
             )?;


### PR DESCRIPTION
## Summary

Some minor fixes as part of my merge into the Core API.

## Details

Basically added explicit types to the various partition keys and values, and removed entity types for the 

## Testing

Also added some unit tests for the validator sort key (to help me make sure I understood it correctly to map it back in `typed_substate_layout`).