### PR TITLE
Tracking missed/made proposals of validators

### DIFF
--- a/radix-engine-interface/src/types/node_layout.rs
+++ b/radix-engine-interface/src/types/node_layout.rs
@@ -127,6 +127,7 @@ pub enum EpochManagerField {
     Config,
     EpochManager,
     CurrentValidatorSet,
+    CurrentProposalStatistic,
 }
 
 #[repr(u8)]

--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -518,7 +518,7 @@ fn to_typed_object_substate_value(
                     TypedEpochManagerFieldValue::CurrentValidatorSet(scrypto_decode(data)?)
                 }
                 EpochManagerField::CurrentProposalStatistic => {
-                    TypedEpochManagerSubstateValue::CurrentProposalStatistic(scrypto_decode(data)?)
+                    TypedEpochManagerFieldValue::CurrentProposalStatistic(scrypto_decode(data)?)
                 }
             })
         }

--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -390,6 +390,7 @@ pub enum TypedEpochManagerSubstateValue {
     Config(EpochManagerConfigSubstate),
     EpochManager(EpochManagerSubstate),
     CurrentValidatorSet(CurrentValidatorSetSubstate),
+    CurrentProposalStatistic(CurrentProposalStatisticSubstate),
 }
 
 #[derive(Debug, Clone)]
@@ -556,6 +557,9 @@ fn to_typed_object_substate_value(
                 }
                 EpochManagerField::CurrentValidatorSet => {
                     TypedEpochManagerSubstateValue::CurrentValidatorSet(scrypto_decode(data)?)
+                }
+                EpochManagerField::CurrentProposalStatistic => {
+                    TypedEpochManagerSubstateValue::CurrentProposalStatistic(scrypto_decode(data)?)
                 }
             })
         }

--- a/radix-engine-tests/tests/epoch_manager.rs
+++ b/radix-engine-tests/tests/epoch_manager.rs
@@ -139,7 +139,7 @@ fn next_round_with_validator_auth_succeeds() {
     let max_validators = 10u32;
     let rounds_per_epoch = 5u64;
     let num_unstake_epochs = 1u64;
-    let genesis = CustomGenesis::empty(
+    let genesis = CustomGenesis::default(
         initial_epoch,
         max_validators,
         rounds_per_epoch,
@@ -151,10 +151,7 @@ fn next_round_with_validator_auth_succeeds() {
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(
-            rounds_per_epoch - 1,
-            0,
-        )),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch - 1)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -178,7 +175,7 @@ fn next_epoch_with_validator_auth_succeeds() {
     let max_validators = 10u32;
     let rounds_per_epoch = 2u64;
     let num_unstake_epochs = 1u64;
-    let genesis = CustomGenesis::empty(
+    let genesis = CustomGenesis::default(
         initial_epoch,
         max_validators,
         rounds_per_epoch,
@@ -190,7 +187,7 @@ fn next_epoch_with_validator_auth_succeeds() {
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -446,7 +443,7 @@ fn registered_validator_with_no_stake_does_not_become_part_of_validator_on_epoch
     let max_validators = 10u32;
     let rounds_per_epoch = 2u64;
     let num_unstake_epochs = 1u64;
-    let genesis = CustomGenesis::empty(
+    let genesis = CustomGenesis::default(
         initial_epoch,
         max_validators,
         rounds_per_epoch,
@@ -470,7 +467,7 @@ fn registered_validator_with_no_stake_does_not_become_part_of_validator_on_epoch
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -578,7 +575,7 @@ fn registered_validator_test(
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -656,7 +653,7 @@ fn unregistered_validator_gets_removed_on_epoch_change() {
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -720,7 +717,7 @@ fn updated_validator_keys_gets_updated_on_epoch_change() {
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -928,7 +925,7 @@ fn unstaked_validator_gets_less_stake_on_epoch_change() {
     let instructions = vec![Instruction::CallMethod {
         component_address: EPOCH_MANAGER,
         method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value(&EpochManagerNextRoundInput::successful(rounds_per_epoch, 0)),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
     }];
     let receipt = test_runner.execute_transaction(
         SystemTransaction {
@@ -1028,4 +1025,15 @@ fn epoch_manager_create_should_succeed_with_system_privilege() {
 
     // Assert
     receipt.expect_commit_success();
+}
+
+fn next_round_after_gap(current_round: u64) -> EpochManagerNextRoundInput {
+    EpochManagerNextRoundInput {
+        round: current_round,
+        leader_proposal_history: LeaderProposalHistory {
+            gap_round_leaders: (1..current_round).map(|_| 0).collect(),
+            current_leader: 0,
+            is_fallback: false,
+        },
+    }
 }

--- a/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
+++ b/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
@@ -67,19 +67,12 @@ impl CurrentProposalStatisticSubstate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, ScryptoSbor)]
 pub struct ProposalStatistic {
     /// A counter of successful proposals made by a specific validator.
     pub made: u64,
     /// A counter of missed proposals (caused both by gap rounds or fallback rounds).
     pub missed: u64,
-}
-
-impl ProposalStatistic {
-    /// Creates a zeroed statistic.
-    pub fn zero() -> Self {
-        Self { made: 0, missed: 0 }
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Sbor)]
@@ -431,7 +424,7 @@ impl EpochManagerBlueprint {
         // statistics (to be used for unreliability penalty calculation); at the moment we only
         // reset it.
         statistic.validator_statistics = (0..next_validator_set.len())
-            .map(|_index| ProposalStatistic::zero())
+            .map(|_index| ProposalStatistic::default())
             .collect();
         api.field_lock_write_typed(statistic_handle, statistic)?;
         api.field_lock_release(statistic_handle)?;

--- a/radix-engine/src/blueprints/epoch_manager/package.rs
+++ b/radix-engine/src/blueprints/epoch_manager/package.rs
@@ -26,6 +26,8 @@ impl EpochManagerNativePackage {
         fields.push(aggregator.add_child_type_and_descendents::<EpochManagerConfigSubstate>());
         fields.push(aggregator.add_child_type_and_descendents::<EpochManagerSubstate>());
         fields.push(aggregator.add_child_type_and_descendents::<CurrentValidatorSetSubstate>());
+        fields
+            .push(aggregator.add_child_type_and_descendents::<CurrentProposalStatisticSubstate>());
 
         let mut collections = Vec::new();
         collections.push(BlueprintCollectionSchema::SortedIndex(
@@ -297,7 +299,11 @@ impl EpochManagerNativePackage {
                 let input: EpochManagerNextRoundInput = input.as_typed().map_err(|e| {
                     RuntimeError::SystemUpstreamError(SystemUpstreamError::InputDecodeError(e))
                 })?;
-                let rtn = EpochManagerBlueprint::next_round(input.round, api)?;
+                let rtn = EpochManagerBlueprint::next_round(
+                    input.round,
+                    input.leader_proposal_history,
+                    api,
+                )?;
 
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -259,7 +259,7 @@ impl WasmerModule {
         }
 
         pub fn preallocate_global_address(env: &WasmerInstanceEnv) -> Result<u64, RuntimeError> {
-            let (instance, runtime) = grab_runtime!(env);
+            let (_instance, runtime) = grab_runtime!(env);
 
             let buffer = runtime
                 .preallocate_global_address()

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -136,19 +136,24 @@ pub struct CustomGenesis {
 }
 
 impl CustomGenesis {
-    pub fn empty(
+    pub fn default(
         initial_epoch: u64,
         max_validators: u32,
         rounds_per_epoch: u64,
         num_unstake_epochs: u64,
     ) -> CustomGenesis {
-        CustomGenesis {
-            genesis_data_chunks: vec![],
+        let pub_key = EcdsaSecp256k1PrivateKey::from_u64(1u64)
+            .unwrap()
+            .public_key();
+        Self::single_validator_and_staker(
+            pub_key,
+            Decimal::one(),
+            ComponentAddress::virtual_account_from_public_key(&pub_key),
             initial_epoch,
             max_validators,
             rounds_per_epoch,
             num_unstake_epochs,
-        }
+        )
     }
 
     pub fn single_validator_and_staker(


### PR DESCRIPTION
In this PR, I add internal tracking of missed/made proposal counters of validators:
- counting on round change;
- resetting on epoch change.

I follow the approach we discussed on Slack (captured as **Q4-B** at https://radixdlt.atlassian.net/wiki/spaces/S/pages/3058827265/REP-83+Calculating+Emissions+and+Handling+Validator+Fees#Unreliability-Penalty).

These numbers are not yet taken into account during Emissions (since Emissions itself is not implemented yet), and in fact, the counting has no externally observable effect on the engine's behavior (which is why I haven't invested much into tests yet - I just fixed a couple of existing tests that were breaking some newly-introduced sanity checks).