### PR TITLE
tweak: Manifest enum variant aliases are idents

### DIFF
--- a/transaction/examples/access_rule/access_rule.rtm
+++ b/transaction/examples/access_rule/access_rule.rtm
@@ -2,4 +2,4 @@ SET_AUTHORITY_ACCESS_RULE
     Address("${resource_address}")
     Enum<0u8>()
     Enum<0u8>()
-    Enum<"AccessRule::AllowAll">();
+    Enum<AccessRule::AllowAll>();

--- a/transaction/examples/account/deposit_modes.rtm
+++ b/transaction/examples/account/deposit_modes.rtm
@@ -16,37 +16,37 @@ CALL_METHOD
 CALL_METHOD 
     Address("${account_address}") 
     "change_account_default_deposit_rule" 
-    Enum<"AccountDefaultDepositRule::Accept">();
+    Enum<AccountDefaultDepositRule::Accept>();
 
 # Example 2: Deny All deposits mode
 CALL_METHOD 
     Address("${account_address}") 
     "change_account_default_deposit_rule" 
-    Enum<"AccountDefaultDepositRule::Reject">();
+    Enum<AccountDefaultDepositRule::Reject>();
 
 # Example 3: Allow existing deposits mode
 CALL_METHOD 
     Address("${account_address}") 
     "change_account_default_deposit_rule" 
-    Enum<"AccountDefaultDepositRule::AllowExisting">();
+    Enum<AccountDefaultDepositRule::AllowExisting>();
 
 # Example 4a: Adding a resource to the allow list
 CALL_METHOD
     Address("${account_address}")
     "configure_resource_deposit_rule"
     Address("${second_resource_address}")
-    Enum<"ResourceDepositRule::Allowed">();
+    Enum<ResourceDepositRule::Allowed>();
 
 # Example 4a: Adding a resource to the deny list
 CALL_METHOD
     Address("${account_address}")
     "configure_resource_deposit_rule"
     Address("${second_resource_address}")
-    Enum<"ResourceDepositRule::Disallowed">();
+    Enum<ResourceDepositRule::Disallowed>();
 
 # Example 4a: Removing a resource from the allow and deny lists
 CALL_METHOD
     Address("${account_address}")
     "configure_resource_deposit_rule"
     Address("${second_resource_address}")
-    Enum<"ResourceDepositRule::Neither">();
+    Enum<ResourceDepositRule::Neither>();

--- a/transaction/examples/metadata/metadata.rtm
+++ b/transaction/examples/metadata/metadata.rtm
@@ -3,7 +3,7 @@ SET_METADATA
     Address("${package_address}")
     "field_name"
     # "Metadata::String" is equivalent to 0u8
-    Enum<"Metadata::String">(
+    Enum<Metadata::String>(
         "Metadata string value, eg description"
     );
 
@@ -12,7 +12,7 @@ SET_METADATA
     Address("${account_address}")
     "field_name"
     # "Metadata::String" is equivalent to 0u8
-    Enum<"Metadata::String">(
+    Enum<Metadata::String>(
         "Metadata string value, eg description"
     );
 
@@ -21,7 +21,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::String" is equivalent to 0u8
-    Enum<"Metadata::String">(
+    Enum<Metadata::String>(
         "Metadata string value, eg description"
     );
 
@@ -30,7 +30,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Bool" is equivalent to 1u8
-    Enum<"Metadata::Bool">(
+    Enum<Metadata::Bool>(
         true
     );
 
@@ -39,7 +39,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::U8" is equivalent to 2u8
-    Enum<"Metadata::U8">(
+    Enum<Metadata::U8>(
         123u8
     );
 
@@ -48,7 +48,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::U32" is equivalent to 3u8
-    Enum<"Metadata::U32">(
+    Enum<Metadata::U32>(
         123u32
     );
 
@@ -57,7 +57,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::U64" is equivalent to 4u8
-    Enum<"Metadata::U64">(
+    Enum<Metadata::U64>(
         123u64
     );
 
@@ -66,7 +66,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::I32" is equivalent to 5u8
-    Enum<"Metadata::I32">(
+    Enum<Metadata::I32>(
         -123i32
     );
 
@@ -75,7 +75,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::I64" is equivalent to 6u8
-    Enum<"Metadata::I64">(
+    Enum<Metadata::I64>(
         -123i64
     );
 
@@ -84,7 +84,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Decimal" is equivalent to 7u8
-    Enum<"Metadata::Decimal">( # Single item
+    Enum<Metadata::Decimal>( # Single item
         Decimal("10.5")
     );
 
@@ -93,7 +93,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Address" is equivalent to 8u8
-    Enum<"Metadata::Address">(
+    Enum<Metadata::Address>(
         Address("${account_address}")
     );
 
@@ -103,8 +103,8 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::PublicKey" is equivalent to 9u8
-    Enum<"Metadata::PublicKey">(
-        Enum<"PublicKey::Secp256k1">( # 0u8 = Secp256k1, 1u8 = Ed25519
+    Enum<Metadata::PublicKey>(
+        Enum<PublicKey::Secp256k1>( # 0u8 = Secp256k1, 1u8 = Ed25519
             # Hex-encoded canonical-Radix encoding of the public key
             Bytes("0000000000000000000000000000000000000000000000000000000000000000ff")
         )
@@ -115,7 +115,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::NonFungibleGlobalId" is equivalent to 10u8
-    Enum<"Metadata::NonFungibleGlobalId">(
+    Enum<Metadata::NonFungibleGlobalId>(
         NonFungibleGlobalId("${non_fungible_resource_address}:<some_string>")
     );
 
@@ -124,7 +124,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::NonFungibleLocalId" is equivalent to 11u8
-    Enum<"Metadata::NonFungibleLocalId">(
+    Enum<Metadata::NonFungibleLocalId>(
         NonFungibleLocalId("<some_string>")
     );
 
@@ -133,7 +133,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Instant" is equivalent to 12u8
-    Enum<"Metadata::Instant">(
+    Enum<Metadata::Instant>(
         # Value in seconds since Unix Epoch
         10000i64
     );
@@ -143,7 +143,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Url" is equivalent to 13u8
-    Enum<"Metadata::Url">( # Single item
+    Enum<Metadata::Url>( # Single item
         "https://radixdlt.com/index.html"
     );
 
@@ -152,7 +152,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::Origin" is equivalent to 14u8
-    Enum<"Metadata::Origin">(
+    Enum<Metadata::Origin>(
         "https://radixdlt.com"
     );
 
@@ -161,8 +161,8 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::PublicKeyHash" is equivalent to 15u8
-    Enum<"Metadata::PublicKeyHash">(
-        Enum<"PublicKeyHash::Secp256k1">( # 0u8 = Secp256k1, 1u8 = Ed25519
+    Enum<Metadata::PublicKeyHash>(
+        Enum<PublicKeyHash::Secp256k1>( # 0u8 = Secp256k1, 1u8 = Ed25519
             # The hex-encoded final 29 bytes of the Blake2b-256 hash of the public key bytes (in the canonical Radix encoding)
             Bytes("0000000000000000000000000000000000000000000000000000000000")
         )
@@ -180,7 +180,7 @@ SET_METADATA
     Address("${resource_address}")
     "field_name"
     # "Metadata::StringArray" is equivalent to 128u8
-    Enum<"Metadata::StringArray">(
+    Enum<Metadata::StringArray>(
         Array<String>(
             "some_string",
             "another_string",

--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -18,9 +18,9 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE
     18u8
     Map<String, Enum>(
-        "name", Enum<"Metadata::String">("MyResource"),                                        # Resource Name
-        "symbol", Enum<"Metadata::String">("RSRC"),                                            # Resource Symbol
-        "description", Enum<"Metadata::String">("A very innovative and important resource")    # Resource Description
+        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "symbol", Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
+        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     ) 
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -36,10 +36,10 @@ CREATE_FUNGIBLE_RESOURCE
         #       b. The mutability of the behaviour. As in, who can change the current behavior in 
         #          the future.
         # 
-        # Lets take `Tuple(Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()))` as an 
+        # Lets take `Tuple(Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()))` as an 
         # example. This means that anybody who is in possession of the resource may withdraw it from
         # a vault that they control. This behavior is permanent and can not be changed by anybody
-        # as the mutability is a `Enum<"AccessRule::DenyAll">()`.
+        # as the mutability is a `Enum<AccessRule::DenyAll>()`.
         # 
         #        ┌ We Are customizing the "Withdraw" behavior of the resource
         #        │                       
@@ -49,6 +49,6 @@ CREATE_FUNGIBLE_RESOURCE
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()),
-        Enum<"ResourceMethodAuthKey::Deposit">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">())
+        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     );

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -18,9 +18,9 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     18u8
     Map<String, Enum>(
-        "name", Enum<"Metadata::String">("MyResource"),                                        # Resource Name
-        "symbol", Enum<"Metadata::String">("RSRC"),                                            # Resource Symbol
-        "description", Enum<"Metadata::String">("A very innovative and important resource")    # Resource Description
+        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "symbol", Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
+        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     ) 
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -36,10 +36,10 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #       b. The mutability of the behaviour. As in, who can change the current behavior in 
         #          the future.
         # 
-        # Lets take `Tuple(Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()))` as an 
+        # Lets take `Tuple(Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()))` as an 
         # example. This means that anybody who is in possession of the resource may withdraw it from
         # a vault that they control. This behavior is permanent and can not be changed by anybody
-        # as the mutability is a `Enum<"AccessRule::DenyAll">()`.
+        # as the mutability is a `Enum<AccessRule::DenyAll>()`.
         # 
         #        ┌ We Are customizing the "Withdraw" behavior of the resource
         #        │                       
@@ -49,8 +49,8 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()),
-        Enum<"ResourceMethodAuthKey::Deposit">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">())
+        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     )
     Decimal("${initial_supply}");
 

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -15,11 +15,11 @@ CALL_METHOD
 
 # Creating a new resource 
 CREATE_NON_FUNGIBLE_RESOURCE
-    Enum<"NonFungibleIdType::Integer">()
+    Enum<NonFungibleIdType::Integer>()
     Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>( 64u8), Array<String>())
     Map<String, Enum>(
-        "name", Enum<"Metadata::String">("MyResource"),                                        # Resource Name
-        "description", Enum<"Metadata::String">("A very innovative and important resource")    # Resource Description
+        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     )
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array
@@ -35,10 +35,10 @@ CREATE_NON_FUNGIBLE_RESOURCE
         #       b. The mutability of the behaviour. As in, who can change the current behavior in
         #          the future.
         #
-        # Lets take `Tuple(Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()))` as an
+        # Lets take `Tuple(Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()))` as an
         # example. This means that anybody who is in possession of the resource may withdraw it from
         # a vault that they control. This behavior is permanent and can not be changed by anybody
-        # as the mutability is a `Enum<"AccessRule::DenyAll">()`.
+        # as the mutability is a `Enum<AccessRule::DenyAll>()`.
         #
         #        ┌ We Are customizing the "Withdraw" behavior of the resource
         #        │
@@ -48,6 +48,6 @@ CREATE_NON_FUNGIBLE_RESOURCE
         #        │                       │                 │ by anybody who has the resource) is permanent and can't
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()),
-        Enum<"ResourceMethodAuthKey::Deposit">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">())
+        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     );

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -15,11 +15,11 @@ CALL_METHOD
 
 # Creating a new resource 
 CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
-    Enum<"NonFungibleIdType::Integer">()
+    Enum<NonFungibleIdType::Integer>()
     Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>(64u8), Array<String>())
     Map<String, Enum>(
-        "name", Enum<"Metadata::String">("MyResource"),                                        # Resource Name
-        "description", Enum<"Metadata::String">("A very innovative and important resource")    # Resource Description
+        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     )
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -35,10 +35,10 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #       b. The mutability of the behaviour. As in, who can change the current behavior in 
         #          the future.
         # 
-        # Lets take `Tuple(Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()))` as an 
+        # Lets take `Tuple(Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()))` as an 
         # example. This means that anybody who is in possession of the resource may withdraw it from
         # a vault that they control. This behavior is permanent and can not be changed by anybody
-        # as the mutability is a `Enum<"AccessRule::DenyAll">()`.
+        # as the mutability is a `Enum<AccessRule::DenyAll>()`.
         # 
         #        ┌ We Are customizing the "Withdraw" behavior of the resource
         #        │                       
@@ -48,8 +48,8 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<"ResourceMethodAuthKey::Withdraw">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">()),
-        Enum<"ResourceMethodAuthKey::Deposit">(), Tuple(Enum<"AccessRule::AllowAll">(), Enum<"AccessRule::DenyAll">())
+        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     )
     Map<NonFungibleLocalId, Tuple>(
         NonFungibleLocalId("${non_fungible_local_id}"),

--- a/transaction/examples/values/values.rtm
+++ b/transaction/examples/values/values.rtm
@@ -18,10 +18,10 @@ CALL_METHOD
     Enum<0u8>( "test")
     Err("test123")
     Enum<1u8>( "test123")
-    Enum<"Option::None">()
-    Enum<"Option::Some">( "a")
-    Enum<"Result::Ok">( "b")
-    Enum<"Result::Err">( "c")
+    Enum<Option::None>()
+    Enum<Option::Some>( "a")
+    Enum<Result::Ok>( "b")
+    Enum<Result::Err>( "c")
 
     # bytes
     Bytes("deadbeef")
@@ -39,7 +39,14 @@ CALL_METHOD
     Array<Bytes>(Bytes("dead"), Array<U8>(5u8, 10u8, 255u8))
     Array<Array>(Bytes("dead"), Array<U8>(5u8, 10u8, 255u8))
     Array<NonFungibleGlobalId>(NonFungibleGlobalId("${non_fungible_resource_address}:<value>"), Tuple(Address("${non_fungible_resource_address}"), NonFungibleLocalId("#1#")))
-    Array<Tuple>(NonFungibleGlobalId("${non_fungible_resource_address}:<value>"), Tuple(Address("${non_fungible_resource_address}"), NonFungibleLocalId("#1#")));
+    Array<Tuple>(NonFungibleGlobalId("${non_fungible_resource_address}:<value>"), Tuple(Address("${non_fungible_resource_address}"), NonFungibleLocalId("#1#")))
+    Array<Enum>(Some("hello"))
+    Array<Enum>(Enum<1u8>(), Enum<Option::None>())
+    Array<Map>(Map<U8, U16>())
+
+    # map
+    Map<U8, U16>(1u8, 5u16)
+;
 
 CALL_METHOD 
     Address("${component_address}")
@@ -62,4 +69,5 @@ CALL_METHOD
     NonFungibleLocalId("<SomeId>")
     NonFungibleLocalId("#12#")
     NonFungibleLocalId("[031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f]")
-    NonFungibleLocalId("{43968a72-5954-45da-9678-8659dd399faa}");
+    NonFungibleLocalId("{43968a72-5954-45da-9678-8659dd399faa}")
+;

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -231,8 +231,10 @@ pub enum Instruction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Type {
-    /* Rust types */
+pub enum ValueKind {
+    // ==============
+    // Simple basic value kinds
+    // ==============
     Bool,
     I8,
     I16,
@@ -246,15 +248,16 @@ pub enum Type {
     U128,
     String,
 
-    /* Struct and enum */
+    // ==============
+    // Composite basic value kinds
+    // ==============
     Enum,
-
-    /* [T; N] and (A, B, C) */
     Array,
     Tuple,
+    Map,
 
     // ==============
-    // Alias
+    // Value kind aliases
     // ==============
     Bytes,
     NonFungibleGlobalId,
@@ -263,57 +266,73 @@ pub enum Type {
     ResourceAddress,
 
     // ==============
-    // Custom Types
+    // Custom value kinds
     // ==============
     Address,
     Bucket,
     Proof,
     Expression,
     Blob,
-
-    // Uninterpreted,
     Decimal,
     PreciseDecimal,
     NonFungibleLocalId,
 }
 
-impl Type {
+impl ValueKind {
     pub fn value_kind(&self) -> ManifestValueKind {
         match self {
-            Type::Bool => ManifestValueKind::Bool,
-            Type::I8 => ManifestValueKind::I8,
-            Type::I16 => ManifestValueKind::I16,
-            Type::I32 => ManifestValueKind::I32,
-            Type::I64 => ManifestValueKind::I64,
-            Type::I128 => ManifestValueKind::I128,
-            Type::U8 => ManifestValueKind::U8,
-            Type::U16 => ManifestValueKind::U16,
-            Type::U32 => ManifestValueKind::U32,
-            Type::U64 => ManifestValueKind::U64,
-            Type::U128 => ManifestValueKind::U128,
-            Type::String => ManifestValueKind::String,
-            Type::Enum => ManifestValueKind::Enum,
-            Type::Array => ManifestValueKind::Array,
-            Type::Tuple => ManifestValueKind::Tuple,
+            // ==============
+            // Simple basic value kinds
+            // ==============
+            ValueKind::Bool => ManifestValueKind::Bool,
+            ValueKind::I8 => ManifestValueKind::I8,
+            ValueKind::I16 => ManifestValueKind::I16,
+            ValueKind::I32 => ManifestValueKind::I32,
+            ValueKind::I64 => ManifestValueKind::I64,
+            ValueKind::I128 => ManifestValueKind::I128,
+            ValueKind::U8 => ManifestValueKind::U8,
+            ValueKind::U16 => ManifestValueKind::U16,
+            ValueKind::U32 => ManifestValueKind::U32,
+            ValueKind::U64 => ManifestValueKind::U64,
+            ValueKind::U128 => ManifestValueKind::U128,
+            ValueKind::String => ManifestValueKind::String,
 
-            // Aliases
-            Type::Bytes => ManifestValueKind::Array,
-            Type::NonFungibleGlobalId => ManifestValueKind::Tuple,
-            Type::PackageAddress => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
-            Type::ComponentAddress => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
-            Type::ResourceAddress => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
+            // ==============
+            // Composite basic value kinds
+            // ==============
+            ValueKind::Enum => ManifestValueKind::Enum,
+            ValueKind::Array => ManifestValueKind::Array,
+            ValueKind::Tuple => ManifestValueKind::Tuple,
+            ValueKind::Map => ManifestValueKind::Map,
 
-            // Custom types
-            Type::Address => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
-            Type::Bucket => ManifestValueKind::Custom(ManifestCustomValueKind::Bucket),
-            Type::Proof => ManifestValueKind::Custom(ManifestCustomValueKind::Proof),
-            Type::Expression => ManifestValueKind::Custom(ManifestCustomValueKind::Expression),
-            Type::Blob => ManifestValueKind::Custom(ManifestCustomValueKind::Blob),
-            Type::Decimal => ManifestValueKind::Custom(ManifestCustomValueKind::Decimal),
-            Type::PreciseDecimal => {
+            // ==============
+            // Value kind aliases
+            // ==============
+            ValueKind::Bytes => ManifestValueKind::Array,
+            ValueKind::NonFungibleGlobalId => ManifestValueKind::Tuple,
+            ValueKind::PackageAddress => {
+                ManifestValueKind::Custom(ManifestCustomValueKind::Address)
+            }
+            ValueKind::ComponentAddress => {
+                ManifestValueKind::Custom(ManifestCustomValueKind::Address)
+            }
+            ValueKind::ResourceAddress => {
+                ManifestValueKind::Custom(ManifestCustomValueKind::Address)
+            }
+
+            // ==============
+            // Custom value kinds
+            // ==============
+            ValueKind::Address => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
+            ValueKind::Bucket => ManifestValueKind::Custom(ManifestCustomValueKind::Bucket),
+            ValueKind::Proof => ManifestValueKind::Custom(ManifestCustomValueKind::Proof),
+            ValueKind::Expression => ManifestValueKind::Custom(ManifestCustomValueKind::Expression),
+            ValueKind::Blob => ManifestValueKind::Custom(ManifestCustomValueKind::Blob),
+            ValueKind::Decimal => ManifestValueKind::Custom(ManifestCustomValueKind::Decimal),
+            ValueKind::PreciseDecimal => {
                 ManifestValueKind::Custom(ManifestCustomValueKind::PreciseDecimal)
             }
-            Type::NonFungibleLocalId => {
+            ValueKind::NonFungibleLocalId => {
                 ManifestValueKind::Custom(ManifestCustomValueKind::NonFungibleLocalId)
             }
         }
@@ -323,7 +342,7 @@ impl Type {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     // ==============
-    // Basic Types
+    // Basic values
     // ==============
     Bool(bool),
     I8(i8),
@@ -338,13 +357,16 @@ pub enum Value {
     U128(u128),
     String(String),
 
+    // ==============
+    // Composite basic values
+    // ==============
     Enum(u8, Vec<Value>),
-    Array(Type, Vec<Value>),
+    Array(ValueKind, Vec<Value>),
     Tuple(Vec<Value>),
-    Map(Type, Type, Vec<Value>),
+    Map(ValueKind, ValueKind, Vec<Value>),
 
     // ==============
-    // Aliases
+    // Alias values
     // ==============
     Some(Box<Value>),
     None,
@@ -354,7 +376,7 @@ pub enum Value {
     NonFungibleGlobalId(Box<Value>),
 
     // ==============
-    // Custom Types
+    // Custom values
     // ==============
     Address(Box<Value>),
     Bucket(Box<Value>),
@@ -370,7 +392,7 @@ impl Value {
     pub const fn value_kind(&self) -> ManifestValueKind {
         match self {
             // ==============
-            // Basic Types
+            // Basic values
             // ==============
             Value::Bool(_) => ManifestValueKind::Bool,
             Value::I8(_) => ManifestValueKind::I8,
@@ -390,7 +412,7 @@ impl Value {
             Value::Map(_, _, _) => ManifestValueKind::Map,
 
             // ==============
-            // Aliases
+            // Aliase values
             // ==============
             Value::Some(_) => ManifestValueKind::Enum,
             Value::None => ManifestValueKind::Enum,
@@ -400,7 +422,7 @@ impl Value {
             Value::NonFungibleGlobalId(_) => ManifestValueKind::Tuple,
 
             // ==============
-            // Custom Types
+            // Custom values
             // ==============
             Value::Address(_) => ManifestValueKind::Custom(ManifestCustomValueKind::Address),
             Value::Bucket(_) => ManifestValueKind::Custom(ManifestCustomValueKind::Bucket),

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -299,6 +299,22 @@ CALL_METHOD
     Array<Tuple>(
         NonFungibleGlobalId("${non_fungible_resource_address}:<value>"),
         NonFungibleGlobalId("${non_fungible_resource_address}:#1#")
+    )
+    Array<Enum>(
+        Enum<1u8>(
+            "hello"
+        )
+    )
+    Array<Enum>(
+        Enum<1u8>(),
+        Enum<0u8>()
+    )
+    Array<Map>(
+        Map<U8, U16>()
+    )
+    Map<U8, U16>(
+        1u8,
+        5u16
     );
 CALL_METHOD
     Address("${component_address}")

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -61,11 +61,11 @@ use sbor::*;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GeneratorError {
     InvalidAstType {
-        expected_type: ast::Type,
-        actual: ast::Type,
+        expected_type: ast::ValueKind,
+        actual: ast::ValueKind,
     },
     InvalidAstValue {
-        expected_type: Vec<ast::Type>,
+        expected_type: Vec<ast::ValueKind>,
         actual: ast::Value,
     },
     UnexpectedValue {
@@ -103,7 +103,7 @@ pub enum GeneratorError {
     InvalidGlobalAddress(String),
     InvalidInternalAddress(String),
     InvalidLength {
-        value_type: ast::Type,
+        value_type: ast::ValueKind,
         expected_length: usize,
         actual: usize,
     },
@@ -697,7 +697,7 @@ fn generate_args(
 fn generate_string(value: &ast::Value) -> Result<String, GeneratorError> {
     match value {
         ast::Value::String(s) => Ok(s.into()),
-        v => invalid_type!(v, ast::Type::String),
+        v => invalid_type!(v, ast::ValueKind::String),
     }
 }
 
@@ -707,9 +707,9 @@ fn generate_decimal(value: &ast::Value) -> Result<Decimal, GeneratorError> {
             ast::Value::String(s) => {
                 Decimal::from_str(s).map_err(|_| GeneratorError::InvalidDecimal(s.into()))
             }
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Decimal),
+        v => invalid_type!(v, ast::ValueKind::Decimal),
     }
 }
 
@@ -719,9 +719,9 @@ fn generate_precise_decimal(value: &ast::Value) -> Result<PreciseDecimal, Genera
             ast::Value::String(s) => PreciseDecimal::from_str(s)
                 .map_err(|_| GeneratorError::InvalidPreciseDecimal(s.into())),
 
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Decimal),
+        v => invalid_type!(v, ast::ValueKind::Decimal),
     }
 }
 
@@ -739,9 +739,9 @@ fn generate_package_address(
                 }
                 return Err(GeneratorError::InvalidGlobalAddress(s.into()));
             }
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::PackageAddress),
+        v => invalid_type!(v, ast::ValueKind::PackageAddress),
     }
 }
 
@@ -759,9 +759,9 @@ fn generate_resource_address(
                 }
                 return Err(GeneratorError::InvalidGlobalAddress(s.into()));
             }
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::ResourceAddress),
+        v => invalid_type!(v, ast::ValueKind::ResourceAddress),
     }
 }
 
@@ -779,14 +779,14 @@ fn generate_global_address(
                 }
                 return Err(GeneratorError::InvalidGlobalAddress(s.into()));
             }
-            v => return invalid_type!(v, ast::Type::String),
+            v => return invalid_type!(v, ast::ValueKind::String),
         },
         v => invalid_type!(
             v,
-            ast::Type::Address,
-            ast::Type::PackageAddress,
-            ast::Type::ResourceAddress,
-            ast::Type::ComponentAddress
+            ast::ValueKind::Address,
+            ast::ValueKind::PackageAddress,
+            ast::ValueKind::ResourceAddress,
+            ast::ValueKind::ComponentAddress
         ),
     }
 }
@@ -805,14 +805,14 @@ fn generate_local_address(
                 }
                 return Err(GeneratorError::InvalidInternalAddress(s.into()));
             }
-            v => return invalid_type!(v, ast::Type::String),
+            v => return invalid_type!(v, ast::ValueKind::String),
         },
         v => invalid_type!(
             v,
-            ast::Type::Address,
-            ast::Type::PackageAddress,
-            ast::Type::ResourceAddress,
-            ast::Type::ComponentAddress
+            ast::ValueKind::Address,
+            ast::ValueKind::PackageAddress,
+            ast::ValueKind::ResourceAddress,
+            ast::ValueKind::ComponentAddress
         ),
     }
 }
@@ -827,9 +827,9 @@ fn declare_bucket(
             ast::Value::String(name) => resolver
                 .insert_bucket(name.to_string(), bucket_id)
                 .map_err(GeneratorError::NameResolverError),
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Bucket),
+        v => invalid_type!(v, ast::ValueKind::Bucket),
     }
 }
 
@@ -843,9 +843,9 @@ fn generate_bucket(
             ast::Value::String(s) => resolver
                 .resolve_bucket(&s)
                 .map_err(GeneratorError::NameResolverError),
-            v => invalid_type!(v, ast::Type::U32, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::U32, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Bucket),
+        v => invalid_type!(v, ast::ValueKind::Bucket),
     }
 }
 
@@ -859,9 +859,9 @@ fn declare_proof(
             ast::Value::String(name) => resolver
                 .insert_proof(name.to_string(), proof_id)
                 .map_err(GeneratorError::NameResolverError),
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Proof),
+        v => invalid_type!(v, ast::ValueKind::Proof),
     }
 }
 
@@ -875,9 +875,9 @@ fn generate_proof(
             ast::Value::String(s) => resolver
                 .resolve_proof(&s)
                 .map_err(GeneratorError::NameResolverError),
-            v => invalid_type!(v, ast::Type::U32, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::U32, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Proof),
+        v => invalid_type!(v, ast::ValueKind::Proof),
     }
 }
 
@@ -888,9 +888,9 @@ fn generate_non_fungible_local_id(
         ast::Value::NonFungibleLocalId(inner) => match inner.as_ref() {
             ast::Value::String(s) => NonFungibleLocalId::from_str(s.as_str())
                 .map_err(|_| GeneratorError::InvalidNonFungibleLocalId(s.clone())),
-            v => invalid_type!(v, ast::Type::String)?,
+            v => invalid_type!(v, ast::ValueKind::String)?,
         },
-        v => invalid_type!(v, ast::Type::NonFungibleLocalId),
+        v => invalid_type!(v, ast::ValueKind::NonFungibleLocalId),
     }
 }
 
@@ -902,9 +902,9 @@ fn generate_expression(value: &ast::Value) -> Result<ManifestExpression, Generat
                 "ENTIRE_AUTH_ZONE" => Ok(ManifestExpression::EntireAuthZone),
                 _ => Err(GeneratorError::InvalidExpression(s.into())),
             },
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Expression),
+        v => invalid_type!(v, ast::ValueKind::Expression),
     }
 }
 
@@ -921,9 +921,9 @@ fn generate_blob(
                     .ok_or(GeneratorError::BlobNotFound(s.clone()))?;
                 Ok(ManifestBlobRef(hash.0))
             }
-            v => invalid_type!(v, ast::Type::String),
+            v => invalid_type!(v, ast::ValueKind::String),
         },
-        v => invalid_type!(v, ast::Type::Blob),
+        v => invalid_type!(v, ast::ValueKind::Blob),
     }
 }
 
@@ -932,9 +932,9 @@ fn generate_non_fungible_local_ids(
 ) -> Result<Vec<NonFungibleLocalId>, GeneratorError> {
     match value {
         ast::Value::Array(kind, values) => {
-            if kind != &ast::Type::NonFungibleLocalId {
+            if kind != &ast::ValueKind::NonFungibleLocalId {
                 return Err(GeneratorError::InvalidAstType {
-                    expected_type: ast::Type::String,
+                    expected_type: ast::ValueKind::String,
                     actual: kind.clone(),
                 });
             }
@@ -944,7 +944,7 @@ fn generate_non_fungible_local_ids(
                 .map(|v| generate_non_fungible_local_id(v))
                 .collect()
         }
-        v => invalid_type!(v, ast::Type::Array),
+        v => invalid_type!(v, ast::ValueKind::Array),
     }
 }
 
@@ -953,7 +953,7 @@ fn generate_byte_vec_from_hex(value: &ast::Value) -> Result<Vec<u8>, GeneratorEr
         ast::Value::String(s) => {
             hex::decode(s).map_err(|_| GeneratorError::InvalidBytesHex(s.to_owned()))?
         }
-        v => invalid_type!(v, ast::Type::String)?,
+        v => invalid_type!(v, ast::ValueKind::String)?,
     };
     Ok(bytes)
 }
@@ -1078,7 +1078,7 @@ pub fn generate_value(
                     NonFungibleGlobalId::try_from_canonical_string(bech32_decoder, s.as_str())
                         .map_err(|_| GeneratorError::InvalidNonFungibleGlobalId)
                 }
-                v => invalid_type!(v, ast::Type::String)?,
+                v => invalid_type!(v, ast::ValueKind::String)?,
             }?;
             Ok(Value::Tuple {
                 fields: vec![
@@ -1131,7 +1131,7 @@ pub fn generate_value(
 
 fn generate_singletons(
     elements: &Vec<ast::Value>,
-    expected_type: Option<ManifestValueKind>,
+    expected_value_kind: Option<ManifestValueKind>,
     resolver: &mut NameResolver,
     bech32_decoder: &Bech32Decoder,
     blobs: &BTreeMap<Hash, Vec<u8>>,
@@ -1140,7 +1140,7 @@ fn generate_singletons(
     for element in elements {
         result.push(generate_value(
             element,
-            expected_type,
+            expected_value_kind,
             resolver,
             bech32_decoder,
             blobs,
@@ -1323,7 +1323,7 @@ mod tests {
             }
         );
         generate_value_ok!(
-            r#"Enum<"AccessRule::AllowAll">()"#,
+            r#"Enum<AccessRule::AllowAll>()"#,
             Value::Enum {
                 discriminator: 0,
                 fields: vec![]
@@ -1342,7 +1342,7 @@ mod tests {
         generate_value_error!(
             r#"Address(100u32)"#,
             GeneratorError::InvalidAstValue {
-                expected_type: vec![ast::Type::String],
+                expected_type: vec![ast::ValueKind::String],
                 actual: ast::Value::U32(100),
             }
         );
@@ -1454,7 +1454,7 @@ mod tests {
     fn test_create_non_fungible_instruction() {
         generate_instruction_ok!(
             r#"CREATE_NON_FUNGIBLE_RESOURCE
-                Enum<"NonFungibleIdType::Integer">()
+                Enum<NonFungibleIdType::Integer>()
                 Tuple(
                     Tuple(
                         Array<Enum>(),
@@ -1465,18 +1465,18 @@ mod tests {
                     Array<String>()
                 )
                 Map<String, Enum>(
-                    "name", Enum<"Metadata::String">("Token")
+                    "name", Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<"ResourceMethodAuthKey::Withdraw">(),
+                    Enum<ResourceMethodAuthKey::Withdraw>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<"ResourceMethodAuthKey::Deposit">(),
+                    Enum<ResourceMethodAuthKey::Deposit>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     )
                 );"#,
             InstructionV1::CallFunction {
@@ -1545,7 +1545,7 @@ mod tests {
     fn test_create_non_fungible_with_initial_supply_instruction() {
         generate_instruction_ok!(
             r##"CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
-                Enum<"NonFungibleIdType::Integer">()
+                Enum<NonFungibleIdType::Integer>()
                 Tuple(
                     Tuple(
                         Array<Enum>(),
@@ -1556,18 +1556,18 @@ mod tests {
                     Array<String>()
                 )
                 Map<String, Enum>(
-                    "name", Enum<"Metadata::String">("Token")
+                    "name", Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<"ResourceMethodAuthKey::Withdraw">(),
+                    Enum<ResourceMethodAuthKey::Withdraw>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<"ResourceMethodAuthKey::Deposit">(),
+                    Enum<ResourceMethodAuthKey::Deposit>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     )
                 )
                 Map<NonFungibleLocalId, Tuple>(
@@ -1622,16 +1622,16 @@ mod tests {
             r#"CREATE_FUNGIBLE_RESOURCE
                 18u8
                 Map<String, Enum>(
-                    "name", Enum<"Metadata::String">("Token")
+                    "name", Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<"ResourceMethodAuthKey::Withdraw">(),
-                    Tuple(Enum<"AccessRule::AllowAll">(),
-                    Enum<"AccessRule::DenyAll">()
+                    Enum<ResourceMethodAuthKey::Withdraw>(),
+                    Tuple(Enum<AccessRule::AllowAll>(),
+                    Enum<AccessRule::DenyAll>()
                 ),
-                Enum<"ResourceMethodAuthKey::Deposit">(),
-                Tuple(Enum<"AccessRule::AllowAll">(),
-                Enum<"AccessRule::DenyAll">()))
+                Enum<ResourceMethodAuthKey::Deposit>(),
+                Tuple(Enum<AccessRule::AllowAll>(),
+                Enum<AccessRule::DenyAll>()))
             ;"#,
             InstructionV1::CallFunction {
                 package_address: RESOURCE_PACKAGE,
@@ -1664,18 +1664,18 @@ mod tests {
             r#"CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 18u8
                 Map<String, Enum>(
-                    "name", Enum<"Metadata::String">("Token")
+                    "name", Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<"ResourceMethodAuthKey::Withdraw">(),
+                    Enum<ResourceMethodAuthKey::Withdraw>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<"ResourceMethodAuthKey::Deposit">(),
+                    Enum<ResourceMethodAuthKey::Deposit>(),
                     Tuple(
-                        Enum<"AccessRule::AllowAll">(),
-                        Enum<"AccessRule::DenyAll">()
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
                     )
                 )
                 Decimal("500")

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -28,47 +28,7 @@ pub enum TokenKind {
     U128Literal(u128),
     StringLiteral(String),
 
-    // ==============
-    // SBOR basic types
-    // ==============
-    Bool,
-    I8,
-    I16,
-    I32,
-    I64,
-    I128,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    String,
-    Enum,
-    Array,
-    Tuple,
-    Map,
-
-    // ==============
-    // SBOR aliases
-    // ==============
-    Some,
-    None,
-    Ok,
-    Err,
-    Bytes,
-    NonFungibleGlobalId,
-
-    // ==============
-    // SBOR custom types
-    // ==============
-    Address,
-    Bucket,
-    Proof,
-    Expression,
-    Blob,
-    Decimal,
-    PreciseDecimal,
-    NonFungibleLocalId,
+    Ident(String),
 
     /* Punctuations */
     OpenParenthesis,
@@ -77,66 +37,6 @@ pub enum TokenKind {
     GreaterThan,
     Comma,
     Semicolon,
-
-    /* Instructions */
-    TakeFromWorktop,
-    TakeNonFungiblesFromWorktop,
-    TakeAllFromWorktop,
-    ReturnToWorktop,
-    AssertWorktopContains,
-    AssertWorktopContainsNonFungibles,
-
-    PopFromAuthZone,
-    PushToAuthZone,
-    ClearAuthZone,
-    CreateProofFromAuthZone,
-    CreateProofFromAuthZoneOfAmount,
-    CreateProofFromAuthZoneOfNonFungibles,
-    CreateProofFromAuthZoneOfAll,
-    ClearSignatureProofs,
-    CreateProofFromBucket,
-    CreateProofFromBucketOfAmount,
-    CreateProofFromBucketOfNonFungibles,
-    CreateProofFromBucketOfAll,
-    BurnResource,
-    CloneProof,
-    DropProof,
-    CallFunction,
-    CallMethod,
-    CallRoyaltyMethod,
-    CallMetadataMethod,
-    CallAccessRulesMethod,
-    RecallResource,
-    DropAllProofs,
-
-    /* Call function aliases */
-    PublishPackage,
-    PublishPackageAdvanced,
-    CreateFungibleResource,
-    CreateFungibleResourceWithInitialSupply,
-    CreateNonFungibleResource,
-    CreateNonFungibleResourceWithInitialSupply,
-    CreateAccessController,
-    CreateIdentity,
-    CreateIdentityAdvanced,
-    CreateAccount,
-    CreateAccountAdvanced,
-
-    /* Call non-main method aliases */
-    SetMetadata,
-    RemoveMetadata,
-    SetComponentRoyaltyConfig,
-    ClaimComponentRoyalty,
-    SetAuthorityAccessRule,
-    SetAuthorityMutability,
-
-    /* Call main method aliases */
-    SetPackageRoyaltyConfig,
-    ClaimPackageRoyalty,
-    MintFungible,
-    MintNonFungible,
-    MintUuidNonFungible,
-    CreateValidator,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -386,125 +286,22 @@ impl Lexer {
         let start = self.current;
 
         let mut id = String::from(self.advance()?);
-        while !self.is_eof() && (self.peek()?.is_ascii_alphanumeric() || self.peek()? == '_') {
+        while !self.is_eof() {
+            let next_char = self.peek()?;
+            let next_char_can_be_part_of_ident =
+                next_char.is_ascii_alphanumeric() || next_char == '_' || next_char == ':';
+            if !next_char_can_be_part_of_ident {
+                break;
+            }
             id.push(self.advance()?);
         }
 
-        match id.as_str() {
-            "true" => Ok(TokenKind::BoolLiteral(true)),
-            "false" => Ok(TokenKind::BoolLiteral(false)),
-
-            "Bool" => Ok(TokenKind::Bool),
-            "I8" => Ok(TokenKind::I8),
-            "I16" => Ok(TokenKind::I16),
-            "I32" => Ok(TokenKind::I32),
-            "I64" => Ok(TokenKind::I64),
-            "I128" => Ok(TokenKind::I128),
-            "U8" => Ok(TokenKind::U8),
-            "U16" => Ok(TokenKind::U16),
-            "U32" => Ok(TokenKind::U32),
-            "U64" => Ok(TokenKind::U64),
-            "U128" => Ok(TokenKind::U128),
-            "String" => Ok(TokenKind::String),
-            "Enum" => Ok(TokenKind::Enum),
-            "Array" => Ok(TokenKind::Array),
-            "Tuple" => Ok(TokenKind::Tuple),
-            "Map" => Ok(TokenKind::Map),
-
-            "Some" => Ok(TokenKind::Some),
-            "None" => Ok(TokenKind::None),
-            "Ok" => Ok(TokenKind::Ok),
-            "Err" => Ok(TokenKind::Err),
-            "Bytes" => Ok(TokenKind::Bytes),
-            "NonFungibleGlobalId" => Ok(TokenKind::NonFungibleGlobalId),
-
-            "Address" => Ok(TokenKind::Address),
-            "Bucket" => Ok(TokenKind::Bucket),
-            "Proof" => Ok(TokenKind::Proof),
-            "Expression" => Ok(TokenKind::Expression),
-            "Blob" => Ok(TokenKind::Blob),
-            "Decimal" => Ok(TokenKind::Decimal),
-            "PreciseDecimal" => Ok(TokenKind::PreciseDecimal),
-            "NonFungibleLocalId" => Ok(TokenKind::NonFungibleLocalId),
-
-            "TAKE_FROM_WORKTOP" => Ok(TokenKind::TakeFromWorktop),
-            "TAKE_NON_FUNGIBLES_FROM_WORKTOP" => Ok(TokenKind::TakeNonFungiblesFromWorktop),
-            "TAKE_ALL_FROM_WORKTOP" => Ok(TokenKind::TakeAllFromWorktop),
-            "RETURN_TO_WORKTOP" => Ok(TokenKind::ReturnToWorktop),
-            "ASSERT_WORKTOP_CONTAINS" => Ok(TokenKind::AssertWorktopContains),
-            "ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES" => {
-                Ok(TokenKind::AssertWorktopContainsNonFungibles)
-            }
-
-            "POP_FROM_AUTH_ZONE" => Ok(TokenKind::PopFromAuthZone),
-            "PUSH_TO_AUTH_ZONE" => Ok(TokenKind::PushToAuthZone),
-            "CLEAR_AUTH_ZONE" => Ok(TokenKind::ClearAuthZone),
-            "CREATE_PROOF_FROM_AUTH_ZONE" => Ok(TokenKind::CreateProofFromAuthZone),
-            "CREATE_PROOF_FROM_AUTH_ZONE_OF_AMOUNT" => {
-                Ok(TokenKind::CreateProofFromAuthZoneOfAmount)
-            }
-            "CREATE_PROOF_FROM_AUTH_ZONE_OF_NON_FUNGIBLES" => {
-                Ok(TokenKind::CreateProofFromAuthZoneOfNonFungibles)
-            }
-            "CREATE_PROOF_FROM_AUTH_ZONE_OF_ALL" => Ok(TokenKind::CreateProofFromAuthZoneOfAll),
-            "CLEAR_SIGNATURE_PROOFS" => Ok(TokenKind::ClearSignatureProofs),
-
-            "CREATE_PROOF_FROM_BUCKET" => Ok(TokenKind::CreateProofFromBucket),
-            "CREATE_PROOF_FROM_BUCKET_OF_AMOUNT" => Ok(TokenKind::CreateProofFromBucketOfAmount),
-            "CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES" => {
-                Ok(TokenKind::CreateProofFromBucketOfNonFungibles)
-            }
-            "CREATE_PROOF_FROM_BUCKET_OF_ALL" => Ok(TokenKind::CreateProofFromBucketOfAll),
-            "BURN_RESOURCE" => Ok(TokenKind::BurnResource),
-
-            "CLONE_PROOF" => Ok(TokenKind::CloneProof),
-            "DROP_PROOF" => Ok(TokenKind::DropProof),
-
-            "CALL_FUNCTION" => Ok(TokenKind::CallFunction),
-            "CALL_METHOD" => Ok(TokenKind::CallMethod),
-            "CALL_ROYALTY_METHOD" => Ok(TokenKind::CallRoyaltyMethod),
-            "CALL_METADATA_METHOD" => Ok(TokenKind::CallMetadataMethod),
-            "CALL_ACCESS_RULES_METHOD" => Ok(TokenKind::CallAccessRulesMethod),
-            "RECALL_RESOURCE" => Ok(TokenKind::RecallResource),
-
-            "DROP_ALL_PROOFS" => Ok(TokenKind::DropAllProofs),
-
-            /* call function aliases */
-            "PUBLISH_PACKAGE" => Ok(TokenKind::PublishPackage),
-            "PUBLISH_PACKAGE_ADVANCED" => Ok(TokenKind::PublishPackageAdvanced),
-            "CREATE_FUNGIBLE_RESOURCE" => Ok(TokenKind::CreateFungibleResource),
-            "CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY" => {
-                Ok(TokenKind::CreateFungibleResourceWithInitialSupply)
-            }
-            "CREATE_NON_FUNGIBLE_RESOURCE" => Ok(TokenKind::CreateNonFungibleResource),
-            "CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY" => {
-                Ok(TokenKind::CreateNonFungibleResourceWithInitialSupply)
-            }
-            "CREATE_IDENTITY" => Ok(TokenKind::CreateIdentity),
-            "CREATE_IDENTITY_ADVANCED" => Ok(TokenKind::CreateIdentityAdvanced),
-            "CREATE_ACCOUNT" => Ok(TokenKind::CreateAccount),
-            "CREATE_ACCOUNT_ADVANCED" => Ok(TokenKind::CreateAccountAdvanced),
-            "CREATE_ACCESS_CONTROLLER" => Ok(TokenKind::CreateAccessController),
-
-            /* call non-main method aliases */
-            "SET_METADATA" => Ok(TokenKind::SetMetadata),
-            "REMOVE_METADATA" => Ok(TokenKind::RemoveMetadata),
-            "SET_COMPONENT_ROYALTY_CONFIG" => Ok(TokenKind::SetComponentRoyaltyConfig),
-            "CLAIM_COMPONENT_ROYALTY" => Ok(TokenKind::ClaimComponentRoyalty),
-            "SET_AUTHORITY_ACCESS_RULE" => Ok(TokenKind::SetAuthorityAccessRule),
-            "SET_AUTHORITY_MUTABILITY" => Ok(TokenKind::SetAuthorityMutability),
-
-            /* call main method aliases */
-            "MINT_FUNGIBLE" => Ok(TokenKind::MintFungible),
-            "MINT_NON_FUNGIBLE" => Ok(TokenKind::MintNonFungible),
-            "MINT_UUID_NON_FUNGIBLE" => Ok(TokenKind::MintUuidNonFungible),
-            "SET_PACKAGE_ROYALTY_CONFIG" => Ok(TokenKind::SetPackageRoyaltyConfig),
-            "CLAIM_PACKAGE_ROYALTY" => Ok(TokenKind::ClaimPackageRoyalty),
-            "CREATE_VALIDATOR" => Ok(TokenKind::CreateValidator),
-
-            s @ _ => Err(LexerError::UnknownIdentifier(s.into())),
-        }
-        .map(|kind| self.new_token(kind, start, self.current))
+        let kind = match id.as_str() {
+            "true" => TokenKind::BoolLiteral(true),
+            "false" => TokenKind::BoolLiteral(false),
+            other => TokenKind::Ident(other.to_string()),
+        };
+        Ok(self.new_token(kind, start, self.current))
     }
 
     fn tokenize_punctuation(&mut self) -> Result<Token, LexerError> {
@@ -585,10 +382,7 @@ mod tests {
     fn test_bool() {
         lex_ok!("true", vec![TokenKind::BoolLiteral(true)]);
         lex_ok!("false", vec![TokenKind::BoolLiteral(false)]);
-        lex_error!(
-            "false123u8",
-            LexerError::UnknownIdentifier("false123u8".into())
-        );
+        lex_ok!("false123u8", vec![TokenKind::Ident("false123u8".into())]);
     }
 
     #[test]
@@ -615,7 +409,7 @@ mod tests {
         lex_ok!("1u8 # comment", vec![TokenKind::U8Literal(1),]);
         lex_ok!(
             "# multiple\n# line\nCALL_FUNCTION",
-            vec![TokenKind::CallFunction,]
+            vec![TokenKind::Ident("CALL_FUNCTION".to_string()),]
         );
     }
 
@@ -637,19 +431,19 @@ mod tests {
         lex_ok!(
             r#"CALL_FUNCTION Map<String, Array>("test", Array<String>("abc"));"#,
             vec![
-                TokenKind::CallFunction,
-                TokenKind::Map,
+                TokenKind::Ident("CALL_FUNCTION".to_string()),
+                TokenKind::Ident("Map".to_string()),
                 TokenKind::LessThan,
-                TokenKind::String,
+                TokenKind::Ident("String".to_string()),
                 TokenKind::Comma,
-                TokenKind::Array,
+                TokenKind::Ident("Array".to_string()),
                 TokenKind::GreaterThan,
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("test".into()),
                 TokenKind::Comma,
-                TokenKind::Array,
+                TokenKind::Ident("Array".to_string()),
                 TokenKind::LessThan,
-                TokenKind::String,
+                TokenKind::Ident("String".to_string()),
                 TokenKind::GreaterThan,
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("abc".into()),
@@ -665,7 +459,7 @@ mod tests {
         lex_ok!(
             "PreciseDecimal(\"12\")",
             vec![
-                TokenKind::PreciseDecimal,
+                TokenKind::Ident("PreciseDecimal".to_string()),
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("12".into()),
                 TokenKind::CloseParenthesis,
@@ -678,22 +472,22 @@ mod tests {
         lex_ok!(
             "Array<PreciseDecimal>(PreciseDecimal(\"12\"), PreciseDecimal(\"212\"), PreciseDecimal(\"1984\"))",
             vec![
-                TokenKind::Array,
+                TokenKind::Ident("Array".to_string()),
                 TokenKind::LessThan,
-                TokenKind::PreciseDecimal,
+                TokenKind::Ident("PreciseDecimal".to_string()),
                 TokenKind::GreaterThan,
                 TokenKind::OpenParenthesis,
-                TokenKind::PreciseDecimal,
+                TokenKind::Ident("PreciseDecimal".to_string()),
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("12".into()),
                 TokenKind::CloseParenthesis,
                 TokenKind::Comma,
-                TokenKind::PreciseDecimal,
+                TokenKind::Ident("PreciseDecimal".to_string()),
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("212".into()),
                 TokenKind::CloseParenthesis,
                 TokenKind::Comma,
-                TokenKind::PreciseDecimal,
+                TokenKind::Ident("PreciseDecimal".to_string()),
                 TokenKind::OpenParenthesis,
                 TokenKind::StringLiteral("1984".into()),
                 TokenKind::CloseParenthesis,

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -1,17 +1,346 @@
-use crate::manifest::ast::{Instruction, Type, Value};
+use crate::manifest::ast::{Instruction, Value, ValueKind};
 use crate::manifest::enums::KNOWN_ENUM_DISCRIMINATORS;
 use crate::manifest::lexer::{Token, TokenKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParserError {
     UnexpectedEof,
-    UnexpectedToken(Token),
-    InvalidNumberOfValues { actual: usize, expected: usize },
-    InvalidNumberOfTypes { actual: usize, expected: usize },
+    UnexpectedToken { expected: TokenType, actual: Token },
+    InvalidNumberOfValues { expected: usize, actual: usize },
+    InvalidNumberOfTypes { expected: usize, actual: usize },
     InvalidHex(String),
-    MissingEnumDiscriminator,
-    InvalidEnumDiscriminator,
     UnknownEnumDiscriminator(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenType {
+    Instruction,
+    Value,
+    ValueKind,
+    EnumDiscriminator,
+    Exact(TokenKind),
+}
+
+pub enum InstructionIdent {
+    // ==============
+    // Standard instructions
+    // ==============
+    TakeFromWorktop,
+    TakeNonFungiblesFromWorktop,
+    TakeAllFromWorktop,
+    ReturnToWorktop,
+    AssertWorktopContains,
+    AssertWorktopContainsNonFungibles,
+
+    PopFromAuthZone,
+    PushToAuthZone,
+    ClearAuthZone,
+    CreateProofFromAuthZone,
+    CreateProofFromAuthZoneOfAmount,
+    CreateProofFromAuthZoneOfNonFungibles,
+    CreateProofFromAuthZoneOfAll,
+    ClearSignatureProofs,
+    CreateProofFromBucket,
+    CreateProofFromBucketOfAmount,
+    CreateProofFromBucketOfNonFungibles,
+    CreateProofFromBucketOfAll,
+    BurnResource,
+    CloneProof,
+    DropProof,
+    CallFunction,
+    CallMethod,
+    CallRoyaltyMethod,
+    CallMetadataMethod,
+    CallAccessRulesMethod,
+    RecallResource,
+    DropAllProofs,
+
+    // ==============
+    // Call function aliases
+    // ==============
+    PublishPackage,
+    PublishPackageAdvanced,
+    CreateFungibleResource,
+    CreateFungibleResourceWithInitialSupply,
+    CreateNonFungibleResource,
+    CreateNonFungibleResourceWithInitialSupply,
+    CreateAccessController,
+    CreateIdentity,
+    CreateIdentityAdvanced,
+    CreateAccount,
+    CreateAccountAdvanced,
+
+    // ==============
+    // Call non-main-method aliases
+    // ==============
+    SetMetadata,
+    RemoveMetadata,
+    SetComponentRoyaltyConfig,
+    ClaimComponentRoyalty,
+    SetAuthorityAccessRule,
+    SetAuthorityMutability,
+
+    // ==============
+    // Call main-method aliases
+    // ==============
+    SetPackageRoyaltyConfig,
+    ClaimPackageRoyalty,
+    MintFungible,
+    MintNonFungible,
+    MintUuidNonFungible,
+    CreateValidator,
+}
+
+impl InstructionIdent {
+    pub fn from_ident(ident: &str) -> Option<Self> {
+        let value = match ident {
+            // ==============
+            // Standard instructions
+            // ==============
+            "TAKE_FROM_WORKTOP" => InstructionIdent::TakeFromWorktop,
+            "TAKE_NON_FUNGIBLES_FROM_WORKTOP" => InstructionIdent::TakeNonFungiblesFromWorktop,
+            "TAKE_ALL_FROM_WORKTOP" => InstructionIdent::TakeAllFromWorktop,
+            "RETURN_TO_WORKTOP" => InstructionIdent::ReturnToWorktop,
+            "ASSERT_WORKTOP_CONTAINS" => InstructionIdent::AssertWorktopContains,
+            "ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES" => {
+                InstructionIdent::AssertWorktopContainsNonFungibles
+            }
+
+            "POP_FROM_AUTH_ZONE" => InstructionIdent::PopFromAuthZone,
+            "PUSH_TO_AUTH_ZONE" => InstructionIdent::PushToAuthZone,
+            "CLEAR_AUTH_ZONE" => InstructionIdent::ClearAuthZone,
+            "CREATE_PROOF_FROM_AUTH_ZONE" => InstructionIdent::CreateProofFromAuthZone,
+            "CREATE_PROOF_FROM_AUTH_ZONE_OF_AMOUNT" => {
+                InstructionIdent::CreateProofFromAuthZoneOfAmount
+            }
+            "CREATE_PROOF_FROM_AUTH_ZONE_OF_NON_FUNGIBLES" => {
+                InstructionIdent::CreateProofFromAuthZoneOfNonFungibles
+            }
+            "CREATE_PROOF_FROM_AUTH_ZONE_OF_ALL" => InstructionIdent::CreateProofFromAuthZoneOfAll,
+            "CLEAR_SIGNATURE_PROOFS" => InstructionIdent::ClearSignatureProofs,
+
+            "CREATE_PROOF_FROM_BUCKET" => InstructionIdent::CreateProofFromBucket,
+            "CREATE_PROOF_FROM_BUCKET_OF_AMOUNT" => InstructionIdent::CreateProofFromBucketOfAmount,
+            "CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES" => {
+                InstructionIdent::CreateProofFromBucketOfNonFungibles
+            }
+            "CREATE_PROOF_FROM_BUCKET_OF_ALL" => InstructionIdent::CreateProofFromBucketOfAll,
+            "BURN_RESOURCE" => InstructionIdent::BurnResource,
+
+            "CLONE_PROOF" => InstructionIdent::CloneProof,
+            "DROP_PROOF" => InstructionIdent::DropProof,
+
+            "CALL_FUNCTION" => InstructionIdent::CallFunction,
+            "CALL_METHOD" => InstructionIdent::CallMethod,
+            "CALL_ROYALTY_METHOD" => InstructionIdent::CallRoyaltyMethod,
+            "CALL_METADATA_METHOD" => InstructionIdent::CallMetadataMethod,
+            "CALL_ACCESS_RULES_METHOD" => InstructionIdent::CallAccessRulesMethod,
+            "RECALL_RESOURCE" => InstructionIdent::RecallResource,
+
+            "DROP_ALL_PROOFS" => InstructionIdent::DropAllProofs,
+
+            // ==============
+            // Call function aliases
+            // ==============
+            "PUBLISH_PACKAGE" => InstructionIdent::PublishPackage,
+            "PUBLISH_PACKAGE_ADVANCED" => InstructionIdent::PublishPackageAdvanced,
+            "CREATE_FUNGIBLE_RESOURCE" => InstructionIdent::CreateFungibleResource,
+            "CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY" => {
+                InstructionIdent::CreateFungibleResourceWithInitialSupply
+            }
+            "CREATE_NON_FUNGIBLE_RESOURCE" => InstructionIdent::CreateNonFungibleResource,
+            "CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY" => {
+                InstructionIdent::CreateNonFungibleResourceWithInitialSupply
+            }
+            "CREATE_IDENTITY" => InstructionIdent::CreateIdentity,
+            "CREATE_IDENTITY_ADVANCED" => InstructionIdent::CreateIdentityAdvanced,
+            "CREATE_ACCOUNT" => InstructionIdent::CreateAccount,
+            "CREATE_ACCOUNT_ADVANCED" => InstructionIdent::CreateAccountAdvanced,
+            "CREATE_ACCESS_CONTROLLER" => InstructionIdent::CreateAccessController,
+
+            // ==============
+            // Call non-main-method aliases
+            // ==============
+            "SET_METADATA" => InstructionIdent::SetMetadata,
+            "REMOVE_METADATA" => InstructionIdent::RemoveMetadata,
+            "SET_COMPONENT_ROYALTY_CONFIG" => InstructionIdent::SetComponentRoyaltyConfig,
+            "CLAIM_COMPONENT_ROYALTY" => InstructionIdent::ClaimComponentRoyalty,
+            "SET_AUTHORITY_ACCESS_RULE" => InstructionIdent::SetAuthorityAccessRule,
+            "SET_AUTHORITY_MUTABILITY" => InstructionIdent::SetAuthorityMutability,
+
+            // ==============
+            // Call main-method aliases
+            // ==============
+            "MINT_FUNGIBLE" => InstructionIdent::MintFungible,
+            "MINT_NON_FUNGIBLE" => InstructionIdent::MintNonFungible,
+            "MINT_UUID_NON_FUNGIBLE" => InstructionIdent::MintUuidNonFungible,
+            "SET_PACKAGE_ROYALTY_CONFIG" => InstructionIdent::SetPackageRoyaltyConfig,
+            "CLAIM_PACKAGE_ROYALTY" => InstructionIdent::ClaimPackageRoyalty,
+            "CREATE_VALIDATOR" => InstructionIdent::CreateValidator,
+            _ => {
+                return None;
+            }
+        };
+        Some(value)
+    }
+}
+
+pub enum SborValueIdent {
+    // ==============
+    // SBOR composite value types
+    // ==============
+    Enum,
+    Array,
+    Tuple,
+    Map,
+    // ==============
+    // SBOR aliases
+    // ==============
+    Some,
+    None,
+    Ok,
+    Err,
+    Bytes,
+    NonFungibleGlobalId,
+    // ==============
+    // SBOR custom types
+    // ==============
+    Address,
+    Bucket,
+    Proof,
+    Expression,
+    Blob,
+    Decimal,
+    PreciseDecimal,
+    NonFungibleLocalId,
+}
+
+impl SborValueIdent {
+    pub fn from_ident(ident: &str) -> Option<Self> {
+        let value = match ident {
+            // ==============
+            // SBOR composite value types
+            // ==============
+            "Enum" => SborValueIdent::Enum,
+            "Array" => SborValueIdent::Array,
+            "Tuple" => SborValueIdent::Tuple,
+            "Map" => SborValueIdent::Map,
+            // ==============
+            // SBOR aliases
+            // ==============
+            "Some" => SborValueIdent::Some,
+            "None" => SborValueIdent::None,
+            "Ok" => SborValueIdent::Ok,
+            "Err" => SborValueIdent::Err,
+            "Bytes" => SborValueIdent::Bytes,
+            "NonFungibleGlobalId" => SborValueIdent::NonFungibleGlobalId,
+            // ==============
+            // Custom types
+            // ==============
+            "Address" => SborValueIdent::Address,
+            "Bucket" => SborValueIdent::Bucket,
+            "Proof" => SborValueIdent::Proof,
+            "Expression" => SborValueIdent::Expression,
+            "Blob" => SborValueIdent::Blob,
+            "Decimal" => SborValueIdent::Decimal,
+            "PreciseDecimal" => SborValueIdent::PreciseDecimal,
+            "NonFungibleLocalId" => SborValueIdent::NonFungibleLocalId,
+            _ => {
+                return None;
+            }
+        };
+        Some(value)
+    }
+}
+
+pub enum SborValueKindIdent {
+    // ==============
+    // Simple basic value kinds
+    // ==============
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    String,
+    // ==============
+    // Composite basic value kinds
+    // ==============
+    Enum,
+    Array,
+    Tuple,
+    Map,
+    // ==============
+    // Value kind aliases
+    // ==============
+    Bytes,
+    NonFungibleGlobalId,
+    // ==============
+    // Custom value kinds
+    // ==============
+    Address,
+    Bucket,
+    Proof,
+    Expression,
+    Blob,
+    Decimal,
+    PreciseDecimal,
+    NonFungibleLocalId,
+}
+
+impl SborValueKindIdent {
+    pub fn from_ident(ident: &str) -> Option<Self> {
+        let value = match ident {
+            // ==============
+            // Basic simple types
+            // ==============
+            "Bool" => SborValueKindIdent::Bool,
+            "I8" => SborValueKindIdent::I8,
+            "I16" => SborValueKindIdent::I16,
+            "I32" => SborValueKindIdent::I32,
+            "I64" => SborValueKindIdent::I64,
+            "I128" => SborValueKindIdent::I128,
+            "U8" => SborValueKindIdent::U8,
+            "U16" => SborValueKindIdent::U16,
+            "U32" => SborValueKindIdent::U32,
+            "U64" => SborValueKindIdent::U64,
+            "U128" => SborValueKindIdent::U128,
+            "String" => SborValueKindIdent::String,
+            // ==============
+            // Basic composite types
+            // ==============
+            "Enum" => SborValueKindIdent::Enum,
+            "Array" => SborValueKindIdent::Array,
+            "Tuple" => SborValueKindIdent::Tuple,
+            "Map" => SborValueKindIdent::Map,
+            // ==============
+            // Value kind aliases
+            // ==============
+            "Bytes" => SborValueKindIdent::Bytes,
+            "NonFungibleGlobalId" => SborValueKindIdent::NonFungibleGlobalId,
+            // ==============
+            // Custom types
+            // ==============
+            "Address" => SborValueKindIdent::Address,
+            "Bucket" => SborValueKindIdent::Bucket,
+            "Proof" => SborValueKindIdent::Proof,
+            "Expression" => SborValueKindIdent::Expression,
+            "Blob" => SborValueKindIdent::Blob,
+            "Decimal" => SborValueKindIdent::Decimal,
+            "PreciseDecimal" => SborValueKindIdent::PreciseDecimal,
+            "NonFungibleLocalId" => SborValueKindIdent::NonFungibleLocalId,
+            _ => {
+                return None;
+            }
+        };
+        Some(value)
+    }
 }
 
 pub struct Parser {
@@ -32,7 +361,10 @@ macro_rules! advance_match {
     ( $self:expr, $expected:expr ) => {{
         let token = $self.advance()?;
         if token.kind != $expected {
-            return Err(ParserError::UnexpectedToken(token));
+            return Err(ParserError::UnexpectedToken {
+                expected: TokenType::Exact($expected),
+                actual: token,
+            });
         }
     }};
 }
@@ -79,287 +411,330 @@ impl Parser {
 
     pub fn parse_instruction(&mut self) -> Result<Instruction, ParserError> {
         let token = self.advance()?;
-        let instruction = match token.kind {
-            TokenKind::TakeFromWorktop => Instruction::TakeFromWorktop {
+        let instruction_ident = match &token.kind {
+            TokenKind::Ident(ident_str) => {
+                InstructionIdent::from_ident(ident_str).ok_or(ParserError::UnexpectedToken {
+                    expected: TokenType::Instruction,
+                    actual: token,
+                })?
+            }
+            _ => {
+                return Err(ParserError::UnexpectedToken {
+                    expected: TokenType::Instruction,
+                    actual: token,
+                });
+            }
+        };
+        let instruction = match instruction_ident {
+            InstructionIdent::TakeFromWorktop => Instruction::TakeFromWorktop {
                 resource_address: self.parse_value()?,
                 amount: self.parse_value()?,
                 new_bucket: self.parse_value()?,
             },
-            TokenKind::TakeNonFungiblesFromWorktop => Instruction::TakeNonFungiblesFromWorktop {
+            InstructionIdent::TakeNonFungiblesFromWorktop => {
+                Instruction::TakeNonFungiblesFromWorktop {
+                    resource_address: self.parse_value()?,
+                    ids: self.parse_value()?,
+                    new_bucket: self.parse_value()?,
+                }
+            }
+            InstructionIdent::TakeAllFromWorktop => Instruction::TakeAllFromWorktop {
                 resource_address: self.parse_value()?,
-                ids: self.parse_value()?,
                 new_bucket: self.parse_value()?,
             },
-            TokenKind::TakeAllFromWorktop => Instruction::TakeAllFromWorktop {
-                resource_address: self.parse_value()?,
-                new_bucket: self.parse_value()?,
-            },
-            TokenKind::ReturnToWorktop => Instruction::ReturnToWorktop {
+            InstructionIdent::ReturnToWorktop => Instruction::ReturnToWorktop {
                 bucket: self.parse_value()?,
             },
-            TokenKind::AssertWorktopContains => Instruction::AssertWorktopContains {
+            InstructionIdent::AssertWorktopContains => Instruction::AssertWorktopContains {
                 resource_address: self.parse_value()?,
                 amount: self.parse_value()?,
             },
-            TokenKind::AssertWorktopContainsNonFungibles => {
+            InstructionIdent::AssertWorktopContainsNonFungibles => {
                 Instruction::AssertWorktopContainsNonFungibles {
                     resource_address: self.parse_value()?,
                     ids: self.parse_value()?,
                 }
             }
-            TokenKind::PopFromAuthZone => Instruction::PopFromAuthZone {
+            InstructionIdent::PopFromAuthZone => Instruction::PopFromAuthZone {
                 new_proof: self.parse_value()?,
             },
-            TokenKind::PushToAuthZone => Instruction::PushToAuthZone {
+            InstructionIdent::PushToAuthZone => Instruction::PushToAuthZone {
                 proof: self.parse_value()?,
             },
-            TokenKind::ClearAuthZone => Instruction::ClearAuthZone,
-            TokenKind::CreateProofFromAuthZone => Instruction::CreateProofFromAuthZone {
+            InstructionIdent::ClearAuthZone => Instruction::ClearAuthZone,
+            InstructionIdent::CreateProofFromAuthZone => Instruction::CreateProofFromAuthZone {
                 resource_address: self.parse_value()?,
                 new_proof: self.parse_value()?,
             },
-            TokenKind::CreateProofFromAuthZoneOfAmount => {
+            InstructionIdent::CreateProofFromAuthZoneOfAmount => {
                 Instruction::CreateProofFromAuthZoneOfAmount {
                     resource_address: self.parse_value()?,
                     amount: self.parse_value()?,
                     new_proof: self.parse_value()?,
                 }
             }
-            TokenKind::CreateProofFromAuthZoneOfNonFungibles => {
+            InstructionIdent::CreateProofFromAuthZoneOfNonFungibles => {
                 Instruction::CreateProofFromAuthZoneOfNonFungibles {
                     resource_address: self.parse_value()?,
                     ids: self.parse_value()?,
                     new_proof: self.parse_value()?,
                 }
             }
-            TokenKind::CreateProofFromAuthZoneOfAll => Instruction::CreateProofFromAuthZoneOfAll {
-                resource_address: self.parse_value()?,
-                new_proof: self.parse_value()?,
-            },
-            TokenKind::ClearSignatureProofs => Instruction::ClearSignatureProofs,
+            InstructionIdent::CreateProofFromAuthZoneOfAll => {
+                Instruction::CreateProofFromAuthZoneOfAll {
+                    resource_address: self.parse_value()?,
+                    new_proof: self.parse_value()?,
+                }
+            }
+            InstructionIdent::ClearSignatureProofs => Instruction::ClearSignatureProofs,
 
-            TokenKind::CreateProofFromBucket => Instruction::CreateProofFromBucket {
+            InstructionIdent::CreateProofFromBucket => Instruction::CreateProofFromBucket {
                 bucket: self.parse_value()?,
                 new_proof: self.parse_value()?,
             },
-            TokenKind::CreateProofFromBucketOfAmount => {
+            InstructionIdent::CreateProofFromBucketOfAmount => {
                 Instruction::CreateProofFromBucketOfAmount {
                     bucket: self.parse_value()?,
                     amount: self.parse_value()?,
                     new_proof: self.parse_value()?,
                 }
             }
-            TokenKind::CreateProofFromBucketOfNonFungibles => {
+            InstructionIdent::CreateProofFromBucketOfNonFungibles => {
                 Instruction::CreateProofFromBucketOfNonFungibles {
                     bucket: self.parse_value()?,
                     ids: self.parse_value()?,
                     new_proof: self.parse_value()?,
                 }
             }
-            TokenKind::CreateProofFromBucketOfAll => Instruction::CreateProofFromBucketOfAll {
-                bucket: self.parse_value()?,
-                new_proof: self.parse_value()?,
-            },
-            TokenKind::BurnResource => Instruction::BurnResource {
+            InstructionIdent::CreateProofFromBucketOfAll => {
+                Instruction::CreateProofFromBucketOfAll {
+                    bucket: self.parse_value()?,
+                    new_proof: self.parse_value()?,
+                }
+            }
+            InstructionIdent::BurnResource => Instruction::BurnResource {
                 bucket: self.parse_value()?,
             },
 
-            TokenKind::CloneProof => Instruction::CloneProof {
+            InstructionIdent::CloneProof => Instruction::CloneProof {
                 proof: self.parse_value()?,
                 new_proof: self.parse_value()?,
             },
-            TokenKind::DropProof => Instruction::DropProof {
+            InstructionIdent::DropProof => Instruction::DropProof {
                 proof: self.parse_value()?,
             },
-            TokenKind::CallFunction => Instruction::CallFunction {
+            InstructionIdent::CallFunction => Instruction::CallFunction {
                 package_address: self.parse_value()?,
                 blueprint_name: self.parse_value()?,
                 function_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CallMethod => Instruction::CallMethod {
+            InstructionIdent::CallMethod => Instruction::CallMethod {
                 address: self.parse_value()?,
                 method_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CallRoyaltyMethod => Instruction::CallRoyaltyMethod {
+            InstructionIdent::CallRoyaltyMethod => Instruction::CallRoyaltyMethod {
                 address: self.parse_value()?,
                 method_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CallMetadataMethod => Instruction::CallMetadataMethod {
+            InstructionIdent::CallMetadataMethod => Instruction::CallMetadataMethod {
                 address: self.parse_value()?,
                 method_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CallAccessRulesMethod => Instruction::CallAccessRulesMethod {
+            InstructionIdent::CallAccessRulesMethod => Instruction::CallAccessRulesMethod {
                 address: self.parse_value()?,
                 method_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::RecallResource => Instruction::RecallResource {
+            InstructionIdent::RecallResource => Instruction::RecallResource {
                 vault_id: self.parse_value()?,
                 amount: self.parse_value()?,
             },
-            TokenKind::DropAllProofs => Instruction::DropAllProofs,
+            InstructionIdent::DropAllProofs => Instruction::DropAllProofs,
 
             /* Call function aliases */
-            TokenKind::PublishPackage => Instruction::PublishPackage {
+            InstructionIdent::PublishPackage => Instruction::PublishPackage {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::PublishPackageAdvanced => Instruction::PublishPackageAdvanced {
+            InstructionIdent::PublishPackageAdvanced => Instruction::PublishPackageAdvanced {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateFungibleResource => Instruction::CreateFungibleResource {
+            InstructionIdent::CreateFungibleResource => Instruction::CreateFungibleResource {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateFungibleResourceWithInitialSupply => {
+            InstructionIdent::CreateFungibleResourceWithInitialSupply => {
                 Instruction::CreateFungibleResourceWithInitialSupply {
                     args: self.parse_values_till_semicolon()?,
                 }
             }
-            TokenKind::CreateNonFungibleResource => Instruction::CreateNonFungibleResource {
+            InstructionIdent::CreateNonFungibleResource => Instruction::CreateNonFungibleResource {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateNonFungibleResourceWithInitialSupply => {
+            InstructionIdent::CreateNonFungibleResourceWithInitialSupply => {
                 Instruction::CreateNonFungibleResourceWithInitialSupply {
                     args: self.parse_values_till_semicolon()?,
                 }
             }
-            TokenKind::CreateAccessController => Instruction::CreateAccessController {
+            InstructionIdent::CreateAccessController => Instruction::CreateAccessController {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateIdentity => Instruction::CreateIdentity {
+            InstructionIdent::CreateIdentity => Instruction::CreateIdentity {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateIdentityAdvanced => Instruction::CreateIdentityAdvanced {
+            InstructionIdent::CreateIdentityAdvanced => Instruction::CreateIdentityAdvanced {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateAccount => Instruction::CreateAccount {
+            InstructionIdent::CreateAccount => Instruction::CreateAccount {
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateAccountAdvanced => Instruction::CreateAccountAdvanced {
+            InstructionIdent::CreateAccountAdvanced => Instruction::CreateAccountAdvanced {
                 args: self.parse_values_till_semicolon()?,
             },
 
             /* Call non-main method aliases */
-            TokenKind::SetMetadata => Instruction::SetMetadata {
+            InstructionIdent::SetMetadata => Instruction::SetMetadata {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::RemoveMetadata => Instruction::RemoveMetadata {
+            InstructionIdent::RemoveMetadata => Instruction::RemoveMetadata {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::SetComponentRoyaltyConfig => Instruction::SetComponentRoyaltyConfig {
+            InstructionIdent::SetComponentRoyaltyConfig => Instruction::SetComponentRoyaltyConfig {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::ClaimComponentRoyalty => Instruction::ClaimComponentRoyalty {
+            InstructionIdent::ClaimComponentRoyalty => Instruction::ClaimComponentRoyalty {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::SetAuthorityAccessRule => Instruction::SetAuthorityAccessRule {
+            InstructionIdent::SetAuthorityAccessRule => Instruction::SetAuthorityAccessRule {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::SetAuthorityMutability => Instruction::SetAuthorityMutability {
+            InstructionIdent::SetAuthorityMutability => Instruction::SetAuthorityMutability {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
 
             /* Call main method aliases */
-            TokenKind::MintFungible => Instruction::MintFungible {
+            InstructionIdent::MintFungible => Instruction::MintFungible {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::MintNonFungible => Instruction::MintNonFungible {
+            InstructionIdent::MintNonFungible => Instruction::MintNonFungible {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::MintUuidNonFungible => Instruction::MintUuidNonFungible {
+            InstructionIdent::MintUuidNonFungible => Instruction::MintUuidNonFungible {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::SetPackageRoyaltyConfig => Instruction::SetPackageRoyaltyConfig {
+            InstructionIdent::SetPackageRoyaltyConfig => Instruction::SetPackageRoyaltyConfig {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::ClaimPackageRoyalty => Instruction::ClaimPackageRoyalty {
+            InstructionIdent::ClaimPackageRoyalty => Instruction::ClaimPackageRoyalty {
                 address: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
-            TokenKind::CreateValidator => Instruction::CreateValidator {
+            InstructionIdent::CreateValidator => Instruction::CreateValidator {
                 args: self.parse_values_till_semicolon()?,
             },
-
-            _ => {
-                return Err(ParserError::UnexpectedToken(token));
-            }
         };
         advance_match!(self, TokenKind::Semicolon);
         Ok(instruction)
     }
 
     pub fn parse_value(&mut self) -> Result<Value, ParserError> {
-        let token = self.peek()?;
-        match token.kind {
+        let token = self.advance()?;
+        let value = match &token.kind {
             // ==============
             // Basic Types
             // ==============
-            TokenKind::BoolLiteral(value) => advance_ok!(self, Value::Bool(value)),
-            TokenKind::U8Literal(value) => advance_ok!(self, Value::U8(value)),
-            TokenKind::U16Literal(value) => advance_ok!(self, Value::U16(value)),
-            TokenKind::U32Literal(value) => advance_ok!(self, Value::U32(value)),
-            TokenKind::U64Literal(value) => advance_ok!(self, Value::U64(value)),
-            TokenKind::U128Literal(value) => advance_ok!(self, Value::U128(value)),
-            TokenKind::I8Literal(value) => advance_ok!(self, Value::I8(value)),
-            TokenKind::I16Literal(value) => advance_ok!(self, Value::I16(value)),
-            TokenKind::I32Literal(value) => advance_ok!(self, Value::I32(value)),
-            TokenKind::I64Literal(value) => advance_ok!(self, Value::I64(value)),
-            TokenKind::I128Literal(value) => advance_ok!(self, Value::I128(value)),
-            TokenKind::StringLiteral(value) => advance_ok!(self, Value::String(value)),
-            TokenKind::Enum => self.parse_enum(),
-            TokenKind::Array => self.parse_array(),
-            TokenKind::Tuple => self.parse_tuple(),
-            TokenKind::Map => self.parse_map(),
+            TokenKind::BoolLiteral(value) => Value::Bool(*value),
+            TokenKind::U8Literal(value) => Value::U8(*value),
+            TokenKind::U16Literal(value) => Value::U16(*value),
+            TokenKind::U32Literal(value) => Value::U32(*value),
+            TokenKind::U64Literal(value) => Value::U64(*value),
+            TokenKind::U128Literal(value) => Value::U128(*value),
+            TokenKind::I8Literal(value) => Value::I8(*value),
+            TokenKind::I16Literal(value) => Value::I16(*value),
+            TokenKind::I32Literal(value) => Value::I32(*value),
+            TokenKind::I64Literal(value) => Value::I64(*value),
+            TokenKind::I128Literal(value) => Value::I128(*value),
+            TokenKind::StringLiteral(value) => Value::String(value.clone()),
+            TokenKind::Ident(ident_str) => {
+                let value_ident =
+                    SborValueIdent::from_ident(ident_str).ok_or(ParserError::UnexpectedToken {
+                        expected: TokenType::Value,
+                        actual: token,
+                    })?;
+                match value_ident {
+                    SborValueIdent::Enum => self.parse_enum_content()?,
+                    SborValueIdent::Array => self.parse_array_content()?,
+                    SborValueIdent::Tuple => self.parse_tuple_content()?,
+                    SborValueIdent::Map => self.parse_map_content()?,
 
-            // ==============
-            // Aliases
-            // ==============
-            TokenKind::Some
-            | TokenKind::None
-            | TokenKind::Ok
-            | TokenKind::Err
-            | TokenKind::Bytes
-            | TokenKind::NonFungibleGlobalId => self.parse_alias(),
+                    // ==============
+                    // Aliases
+                    // ==============
+                    SborValueIdent::Some => Value::Some(Box::new(self.parse_values_one()?)),
+                    SborValueIdent::None => Value::None,
+                    SborValueIdent::Ok => Value::Ok(Box::new(self.parse_values_one()?)),
+                    SborValueIdent::Err => Value::Err(Box::new(self.parse_values_one()?)),
+                    SborValueIdent::Bytes => Value::Bytes(Box::new(self.parse_values_one()?)),
+                    SborValueIdent::NonFungibleGlobalId => {
+                        Value::NonFungibleGlobalId(Box::new(self.parse_values_one()?))
+                    }
 
-            // ==============
-            // Custom Types
-            // ==============
-            TokenKind::Address
-            | TokenKind::Bucket
-            | TokenKind::Proof
-            | TokenKind::Expression
-            | TokenKind::Blob
-            | TokenKind::Decimal
-            | TokenKind::PreciseDecimal
-            | TokenKind::NonFungibleLocalId => self.parse_custom_types(),
-            _ => Err(ParserError::UnexpectedToken(token)),
-        }
+                    // ==============
+                    // Custom Types
+                    // ==============
+                    SborValueIdent::Address => Value::Address(self.parse_values_one()?.into()),
+                    SborValueIdent::Bucket => Value::Bucket(self.parse_values_one()?.into()),
+                    SborValueIdent::Proof => Value::Proof(self.parse_values_one()?.into()),
+                    SborValueIdent::Expression => {
+                        Value::Expression(self.parse_values_one()?.into())
+                    }
+                    SborValueIdent::Blob => Value::Blob(self.parse_values_one()?.into()),
+                    SborValueIdent::Decimal => Value::Decimal(self.parse_values_one()?.into()),
+                    SborValueIdent::PreciseDecimal => {
+                        Value::PreciseDecimal(self.parse_values_one()?.into())
+                    }
+                    SborValueIdent::NonFungibleLocalId => {
+                        Value::NonFungibleLocalId(self.parse_values_one()?.into())
+                    }
+                }
+            }
+            _ => {
+                return Err(ParserError::UnexpectedToken {
+                    expected: TokenType::Value,
+                    actual: token,
+                });
+            }
+        };
+        Ok(value)
     }
 
-    pub fn parse_enum(&mut self) -> Result<Value, ParserError> {
-        advance_match!(self, TokenKind::Enum);
-
+    pub fn parse_enum_content(&mut self) -> Result<Value, ParserError> {
         advance_match!(self, TokenKind::LessThan);
-        let discriminator = match self.parse_value()? {
-            Value::U8(discriminator) => discriminator,
-            Value::String(discriminator) => KNOWN_ENUM_DISCRIMINATORS
+        let discriminator_token = self.advance()?;
+        let discriminator = match discriminator_token.kind {
+            TokenKind::U8Literal(discriminator) => discriminator,
+            TokenKind::Ident(discriminator) => KNOWN_ENUM_DISCRIMINATORS
                 .get(discriminator.as_str())
                 .cloned()
                 .ok_or(ParserError::UnknownEnumDiscriminator(discriminator.clone()))?,
-            _ => return Err(ParserError::InvalidEnumDiscriminator),
+            _ => {
+                return Err(ParserError::UnexpectedToken {
+                    expected: TokenType::EnumDiscriminator,
+                    actual: discriminator_token,
+                })
+            }
         };
         advance_match!(self, TokenKind::GreaterThan);
 
@@ -369,8 +744,7 @@ impl Parser {
         Ok(Value::Enum(discriminator, fields))
     }
 
-    pub fn parse_array(&mut self) -> Result<Value, ParserError> {
-        advance_match!(self, TokenKind::Array);
+    pub fn parse_array_content(&mut self) -> Result<Value, ParserError> {
         let generics = self.parse_generics(1)?;
         Ok(Value::Array(
             generics[0],
@@ -378,55 +752,20 @@ impl Parser {
         ))
     }
 
-    pub fn parse_tuple(&mut self) -> Result<Value, ParserError> {
-        advance_match!(self, TokenKind::Tuple);
+    pub fn parse_tuple_content(&mut self) -> Result<Value, ParserError> {
         Ok(Value::Tuple(self.parse_values_any(
             TokenKind::OpenParenthesis,
             TokenKind::CloseParenthesis,
         )?))
     }
 
-    pub fn parse_map(&mut self) -> Result<Value, ParserError> {
-        advance_match!(self, TokenKind::Map);
+    pub fn parse_map_content(&mut self) -> Result<Value, ParserError> {
         let generics = self.parse_generics(2)?;
         Ok(Value::Map(
             generics[0],
             generics[1],
             self.parse_values_any(TokenKind::OpenParenthesis, TokenKind::CloseParenthesis)?,
         ))
-    }
-
-    pub fn parse_alias(&mut self) -> Result<Value, ParserError> {
-        let token = self.advance()?;
-        match token.kind {
-            TokenKind::Some => Ok(Value::Some(Box::new(self.parse_values_one()?))),
-            TokenKind::None => Ok(Value::None),
-            TokenKind::Ok => Ok(Value::Ok(Box::new(self.parse_values_one()?))),
-            TokenKind::Err => Ok(Value::Err(Box::new(self.parse_values_one()?))),
-            TokenKind::Bytes => Ok(Value::Bytes(Box::new(self.parse_values_one()?))),
-            TokenKind::NonFungibleGlobalId => Ok(Value::NonFungibleGlobalId(Box::new(
-                self.parse_values_one()?,
-            ))),
-            _ => Err(ParserError::UnexpectedToken(token)),
-        }
-    }
-
-    pub fn parse_custom_types(&mut self) -> Result<Value, ParserError> {
-        let token = self.advance()?;
-        match token.kind {
-            TokenKind::Address => Ok(Value::Address(self.parse_values_one()?.into())),
-            TokenKind::Bucket => Ok(Value::Bucket(self.parse_values_one()?.into())),
-            TokenKind::Proof => Ok(Value::Proof(self.parse_values_one()?.into())),
-            TokenKind::Expression => Ok(Value::Expression(self.parse_values_one()?.into())),
-            TokenKind::Blob => Ok(Value::Blob(self.parse_values_one()?.into())),
-            TokenKind::Decimal => Ok(Value::Decimal(self.parse_values_one()?.into())),
-            TokenKind::PreciseDecimal => Ok(Value::PreciseDecimal(self.parse_values_one()?.into())),
-            TokenKind::NonFungibleLocalId => {
-                Ok(Value::NonFungibleLocalId(self.parse_values_one()?.into()))
-            }
-
-            _ => Err(ParserError::UnexpectedToken(token)),
-        }
     }
 
     /// Parse a comma-separated value list, enclosed by a pair of marks.
@@ -460,7 +799,7 @@ impl Parser {
         }
     }
 
-    fn parse_generics(&mut self, n: usize) -> Result<Vec<Type>, ParserError> {
+    fn parse_generics(&mut self, n: usize) -> Result<Vec<ValueKind>, ParserError> {
         advance_match!(self, TokenKind::LessThan);
         let mut types = Vec::new();
         while self.peek()?.kind != TokenKind::GreaterThan {
@@ -481,41 +820,68 @@ impl Parser {
         }
     }
 
-    fn parse_type(&mut self) -> Result<Type, ParserError> {
+    fn parse_type(&mut self) -> Result<ValueKind, ParserError> {
         let token = self.advance()?;
-        match &token.kind {
-            TokenKind::Bool => Ok(Type::Bool),
-            TokenKind::I8 => Ok(Type::I8),
-            TokenKind::I16 => Ok(Type::I16),
-            TokenKind::I32 => Ok(Type::I32),
-            TokenKind::I64 => Ok(Type::I64),
-            TokenKind::I128 => Ok(Type::I128),
-            TokenKind::U8 => Ok(Type::U8),
-            TokenKind::U16 => Ok(Type::U16),
-            TokenKind::U32 => Ok(Type::U32),
-            TokenKind::U64 => Ok(Type::U64),
-            TokenKind::U128 => Ok(Type::U128),
-            TokenKind::String => Ok(Type::String),
-            TokenKind::Enum => Ok(Type::Enum),
-            TokenKind::Array => Ok(Type::Array),
-            TokenKind::Tuple => Ok(Type::Tuple),
+        let the_type = match &token.kind {
+            TokenKind::Ident(ident_str) => {
+                let value_kind_ident = SborValueKindIdent::from_ident(&ident_str).ok_or(
+                    ParserError::UnexpectedToken {
+                        expected: TokenType::ValueKind,
+                        actual: token,
+                    },
+                )?;
+                match value_kind_ident {
+                    // ==============
+                    // Simple basic value kinds
+                    // ==============
+                    SborValueKindIdent::Bool => ValueKind::Bool,
+                    SborValueKindIdent::I8 => ValueKind::I8,
+                    SborValueKindIdent::I16 => ValueKind::I16,
+                    SborValueKindIdent::I32 => ValueKind::I32,
+                    SborValueKindIdent::I64 => ValueKind::I64,
+                    SborValueKindIdent::I128 => ValueKind::I128,
+                    SborValueKindIdent::U8 => ValueKind::U8,
+                    SborValueKindIdent::U16 => ValueKind::U16,
+                    SborValueKindIdent::U32 => ValueKind::U32,
+                    SborValueKindIdent::U64 => ValueKind::U64,
+                    SborValueKindIdent::U128 => ValueKind::U128,
+                    SborValueKindIdent::String => ValueKind::String,
 
-            // Alias
-            TokenKind::Bytes => Ok(Type::Bytes),
-            TokenKind::NonFungibleGlobalId => Ok(Type::NonFungibleGlobalId),
+                    // ==============
+                    // Composite basic value kinds
+                    // ==============
+                    SborValueKindIdent::Enum => ValueKind::Enum,
+                    SborValueKindIdent::Array => ValueKind::Array,
+                    SborValueKindIdent::Tuple => ValueKind::Tuple,
+                    SborValueKindIdent::Map => ValueKind::Map,
 
-            // Custom types
-            TokenKind::Address => Ok(Type::Address),
-            TokenKind::Bucket => Ok(Type::Bucket),
-            TokenKind::Proof => Ok(Type::Proof),
-            TokenKind::Expression => Ok(Type::Expression),
-            TokenKind::Blob => Ok(Type::Blob),
-            TokenKind::Decimal => Ok(Type::Decimal),
-            TokenKind::PreciseDecimal => Ok(Type::PreciseDecimal),
-            TokenKind::NonFungibleLocalId => Ok(Type::NonFungibleLocalId),
+                    // ==============
+                    // Value kind aliases
+                    // ==============
+                    SborValueKindIdent::Bytes => ValueKind::Bytes,
+                    SborValueKindIdent::NonFungibleGlobalId => ValueKind::NonFungibleGlobalId,
 
-            _ => Err(ParserError::UnexpectedToken(token)),
-        }
+                    // ==============
+                    // Custom value kinds
+                    // ==============
+                    SborValueKindIdent::Address => ValueKind::Address,
+                    SborValueKindIdent::Bucket => ValueKind::Bucket,
+                    SborValueKindIdent::Proof => ValueKind::Proof,
+                    SborValueKindIdent::Expression => ValueKind::Expression,
+                    SborValueKindIdent::Blob => ValueKind::Blob,
+                    SborValueKindIdent::Decimal => ValueKind::Decimal,
+                    SborValueKindIdent::PreciseDecimal => ValueKind::PreciseDecimal,
+                    SborValueKindIdent::NonFungibleLocalId => ValueKind::NonFungibleLocalId,
+                }
+            }
+            _ => {
+                return Err(ParserError::UnexpectedToken {
+                    expected: TokenType::ValueKind,
+                    actual: token,
+                });
+            }
+        };
+        Ok(the_type)
     }
 }
 
@@ -581,13 +947,17 @@ mod tests {
             Value::Enum(0, vec![Value::String("Hello".into()), Value::U8(123)],)
         );
         parse_value_ok!(r#"Enum<0u8>()"#, Value::Enum(0, Vec::new()));
+        parse_value_ok!(
+            r#"Enum<PublicKey::Secp256k1>()"#,
+            Value::Enum(0, Vec::new())
+        );
     }
 
     #[test]
     fn test_array() {
         parse_value_ok!(
             r#"Array<U8>(1u8, 2u8)"#,
-            Value::Array(Type::U8, vec![Value::U8(1), Value::U8(2)])
+            Value::Array(ValueKind::U8, vec![Value::U8(1), Value::U8(2)])
         );
     }
 
@@ -609,8 +979,8 @@ mod tests {
         parse_value_ok!(
             r#"Map<String, U8>("Hello", 123u8)"#,
             Value::Map(
-                Type::String,
-                Type::U8,
+                ValueKind::String,
+                ValueKind::U8,
                 vec![Value::String("Hello".into()), Value::U8(123)]
             )
         );
@@ -621,10 +991,13 @@ mod tests {
         parse_value_error!(r#"Enum<0u8"#, ParserError::UnexpectedEof);
         parse_value_error!(
             r#"Enum<0u8)"#,
-            ParserError::UnexpectedToken(Token {
-                kind: TokenKind::CloseParenthesis,
-                span: Span { start: 8, end: 9 }
-            })
+            ParserError::UnexpectedToken {
+                expected: TokenType::Exact(TokenKind::GreaterThan),
+                actual: Token {
+                    kind: TokenKind::CloseParenthesis,
+                    span: Span { start: 8, end: 9 }
+                },
+            }
         );
         parse_value_error!(
             r#"Address("abc", "def")"#,


### PR DESCRIPTION
## Summary
* A medium-sized refactor to the lexer/parser to separate the concept of lexing an ident, and parsing a particular symbol from that ident.
* Also enables and implements the change from `Enum<"Well::Known">()` to `Enum<Well::Known>()`
* Also fixes a bug that you couldn't specify an `Array<Map>`

## Update Recommendations

### For dApp Developers
As a slight change to https://github.com/radixdlt/radixdlt-scrypto/pull/1050 - enum discriminator aliases are now without quotes, eg:
```
Enum<Well::Known>()
``` 
