### PR TITLE
fix: Capture invalid SBOR values at Encode time

### DIFF
--- a/radix-engine-common/src/data/manifest/custom_value.rs
+++ b/radix-engine-common/src/data/manifest/custom_value.rs
@@ -13,8 +13,8 @@ pub enum ManifestCustomValue {
     NonFungibleLocalId(ManifestNonFungibleLocalId),
 }
 
-impl ManifestCustomValue {
-    pub fn get_custom_value_kind(&self) -> ManifestCustomValueKind {
+impl CustomValue<ManifestCustomValueKind> for ManifestCustomValue {
+    fn get_custom_value_kind(&self) -> ManifestCustomValueKind {
         match self {
             ManifestCustomValue::Address(_) => ManifestCustomValueKind::Address,
             ManifestCustomValue::Bucket(_) => ManifestCustomValueKind::Bucket,

--- a/radix-engine-common/src/data/scrypto/custom_value.rs
+++ b/radix-engine-common/src/data/scrypto/custom_value.rs
@@ -13,8 +13,8 @@ pub enum ScryptoCustomValue {
     NonFungibleLocalId(NonFungibleLocalId),
 }
 
-impl ScryptoCustomValue {
-    pub fn get_custom_value_kind(&self) -> ScryptoCustomValueKind {
+impl CustomValue<ScryptoCustomValueKind> for ScryptoCustomValue {
+    fn get_custom_value_kind(&self) -> ScryptoCustomValueKind {
         match self {
             ScryptoCustomValue::Reference(_) => ScryptoCustomValueKind::Reference,
             ScryptoCustomValue::Own(_) => ScryptoCustomValueKind::Own,

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -19,6 +19,12 @@ pub enum NoCustomValueKind {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NoCustomValue {}
 
+impl CustomValue<NoCustomValueKind> for NoCustomValue {
+    fn get_custom_value_kind(&self) -> NoCustomValueKind {
+        panic!("No custom value")
+    }
+}
+
 pub type BasicEncoder<'a> = VecEncoder<'a, NoCustomValueKind>;
 pub type BasicDecoder<'a> = VecDecoder<'a, NoCustomValueKind>;
 pub type BasicTraverser<'a> = VecTraverser<'a, NoCustomTraversal>;

--- a/sbor/src/encoder.rs
+++ b/sbor/src/encoder.rs
@@ -14,11 +14,11 @@ pub enum EncodeError {
         element_value_kind: u8,
         actual_value_kind: u8,
     },
-    MismatchingMapKeyType {
+    MismatchingMapKeyValueKind {
         key_value_kind: u8,
         actual_value_kind: u8,
     },
-    MismatchingMapValueType {
+    MismatchingMapValueValueKind {
         value_value_kind: u8,
         actual_value_kind: u8,
     },

--- a/sbor/src/encoder.rs
+++ b/sbor/src/encoder.rs
@@ -6,7 +6,22 @@ use crate::*;
 #[derive(Debug, Clone, PartialEq, Eq, Sbor)]
 pub enum EncodeError {
     MaxDepthExceeded(usize),
-    SizeTooLarge { actual: usize, max_allowed: usize },
+    SizeTooLarge {
+        actual: usize,
+        max_allowed: usize,
+    },
+    MismatchingArrayElementValueKind {
+        element_value_kind: u8,
+        actual_value_kind: u8,
+    },
+    MismatchingMapKeyType {
+        key_value_kind: u8,
+        actual_value_kind: u8,
+    },
+    MismatchingMapValueType {
+        value_value_kind: u8,
+        actual_value_kind: u8,
+    },
 }
 
 pub trait Encoder<X: CustomValueKind>: Sized {

--- a/sbor/src/path.rs
+++ b/sbor/src/path.rs
@@ -2,6 +2,7 @@ use crate::rust::vec;
 use crate::rust::vec::Vec;
 use crate::value::Value;
 use crate::CustomValueKind;
+use crate::*;
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct SborPathBuf(Vec<usize>);
@@ -41,7 +42,7 @@ impl SborPath {
         SborPath(path)
     }
 
-    pub fn get_from_value<'a, X: CustomValueKind, Y>(
+    pub fn get_from_value<'a, X: CustomValueKind, Y: CustomValue<X>>(
         &'a self,
         value: &'a Value<X, Y>,
     ) -> Option<&'a Value<X, Y>> {
@@ -49,7 +50,7 @@ impl SborPath {
         rel_path.get_from(value)
     }
 
-    pub fn get_from_value_mut<'a, X: CustomValueKind, Y>(
+    pub fn get_from_value_mut<'a, X: CustomValueKind, Y: CustomValue<X>>(
         &'a self,
         value: &'a mut Value<X, Y>,
     ) -> Option<&'a mut Value<X, Y>> {
@@ -76,7 +77,10 @@ impl<'a> ValueRetriever<'a> {
         Some((index, ValueRetriever(extended_path)))
     }
 
-    fn get_from<X: CustomValueKind, Y>(self, value: &'a Value<X, Y>) -> Option<&'a Value<X, Y>> {
+    fn get_from<X: CustomValueKind, Y: CustomValue<X>>(
+        self,
+        value: &'a Value<X, Y>,
+    ) -> Option<&'a Value<X, Y>> {
         if self.is_empty() {
             return Option::Some(value);
         }
@@ -106,7 +110,7 @@ impl<'a> ValueRetriever<'a> {
         }
     }
 
-    fn get_from_mut<X: CustomValueKind, Y>(
+    fn get_from_mut<X: CustomValueKind, Y: CustomValue<X>>(
         self,
         value: &'a mut Value<X, Y>,
     ) -> Option<&'a mut Value<X, Y>> {
@@ -144,7 +148,6 @@ impl<'a> ValueRetriever<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sbor::*;
 
     #[test]
     fn query_array() {

--- a/sbor/src/value.rs
+++ b/sbor/src/value.rs
@@ -16,7 +16,7 @@ use crate::value_kind::*;
     serde(tag = "type") // See https://serde.rs/enum-representations.html
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Value<X: CustomValueKind, Y> {
+pub enum Value<X: CustomValueKind, Y: CustomValue<X>> {
     Bool {
         value: bool,
     },
@@ -74,7 +74,37 @@ pub enum Value<X: CustomValueKind, Y> {
     },
 }
 
-impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E>> Encode<X, E> for Value<X, Y> {
+pub trait CustomValue<X: CustomValueKind> {
+    fn get_custom_value_kind(&self) -> X;
+}
+
+impl<X: CustomValueKind, Y: CustomValue<X>> Value<X, Y> {
+    fn get_value_kind(&self) -> ValueKind<X> {
+        match self {
+            Value::Bool { .. } => ValueKind::Bool,
+            Value::I8 { .. } => ValueKind::I8,
+            Value::I16 { .. } => ValueKind::I16,
+            Value::I32 { .. } => ValueKind::I32,
+            Value::I64 { .. } => ValueKind::I64,
+            Value::I128 { .. } => ValueKind::U128,
+            Value::U8 { .. } => ValueKind::U8,
+            Value::U16 { .. } => ValueKind::U16,
+            Value::U32 { .. } => ValueKind::U32,
+            Value::U64 { .. } => ValueKind::U64,
+            Value::U128 { .. } => ValueKind::U128,
+            Value::String { .. } => ValueKind::String,
+            Value::Enum { .. } => ValueKind::Enum,
+            Value::Array { .. } => ValueKind::Array,
+            Value::Tuple { .. } => ValueKind::Tuple,
+            Value::Map { .. } => ValueKind::Map,
+            Value::Custom { value } => ValueKind::Custom(value.get_custom_value_kind()),
+        }
+    }
+}
+
+impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E> + CustomValue<X>> Encode<X, E>
+    for Value<X, Y>
+{
     #[inline]
     fn encode_value_kind(&self, encoder: &mut E) -> Result<(), EncodeError> {
         match self {
@@ -154,6 +184,12 @@ impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E>> Encode<X, E> for Value<
                 encoder.write_value_kind(*element_value_kind)?;
                 encoder.write_size(elements.len())?;
                 for item in elements {
+                    if item.get_value_kind() != *element_value_kind {
+                        return Err(EncodeError::MismatchingArrayElementValueKind {
+                            element_value_kind: element_value_kind.as_u8(),
+                            actual_value_kind: item.get_value_kind().as_u8(),
+                        });
+                    }
                     encoder.encode_deeper_body(item)?;
                 }
             }
@@ -172,7 +208,21 @@ impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E>> Encode<X, E> for Value<
                 encoder.write_value_kind(*value_value_kind)?;
                 encoder.write_size(entries.len())?;
                 for entry in entries {
+                    let actual_key_value_kind = entry.0.get_value_kind();
+                    if actual_key_value_kind != *key_value_kind {
+                        return Err(EncodeError::MismatchingMapKeyType {
+                            key_value_kind: key_value_kind.as_u8(),
+                            actual_value_kind: actual_key_value_kind.as_u8(),
+                        });
+                    }
                     encoder.encode_deeper_body(&entry.0)?;
+                    let actual_value_value_kind = entry.1.get_value_kind();
+                    if actual_value_value_kind != *value_value_kind {
+                        return Err(EncodeError::MismatchingMapValueType {
+                            value_value_kind: value_value_kind.as_u8(),
+                            actual_value_kind: actual_value_value_kind.as_u8(),
+                        });
+                    }
                     encoder.encode_deeper_body(&entry.1)?;
                 }
             }
@@ -185,7 +235,9 @@ impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E>> Encode<X, E> for Value<
     }
 }
 
-impl<X: CustomValueKind, D: Decoder<X>, Y: Decode<X, D>> Decode<X, D> for Value<X, Y> {
+impl<X: CustomValueKind, D: Decoder<X>, Y: Decode<X, D> + CustomValue<X>> Decode<X, D>
+    for Value<X, Y>
+{
     #[inline]
     fn decode_body_with_value_kind(
         decoder: &mut D,
@@ -291,12 +343,14 @@ mod schema {
     use super::*;
     use crate::*;
 
-    impl<X: CustomValueKind, Y, C: CustomTypeKind<GlobalTypeId>> Describe<C> for Value<X, Y> {
+    impl<X: CustomValueKind, Y: CustomValue<X>, C: CustomTypeKind<GlobalTypeId>> Describe<C>
+        for Value<X, Y>
+    {
         const TYPE_ID: GlobalTypeId = GlobalTypeId::well_known(basic_well_known_types::ANY_ID);
     }
 }
 
-pub fn traverse_any<X: CustomValueKind, Y, V: ValueVisitor<X, Y, Err = E>, E>(
+pub fn traverse_any<X: CustomValueKind, Y: CustomValue<X>, V: ValueVisitor<X, Y, Err = E>, E>(
     path: &mut SborPathBuf,
     value: &Value<X, Y>,
     visitor: &mut V,
@@ -369,7 +423,7 @@ pub fn traverse_any<X: CustomValueKind, Y, V: ValueVisitor<X, Y, Err = E>, E>(
     Ok(())
 }
 
-pub trait ValueVisitor<X: CustomValueKind, Y> {
+pub trait ValueVisitor<X: CustomValueKind, Y: CustomValue<X>> {
     type Err;
 
     fn visit_array(
@@ -570,6 +624,41 @@ mod tests {
         let encoded_sbor_value = basic_encode(&sbor_value).unwrap();
 
         assert_eq!(encoded_sbor_value, encoded_typed_value);
+    }
+
+    #[test]
+    pub fn invalid_array_value_errors_on_encode() {
+        let invalid_value = BasicValue::Array {
+            element_value_kind: ValueKind::U8,
+            elements: vec![BasicValue::U8 { value: 1 }, BasicValue::U16 { value: 2 }],
+        };
+        assert!(matches!(
+            basic_encode(&invalid_value),
+            Err(EncodeError::MismatchingArrayElementValueKind { .. })
+        ));
+    }
+
+    #[test]
+    pub fn invalid_map_value_errors_on_encode() {
+        let invalid_value = BasicValue::Map {
+            key_value_kind: ValueKind::U8,
+            value_value_kind: ValueKind::I8,
+            entries: vec![(BasicValue::U16 { value: 1 }, BasicValue::I8 { value: 1 })],
+        };
+        assert!(matches!(
+            basic_encode(&invalid_value),
+            Err(EncodeError::MismatchingMapKeyType { .. })
+        ));
+
+        let invalid_value = BasicValue::Map {
+            key_value_kind: ValueKind::U8,
+            value_value_kind: ValueKind::I8,
+            entries: vec![(BasicValue::U8 { value: 1 }, BasicValue::I16 { value: 1 })],
+        };
+        assert!(matches!(
+            basic_encode(&invalid_value),
+            Err(EncodeError::MismatchingMapValueType { .. })
+        ));
     }
 
     #[test]

--- a/sbor/src/value.rs
+++ b/sbor/src/value.rs
@@ -210,7 +210,7 @@ impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E> + CustomValue<X>> Encode
                 for entry in entries {
                     let actual_key_value_kind = entry.0.get_value_kind();
                     if actual_key_value_kind != *key_value_kind {
-                        return Err(EncodeError::MismatchingMapKeyType {
+                        return Err(EncodeError::MismatchingMapKeyValueKind {
                             key_value_kind: key_value_kind.as_u8(),
                             actual_value_kind: actual_key_value_kind.as_u8(),
                         });
@@ -218,7 +218,7 @@ impl<X: CustomValueKind, E: Encoder<X>, Y: Encode<X, E> + CustomValue<X>> Encode
                     encoder.encode_deeper_body(&entry.0)?;
                     let actual_value_value_kind = entry.1.get_value_kind();
                     if actual_value_value_kind != *value_value_kind {
-                        return Err(EncodeError::MismatchingMapValueType {
+                        return Err(EncodeError::MismatchingMapValueValueKind {
                             value_value_kind: value_value_kind.as_u8(),
                             actual_value_kind: actual_value_value_kind.as_u8(),
                         });
@@ -647,7 +647,7 @@ mod tests {
         };
         assert!(matches!(
             basic_encode(&invalid_value),
-            Err(EncodeError::MismatchingMapKeyType { .. })
+            Err(EncodeError::MismatchingMapKeyValueKind { .. })
         ));
 
         let invalid_value = BasicValue::Map {
@@ -657,7 +657,7 @@ mod tests {
         };
         assert!(matches!(
             basic_encode(&invalid_value),
-            Err(EncodeError::MismatchingMapValueType { .. })
+            Err(EncodeError::MismatchingMapValueValueKind { .. })
         ));
     }
 


### PR DESCRIPTION
## Summary

Fixes some crashes noted by Rubin whereby a Value could be encoded but that encoded Value could not be decoded.

It transpires the Value itself wasn't in a valid structure to start with, so arguably it's not too important, but I'll put in this PR for completeness and see if being fully correct impacts the benchmarks at all.

## Testing
Added a couple of tests for the new behaviour
