### PR TITLE
Explicit (transparent) structs for different timestamps in ConsensusManager

### DIFF
--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -380,8 +380,8 @@ pub enum TypedConsensusManagerFieldValue {
     ConsensusManager(ConsensusManagerSubstate),
     CurrentValidatorSet(CurrentValidatorSetSubstate),
     CurrentProposalStatistic(CurrentProposalStatisticSubstate),
-    CurrentTimeRoundedToMinutes(i64),
-    CurrentTime(i64),
+    CurrentTimeRoundedToMinutes(ProposerMinuteTimestampSubstate),
+    CurrentTime(ProposerMilliTimestampSubstate),
 }
 
 #[derive(Debug, Clone)]

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -1,3 +1,4 @@
+use radix_engine::blueprints::consensus_manager::ProposerMinuteTimestampSubstate;
 use radix_engine::blueprints::resource::FungibleResourceManagerTotalSupplySubstate;
 use radix_engine::system::bootstrap::{
     Bootstrapper, GenesisDataChunk, GenesisReceipts, GenesisResource, GenesisResourceAllocation,
@@ -384,15 +385,15 @@ fn test_genesis_time() {
         )
         .unwrap();
 
-    let current_time_rounded_to_minutes_ms = substate_db
-        .get_mapped::<SpreadPrefixKeyMapper, i64>(
+    let proposer_minute_timestamp = substate_db
+        .get_mapped::<SpreadPrefixKeyMapper, ProposerMinuteTimestampSubstate>(
             CONSENSUS_MANAGER.as_node_id(),
             OBJECT_BASE_PARTITION,
             &ConsensusManagerField::CurrentTimeRoundedToMinutes.into(),
         )
         .unwrap();
 
-    assert_eq!(current_time_rounded_to_minutes_ms, 123 * 60 * 1000);
+    assert_eq!(proposer_minute_timestamp.epoch_minute, 123);
 }
 
 fn dummy_consensus_manager_configuration() -> ConsensusManagerInitialConfiguration {

--- a/radix-engine/src/blueprints/consensus_manager/package.rs
+++ b/radix-engine/src/blueprints/consensus_manager/package.rs
@@ -28,8 +28,8 @@ impl ConsensusManagerNativePackage {
         fields.push(aggregator.add_child_type_and_descendents::<CurrentValidatorSetSubstate>());
         fields
             .push(aggregator.add_child_type_and_descendents::<CurrentProposalStatisticSubstate>());
-        fields.push(aggregator.add_child_type_and_descendents::<i64>());
-        fields.push(aggregator.add_child_type_and_descendents::<i64>());
+        fields.push(aggregator.add_child_type_and_descendents::<ProposerMinuteTimestampSubstate>());
+        fields.push(aggregator.add_child_type_and_descendents::<ProposerMilliTimestampSubstate>());
 
         let mut collections = Vec::new();
         collections.push(BlueprintCollectionSchema::SortedIndex(


### PR DESCRIPTION
This is a pure refactor (no behavior changes), as promised in https://github.com/radixdlt/radixdlt-scrypto/pull/1052#discussion_r1202637972.