### PR TITLE
Rename ComponentAuthZone to LocalAuthZone

### DIFF
--- a/native-sdk/src/resource/auth_zone.rs
+++ b/native-sdk/src/resource/auth_zone.rs
@@ -10,9 +10,9 @@ use sbor::rust::collections::BTreeSet;
 use sbor::rust::fmt::Debug;
 use sbor::rust::vec::Vec;
 
-pub struct ComponentAuthZone {}
+pub struct LocalAuthZone {}
 
-impl ComponentAuthZone {
+impl LocalAuthZone {
     pub fn sys_drain<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
         api: &mut Y,
     ) -> Result<Vec<Proof>, E>

--- a/radix-engine-tests/tests/blueprints/proof/src/vault_proof.rs
+++ b/radix-engine-tests/tests/blueprints/proof/src/vault_proof.rs
@@ -102,10 +102,8 @@ mod vault_proof {
         ) {
             self.vault.authorize(|| {
                 bucket.authorize(|| {
-                    let proof = LocalAuthZone::create_proof_by_amount(
-                        amount,
-                        bucket.resource_address(),
-                    );
+                    let proof =
+                        LocalAuthZone::create_proof_by_amount(amount, bucket.resource_address());
                     let proof = proof.validate_proof(self.vault.resource_address()).unwrap();
                     assert_eq!(proof.amount(), amount);
                     proof.drop();
@@ -121,8 +119,7 @@ mod vault_proof {
         ) {
             self.vault.authorize(|| {
                 bucket.authorize(|| {
-                    let proof =
-                        LocalAuthZone::create_proof_by_ids(&ids, bucket.resource_address());
+                    let proof = LocalAuthZone::create_proof_by_ids(&ids, bucket.resource_address());
                     let proof = proof.validate_proof(self.vault.resource_address()).unwrap();
                     assert_eq!(proof.non_fungible_local_ids(), ids);
                     proof.drop();

--- a/radix-engine-tests/tests/blueprints/proof/src/vault_proof.rs
+++ b/radix-engine-tests/tests/blueprints/proof/src/vault_proof.rs
@@ -79,14 +79,14 @@ mod vault_proof {
         }
 
         pub fn receive_proof_and_push_to_auth_zone(proof: Proof) {
-            ComponentAuthZone::push(proof); // should fail here
+            LocalAuthZone::push(proof); // should fail here
         }
 
         pub fn compose_vault_and_bucket_proof(&mut self, bucket: Bucket) {
             let expected_amount = self.vault.amount() + bucket.amount();
             self.vault.authorize(|| {
                 bucket.authorize(|| {
-                    let proof = ComponentAuthZone::create_proof(bucket.resource_address());
+                    let proof = LocalAuthZone::create_proof(bucket.resource_address());
                     let proof = proof.validate_proof(self.vault.resource_address()).unwrap();
                     assert_eq!(proof.amount(), expected_amount);
                     proof.drop();
@@ -102,7 +102,7 @@ mod vault_proof {
         ) {
             self.vault.authorize(|| {
                 bucket.authorize(|| {
-                    let proof = ComponentAuthZone::create_proof_by_amount(
+                    let proof = LocalAuthZone::create_proof_by_amount(
                         amount,
                         bucket.resource_address(),
                     );
@@ -122,7 +122,7 @@ mod vault_proof {
             self.vault.authorize(|| {
                 bucket.authorize(|| {
                     let proof =
-                        ComponentAuthZone::create_proof_by_ids(&ids, bucket.resource_address());
+                        LocalAuthZone::create_proof_by_ids(&ids, bucket.resource_address());
                     let proof = proof.validate_proof(self.vault.resource_address()).unwrap();
                     assert_eq!(proof.non_fungible_local_ids(), ids);
                     proof.drop();

--- a/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
+++ b/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
@@ -6,7 +6,7 @@ use crate::kernel::kernel_api::KernelNodeApi;
 use crate::system::node_init::ModuleInit;
 use crate::system::node_modules::type_info::TypeInfoSubstate;
 use crate::types::*;
-use native_sdk::resource::{ComponentAuthZone, SysBucket, SysProof, Worktop};
+use native_sdk::resource::{LocalAuthZone, SysBucket, SysProof, Worktop};
 use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::node_modules::auth::{
     AccessRulesSetMethodAccessRuleInput, ACCESS_RULES_SET_METHOD_ACCESS_RULE_IDENT,
@@ -142,25 +142,25 @@ impl TransactionProcessorBlueprint {
                     InstructionOutput::None
                 }
                 Instruction::PopFromAuthZone {} => {
-                    let proof = ComponentAuthZone::sys_pop(api)?;
+                    let proof = LocalAuthZone::sys_pop(api)?;
                     processor.create_manifest_proof(proof)?;
                     InstructionOutput::None
                 }
                 Instruction::ClearAuthZone => {
-                    ComponentAuthZone::sys_clear(api)?;
+                    LocalAuthZone::sys_clear(api)?;
                     InstructionOutput::None
                 }
                 Instruction::ClearSignatureProofs => {
-                    ComponentAuthZone::sys_clear_signature_proofs(api)?;
+                    LocalAuthZone::sys_clear_signature_proofs(api)?;
                     InstructionOutput::None
                 }
                 Instruction::PushToAuthZone { proof_id } => {
                     let proof = processor.take_proof(&proof_id)?;
-                    ComponentAuthZone::sys_push(proof, api)?;
+                    LocalAuthZone::sys_push(proof, api)?;
                     InstructionOutput::None
                 }
                 Instruction::CreateProofFromAuthZone { resource_address } => {
-                    let proof = ComponentAuthZone::sys_create_proof(resource_address, api)?;
+                    let proof = LocalAuthZone::sys_create_proof(resource_address, api)?;
                     processor.create_manifest_proof(proof)?;
                     InstructionOutput::None
                 }
@@ -168,11 +168,8 @@ impl TransactionProcessorBlueprint {
                     amount,
                     resource_address,
                 } => {
-                    let proof = ComponentAuthZone::sys_create_proof_by_amount(
-                        amount,
-                        resource_address,
-                        api,
-                    )?;
+                    let proof =
+                        LocalAuthZone::sys_create_proof_by_amount(amount, resource_address, api)?;
                     processor.create_manifest_proof(proof)?;
                     InstructionOutput::None
                 }
@@ -181,7 +178,7 @@ impl TransactionProcessorBlueprint {
                     resource_address,
                 } => {
                     let proof =
-                        ComponentAuthZone::sys_create_proof_by_ids(&ids, resource_address, api)?;
+                        LocalAuthZone::sys_create_proof_by_ids(&ids, resource_address, api)?;
                     processor.create_manifest_proof(proof)?;
                     InstructionOutput::None
                 }
@@ -210,7 +207,7 @@ impl TransactionProcessorBlueprint {
                         let proof = Proof(Own(real_id));
                         proof.sys_drop(api).map(|_| IndexedScryptoValue::unit())?;
                     }
-                    ComponentAuthZone::sys_clear(api)?;
+                    LocalAuthZone::sys_clear(api)?;
                     InstructionOutput::None
                 }
                 Instruction::CallFunction {
@@ -697,7 +694,7 @@ impl<'blob> TransactionProcessor<'blob> {
                 (RESOURCE_PACKAGE, FUNGIBLE_PROOF_BLUEPRINT)
                 | (RESOURCE_PACKAGE, NON_FUNGIBLE_PROOF_BLUEPRINT) => {
                     let proof = Proof(Own(owned_node.clone()));
-                    ComponentAuthZone::sys_push(proof, api)?;
+                    LocalAuthZone::sys_push(proof, api)?;
                 }
                 _ => {}
             }
@@ -779,7 +776,7 @@ impl<'blob, 'a, Y: ClientApi<RuntimeError>> TransformHandler<RuntimeError>
                 Ok(buckets.into_iter().map(|b| b.0).collect())
             }
             ManifestExpression::EntireAuthZone => {
-                let proofs = ComponentAuthZone::sys_drain(self.api)?;
+                let proofs = LocalAuthZone::sys_drain(self.api)?;
                 Ok(proofs.into_iter().map(|p| p.0).collect())
             }
         }

--- a/scrypto/src/resource/auth_zone.rs
+++ b/scrypto/src/resource/auth_zone.rs
@@ -13,9 +13,9 @@ use scrypto::engine::scrypto_env::ScryptoEnv;
 ///
 /// 1. Call methods on another component;
 /// 2. Access resource system.
-pub struct ComponentAuthZone {}
+pub struct LocalAuthZone {}
 
-impl ComponentAuthZone {
+impl LocalAuthZone {
     pub fn push<P: Into<Proof>>(proof: P) {
         let mut env = ScryptoEnv;
 

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -1,5 +1,5 @@
 use crate::borrow_resource_manager;
-use crate::resource::{ComponentAuthZone, NonFungible, ScryptoProof};
+use crate::resource::{LocalAuthZone, NonFungible, ScryptoProof};
 use radix_engine_interface::api::ClientObjectApi;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::scrypto::model::*;
@@ -169,9 +169,9 @@ impl ScryptoBucket for Bucket {
 
     /// Uses resources in this bucket as authorization for an operation.
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
-        ComponentAuthZone::push(self.create_proof());
+        LocalAuthZone::push(self.create_proof());
         let output = f();
-        ComponentAuthZone::pop().drop();
+        LocalAuthZone::pop().drop();
         output
     }
 

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -54,9 +54,9 @@ pub trait ScryptoProof: Sized {
 impl ScryptoProof for Proof {
     /// Uses resources in this proof as authorization for an operation.
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
-        ComponentAuthZone::push(ScryptoProof::clone(self));
+        LocalAuthZone::push(ScryptoProof::clone(self));
         let output = f();
-        ComponentAuthZone::pop().drop();
+        LocalAuthZone::pop().drop();
         output
     }
 

--- a/scrypto/src/resource/vault.rs
+++ b/scrypto/src/resource/vault.rs
@@ -239,9 +239,9 @@ impl ScryptoVault for Vault {
 
     /// Uses resources in this vault as authorization for an operation.
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
-        ComponentAuthZone::push(self.create_proof());
+        LocalAuthZone::push(self.create_proof());
         let output = f();
-        ComponentAuthZone::pop().drop();
+        LocalAuthZone::pop().drop();
         output
     }
 

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "peeking_take_while"
@@ -858,6 +858,7 @@ dependencies = [
  "moka",
  "native-sdk",
  "parity-wasm",
+ "paste",
  "radix-engine-common",
  "radix-engine-constants",
  "radix-engine-interface",


### PR DESCRIPTION
## Summary

Rename `ComponentAuthZone` to `LocalAuthZone`, since there is an auth zone for every call frame (except the root), including both component and blueprint functions.

## Update Recommendations

### For Dapp Developers

Use `LocalAuthZone` instead of `ComponentAuthZone`
