### PR TITLE
Tweak/Transaction hash prefix

### DIFF
--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 sbor = { path = "../sbor", default-features = false }
 utils = { path = "../utils", default-features = false }
 radix-engine-derive = { path = "../radix-engine-derive", default-features = false }
-radix-engine-constants = { path = "../radix-engine-constants", default-features = false }
+radix-engine-constants = { path = "../radix-engine-constants" }
 
 serde = { version = "1.0.137", default-features = false, optional = true, features=["derive"] }
 hex = { version = "0.4.3", default-features = false }

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 sbor = { path = "../sbor", default-features = false }
 utils = { path = "../utils", default-features = false }
 radix-engine-derive = { path = "../radix-engine-derive", default-features = false }
+radix-engine-constants = { path = "../radix-engine-constants", default-features = false }
 
 serde = { version = "1.0.137", default-features = false, optional = true, features=["derive"] }
 hex = { version = "0.4.3", default-features = false }

--- a/radix-engine-common/src/data/manifest/mod.rs
+++ b/radix-engine-common/src/data/manifest/mod.rs
@@ -25,7 +25,7 @@ pub use custom_value::*;
 pub use custom_value_kind::*;
 pub use display_context::*;
 
-pub const MANIFEST_SBOR_V1_PAYLOAD_PREFIX: u8 = 77; // [M] ASCII code
+pub use radix_engine_constants::MANIFEST_SBOR_V1_PAYLOAD_PREFIX;
 pub const MANIFEST_SBOR_V1_MAX_DEPTH: usize = 24;
 
 pub type ManifestEncoder<'a> = VecEncoder<'a, ManifestCustomValueKind>;

--- a/radix-engine-common/src/data/scrypto/mod.rs
+++ b/radix-engine-common/src/data/scrypto/mod.rs
@@ -38,8 +38,7 @@ use sbor::rust::vec::Vec;
 use sbor::traversal::VecTraverser;
 use sbor::*;
 
-// 0x5c for [5c]rypto - (91 in decimal)
-pub const SCRYPTO_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5c;
+pub use radix_engine_constants::SCRYPTO_SBOR_V1_PAYLOAD_PREFIX;
 pub const SCRYPTO_SBOR_V1_MAX_DEPTH: usize = 64;
 
 pub type ScryptoEncoder<'a> = VecEncoder<'a, ScryptoCustomValueKind>;

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -1,4 +1,27 @@
 //==========================
+// Prefix bytes
+//==========================
+
+// In order to distinguish payloads, all of these should be distinct!
+// This is particularly important for payloads which will be signed (Transaction / ROLA)
+
+/// 0x5b for [5b]or - (90 in decimal)
+pub const BASIC_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5b; // Duplicated due to dependency issues
+/// 0x5c for [5c]rypto - (91 in decimal)
+pub const SCRYPTO_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5c;
+/// 0x4d = M in ASCII for Manifest - (77 in decimal)
+pub const MANIFEST_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x4d;
+/// The ROLA hash which is signed is created as `hash(ROLA_HASHABLE_PAYLOAD_PREFIX || ..)`
+/// 
+/// 0x52 = R in ASCII for ROLA - (82 in decimal)
+pub const ROLA_HASHABLE_PAYLOAD_PREFIX: u8 = 0x52;
+/// The Transaction hash which is signed is created as:
+/// `hash(TRANSACTION_HASHABLE_PAYLOAD_PREFIX || version prefix according to type of transaction payload || ..)`
+/// 
+/// 0x54 = T in ASCII for Transaction - (84 in decimal)
+pub const TRANSACTION_HASHABLE_PAYLOAD_PREFIX: u8 = 0x54;
+
+//==========================
 // Transaction construction
 //==========================
 

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //==========================
 // Prefix bytes
 //==========================
@@ -12,12 +14,12 @@ pub const SCRYPTO_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5c;
 /// 0x4d = M in ASCII for Manifest - (77 in decimal)
 pub const MANIFEST_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x4d;
 /// The ROLA hash which is signed is created as `hash(ROLA_HASHABLE_PAYLOAD_PREFIX || ..)`
-/// 
+///
 /// 0x52 = R in ASCII for ROLA - (82 in decimal)
 pub const ROLA_HASHABLE_PAYLOAD_PREFIX: u8 = 0x52;
 /// The Transaction hash which is signed is created as:
 /// `hash(TRANSACTION_HASHABLE_PAYLOAD_PREFIX || version prefix according to type of transaction payload || ..)`
-/// 
+///
 /// 0x54 = T in ASCII for Transaction - (84 in decimal)
 pub const TRANSACTION_HASHABLE_PAYLOAD_PREFIX: u8 = 0x54;
 

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "paste",
+ "radix-engine-constants",
  "radix-engine-derive",
  "sbor",
  "strum",

--- a/transaction/src/model/preparation/summarized_composite.rs
+++ b/transaction/src/model/preparation/summarized_composite.rs
@@ -1,4 +1,5 @@
 use super::*;
+use radix_engine_constants::*;
 
 pub enum ConcatenatedDigest {}
 
@@ -8,7 +9,8 @@ impl ConcatenatedDigest {
         decoder: &mut TransactionDecoder,
         discriminator: TransactionDiscriminator,
     ) -> Result<(T, Summary), PrepareError> {
-        let digest = HashAccumulator::new().update(&[discriminator as u8]);
+        let digest = HashAccumulator::new()
+            .update(&[TRANSACTION_HASHABLE_PAYLOAD_PREFIX, discriminator as u8]);
         T::prepare_into_concatenated_digest(decoder, digest, discriminator as u8)
     }
 
@@ -17,7 +19,8 @@ impl ConcatenatedDigest {
         decoder: &mut TransactionDecoder,
         discriminator: TransactionDiscriminator,
     ) -> Result<(T, Summary), PrepareError> {
-        let digest = HashAccumulator::new().update(&[discriminator as u8]);
+        let digest = HashAccumulator::new()
+            .update(&[TRANSACTION_HASHABLE_PAYLOAD_PREFIX, discriminator as u8]);
         T::prepare_into_concatenated_digest(decoder, digest)
     }
 

--- a/transaction/src/model/versioned.rs
+++ b/transaction/src/model/versioned.rs
@@ -1,6 +1,13 @@
 use super::v1::*;
 use crate::internal_prelude::*;
 
+//=============================================================================
+// TRANSACTION PAYLOAD VERSIONING
+//
+// This file aligns with REP-82 - please see the REP for details on why the
+// payloads are versioned this way.
+//=============================================================================
+
 /// Note - some of these are reserved for use in the node.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -141,7 +148,11 @@ mod tests {
         };
         let expected_intent_hash = IntentHash::from_hash(hash(
             [
-                [TransactionDiscriminator::V1Intent as u8].as_slice(),
+                [
+                    TRANSACTION_HASHABLE_PAYLOAD_PREFIX,
+                    TransactionDiscriminator::V1Intent as u8,
+                ]
+                .as_slice(),
                 expected_header_hash.0.as_slice(),
                 expected_instructions_hash.0.as_slice(),
                 expected_blobs_hash.0.as_slice(),
@@ -171,7 +182,7 @@ mod tests {
 
         assert_eq!(
             intent_hash.to_string(),
-            "98ae3b6d9eba7681421f1df4e5249ad54f6df7612d00f486eeea504556ee13b3"
+            "6ec1aad83ad0796bf7ae2d01ca6981c166983e89dc5e7a4158abac892a191cc3"
         );
         assert_eq!(
             hex::encode(intent_payload_bytes),
@@ -196,7 +207,11 @@ mod tests {
         };
         let expected_signed_intent_hash = SignedIntentHash::from_hash(hash(
             [
-                [TransactionDiscriminator::V1SignedIntent as u8].as_slice(),
+                [
+                    TRANSACTION_HASHABLE_PAYLOAD_PREFIX,
+                    TransactionDiscriminator::V1SignedIntent as u8,
+                ]
+                .as_slice(),
                 intent_hash.0.as_slice(),
                 expected_intent_signatures_hash.0.as_slice(),
             ]
@@ -226,11 +241,11 @@ mod tests {
 
         assert_eq!(
             signed_intent_hash.to_string(),
-            "e182c9cc287e5f46c1062192c92fdeae866846676cd1cbbae97036eed1faaafd"
+            "05840aa1b54235bf9fae522578497f554d202ab7019813ea97009d5f96f51291"
         );
         assert_eq!(
             hex::encode(signed_intent_payload_bytes),
-            "4d2202022104210707f2090100000009050000000900000000220101200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b010008000020220112002020020704000102030702050621002022020001210120074101c5454b832fdd19997f592a4be0ccbd1fdd4dbd0d19a88fc520efe768aa140d76579cdf2be41d159dc127da1a4765eeaf6ee6abbddbb4a8abe169012c2e8f9e5101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074011581f7b88812dbd0c97693a18e7d86af6f0cc425fea894a1fa6c9ba25f740bd85488c89468b174d19a68883d26713c3838a67576b42f27304e8f62b0dbe940e"
+            "4d2202022104210707f2090100000009050000000900000000220101200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b010008000020220112002020020704000102030702050621002022020001210120074100821f54ad0e11d08e46debae1167d4181f6343ba5a431a45dd3b66a9e9c873ffa22870316f53cd1aed1b6ea4d29f8424d185b5d2d6202e73fdd8b183eec5ef9db01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe267421012007402506c9295fa7210554d16bfdb4b0f22ab979c0148c505431d634a4aa9acc7758e25bcd8914773599cb70ffbc59d40a567b54715f63656f2d017ea8bf371bf500"
         );
 
         //======================
@@ -248,7 +263,11 @@ mod tests {
         };
         let expected_notarized_transaction_hash = NotarizedTransactionHash::from_hash(hash(
             [
-                [TransactionDiscriminator::V1Notarized as u8].as_slice(),
+                [
+                    TRANSACTION_HASHABLE_PAYLOAD_PREFIX,
+                    TransactionDiscriminator::V1Notarized as u8,
+                ]
+                .as_slice(),
                 signed_intent_hash.0.as_slice(),
                 expected_notary_signature_v1_hash.0.as_slice(),
             ]
@@ -285,11 +304,11 @@ mod tests {
 
         assert_eq!(
             notarized_transaction_hash.to_string(),
-            "2e3188ad23cb72c61b1563ea3801dc80235c50e17aca92b75d747129440f5f63"
+            "2a384e0817104e4dd3e566339cccd445c400459e0779dba60a3dd9a9f8564082"
         );
         assert_eq!(
             hex::encode(notarized_transaction_payload_bytes),
-            "4d22030221022104210707f2090100000009050000000900000000220101200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b010008000020220112002020020704000102030702050621002022020001210120074101c5454b832fdd19997f592a4be0ccbd1fdd4dbd0d19a88fc520efe768aa140d76579cdf2be41d159dc127da1a4765eeaf6ee6abbddbb4a8abe169012c2e8f9e5101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074011581f7b88812dbd0c97693a18e7d86af6f0cc425fea894a1fa6c9ba25f740bd85488c89468b174d19a68883d26713c3838a67576b42f27304e8f62b0dbe940e220101210120074002e15f71c051131ad23be8b60e37317956b78cfffba66c007402630a649d05e06fde7d68da8ecdf16598a84e946e6e4d790a844a86b597c11ffae101e70c3f0a"
+            "4d22030221022104210707f2090100000009050000000900000000220101200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b010008000020220112002020020704000102030702050621002022020001210120074100821f54ad0e11d08e46debae1167d4181f6343ba5a431a45dd3b66a9e9c873ffa22870316f53cd1aed1b6ea4d29f8424d185b5d2d6202e73fdd8b183eec5ef9db01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe267421012007402506c9295fa7210554d16bfdb4b0f22ab979c0148c505431d634a4aa9acc7758e25bcd8914773599cb70ffbc59d40a567b54715f63656f2d017ea8bf371bf5002201012101200740eb907630079ab07da8598742cc3ed1c3831f02a3e8b5985473a441bdea17ac7e983584410f4c67ffe30ea840cc88f7948fa053346fe6cf0cf1af70373a848608"
         );
     }
 }


### PR DESCRIPTION
## Summary

As per discussion with the Core Apps team, this PR adds an additional transaction-hash-specific prefix to the payload which is hashed for the intent / signed intent / notarized transaction / ledger transaction hash.

This ensures the payload is distinct from EG ROLA payloads which may need to be hashed with the same key pair.

## Testing

Updated `versioned.rs`
