### PR TITLE
fix: Let 'resim show-ledger' list items as before

### DIFF
--- a/radix-engine-stores/src/memory_db.rs
+++ b/radix-engine-stores/src/memory_db.rs
@@ -62,3 +62,10 @@ impl CommittableSubstateDatabase for InMemorySubstateDatabase {
         }
     }
 }
+
+impl ListableSubstateDatabase for InMemorySubstateDatabase {
+    fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_> {
+        let partition_iter = self.partitions.iter().map(|(key, _)| key.clone());
+        Box::new(partition_iter)
+    }
+}

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -64,7 +64,7 @@ impl CommittableSubstateDatabase for RocksdbSubstateStore {
 
 impl ListableSubstateDatabase for RocksdbSubstateStore {
     fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_> {
-        let partition_keys: Vec<DbPartitionKey> = self
+        let mut partition_keys: Vec<DbPartitionKey> = self
             .db
             .iterator(IteratorMode::Start)
             .map(|kv| {
@@ -73,6 +73,9 @@ impl ListableSubstateDatabase for RocksdbSubstateStore {
                 iter_key
             })
             .collect();
+        // Eliminate duplicated keys (if any). Rocksdb iterator returns sorted entries, so we can
+        // dedup() directly.
+        partition_keys.dedup();
 
         Box::new(partition_keys.into_iter())
     }

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use radix_engine_store_interface::interface::*;
 use rocksdb::{DBWithThreadMode, Direction, IteratorMode, SingleThreaded, DB};
 use sbor::rust::prelude::*;
@@ -64,18 +65,18 @@ impl CommittableSubstateDatabase for RocksdbSubstateStore {
 
 impl ListableSubstateDatabase for RocksdbSubstateStore {
     fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_> {
-        let mut partition_keys: Vec<DbPartitionKey> = vec![];
-
-        self.db.iterator(IteratorMode::Start).for_each(|kv| {
-            let (iter_key_bytes, _) = kv.as_ref().unwrap();
-            let (iter_key, _) = decode_from_rocksdb_bytes(iter_key_bytes);
-            // Eliminate duplicated keys (if any).
-            if !partition_keys.contains(&iter_key) {
-                partition_keys.push(iter_key)
-            }
-        });
-
-        Box::new(partition_keys.into_iter())
+        Box::new(
+            self.db
+                .iterator(IteratorMode::Start)
+                .map(|kv| {
+                    let (iter_key_bytes, _) = kv.as_ref().unwrap();
+                    let (iter_key, _) = decode_from_rocksdb_bytes(iter_key_bytes);
+                    iter_key
+                })
+                // Rocksdb iterator returns sorted entries, so ok to to eliminate
+                // duplicates with dedup()
+                .dedup(),
+        )
     }
 }
 

--- a/radix-engine/src/track/db_key_mapper.rs
+++ b/radix-engine/src/track/db_key_mapper.rs
@@ -62,7 +62,7 @@ pub trait DatabaseKeyMapper {
 /// This implementation is the actual, protocol-enforced one, to be used in public Radix networks.
 ///
 /// This implementation achieves the prefix-spreading by adding a hash prefix (shortened hash for
-/// performance reasons, but still hard to crach) to:
+/// performance reasons, but still hard to crack) to:
 /// - the PartitionKey (namely a RE Node and Module ID)
 /// - the SubstateKey
 pub struct SpreadPrefixKeyMapper;

--- a/simulator/tests/resim.sh
+++ b/simulator/tests/resim.sh
@@ -15,9 +15,14 @@ account2=`$resim new-account | awk '/Account component address:/ {print $NF}'`
 
 # Dump each entity in the ledger
 addresses=`$resim show-ledger | grep -e "─ " | awk '{print $2}'`
-for addr in $addresses ; do
-    $resim show $addr
-done
+if [ "$addresses" != "" ] ; then
+    for addr in $addresses ; do
+        $resim show $addr
+    done
+else
+    echo "No entities found in the ledger"
+    exit 1
+fi
 
 # Test - set epoch & time
 $resim set-current-epoch 858585


### PR DESCRIPTION
## Summary

This PR fixes `resim show-ledger` command and let it display ledger entries as before.

## Details

- Added support for reverse mapping for the `DbPartitionKey` in order to retrieve `NodeId` used to restore ledger addresses.
It was agreed to change `DbPartitionKey` format to:
`HashPrefix(NodeId + ParitionNumber) + NodeId + PartitionNumber`
 It extends its size from `32` to `51` bytes, which is the price wa are willing to pay to have the reverse mapping available.
 
- Implemented `list_partition_keys()` for `InMemorySubstateDatabase` and `RocksdbSubstateStore`

## Testing

Added test to `resim.sh` to check if 'resim show-ledger' dumps entities.

## Update Recommendations

### For Internal Integrators

Node shall be updated to align to the new `DbPartitionKey` format. Database needs to be reset.
