### PR TITLE
tweak: Active Validator set is ordered by stake desc

### DIFF
--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -189,7 +189,7 @@ pub struct LeaderProposalHistory {
 
 /// An index of a specific validator within the current validator set.
 /// To be exact: a `ValidatorIndex` equal to `k` references the `k-th` element returned by the
-/// iterator of `BTreeMap<ComponentAddress, Validator>`.
+/// iterator of the `IndexMap<ComponentAddress, Validator>` in this epoch's active validator set.
 /// This uniquely identifies the validator, while being shorter than `ComponentAddress` (we do care
 /// about the constant factor of the space taken by `LeaderProposalHistory` under prolonged liveness
 /// break scenarios).

--- a/radix-engine/src/blueprints/consensus_manager/events/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/events/consensus_manager.rs
@@ -10,6 +10,6 @@ pub struct RoundChangeEvent {
 pub struct EpochChangeEvent {
     /// The *new* epoch's number.
     pub epoch: u64,
-    /// The *new* epoch's validator set.
-    pub validators: BTreeMap<ComponentAddress, Validator>,
+    /// The *new* epoch's validator set, ordered by stake descending.
+    pub validators: IndexMap<ComponentAddress, Validator>,
 }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -1,5 +1,5 @@
 use super::{BalanceChange, StateUpdateSummary};
-use crate::blueprints::consensus_manager::{EpochChangeEvent, Validator};
+use crate::blueprints::consensus_manager::EpochChangeEvent;
 use crate::errors::*;
 use crate::system::system_modules::costing::FeeSummary;
 use crate::system::system_modules::execution_trace::{
@@ -90,7 +90,7 @@ pub struct CommitResult {
 }
 
 impl CommitResult {
-    pub fn next_epoch(&self) -> Option<(BTreeMap<ComponentAddress, Validator>, u64)> {
+    pub fn next_epoch(&self) -> Option<EpochChangeEvent> {
         // Note: Node should use a well-known index id
         for (ref event_type_id, ref event_data) in self.application_events.iter() {
             if let EventTypeIdentifier(
@@ -102,11 +102,9 @@ impl CommitResult {
                 if node_id == CONSENSUS_MANAGER_PACKAGE.as_node_id()
                     || node_id.entity_type() == Some(EntityType::GlobalConsensusManager)
                 {
-                    if let Ok(EpochChangeEvent {
-                        epoch, validators, ..
-                    }) = scrypto_decode(&event_data)
+                    if let Ok(epoch_change_event) = scrypto_decode::<EpochChangeEvent>(&event_data)
                     {
-                        return Some((validators, epoch));
+                        return Some(epoch_change_event);
                     }
                 }
             }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -205,7 +205,7 @@ impl TestRunnerBuilder {
         self
     }
 
-    pub fn build_and_get_epoch(self) -> (TestRunner, BTreeMap<ComponentAddress, Validator>) {
+    pub fn build_and_get_epoch(self) -> (TestRunner, IndexMap<ComponentAddress, Validator>) {
         let scrypto_interpreter = ScryptoVm {
             wasm_engine: DefaultWasmEngine::default(),
             wasm_instrumenter: WasmInstrumenter::default(),
@@ -249,7 +249,7 @@ impl TestRunnerBuilder {
             .expect_commit_success()
             .next_epoch()
             .unwrap();
-        (runner, next_epoch.0)
+        (runner, next_epoch.validators)
     }
 
     pub fn build(self) -> TestRunner {


### PR DESCRIPTION
## Summary
In the node, we were in some places ordering the active validator set by stake DESC and in some places using the engine ordering, this made the Core API confusing when we exposed the ValidatorIndex concept in the round change transactions.

So instead, this PR pushes that ordering up to the ActiveValidatorSet substate, so everything can be in harmony. (Note - if two validators have equal stake, they're ordered by their DbSortKey in the SortedIndex).

Also whilst I was at it, changed `next_epoch` method on the receipt to actually return the clearer `EpochChangeEvent`.

## Testing
Updated / expanded the consensus manager tests in `radix-engine-tests`.

## Update Recommendations

### Node

Will need to update some API docs, and possibly remove some explicit ordering. Should be a small change :)