### PR TITLE
Emitting validator rewards on epoch change

### DIFF
--- a/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
@@ -20,11 +20,40 @@ pub struct EpochManagerCreateInput {
     pub initial_configuration: EpochManagerInitialConfiguration,
 }
 
-#[derive(Debug, Eq, PartialEq, Sbor)]
+#[derive(Debug, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
 pub struct EpochManagerInitialConfiguration {
     pub max_validators: u32,
     pub rounds_per_epoch: u64,
     pub num_unstake_epochs: u64,
+    pub total_emission_xrd_per_epoch: Decimal,
+    pub min_validator_reliability: Decimal,
+}
+
+impl EpochManagerInitialConfiguration {
+    pub fn with_max_validators(mut self, new_value: u32) -> Self {
+        self.max_validators = new_value;
+        self
+    }
+
+    pub fn with_rounds_per_epoch(mut self, new_value: u64) -> Self {
+        self.rounds_per_epoch = new_value;
+        self
+    }
+
+    pub fn with_num_unstake_epochs(mut self, new_value: u64) -> Self {
+        self.num_unstake_epochs = new_value;
+        self
+    }
+
+    pub fn with_total_emission_xrd_per_epoch(mut self, new_value: Decimal) -> Self {
+        self.total_emission_xrd_per_epoch = new_value;
+        self
+    }
+
+    pub fn with_min_validator_reliability(mut self, new_value: Decimal) -> Self {
+        self.min_validator_reliability = new_value;
+        self
+    }
 }
 
 pub type EpochManagerCreateOutput = ();
@@ -211,3 +240,12 @@ pub struct ValidatorUpdateAcceptDelegatedStakeInput {
 }
 
 pub type ValidatorUpdateAcceptDelegatedStakeOutput = ();
+
+pub const VALIDATOR_PUT_INTO_STAKE_IDENT: &str = "put_into_stake";
+
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
+pub struct ValidatorPutIntoStakeInput {
+    pub xrd_bucket: Bucket,
+}
+
+pub type ValidatorPutIntoStakeOutput = ();

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -368,5 +368,7 @@ fn dummy_epoch_manager_configuration() -> EpochManagerInitialConfiguration {
         max_validators: 100,
         rounds_per_epoch: 1,
         num_unstake_epochs: 1,
+        total_emission_xrd_per_epoch: Decimal::one(),
+        min_validator_reliability: Decimal::one(),
     }
 }

--- a/radix-engine-tests/tests/epoch_manager.rs
+++ b/radix-engine-tests/tests/epoch_manager.rs
@@ -61,11 +61,8 @@ fn genesis_epoch_has_correct_initial_validators() {
     let genesis = CustomGenesis {
         genesis_data_chunks,
         initial_epoch,
-        initial_configuration: EpochManagerInitialConfiguration {
-            rounds_per_epoch: 5,
-            num_unstake_epochs: 1,
-            max_validators,
-        },
+        initial_configuration: dummy_epoch_manager_configuration()
+            .with_max_validators(max_validators),
     };
 
     // Act
@@ -144,11 +141,7 @@ fn next_round_with_validator_auth_succeeds() {
     let rounds_per_epoch = 5u64;
     let genesis = CustomGenesis::default(
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
 
@@ -180,11 +173,7 @@ fn next_epoch_with_validator_auth_succeeds() {
     let rounds_per_epoch = 2u64;
     let genesis = CustomGenesis::default(
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
 
@@ -417,17 +406,13 @@ fn not_allowing_delegated_stake_should_not_let_non_owner_stake() {
 }
 
 #[test]
-fn registered_validator_with_no_stake_does_not_become_part_of_validator_on_epoch_change() {
+fn registered_validator_with_no_stake_does_not_become_part_of_validator_set_on_epoch_change() {
     // Arrange
     let initial_epoch = 5u64;
     let rounds_per_epoch = 2u64;
     let genesis = CustomGenesis::default(
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
     let (pub_key, _, account_address) = test_runner.new_account(false);
@@ -464,6 +449,240 @@ fn registered_validator_with_no_stake_does_not_become_part_of_validator_on_epoch
     let next_epoch = result.next_epoch().expect("Should have next epoch");
     assert_eq!(next_epoch.1, initial_epoch + 1);
     assert!(!next_epoch.0.contains_key(&validator_address));
+}
+
+#[test]
+fn validator_set_receives_emissions_proportional_to_stake_on_epoch_change() {
+    // Arrange
+    let epoch_emissions_xrd = dec!("0.1");
+    let a_stake = dec!("2.5");
+    let b_stake = dec!("7.5");
+    let both_stake = a_stake + b_stake;
+
+    let a_key = EcdsaSecp256k1PrivateKey::from_u64(1).unwrap().public_key();
+    let b_key = EcdsaSecp256k1PrivateKey::from_u64(2).unwrap().public_key();
+    let validators = vec![GenesisValidator::from(a_key), GenesisValidator::from(b_key)];
+    let allocations = vec![
+        (
+            a_key,
+            vec![GenesisStakeAllocation {
+                account_index: 0,
+                xrd_amount: a_stake,
+            }],
+        ),
+        (
+            b_key,
+            vec![GenesisStakeAllocation {
+                account_index: 1,
+                xrd_amount: b_stake,
+            }],
+        ),
+    ];
+    let accounts = validators
+        .iter()
+        .map(|validator| validator.owner)
+        .collect::<Vec<_>>();
+    let genesis_data_chunks = vec![
+        GenesisDataChunk::Validators(validators),
+        GenesisDataChunk::Stakes {
+            accounts,
+            allocations,
+        },
+    ];
+    let genesis = CustomGenesis {
+        genesis_data_chunks,
+        initial_epoch: 4,
+        initial_configuration: dummy_epoch_manager_configuration()
+            .with_rounds_per_epoch(1)
+            .with_total_emission_xrd_per_epoch(epoch_emissions_xrd),
+    };
+
+    // Act
+    let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
+    let instructions = vec![Instruction::CallMethod {
+        component_address: EPOCH_MANAGER,
+        method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
+        args: to_manifest_value(&EpochManagerNextRoundInput::successful(1, 0)),
+    }];
+    let receipt = test_runner.execute_transaction(
+        SystemTransaction {
+            instructions,
+            blobs: vec![],
+            nonce: 0,
+            pre_allocated_ids: BTreeSet::new(),
+        }
+        .get_executable(btreeset![AuthAddresses::validator_role()]),
+    );
+
+    // Assert
+    let a_substate = test_runner.get_validator_info_by_key(&a_key);
+    let a_new_stake = test_runner
+        .inspect_vault_balance(a_substate.stake_xrd_vault_id.0)
+        .unwrap();
+    assert_eq!(
+        a_new_stake,
+        a_stake + epoch_emissions_xrd * a_stake / both_stake
+    );
+
+    let b_substate = test_runner.get_validator_info_by_key(&b_key);
+    let b_new_stake = test_runner
+        .inspect_vault_balance(b_substate.stake_xrd_vault_id.0)
+        .unwrap();
+    assert_eq!(
+        b_new_stake,
+        b_stake + epoch_emissions_xrd * b_stake / both_stake
+    );
+
+    // TODO(emissions): we should also be able to verify the same information being returned in the
+    // `result.next_epoch()`'s validator set - however, a current bug in "list sorted after write"
+    // makes this information incorrect and has to be fixed first.
+    let result = receipt.expect_commit_success();
+    let next_epoch_validators = result
+        .next_epoch()
+        .expect("Should have next epoch")
+        .0
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        next_epoch_validators,
+        vec![
+            Validator {
+                key: a_key,
+                stake: a_stake // exposing a bug: should be `a_new_stake`
+            },
+            Validator {
+                key: b_key,
+                stake: b_stake // exposing a bug: should be `b_new_stake`
+            },
+        ]
+    );
+}
+
+#[test]
+fn validator_receives_emission_penalty_when_some_proposals_missed() {
+    // Arrange
+    let epoch_emissions_xrd = dec!("10");
+    let rounds_per_epoch = 4; // we will simulate 3 gap rounds + 1 successfully made proposal...
+    let min_required_reliability = dec!("0.2"); // ...which barely meets the threshold
+    let validator_pub_key = EcdsaSecp256k1PrivateKey::from_u64(1).unwrap().public_key();
+    let validator_stake = dec!("500.0");
+    let genesis = CustomGenesis::single_validator_and_staker(
+        validator_pub_key,
+        validator_stake,
+        ComponentAddress::virtual_account_from_public_key(&validator_pub_key),
+        4,
+        dummy_epoch_manager_configuration()
+            .with_rounds_per_epoch(rounds_per_epoch)
+            .with_total_emission_xrd_per_epoch(epoch_emissions_xrd)
+            .with_min_validator_reliability(min_required_reliability),
+    );
+
+    // Act
+    let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
+    let instructions = vec![Instruction::CallMethod {
+        component_address: EPOCH_MANAGER,
+        method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
+    }];
+    let receipt = test_runner.execute_transaction(
+        SystemTransaction {
+            instructions,
+            blobs: vec![],
+            nonce: 0,
+            pre_allocated_ids: BTreeSet::new(),
+        }
+        .get_executable(btreeset![AuthAddresses::validator_role()]),
+    );
+
+    // Assert
+    let validator_substate = test_runner.get_validator_info_by_key(&validator_pub_key);
+    let validator_new_stake = test_runner
+        .inspect_vault_balance(validator_substate.stake_xrd_vault_id.0)
+        .unwrap();
+    let actual_reliability = Decimal::one() / Decimal::from(rounds_per_epoch);
+    let tolerated_range = Decimal::one() - min_required_reliability;
+    let reliability_factor = (actual_reliability - min_required_reliability) / tolerated_range;
+    assert_eq!(
+        validator_new_stake,
+        validator_stake + epoch_emissions_xrd * reliability_factor
+    );
+
+    // TODO(emissions): we should also be able to verify the same information being returned in the
+    // `result.next_epoch()`'s validator set - however, a current bug in "list sorted after write"
+    // makes this information incorrect and has to be fixed first.
+    let result = receipt.expect_commit_success();
+    let next_epoch_validators = result
+        .next_epoch()
+        .expect("Should have next epoch")
+        .0
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        next_epoch_validators,
+        vec![Validator {
+            key: validator_pub_key,
+            stake: validator_stake // exposing a bug: should be `validator_new_stake`
+        },]
+    );
+}
+
+#[test]
+fn validator_receives_no_emission_when_too_many_proposals_missed() {
+    // Arrange
+    let epoch_emissions_xrd = dec!("10");
+    let rounds_per_epoch = 4; // we will simulate 3 gap rounds + 1 successfully made proposal...
+    let min_required_reliability = dec!("0.3"); // ...which does NOT meet the threshold
+    let validator_pub_key = EcdsaSecp256k1PrivateKey::from_u64(1).unwrap().public_key();
+    let validator_stake = dec!("500.0");
+    let genesis = CustomGenesis::single_validator_and_staker(
+        validator_pub_key,
+        validator_stake,
+        ComponentAddress::virtual_account_from_public_key(&validator_pub_key),
+        4,
+        dummy_epoch_manager_configuration()
+            .with_rounds_per_epoch(rounds_per_epoch)
+            .with_total_emission_xrd_per_epoch(epoch_emissions_xrd)
+            .with_min_validator_reliability(min_required_reliability),
+    );
+
+    // Act
+    let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
+    let instructions = vec![Instruction::CallMethod {
+        component_address: EPOCH_MANAGER,
+        method_name: EPOCH_MANAGER_NEXT_ROUND_IDENT.to_string(),
+        args: to_manifest_value(&next_round_after_gap(rounds_per_epoch)),
+    }];
+    let receipt = test_runner.execute_transaction(
+        SystemTransaction {
+            instructions,
+            blobs: vec![],
+            nonce: 0,
+            pre_allocated_ids: BTreeSet::new(),
+        }
+        .get_executable(btreeset![AuthAddresses::validator_role()]),
+    );
+
+    // Assert
+    let validator_substate = test_runner.get_validator_info_by_key(&validator_pub_key);
+    let validator_new_stake = test_runner
+        .inspect_vault_balance(validator_substate.stake_xrd_vault_id.0)
+        .unwrap();
+    assert_eq!(validator_new_stake, validator_stake);
+
+    let result = receipt.expect_commit_success();
+    let next_epoch_validators = result
+        .next_epoch()
+        .expect("Should have next epoch")
+        .0
+        .into_values()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        next_epoch_validators,
+        vec![Validator {
+            key: validator_pub_key,
+            stake: validator_stake
+        },]
+    );
 }
 
 fn create_custom_genesis(
@@ -533,11 +752,9 @@ fn create_custom_genesis(
     let genesis = CustomGenesis {
         genesis_data_chunks,
         initial_epoch,
-        initial_configuration: EpochManagerInitialConfiguration {
-            max_validators: max_validators as u32,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        initial_configuration: dummy_epoch_manager_configuration()
+            .with_max_validators(max_validators as u32)
+            .with_rounds_per_epoch(rounds_per_epoch),
     };
 
     (genesis, pub_key_accounts)
@@ -872,11 +1089,7 @@ fn unregistered_validator_gets_removed_on_epoch_change() {
         Decimal::one(),
         validator_account_address,
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
     let validator_address = test_runner.get_validator_with_key(&validator_pub_key);
@@ -929,11 +1142,7 @@ fn updated_validator_keys_gets_updated_on_epoch_change() {
         Decimal::one(),
         validator_account_address,
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
     let validator_address = test_runner.get_validator_with_key(&validator_pub_key);
@@ -1055,11 +1264,7 @@ fn can_claim_unstake_after_epochs() {
         Decimal::from(10),
         account_with_lp,
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch: 2,
-            num_unstake_epochs,
-        },
+        dummy_epoch_manager_configuration().with_num_unstake_epochs(num_unstake_epochs),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
     let validator_address = test_runner.get_validator_with_key(&validator_pub_key);
@@ -1127,11 +1332,7 @@ fn unstaked_validator_gets_less_stake_on_epoch_change() {
         Decimal::from(10),
         account_with_lp,
         initial_epoch,
-        EpochManagerInitialConfiguration {
-            max_validators: 10,
-            rounds_per_epoch,
-            num_unstake_epochs: 1,
-        },
+        dummy_epoch_manager_configuration().with_rounds_per_epoch(rounds_per_epoch),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
     let validator_address = test_runner.get_validator_with_key(&validator_pub_key);
@@ -1242,11 +1443,7 @@ fn epoch_manager_create_should_succeed_with_system_privilege() {
             Into::<[u8; NodeId::LENGTH]>::into(VALIDATOR_OWNER_BADGE),
             Into::<[u8; NodeId::LENGTH]>::into(EPOCH_MANAGER),
             1u64,
-            EpochManagerInitialConfiguration {
-                max_validators: 10,
-                rounds_per_epoch: 1,
-                num_unstake_epochs: 1,
-            }
+            dummy_epoch_manager_configuration()
         ),
     }];
     let blobs = vec![];
@@ -1280,5 +1477,7 @@ fn dummy_epoch_manager_configuration() -> EpochManagerInitialConfiguration {
         max_validators: 10,
         rounds_per_epoch: 5,
         num_unstake_epochs: 1,
+        total_emission_xrd_per_epoch: Decimal::one(),
+        min_validator_reliability: Decimal::one(),
     }
 }

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -70,7 +70,7 @@ fn test_basic_transfer() {
         + 5587 /* DropLock */
         + 1575 /* DropNode */
         + 1050432 /* Invoke */
-        + 526396 /* LockSubstate */
+        + 527719 /* LockSubstate */
         + 7840 /* ReadSubstate */
         + 62500 /* RunNative */
         + 7500 /* RunSystem */
@@ -205,7 +205,7 @@ fn test_radiswap() {
         + 13912 /* DropLock */
         + 3570 /* DropNode */
         + 3305144 /* Invoke */
-        + 5641349 /* LockSubstate */
+        + 5642672 /* LockSubstate */
         + 19488 /* ReadSubstate */
         + 135000 /* RunNative */
         + 15000 /* RunSystem */
@@ -316,7 +316,7 @@ fn test_flash_loan() {
         + 21978 /* DropLock */
         + 5880 /* DropNode */
         + 4407857 /* Invoke */
-        + 6838988 /* LockSubstate */
+        + 6840311 /* LockSubstate */
         + 31192 /* ReadSubstate */
         + 200000 /* RunNative */
         + 40000 /* RunSystem */

--- a/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
+++ b/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
@@ -6,7 +6,7 @@ use crate::types::*;
 use native_sdk::modules::access_rules::{AccessRules, AccessRulesObject, AttachedAccessRules};
 use native_sdk::modules::metadata::Metadata;
 use native_sdk::modules::royalty::ComponentRoyalty;
-use native_sdk::resource::ResourceManager;
+use native_sdk::resource::{ResourceManager, SysBucket};
 use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::field_lock_api::LockFlags;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
@@ -21,6 +21,8 @@ pub struct EpochManagerConfigSubstate {
     pub max_validators: u32,
     pub rounds_per_epoch: u64,
     pub num_unstake_epochs: u64,
+    pub total_emission_xrd_per_epoch: Decimal,
+    pub min_validator_reliability: Decimal,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
@@ -75,6 +77,19 @@ pub struct ProposalStatistic {
     pub missed: u64,
 }
 
+impl ProposalStatistic {
+    /// A ratio of successful to total proposals.
+    /// There is a special case of a validator which did not have a chance of leading even a single
+    /// round of consensus - currently we assume they should not be punished (i.e. we return `1.0`).
+    pub fn success_ratio(&self) -> Decimal {
+        let total = self.made + self.missed;
+        if total == 0 {
+            return Decimal::one();
+        }
+        Decimal::from(self.made) / Decimal::from(total)
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Sbor)]
 pub enum EpochManagerError {
     InvalidRoundUpdate {
@@ -95,8 +110,8 @@ pub const EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX: CollectionIndex = 
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct EpochRegisteredValidatorByStakeEntry {
-    component_address: ComponentAddress,
-    validator: Validator,
+    pub component_address: ComponentAddress,
+    pub validator: Validator,
 }
 
 pub struct EpochManagerBlueprint;
@@ -141,6 +156,8 @@ impl EpochManagerBlueprint {
                 max_validators: initial_configuration.max_validators,
                 rounds_per_epoch: initial_configuration.rounds_per_epoch,
                 num_unstake_epochs: initial_configuration.num_unstake_epochs,
+                total_emission_xrd_per_epoch: initial_configuration.total_emission_xrd_per_epoch,
+                min_validator_reliability: initial_configuration.min_validator_reliability,
             };
             let epoch_manager = EpochManagerSubstate {
                 epoch: initial_epoch,
@@ -250,7 +267,7 @@ impl EpochManagerBlueprint {
         )?;
         let mgr: EpochManagerSubstate = api.field_lock_read_typed(mgr_handle)?;
 
-        Self::epoch_change(mgr.epoch, config.max_validators, api)?;
+        Self::epoch_change(mgr.epoch, &config, api)?;
 
         let access_rules = AttachedAccessRules(*receiver);
         access_rules.set_method_access_rule_and_mutability(
@@ -298,8 +315,7 @@ impl EpochManagerBlueprint {
 
         if round >= config.rounds_per_epoch {
             let next_epoch = epoch_manager.epoch + 1;
-            let max_validators = config.max_validators;
-            Self::epoch_change(next_epoch, max_validators, api)?;
+            Self::epoch_change(next_epoch, &config, api)?;
             epoch_manager.epoch = next_epoch;
             epoch_manager.round = 0;
         } else {
@@ -383,58 +399,178 @@ impl EpochManagerBlueprint {
         Ok(())
     }
 
-    fn epoch_change<Y>(epoch: u64, max_validators: u32, api: &mut Y) -> Result<(), RuntimeError>
+    fn epoch_change<Y>(
+        epoch: u64,
+        config: &EpochManagerConfigSubstate,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
-        let validators: Vec<EpochRegisteredValidatorByStakeEntry> = api
-            .actor_sorted_index_scan_typed(
-                OBJECT_HANDLE_SELF,
-                EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX,
-                max_validators,
-            )?;
-        let next_validator_set: BTreeMap<ComponentAddress, Validator> = validators
-            .into_iter()
-            .map(|entry| (entry.component_address, entry.validator))
-            .collect();
-
+        // read previous validator set
         let validator_set_handle = api.actor_lock_field(
             OBJECT_HANDLE_SELF,
             EpochManagerField::CurrentValidatorSet.into(),
             LockFlags::MUTABLE,
         )?;
-        api.field_lock_write_typed(
-            validator_set_handle,
-            CurrentValidatorSetSubstate {
-                validator_set: next_validator_set.clone(),
-            },
-        )?;
-        api.field_lock_release(validator_set_handle)?;
+        let mut validator_set_substate: CurrentValidatorSetSubstate =
+            api.field_lock_read_typed(validator_set_handle)?;
+        let previous_validator_set = validator_set_substate.validator_set;
 
+        // read previous validator statistics
         let statistic_handle = api.actor_lock_field(
             OBJECT_HANDLE_SELF,
             EpochManagerField::CurrentProposalStatistic.into(),
             LockFlags::MUTABLE,
         )?;
-        let mut statistic: CurrentProposalStatisticSubstate =
+        let mut statistic_substate: CurrentProposalStatisticSubstate =
             api.field_lock_read_typed(statistic_handle)?;
-        // TODO(emissions): In some next "emissions" PR, capture the concluded epoch's validator
-        // statistics (to be used for unreliability penalty calculation); at the moment we only
-        // reset it.
-        statistic.validator_statistics = (0..next_validator_set.len())
-            .map(|_index| ProposalStatistic::default())
-            .collect();
-        api.field_lock_write_typed(statistic_handle, statistic)?;
-        api.field_lock_release(statistic_handle)?;
+        let previous_statistics = statistic_substate.validator_statistics;
 
+        // apply emissions
+        Self::emit_validator_rewards(previous_validator_set, previous_statistics, config, api)?;
+
+        // select next validator set
+        let registered_validators: Vec<EpochRegisteredValidatorByStakeEntry> = api
+            .actor_sorted_index_scan_typed(
+                OBJECT_HANDLE_SELF,
+                EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX,
+                config.max_validators,
+            )?;
+        let next_validator_set: BTreeMap<ComponentAddress, Validator> = registered_validators
+            .into_iter()
+            .map(|entry| (entry.component_address, entry.validator))
+            .collect();
+
+        // emit epoch change event
         Runtime::emit_event(
             api,
             EpochChangeEvent {
                 epoch,
-                validators: next_validator_set,
+                validators: next_validator_set.clone(),
             },
         )?;
 
+        // write zeroed statistics of next validators
+        statistic_substate.validator_statistics = (0..next_validator_set.len())
+            .map(|_index| ProposalStatistic::default())
+            .collect();
+        api.field_lock_write_typed(statistic_handle, statistic_substate)?;
+        api.field_lock_release(statistic_handle)?;
+
+        // write next validator set
+        validator_set_substate.validator_set = next_validator_set;
+        api.field_lock_write_typed(validator_set_handle, validator_set_substate)?;
+        api.field_lock_release(validator_set_handle)?;
+
         Ok(())
+    }
+
+    /// Emits a configured XRD amount ([`EpochManagerConfigSubstate.total_emission_xrd_per_epoch`])
+    /// and distributes it across the given validator set, according to their stake.
+    fn emit_validator_rewards<Y>(
+        validator_set: BTreeMap<ComponentAddress, Validator>,
+        validator_statistics: Vec<ProposalStatistic>,
+        config: &EpochManagerConfigSubstate,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        let validator_rewards = validator_set
+            .into_iter()
+            .zip(validator_statistics)
+            .filter_map(|((address, validator), statistic)| {
+                ValidatorReward::create_if_applicable(
+                    address,
+                    validator.stake,
+                    statistic.success_ratio(),
+                    config.min_validator_reliability,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        if validator_rewards.is_empty() {
+            return Ok(());
+        }
+
+        let stake_sum_xrd = validator_rewards
+            .iter()
+            .map(|validator_reward| validator_reward.stake_xrd)
+            .sum::<Decimal>();
+        let emission_per_staked_xrd = config.total_emission_xrd_per_epoch / stake_sum_xrd;
+        let effective_total_emission_xrd = validator_rewards
+            .iter()
+            .map(|validator_reward| validator_reward.effective_stake_xrd * emission_per_staked_xrd)
+            .sum::<Decimal>();
+
+        let total_emission_xrd_bucket =
+            ResourceManager(RADIX_TOKEN).mint_fungible(effective_total_emission_xrd, api)?;
+
+        for validator_reward in validator_rewards {
+            let emission_xrd_bucket = total_emission_xrd_bucket.sys_take(
+                validator_reward.effective_stake_xrd * emission_per_staked_xrd,
+                api,
+            )?;
+            api.call_method(
+                validator_reward.address.as_node_id(),
+                VALIDATOR_PUT_INTO_STAKE_IDENT,
+                scrypto_encode(&ValidatorPutIntoStakeInput {
+                    xrd_bucket: emission_xrd_bucket,
+                })
+                .unwrap(),
+            )?;
+        }
+        total_emission_xrd_bucket.sys_drop_empty(api)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ValidatorReward {
+    pub address: ComponentAddress,
+    pub stake_xrd: Decimal,
+    pub effective_stake_xrd: Decimal,
+}
+
+impl ValidatorReward {
+    fn create_if_applicable(
+        address: ComponentAddress,
+        stake_xrd: Decimal,
+        reliability: Decimal,
+        min_required_reliability: Decimal,
+    ) -> Option<Self> {
+        if stake_xrd.is_positive() {
+            let effective_stake_xrd =
+                stake_xrd * Self::to_reliability_factor(reliability, min_required_reliability);
+            Some(Self {
+                address,
+                stake_xrd,
+                effective_stake_xrd,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Converts the absolute reliability measure (e.g. "0.97 uptime") into a reliability factor
+    /// which directly drives the fraction of received reward (e.g. "0.25 of base reward"), by
+    /// rescaling it into the allowed reliability range (e.g. "required >0.96 uptime").
+    fn to_reliability_factor(reliability: Decimal, min_required_reliability: Decimal) -> Decimal {
+        let reliability_reserve = reliability - min_required_reliability;
+        if reliability_reserve.is_negative() {
+            return Decimal::zero();
+        }
+        let max_allowed_unreliability = Decimal::one() - min_required_reliability;
+        if max_allowed_unreliability.is_zero() {
+            // special-casing the dirac delta behavior
+            if reliability == Decimal::one() {
+                return Decimal::one();
+            } else {
+                return Decimal::zero();
+            }
+        }
+        reliability_reserve / max_allowed_unreliability
     }
 }

--- a/radix-engine/src/blueprints/epoch_manager/package.rs
+++ b/radix-engine/src/blueprints/epoch_manager/package.rs
@@ -184,6 +184,15 @@ impl EpochManagerNativePackage {
                 export_name: VALIDATOR_UPDATE_ACCEPT_DELEGATED_STAKE_IDENT.to_string(),
             },
         );
+        functions.insert(
+            VALIDATOR_PUT_INTO_STAKE_IDENT.to_string(),
+            FunctionSchema {
+                receiver: Some(Receiver::SelfRefMut),
+                input: aggregator.add_child_type_and_descendents::<ValidatorPutIntoStakeInput>(),
+                output: aggregator.add_child_type_and_descendents::<ValidatorPutIntoStakeOutput>(),
+                export_name: VALIDATOR_PUT_INTO_STAKE_IDENT.to_string(),
+            },
+        );
 
         let event_schema = event_schema! {
             aggregator,
@@ -384,6 +393,15 @@ impl EpochManagerNativePackage {
                     input.accept_delegated_stake,
                     api,
                 )?;
+                Ok(IndexedScryptoValue::from_typed(&rtn))
+            }
+            VALIDATOR_PUT_INTO_STAKE_IDENT => {
+                api.consume_cost_units(FIXED_LOW_FEE, ClientCostingReason::RunNative)?;
+
+                let input: ValidatorPutIntoStakeInput = input.as_typed().map_err(|e| {
+                    RuntimeError::SystemUpstreamError(SystemUpstreamError::InputDecodeError(e))
+                })?;
+                let rtn = ValidatorBlueprint::put_into_stake(input.xrd_bucket, api)?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             _ => Err(RuntimeError::SystemUpstreamError(

--- a/radix-engine/src/blueprints/epoch_manager/validator.rs
+++ b/radix-engine/src/blueprints/epoch_manager/validator.rs
@@ -403,6 +403,34 @@ impl ValidatorBlueprint {
         Ok(())
     }
 
+    /// Puts the given bucket into this validator's stake XRD vault, effectively increasing the
+    /// value of all its stake units.
+    pub fn put_into_stake<Y>(xrd_bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
+    where
+        Y: ClientApi<RuntimeError>,
+    {
+        let handle = api.actor_lock_field(
+            OBJECT_HANDLE_SELF,
+            ValidatorField::Validator.into(),
+            LockFlags::MUTABLE,
+        )?;
+        let mut substate: ValidatorSubstate = api.field_lock_read_typed(handle)?;
+
+        let mut stake_xrd_vault = Vault(substate.stake_xrd_vault_id);
+        stake_xrd_vault.sys_put(xrd_bucket, api)?;
+
+        let new_stake_xrd = stake_xrd_vault.sys_amount(api)?;
+        let new_index_key =
+            Self::index_update(&substate, substate.is_registered, new_stake_xrd, api)?;
+        substate.sorted_key = new_index_key;
+        api.field_lock_write_typed(handle, &substate)?;
+        api.field_lock_release(handle)?;
+
+        // TODO(emissions): emit a "reward received" event here
+
+        Ok(())
+    }
+
     fn to_sorted_key(
         registered: bool,
         stake: Decimal,
@@ -436,7 +464,10 @@ impl ValidatorBlueprint {
                     OBJECT_HANDLE_OUTER_OBJECT,
                     EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX,
                     index_key,
-                    (address, Validator { key, stake }),
+                    EpochRegisteredValidatorByStakeEntry {
+                        component_address: address,
+                        validator: Validator { key, stake },
+                    },
                 )?;
             }
             UpdateSecondaryIndex::UpdatePublicKey { index_key, key } => {
@@ -452,7 +483,10 @@ impl ValidatorBlueprint {
                     OBJECT_HANDLE_OUTER_OBJECT,
                     EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX,
                     index_key,
-                    (address, validator),
+                    EpochRegisteredValidatorByStakeEntry {
+                        component_address: address,
+                        validator,
+                    },
                 )?;
             }
             UpdateSecondaryIndex::UpdateStake {
@@ -472,7 +506,10 @@ impl ValidatorBlueprint {
                     OBJECT_HANDLE_OUTER_OBJECT,
                     EPOCH_MANAGER_REGISTERED_VALIDATORS_BY_STAKE_INDEX,
                     new_index_key,
-                    (address, validator),
+                    EpochRegisteredValidatorByStakeEntry {
+                        component_address: address,
+                        validator,
+                    },
                 )?;
             }
             UpdateSecondaryIndex::Remove { index_key } => {
@@ -523,6 +560,16 @@ impl SecurifiedAccessRules for SecurifiedValidator {
                     AccessRuleEntry::AccessRule(rule!(require(package_of_direct_caller(
                         EPOCH_MANAGER_PACKAGE
                     )))),
+                ),
+            ),
+            (
+                // TODO(resolve during review): we should probably rename it, but this is actually
+                // 100% precisely what this method does... Alternatively, we can make it public?
+                // (maybe there are cases where someone wants to simply boost the SU value?)
+                VALIDATOR_PUT_INTO_STAKE_IDENT,
+                MethodType::Custom(
+                    AccessRuleEntry::AccessRule(rule!(require(global_caller(EPOCH_MANAGER)))),
+                    AccessRuleEntry::AccessRule(AccessRule::DenyAll),
                 ),
             ),
         ]

--- a/radix-engine/src/blueprints/resource/events/resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/events/resource_manager.rs
@@ -5,7 +5,7 @@ pub struct VaultCreationEvent {
     pub vault_id: NodeId,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct MintFungibleResourceEvent {
     pub amount: Decimal,
 }

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -141,6 +141,8 @@ where
                 max_validators: 10,
                 rounds_per_epoch: 1,
                 num_unstake_epochs: 1,
+                total_emission_xrd_per_epoch: Decimal::one(),
+                min_validator_reliability: Decimal::one(),
             },
         )
     }
@@ -377,6 +379,13 @@ pub fn create_system_bootstrap_transaction(
 
         let mut access_rules = BTreeMap::new();
         access_rules.insert(Withdraw, (rule!(allow_all), rule!(deny_all)));
+        access_rules.insert(
+            Mint,
+            (
+                rule!(require(global_caller(EPOCH_MANAGER))),
+                rule!(deny_all),
+            ),
+        );
         let initial_supply: Decimal = XRD_MAX_SUPPLY.into();
         let resource_address = RADIX_TOKEN.into();
         pre_allocated_ids.insert(RADIX_TOKEN.into());

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -575,7 +575,12 @@ impl TestRunner {
         (pub_key, priv_key, account)
     }
 
-    pub fn get_validator_info(&mut self, address: ComponentAddress) -> ValidatorSubstate {
+    pub fn get_validator_info_by_key(&self, key: &EcdsaSecp256k1PublicKey) -> ValidatorSubstate {
+        let address = self.get_validator_with_key(key);
+        self.get_validator_info(address)
+    }
+
+    pub fn get_validator_info(&self, address: ComponentAddress) -> ValidatorSubstate {
         self.substate_db()
             .get_mapped::<SpreadPrefixKeyMapper, ValidatorSubstate>(
                 address.as_node_id(),
@@ -585,7 +590,7 @@ impl TestRunner {
             .unwrap()
     }
 
-    pub fn get_validator_with_key(&mut self, key: &EcdsaSecp256k1PublicKey) -> ComponentAddress {
+    pub fn get_validator_with_key(&self, key: &EcdsaSecp256k1PublicKey) -> ComponentAddress {
         let substate = self
             .substate_db()
             .get_mapped::<SpreadPrefixKeyMapper, CurrentValidatorSetSubstate>(


### PR DESCRIPTION
⚠️ The implemented behavior is bugged in one aspect: the validator set reported in the epoch change result contains validator stakes from before the emissions. See `TODO`s in tests and this thread: https://rdxworks.slack.com/archives/C01HK4QFXNY/p1683889840625609

In scope of this PR:
- base emission calculation;
- (un)reliability penalty adjustment.

Out of scope of this PR:
- validator fees