### PR TITLE
Introducing "locked owner su vault" structs-only in validator + Renames

### DIFF
--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1476379af3b7c37c15d168c6afe72742de86f2f1cb82549bfc9ff5ffb9580d9"
+checksum = "6a66412baacf51dfc30a1e220bc7cc947001e8c47e3716468a3857f98887a7f3"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/assets/blueprints/genesis_helper/src/lib.rs
+++ b/assets/blueprints/genesis_helper/src/lib.rs
@@ -145,11 +145,11 @@ mod genesis_helper {
                 {
                     let staker_account_address = accounts[account_index as usize].clone();
                     let stake_xrd_bucket = self.xrd_vault.take(xrd_amount);
-                    let su_bucket = Validator(validator_address.clone())
+                    let stake_unit_bucket = Validator(validator_address.clone())
                         .stake(stake_xrd_bucket, &mut ScryptoEnv)
                         .unwrap();
                     let _: () = Account(staker_account_address)
-                        .deposit(su_bucket, &mut ScryptoEnv)
+                        .deposit(stake_unit_bucket, &mut ScryptoEnv)
                         .unwrap();
                 }
             }

--- a/assets/blueprints/genesis_helper/src/lib.rs
+++ b/assets/blueprints/genesis_helper/src/lib.rs
@@ -144,12 +144,12 @@ mod genesis_helper {
                 } in stake_allocations.into_iter()
                 {
                     let staker_account_address = accounts[account_index as usize].clone();
-                    let stake_bucket = self.xrd_vault.take(xrd_amount);
-                    let lp_bucket = Validator(validator_address.clone())
-                        .stake(stake_bucket, &mut ScryptoEnv)
+                    let stake_xrd_bucket = self.xrd_vault.take(xrd_amount);
+                    let su_bucket = Validator(validator_address.clone())
+                        .stake(stake_xrd_bucket, &mut ScryptoEnv)
                         .unwrap();
                     let _: () = Account(staker_account_address)
-                        .deposit(lp_bucket, &mut ScryptoEnv)
+                        .deposit(su_bucket, &mut ScryptoEnv)
                         .unwrap();
                 }
             }

--- a/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/epoch_manager/invocations.rs
@@ -27,6 +27,7 @@ pub struct EpochManagerInitialConfiguration {
     pub num_unstake_epochs: u64,
     pub total_emission_xrd_per_epoch: Decimal,
     pub min_validator_reliability: Decimal,
+    pub num_owner_su_unlock_epochs: u64,
 }
 
 impl EpochManagerInitialConfiguration {
@@ -209,7 +210,7 @@ pub const VALIDATOR_UNSTAKE_IDENT: &str = "unstake";
 
 #[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct ValidatorUnstakeInput {
-    pub lp_tokens: Bucket,
+    pub su_bucket: Bucket,
 }
 
 pub type ValidatorUnstakeOutput = Bucket;

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -370,5 +370,6 @@ fn dummy_epoch_manager_configuration() -> EpochManagerInitialConfiguration {
         num_unstake_epochs: 1,
         total_emission_xrd_per_epoch: Decimal::one(),
         min_validator_reliability: Decimal::one(),
+        num_owner_su_unlock_epochs: 2,
     }
 }

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -1019,11 +1019,11 @@ fn validator_unstake_emits_correct_events() {
     let account_pub_key = EcdsaSecp256k1PrivateKey::from_u64(1u64)
         .unwrap()
         .public_key();
-    let account_with_lp = ComponentAddress::virtual_account_from_public_key(&account_pub_key);
+    let account_with_su = ComponentAddress::virtual_account_from_public_key(&account_pub_key);
     let genesis = CustomGenesis::single_validator_and_staker(
         validator_pub_key,
         Decimal::from(10),
-        account_with_lp,
+        account_with_su,
         initial_epoch,
         dummy_epoch_manager_configuration().with_num_unstake_epochs(num_unstake_epochs),
     );
@@ -1034,16 +1034,12 @@ fn validator_unstake_emits_correct_events() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee(test_runner.faucet_component(), 10.into())
-        .withdraw_from_account(
-            account_with_lp,
-            validator_substate.liquidity_token,
-            1.into(),
-        )
-        .take_all_from_worktop(validator_substate.liquidity_token, |builder, bucket| {
+        .withdraw_from_account(account_with_su, validator_substate.su_token, 1.into())
+        .take_all_from_worktop(validator_substate.su_token, |builder, bucket| {
             builder.unstake_validator(validator_address, bucket)
         })
         .call_method(
-            account_with_lp,
+            account_with_su,
             ACCOUNT_DEPOSIT_BATCH_IDENT,
             manifest_args!(ManifestExpression::EntireWorktop),
         )
@@ -1175,11 +1171,11 @@ fn validator_claim_xrd_emits_correct_events() {
     let account_pub_key = EcdsaSecp256k1PrivateKey::from_u64(1u64)
         .unwrap()
         .public_key();
-    let account_with_lp = ComponentAddress::virtual_account_from_public_key(&account_pub_key);
+    let account_with_su = ComponentAddress::virtual_account_from_public_key(&account_pub_key);
     let genesis = CustomGenesis::single_validator_and_staker(
         validator_pub_key,
         Decimal::from(10),
-        account_with_lp,
+        account_with_su,
         initial_epoch,
         dummy_epoch_manager_configuration().with_num_unstake_epochs(num_unstake_epochs),
     );
@@ -1188,16 +1184,12 @@ fn validator_claim_xrd_emits_correct_events() {
     let validator_substate = test_runner.get_validator_info(validator_address);
     let manifest = ManifestBuilder::new()
         .lock_fee(test_runner.faucet_component(), 10.into())
-        .withdraw_from_account(
-            account_with_lp,
-            validator_substate.liquidity_token,
-            1.into(),
-        )
-        .take_all_from_worktop(validator_substate.liquidity_token, |builder, bucket| {
+        .withdraw_from_account(account_with_su, validator_substate.su_token, 1.into())
+        .take_all_from_worktop(validator_substate.su_token, |builder, bucket| {
             builder.unstake_validator(validator_address, bucket)
         })
         .call_method(
-            account_with_lp,
+            account_with_su,
             ACCOUNT_DEPOSIT_BATCH_IDENT,
             manifest_args!(ManifestExpression::EntireWorktop),
         )
@@ -1212,12 +1204,12 @@ fn validator_claim_xrd_emits_correct_events() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee(test_runner.faucet_component(), 10.into())
-        .withdraw_from_account(account_with_lp, validator_substate.unstake_nft, 1.into())
+        .withdraw_from_account(account_with_su, validator_substate.unstake_nft, 1.into())
         .take_all_from_worktop(validator_substate.unstake_nft, |builder, bucket| {
             builder.claim_xrd(validator_address, bucket)
         })
         .call_method(
-            account_with_lp,
+            account_with_su,
             ACCOUNT_DEPOSIT_BATCH_IDENT,
             manifest_args!(ManifestExpression::EntireWorktop),
         )
@@ -1523,5 +1515,6 @@ fn dummy_epoch_manager_configuration() -> EpochManagerInitialConfiguration {
         num_unstake_epochs: 1,
         total_emission_xrd_per_epoch: Decimal::one(),
         min_validator_reliability: Decimal::one(),
+        num_owner_su_unlock_epochs: 2,
     }
 }

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -1033,8 +1033,12 @@ fn validator_unstake_emits_correct_events() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee(test_runner.faucet_component(), 10.into())
-        .withdraw_from_account(account_with_su, validator_substate.stake_unit_token, 1.into())
-        .take_all_from_worktop(validator_substate.stake_unit_token, |builder, bucket| {
+        .withdraw_from_account(
+            account_with_su,
+            validator_substate.stake_unit_resource,
+            1.into(),
+        )
+        .take_all_from_worktop(validator_substate.stake_unit_resource, |builder, bucket| {
             builder.unstake_validator(validator_address, bucket)
         })
         .call_method(
@@ -1183,8 +1187,12 @@ fn validator_claim_xrd_emits_correct_events() {
     let validator_substate = test_runner.get_validator_info(validator_address);
     let manifest = ManifestBuilder::new()
         .lock_fee(test_runner.faucet_component(), 10.into())
-        .withdraw_from_account(account_with_su, validator_substate.stake_unit_token, 1.into())
-        .take_all_from_worktop(validator_substate.stake_unit_token, |builder, bucket| {
+        .withdraw_from_account(
+            account_with_su,
+            validator_substate.stake_unit_resource,
+            1.into(),
+        )
+        .take_all_from_worktop(validator_substate.stake_unit_resource, |builder, bucket| {
             builder.unstake_validator(validator_address, bucket)
         })
         .call_method(

--- a/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
+++ b/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
@@ -159,7 +159,8 @@ impl EpochManagerBlueprint {
                 num_unstake_epochs: initial_configuration.num_unstake_epochs,
                 total_emission_xrd_per_epoch: initial_configuration.total_emission_xrd_per_epoch,
                 min_validator_reliability: initial_configuration.min_validator_reliability,
-                num_owner_stake_units_unlock_epochs: initial_configuration.num_owner_stake_units_unlock_epochs,
+                num_owner_stake_units_unlock_epochs: initial_configuration
+                    .num_owner_stake_units_unlock_epochs,
             };
             let epoch_manager = EpochManagerSubstate {
                 epoch: initial_epoch,

--- a/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
+++ b/radix-engine/src/blueprints/epoch_manager/epoch_manager.rs
@@ -23,6 +23,7 @@ pub struct EpochManagerConfigSubstate {
     pub num_unstake_epochs: u64,
     pub total_emission_xrd_per_epoch: Decimal,
     pub min_validator_reliability: Decimal,
+    pub num_owner_su_unlock_epochs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
@@ -158,6 +159,7 @@ impl EpochManagerBlueprint {
                 num_unstake_epochs: initial_configuration.num_unstake_epochs,
                 total_emission_xrd_per_epoch: initial_configuration.total_emission_xrd_per_epoch,
                 min_validator_reliability: initial_configuration.min_validator_reliability,
+                num_owner_su_unlock_epochs: initial_configuration.num_owner_su_unlock_epochs,
             };
             let epoch_manager = EpochManagerSubstate {
                 epoch: initial_epoch,

--- a/radix-engine/src/blueprints/epoch_manager/events/validator.rs
+++ b/radix-engine/src/blueprints/epoch_manager/events/validator.rs
@@ -34,10 +34,10 @@ pub struct RewardAppliedEvent {
     /// means that any applicable reliability penalty and validator fee were already subtracted.
     pub stake_added_xrd: Decimal,
     /// A total supply of stake units of the validator at the moment of applying this reward.
-    /// Note: calculating `stake_added_xrd / liquidity_token_supply` gives a convenient "XRD reward
-    /// per stake unit" factor, which may be used to easily calculate individual staker's gains.
+    /// Note: calculating `stake_added_xrd / total_su_supply` gives a convenient "XRD reward per
+    /// stake unit" factor, which may be used to easily calculate individual staker's gains.
     /// Note: this number is captured *before* auto-staking of the validator fee described below.
-    pub liquidity_token_supply: Decimal,
+    pub total_su_supply: Decimal,
     /// An amount of XRD received by the validator's owner (according to the configured fee
     /// percentage).
     /// Note: this fee is automatically staked and placed inside the owner's stake vault (internal

--- a/radix-engine/src/blueprints/epoch_manager/package.rs
+++ b/radix-engine/src/blueprints/epoch_manager/package.rs
@@ -358,7 +358,7 @@ impl EpochManagerNativePackage {
                 let input: ValidatorUnstakeInput = input.as_typed().map_err(|e| {
                     RuntimeError::SystemUpstreamError(SystemUpstreamError::InputDecodeError(e))
                 })?;
-                let rtn = ValidatorBlueprint::unstake(input.lp_tokens, api)?;
+                let rtn = ValidatorBlueprint::unstake(input.su_bucket, api)?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             VALIDATOR_CLAIM_XRD_IDENT => {

--- a/radix-engine/src/blueprints/epoch_manager/validator.rs
+++ b/radix-engine/src/blueprints/epoch_manager/validator.rs
@@ -24,21 +24,72 @@ use super::{
     UpdateAcceptingStakeDelegationStateEvent,
 };
 
+/// A performance-driven limit on the number of simultaneously pending "delayed withdrawal"
+/// operations on any validator's owner's SU vault.
+pub const OWNER_SU_PENDING_WITHDRAWALS_LIMIT: usize = 100;
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ValidatorSubstate {
+    /// A key used internally for storage of registered validators sorted by their stake descending.
+    /// It is only useful when the validator is registered and has non-zero stake - hence, the field
+    /// is [`None`] otherwise.
+    /// Note: in theory, this value could be always computed from the [`is_registered`] status and
+    /// the amount stored in [`stake_xrd_vault_id`]; we simply keep it cached to simplify certain
+    /// updates.
     pub sorted_key: Option<SortedKey>,
+
+    /// This validator's public key.
     pub key: EcdsaSecp256k1PublicKey,
+
+    /// Whether this validator is currently interested in participating in the consensus.
     pub is_registered: bool,
 
-    pub unstake_nft: ResourceAddress,
-    pub liquidity_token: ResourceAddress,
+    /// A type of fungible token representing stake units specific to this validator.
+    /// Conceptually, "staking to validator A" means "exchanging XRDs for SUs of A".
+    pub su_token: ResourceAddress,
+
+    /// A vault holding the XRDs currently staked to this validator.
     pub stake_xrd_vault_id: Own,
+
+    /// A type of non-fungible token used as a receipt for unstaked stake units.
+    /// Unstaking burns the SUs and inactivates the staked XRDs (i.e. moves it from the regular
+    /// [`stake_xrd_vault_id`] to the [`pending_xrd_withdraw_vault_id`]), and then requires to claim
+    /// the XRDs using this NFT after a delay (see [`UnstakeData.epoch_unlocked`]).
+    pub unstake_nft: ResourceAddress,
+
+    /// A vault holding the XRDs that were unstaked (see the [`unstake_nft`]) but not yet claimed.
     pub pending_xrd_withdraw_vault_id: Own,
+
+    /// A vault holding the SUs that this validator's owner voluntarily decided to temporarily lock
+    /// here, as a public display of their confidence in this validator's future reliability.
+    /// Withdrawing SUs from this vault is subject to a delay (which is configured separately from
+    /// the regular unstaking delay, see [`EpochManagerConfigSubstate.num_owner_su_unlock_epochs`]).
+    /// This vault is private to the owner (i.e. the owner's badge is required for any interaction
+    /// with this vault).
+    pub locked_owner_su_vault_id: Own,
+
+    /// A vault holding the SUs which the owner has decided to withdraw from their "public display"
+    /// vault (see [`locked_owner_su_vault_id`]) but which have not yet been unlocked after the
+    /// mandatory delay (see [`pending_owner_su_withdrawals`]).
+    pub pending_owner_su_unlock_vault_id: Own,
+
+    /// All currently pending "delayed withdrawal" operations of the owner's SU vault (see
+    /// [`locked_owner_su_vault_id`).
+    /// This maps an epoch number to an amount of SU that becomes unlocked at that epoch.
+    /// Note: because of performance considerations, a maximum size of this map is limited to
+    /// [`OWNER_SU_PENDING_WITHDRAWALS_LIMIT`]: starting another withdrawal will first attempt to
+    /// automatically claim any withdrawals that have finished their wait, and only then will fail
+    /// if the limit is exceeded.
+    pub pending_owner_su_withdrawals: BTreeMap<u64, Decimal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct UnstakeData {
+    /// An epoch number at (or after) which the pending unstaked XRD may be claimed.
+    /// Note: on unstake, it is fixed to be [`EpochManagerConfigSubstate.num_unstake_epochs`] away.
     epoch_unlocked: u64,
+
+    /// An XRD amount to be claimed.
     amount: Decimal,
 }
 
@@ -69,15 +120,11 @@ impl ValidatorBlueprint {
         Self::register_update(false, api)
     }
 
-    pub fn stake<Y>(stake: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
+    pub fn stake<Y>(xrd_bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
-        // Prepare the event and emit it once the operations succeed
-        let event = {
-            let amount = stake.sys_amount(api)?;
-            StakeEvent { xrd_staked: amount }
-        };
+        let xrd_bucket_amount = xrd_bucket.sys_amount(api)?;
 
         let handle = api.actor_lock_field(
             OBJECT_HANDLE_SELF,
@@ -88,24 +135,22 @@ impl ValidatorBlueprint {
         let mut validator: ValidatorSubstate = api.field_lock_read_typed(handle)?;
 
         // Stake
-        let (lp_token_bucket, new_stake_amount) = {
-            let mut lp_token_resman = ResourceManager(validator.liquidity_token);
+        let (su_bucket, new_stake_amount) = {
+            let mut su_resman = ResourceManager(validator.su_token);
             let mut xrd_vault = Vault(validator.stake_xrd_vault_id);
 
-            let total_lp_supply = lp_token_resman.total_supply(api)?;
+            let total_su_supply = su_resman.total_supply(api)?;
             let active_stake_amount = xrd_vault.sys_amount(api)?;
-            let xrd_bucket = stake;
-            let stake_amount = xrd_bucket.sys_amount(api)?;
-            let lp_mint_amount = if active_stake_amount.is_zero() {
-                stake_amount
+            let su_mint_amount = if active_stake_amount.is_zero() {
+                xrd_bucket_amount
             } else {
-                stake_amount * total_lp_supply / active_stake_amount
+                xrd_bucket_amount * total_su_supply / active_stake_amount
             };
 
-            let lp_token_bucket = lp_token_resman.mint_fungible(lp_mint_amount, api)?;
+            let su_bucket = su_resman.mint_fungible(su_mint_amount, api)?;
             xrd_vault.sys_put(xrd_bucket, api)?;
             let new_stake_amount = xrd_vault.sys_amount(api)?;
-            (lp_token_bucket, new_stake_amount)
+            (su_bucket, new_stake_amount)
         };
 
         // Update EpochManager
@@ -114,22 +159,22 @@ impl ValidatorBlueprint {
 
         validator.sorted_key = new_index_key;
         api.field_lock_write_typed(handle, &validator)?;
-        Runtime::emit_event(api, event)?;
 
-        Ok(lp_token_bucket)
+        Runtime::emit_event(
+            api,
+            StakeEvent {
+                xrd_staked: xrd_bucket_amount,
+            },
+        )?;
+
+        Ok(su_bucket)
     }
 
-    pub fn unstake<Y>(lp_tokens: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
+    pub fn unstake<Y>(su_bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
-        // Prepare event and emit it once operations finish
-        let event = {
-            let amount = lp_tokens.sys_amount(api)?;
-            UnstakeEvent {
-                stake_units: amount,
-            }
-        };
+        let su_bucket_amount = su_bucket.sys_amount(api)?;
 
         let handle = api.actor_lock_field(
             OBJECT_HANDLE_SELF,
@@ -143,18 +188,17 @@ impl ValidatorBlueprint {
             let mut stake_vault = Vault(validator.stake_xrd_vault_id);
             let mut unstake_vault = Vault(validator.pending_xrd_withdraw_vault_id);
             let nft_resman = ResourceManager(validator.unstake_nft);
-            let mut lp_token_resman = ResourceManager(validator.liquidity_token);
+            let mut su_resman = ResourceManager(validator.su_token);
 
             let active_stake_amount = stake_vault.sys_amount(api)?;
-            let total_lp_supply = lp_token_resman.total_supply(api)?;
-            let lp_token_amount = lp_tokens.sys_amount(api)?;
-            let xrd_amount = if total_lp_supply.is_zero() {
+            let total_su_supply = su_resman.total_supply(api)?;
+            let xrd_amount = if total_su_supply.is_zero() {
                 Decimal::zero()
             } else {
-                lp_token_amount * active_stake_amount / total_lp_supply
+                su_bucket_amount * active_stake_amount / total_su_supply
             };
 
-            lp_token_resman.burn(lp_tokens, api)?;
+            su_resman.burn(su_bucket, api)?;
 
             let manager_handle = api.actor_lock_field(
                 OBJECT_HANDLE_OUTER_OBJECT,
@@ -194,7 +238,13 @@ impl ValidatorBlueprint {
 
         validator.sorted_key = new_index_key;
         api.field_lock_write_typed(handle, &validator)?;
-        Runtime::emit_event(api, event)?;
+
+        Runtime::emit_event(
+            api,
+            UnstakeEvent {
+                stake_units: su_bucket_amount,
+            },
+        )?;
 
         Ok(unstake_bucket)
     }
@@ -424,7 +474,7 @@ impl ValidatorBlueprint {
         let mut substate: ValidatorSubstate = api.field_lock_read_typed(handle)?;
 
         let stake_added_xrd = xrd_bucket.sys_amount(api)?;
-        let liquidity_token_supply = ResourceManager(substate.liquidity_token).total_supply(api)?;
+        let total_su_supply = ResourceManager(substate.su_token).total_supply(api)?;
 
         let mut stake_xrd_vault = Vault(substate.stake_xrd_vault_id);
         stake_xrd_vault.sys_put(xrd_bucket, api)?;
@@ -440,7 +490,7 @@ impl ValidatorBlueprint {
             api,
             RewardAppliedEvent {
                 stake_added_xrd,
-                liquidity_token_supply,
+                total_su_supply,
                 validator_fee_xrd: Decimal::zero(), // TODO(emissions): update after implementing validator fees
                 proposals_made,
                 proposals_missed,
@@ -595,29 +645,29 @@ impl SecurifiedAccessRules for SecurifiedValidator {
 pub(crate) struct ValidatorCreator;
 
 impl ValidatorCreator {
-    fn create_liquidity_token<Y>(
+    fn create_stake_unit_token<Y>(
         address: GlobalAddress,
         api: &mut Y,
     ) -> Result<ResourceAddress, RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
-        let mut liquidity_token_auth = BTreeMap::new();
-        liquidity_token_auth.insert(
+        let mut su_token_auth = BTreeMap::new();
+        su_token_auth.insert(
             Mint,
             (rule!(require(global_caller(address))), rule!(deny_all)),
         );
-        liquidity_token_auth.insert(
+        su_token_auth.insert(
             Burn,
             (rule!(require(global_caller(address))), rule!(deny_all)),
         );
-        liquidity_token_auth.insert(Withdraw, (rule!(allow_all), rule!(deny_all)));
-        liquidity_token_auth.insert(Deposit, (rule!(allow_all), rule!(deny_all)));
+        su_token_auth.insert(Withdraw, (rule!(allow_all), rule!(deny_all)));
+        su_token_auth.insert(Deposit, (rule!(allow_all), rule!(deny_all)));
 
-        let liquidity_token_resource_manager =
-            ResourceManager::new_fungible(18, BTreeMap::new(), liquidity_token_auth, api)?;
+        let su_token_resource_manager =
+            ResourceManager::new_fungible(18, BTreeMap::new(), su_token_auth, api)?;
 
-        Ok(liquidity_token_resource_manager.0)
+        Ok(su_token_resource_manager.0)
     }
 
     fn create_unstake_nft<Y>(
@@ -663,19 +713,26 @@ impl ValidatorCreator {
             api.kernel_allocate_node_id(EntityType::GlobalValidator)?.0,
         );
 
-        let stake_vault = Vault::sys_new(RADIX_TOKEN, api)?;
-        let unstake_vault = Vault::sys_new(RADIX_TOKEN, api)?;
+        let stake_xrd_vault = Vault::sys_new(RADIX_TOKEN, api)?;
+        let pending_xrd_withdraw_vault = Vault::sys_new(RADIX_TOKEN, api)?;
         let unstake_nft = Self::create_unstake_nft(address, api)?;
-        let liquidity_token = Self::create_liquidity_token(address, api)?;
+        let su_token = Self::create_stake_unit_token(address, api)?;
+        let locked_owner_su_vault = Vault::sys_new(su_token, api)?;
+        let pending_owner_su_unlock_vault = Vault::sys_new(su_token, api)?;
+        let pending_owner_su_withdrawals = BTreeMap::new();
+        // TODO(emissions): add `lock(), withdraw(), unlock()` owner-only methods for the 3 above
 
         let substate = ValidatorSubstate {
             sorted_key: None,
             key,
-            liquidity_token,
-            unstake_nft,
-            stake_xrd_vault_id: stake_vault.0,
-            pending_xrd_withdraw_vault_id: unstake_vault.0,
             is_registered,
+            su_token,
+            unstake_nft,
+            stake_xrd_vault_id: stake_xrd_vault.0,
+            pending_xrd_withdraw_vault_id: pending_xrd_withdraw_vault.0,
+            locked_owner_su_vault_id: locked_owner_su_vault.0,
+            pending_owner_su_unlock_vault_id: pending_owner_su_unlock_vault.0,
+            pending_owner_su_withdrawals,
         };
 
         let validator_id = api.new_simple_object(

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -143,6 +143,7 @@ where
                 num_unstake_epochs: 1,
                 total_emission_xrd_per_epoch: Decimal::one(),
                 min_validator_reliability: Decimal::one(),
+                num_owner_su_unlock_epochs: 2,
             },
         )
     }


### PR DESCRIPTION
⚠️ This PR builds on top of https://github.com/radixdlt/radixdlt-scrypto/pull/1029

This PR **only** introduces structs needed for **Q5-B** of https://radixdlt.atlassian.net/wiki/spaces/S/pages/3058827265/REP-83+Calculating+Emissions+and+Handling+Validator+Fees
(the impl will come in some next PR)

Also, this PR applies a few renames (mostly regarding consistent naming of "stake unit" inside validator) and adds missing rustdocs _(mostly for my own convenience, since I am recently reading a lot of code there and I sometimes forget whether some amount is XRD or SU...)_.
So, **let's use it to establish some naming** (and avoid discussing names in the coming more logic-heavy PRs).