### PR TITLE
Tweak/manifest maps and semicolon change

### DIFF
--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -18,9 +18,9 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE
     18u8
     Map<String, Enum>(
-        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
-        "symbol", Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
-        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
+        "name" =>  Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "symbol" => Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
+        "description" => Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     ) 
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -49,6 +49,6 @@ CREATE_FUNGIBLE_RESOURCE
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
-        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
+        Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     );

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -18,9 +18,9 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     18u8
     Map<String, Enum>(
-        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
-        "symbol", Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
-        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
+        "name" => Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "symbol" => Enum<Metadata::String>("RSRC"),                                            # Resource Symbol
+        "description" => Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     ) 
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -49,8 +49,8 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
-        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
+        Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     )
     Decimal("${initial_supply}");
 

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -16,10 +16,10 @@ CALL_METHOD
 # Creating a new resource 
 CREATE_NON_FUNGIBLE_RESOURCE
     Enum<NonFungibleIdType::Integer>()
-    Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>( 64u8), Array<String>())
+    Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>(64u8), Array<String>())
     Map<String, Enum>(
-        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
-        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
+        "name" => Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "description" => Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     )
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array
@@ -48,6 +48,6 @@ CREATE_NON_FUNGIBLE_RESOURCE
         #        │                       │                 │ by anybody who has the resource) is permanent and can't
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
-        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
+        Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     );

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -18,8 +18,8 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Enum<NonFungibleIdType::Integer>()
     Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>(64u8), Array<String>())
     Map<String, Enum>(
-        "name", Enum<Metadata::String>("MyResource"),                                        # Resource Name
-        "description", Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
+        "name" => Enum<Metadata::String>("MyResource"),                                        # Resource Name
+        "description" => Enum<Metadata::String>("A very innovative and important resource")    # Resource Description
     )
     Map<Enum, Tuple>(
         # This array of tuples defines the behavior of the resource. Each element in the array 
@@ -48,12 +48,11 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
         #        │                       │                 │ by anybody who has the resource) is permanent and can't 
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
-        Enum<ResourceMethodAuthKey::Withdraw>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
-        Enum<ResourceMethodAuthKey::Deposit>(), Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
+        Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>()),
+        Enum<ResourceMethodAuthKey::Deposit>() => Tuple(Enum<AccessRule::AllowAll>(), Enum<AccessRule::DenyAll>())
     )
     Map<NonFungibleLocalId, Tuple>(
-        NonFungibleLocalId("${non_fungible_local_id}"),
-        Tuple(Tuple("Hello World", Decimal("12")))
+        NonFungibleLocalId("${non_fungible_local_id}") => Tuple(Tuple("Hello World", Decimal("12")))
     );
 
 # Depositing the entirety of the initial supply of the newly created resource into our account 

--- a/transaction/examples/resources/mint/non_fungible/mint.rtm
+++ b/transaction/examples/resources/mint/non_fungible/mint.rtm
@@ -31,8 +31,7 @@ CALL_METHOD
 MINT_NON_FUNGIBLE
     Address("${mintable_non_fungible_resource_address}")
     Map<NonFungibleLocalId, Tuple>(
-        NonFungibleLocalId("${non_fungible_local_id}"),
-        Tuple(Tuple())
+        NonFungibleLocalId("${non_fungible_local_id}") => Tuple(Tuple())
     );
 
 # Depositing the entirety of the newly minted tokens into out account

--- a/transaction/examples/royalty/royalty.rtm
+++ b/transaction/examples/royalty/royalty.rtm
@@ -1,10 +1,9 @@
 SET_PACKAGE_ROYALTY_CONFIG
     Address("${package_address}")
     Map<String, Tuple>(
-        "Blueprint",
-        Tuple(
+        "Blueprint" => Tuple(
             Map<String, U32>(
-                "method", 1u32
+                "method" => 1u32
             ),
             0u32
         )
@@ -14,7 +13,7 @@ SET_COMPONENT_ROYALTY_CONFIG
     Address("${account_address}")
     Tuple(
         Map<String, U32>(
-            "method", 1u32
+            "method" => 1u32
         ),
         0u32
     );

--- a/transaction/examples/values/values.rtm
+++ b/transaction/examples/values/values.rtm
@@ -45,7 +45,7 @@ CALL_METHOD
     Array<Map>(Map<U8, U16>())
 
     # map
-    Map<U8, U16>(1u8, 5u16)
+    Map<U8, U16>(1u8 => 5u16)
 ;
 
 CALL_METHOD 

--- a/transaction/src/data/formatter.rs
+++ b/transaction/src/data/formatter.rs
@@ -136,16 +136,34 @@ pub fn format_manifest_value<F: fmt::Write>(
         // primitive types
         Value::Bool { value } => write_with_indent!(f, context, indent_start, depth, "{}", value)?,
         Value::I8 { value } => write_with_indent!(f, context, indent_start, depth, "{}i8", value)?,
-        Value::I16 { value } => write_with_indent!(f, context, indent_start, depth, "{}i16", value)?,
-        Value::I32 { value } => write_with_indent!(f, context, indent_start, depth, "{}i32", value)?,
-        Value::I64 { value } => write_with_indent!(f, context, indent_start, depth, "{}i64", value)?,
-        Value::I128 { value } => write_with_indent!(f, context, indent_start, depth, "{}i128", value)?,
+        Value::I16 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}i16", value)?
+        }
+        Value::I32 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}i32", value)?
+        }
+        Value::I64 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}i64", value)?
+        }
+        Value::I128 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}i128", value)?
+        }
         Value::U8 { value } => write_with_indent!(f, context, indent_start, depth, "{}u8", value)?,
-        Value::U16 { value } => write_with_indent!(f, context, indent_start, depth, "{}u16", value)?,
-        Value::U32 { value } => write_with_indent!(f, context, indent_start, depth, "{}u32", value)?,
-        Value::U64 { value } => write_with_indent!(f, context, indent_start, depth, "{}u64", value)?,
-        Value::U128 { value } => write_with_indent!(f, context, indent_start, depth, "{}u128", value)?,
-        Value::String { value } => write_with_indent!(f, context, indent_start, depth, "\"{}\"", value)?,
+        Value::U16 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}u16", value)?
+        }
+        Value::U32 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}u32", value)?
+        }
+        Value::U64 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}u64", value)?
+        }
+        Value::U128 { value } => {
+            write_with_indent!(f, context, indent_start, depth, "{}u128", value)?
+        }
+        Value::String { value } => {
+            write_with_indent!(f, context, indent_start, depth, "\"{}\"", value)?
+        }
         Value::Tuple { fields } => {
             if fields.len() == 2 {
                 if let (
@@ -177,7 +195,14 @@ pub fn format_manifest_value<F: fmt::Write>(
             if fields.is_empty() {
                 write_with_indent!(f, context, indent_start, depth, "Tuple()")?;
             } else {
-                write_with_indent!(f, context, indent_start, depth, "Tuple({}", context.get_new_line())?;
+                write_with_indent!(
+                    f,
+                    context,
+                    indent_start,
+                    depth,
+                    "Tuple({}",
+                    context.get_new_line()
+                )?;
                 format_elements(f, fields, context, depth + 1)?;
                 write_with_indent!(f, context, true, depth, ")")?;
             }
@@ -187,7 +212,14 @@ pub fn format_manifest_value<F: fmt::Write>(
             fields,
         } => {
             if fields.is_empty() {
-                write_with_indent!(f, context, indent_start, depth, "Enum<{}u8>()", discriminator)?;
+                write_with_indent!(
+                    f,
+                    context,
+                    indent_start,
+                    depth,
+                    "Enum<{}u8>()",
+                    discriminator
+                )?;
             } else {
                 write_with_indent!(
                     f,
@@ -215,7 +247,14 @@ pub fn format_manifest_value<F: fmt::Write>(
                     })
                     .collect::<Result<_, _>>()?;
 
-                write_with_indent!(f, context, indent_start, depth, "Bytes(\"{}\")", hex::encode(vec))?;
+                write_with_indent!(
+                    f,
+                    context,
+                    indent_start,
+                    depth,
+                    "Bytes(\"{}\")",
+                    hex::encode(vec)
+                )?;
             }
             _ => {
                 if elements.is_empty() {
@@ -370,7 +409,14 @@ pub fn format_custom_value<F: fmt::Write>(
             )?;
         }
         ManifestCustomValue::Blob(value) => {
-            write_with_indent!(f, context, indent_start, depth, "Blob(\"{}\")", hex::encode(&value.0))?;
+            write_with_indent!(
+                f,
+                context,
+                indent_start,
+                depth,
+                "Blob(\"{}\")",
+                hex::encode(&value.0)
+            )?;
         }
         ManifestCustomValue::Decimal(value) => {
             write_with_indent!(

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -363,7 +363,7 @@ pub enum Value {
     Enum(u8, Vec<Value>),
     Array(ValueKind, Vec<Value>),
     Tuple(Vec<Value>),
-    Map(ValueKind, ValueKind, Vec<Value>),
+    Map(ValueKind, ValueKind, Vec<(Value, Value)>),
 
     // ==============
     // Alias values

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -528,11 +528,16 @@ pub fn decompile_instruction<F: fmt::Write>(
 
     write!(f, "{}", display_name)?;
     if let Value::Tuple { fields } = display_parameters {
+        let field_count = fields.len();
         for field in fields {
             write!(f, "\n")?;
             format_manifest_value(f, &field, &context.for_value_display(), true, 0)?;
         }
-        write!(f, ";\n")?;
+        if field_count > 0 {
+            write!(f, "\n;\n")?;
+        } else {
+            write!(f, ";\n")?;
+        }
     } else {
         panic!(
             "Parameters are not a tuple: name = {:?}, parameters = {:?}",

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -530,7 +530,7 @@ pub fn decompile_instruction<F: fmt::Write>(
     if let Value::Tuple { fields } = display_parameters {
         for field in fields {
             write!(f, "\n")?;
-            format_manifest_value(f, &field, &context.for_value_display(), 0)?;
+            format_manifest_value(f, &field, &context.for_value_display(), true, 0)?;
         }
         write!(f, ";\n")?;
     } else {

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -313,8 +313,7 @@ CALL_METHOD
         Map<U8, U16>()
     )
     Map<U8, U16>(
-        1u8,
-        5u16
+        1u8 => 5u16
     );
 CALL_METHOD
     Address("${component_address}")
@@ -351,11 +350,9 @@ CALL_METHOD
 SET_PACKAGE_ROYALTY_CONFIG
     Address("${package_address}")
     Map<String, Tuple>(
-        "Blueprint",
-        Tuple(
+        "Blueprint" => Tuple(
             Map<String, U32>(
-                "method",
-                1u32
+                "method" => 1u32
             ),
             0u32
         )
@@ -364,8 +361,7 @@ SET_COMPONENT_ROYALTY_CONFIG
     Address("${account_address}")
     Tuple(
         Map<String, U32>(
-            "method",
-            1u32
+            "method" => 1u32
         ),
         0u32
     );
@@ -561,27 +557,22 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     18u8
     Map<String, Enum>(
-        "name",
-        Enum<0u8>(
+        "name" => Enum<0u8>(
             "MyResource"
         ),
-        "symbol",
-        Enum<0u8>(
+        "symbol" => Enum<0u8>(
             "RSRC"
         ),
-        "description",
-        Enum<0u8>(
+        "description" => Enum<0u8>(
             "A very innovative and important resource"
         )
     )
     Map<Enum, Tuple>(
-        Enum<4u8>(),
-        Tuple(
+        Enum<4u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         ),
-        Enum<5u8>(),
-        Tuple(
+        Enum<5u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         )
@@ -615,27 +606,22 @@ CALL_METHOD
 CREATE_FUNGIBLE_RESOURCE
     18u8
     Map<String, Enum>(
-        "name",
-        Enum<0u8>(
+        "name" => Enum<0u8>(
             "MyResource"
         ),
-        "symbol",
-        Enum<0u8>(
+        "symbol" => Enum<0u8>(
             "RSRC"
         ),
-        "description",
-        Enum<0u8>(
+        "description" => Enum<0u8>(
             "A very innovative and important resource"
         )
     )
     Map<Enum, Tuple>(
-        Enum<4u8>(),
-        Tuple(
+        Enum<4u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         ),
-        Enum<5u8>(),
-        Tuple(
+        Enum<5u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         )
@@ -669,9 +655,9 @@ CALL_METHOD
 CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Enum<1u8>()
     Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>( 64u8))
-    Map<String, Enum>("name", Enum<0u8>("MyResource"), "description", Enum<0u8>("A very innovative and important resource"))
-    Map<Enum, Tuple>(Enum<4u8>(), Tuple(Enum<0u8>(), Enum<1u8>()), Enum<5u8>(), Tuple(Enum<0u8>(), Enum<1u8>()))
-    Map<NonFungibleLocalId, Array>(NonFungibleLocalId("#12#"), Bytes("5c21020c0b48656c6c6f20576f726c64a00000b0d86b9088a6000000000000000000000000000000000000000000000000"));
+    Map<String, Enum>("name" => Enum<0u8>("MyResource"), "description" => Enum<0u8>("A very innovative and important resource"))
+    Map<Enum, Tuple>(Enum<4u8>() => Tuple(Enum<0u8>(), Enum<1u8>()), Enum<5u8>() => Tuple(Enum<0u8>(), Enum<1u8>()))
+    Map<NonFungibleLocalId, Array>(NonFungibleLocalId("#12#") => Bytes("5c21020c0b48656c6c6f20576f726c64a00000b0d86b9088a6000000000000000000000000000000000000000000000000"));
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
@@ -713,23 +699,19 @@ CREATE_NON_FUNGIBLE_RESOURCE
         Array<String>()
     )
     Map<String, Enum>(
-        "name",
-        Enum<0u8>(
+        "name" => Enum<0u8>(
             "MyResource"
         ),
-        "description",
-        Enum<0u8>(
+        "description" => Enum<0u8>(
             "A very innovative and important resource"
         )
     )
     Map<Enum, Tuple>(
-        Enum<4u8>(),
-        Tuple(
+        Enum<4u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         ),
-        Enum<5u8>(),
-        Tuple(
+        Enum<5u8>() => Tuple(
             Enum<0u8>(),
             Enum<1u8>()
         )
@@ -794,8 +776,7 @@ CALL_METHOD
 MINT_NON_FUNGIBLE
     Address("${mintable_non_fungible_resource_address}")
     Map<NonFungibleLocalId, Tuple>(
-        NonFungibleLocalId("${non_fungible_local_id}"),
-        Tuple(
+        NonFungibleLocalId("${non_fungible_local_id}") => Tuple(
             Tuple()
         )
     );

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -18,7 +18,8 @@ mod tests {
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 PUBLISH_PACKAGE_ADVANCED
     Enum<0u8>()
     Blob("${code_blob_hash}")
@@ -27,7 +28,8 @@ PUBLISH_PACKAGE_ADVANCED
     )
     Map<String, Tuple>()
     Map<String, Enum>()
-    Map<Enum, Tuple>();
+    Map<Enum, Tuple>()
+;
 "##,
             ),
         );
@@ -46,33 +48,41 @@ CALL_METHOD
     Address("${account_address}")
     "withdraw"
     Address("${xrd_resource_address}")
-    Decimal("5");
+    Decimal("5")
+;
 TAKE_FROM_WORKTOP
     Address("${xrd_resource_address}")
     Decimal("2")
-    Bucket("bucket1");
+    Bucket("bucket1")
+;
 CALL_METHOD
     Address("${component_address}")
     "buy_gumball"
-    Bucket("bucket1");
+    Bucket("bucket1")
+;
 ASSERT_WORKTOP_CONTAINS
     Address("${gumball_resource_address}")
-    Decimal("3");
+    Decimal("3")
+;
 TAKE_ALL_FROM_WORKTOP
     Address("${xrd_resource_address}")
-    Bucket("bucket2");
+    Bucket("bucket2")
+;
 RETURN_TO_WORKTOP
-    Bucket("bucket2");
+    Bucket("bucket2")
+;
 TAKE_NON_FUNGIBLES_FROM_WORKTOP
     Address("${non_fungible_resource_address}")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#1#")
     )
-    Bucket("bucket3");
+    Bucket("bucket3")
+;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -91,71 +101,89 @@ CALL_METHOD
     Address("${account_address}")
     "withdraw"
     Address("${xrd_resource_address}")
-    Decimal("5");
+    Decimal("5")
+;
 TAKE_ALL_FROM_WORKTOP
     Address("${xrd_resource_address}")
-    Bucket("bucket1");
+    Bucket("bucket1")
+;
 CREATE_PROOF_FROM_BUCKET
     Bucket("bucket1")
-    Proof("proof1");
+    Proof("proof1")
+;
 CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
     Bucket("bucket1")
     Decimal("1")
-    Proof("proof2");
+    Proof("proof2")
+;
 CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES
     Bucket("bucket1")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#123#")
     )
-    Proof("proof3");
+    Proof("proof3")
+;
 CREATE_PROOF_FROM_BUCKET_OF_ALL
     Bucket("bucket1")
-    Proof("proof4");
+    Proof("proof4")
+;
 CLONE_PROOF
     Proof("proof1")
-    Proof("proof5");
+    Proof("proof5")
+;
 DROP_PROOF
-    Proof("proof1");
+    Proof("proof1")
+;
 DROP_PROOF
-    Proof("proof5");
+    Proof("proof5")
+;
 CLEAR_AUTH_ZONE;
 CALL_METHOD
     Address("${account_address}")
     "create_proof_of_amount"
     Address("${resource_address}")
-    Decimal("5");
+    Decimal("5")
+;
 POP_FROM_AUTH_ZONE
-    Proof("proof6");
+    Proof("proof6")
+;
 DROP_PROOF
-    Proof("proof6");
+    Proof("proof6")
+;
 CALL_METHOD
     Address("${account_address}")
     "create_proof_of_amount"
     Address("${resource_address}")
-    Decimal("5");
+    Decimal("5")
+;
 CREATE_PROOF_FROM_AUTH_ZONE
     Address("${resource_address}")
-    Proof("proof7");
+    Proof("proof7")
+;
 CREATE_PROOF_FROM_AUTH_ZONE_OF_AMOUNT
     Address("${resource_address}")
     Decimal("1")
-    Proof("proof8");
+    Proof("proof8")
+;
 CREATE_PROOF_FROM_AUTH_ZONE_OF_NON_FUNGIBLES
     Address("${non_fungible_resource_address}")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#123#")
     )
-    Proof("proof9");
+    Proof("proof9")
+;
 CREATE_PROOF_FROM_AUTH_ZONE_OF_ALL
     Address("${non_fungible_resource_address}")
-    Proof("proof10");
+    Proof("proof10")
+;
 CLEAR_AUTH_ZONE;
 CLEAR_SIGNATURE_PROOFS;
 DROP_ALL_PROOFS;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -172,7 +200,8 @@ CALL_METHOD
                 r##"
 RECALL_RESOURCE
     Address("${vault_address}")
-    Decimal("1.2");
+    Decimal("1.2")
+;
 "##,
             ),
         );
@@ -191,7 +220,8 @@ CALL_FUNCTION
     Address("${package_address}")
     "BlueprintName"
     "f"
-    "string";
+    "string"
+;
 "##,
             ),
         );
@@ -210,19 +240,23 @@ CALL_METHOD
     Address("${component_address}")
     "complicated_method"
     Decimal("1")
-    PreciseDecimal("2");
+    PreciseDecimal("2")
+;
 CALL_ROYALTY_METHOD
     Address("${component_address}")
     "some_method_1"
-    Decimal("1");
+    Decimal("1")
+;
 CALL_METADATA_METHOD
     Address("${component_address}")
     "some_method_2"
-    Decimal("2");
+    Decimal("2")
+;
 CALL_ACCESS_RULES_METHOD
     Address("${component_address}")
     "some_method_3"
-    Decimal("3");
+    Decimal("3")
+;
 "##,
             ),
         );
@@ -239,10 +273,12 @@ CALL_ACCESS_RULES_METHOD
                 r##"
 TAKE_ALL_FROM_WORKTOP
     Address("${resource_address}")
-    Bucket("bucket1");
+    Bucket("bucket1")
+;
 CREATE_PROOF_FROM_AUTH_ZONE
     Address("${resource_address}")
-    Proof("proof1");
+    Proof("proof1")
+;
 CALL_METHOD
     Address("${component_address}")
     "aliases"
@@ -314,7 +350,8 @@ CALL_METHOD
     )
     Map<U8, U16>(
         1u8 => 5u16
-    );
+    )
+;
 CALL_METHOD
     Address("${component_address}")
     "custom_types"
@@ -332,7 +369,8 @@ CALL_METHOD
     NonFungibleLocalId("<SomeId>")
     NonFungibleLocalId("#12#")
     NonFungibleLocalId("[031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f]")
-    NonFungibleLocalId("{43968a72-5954-45da-9678-8659dd399faa}");
+    NonFungibleLocalId("{43968a72-5954-45da-9678-8659dd399faa}")
+;
 "##,
             ),
         );
@@ -356,7 +394,8 @@ SET_PACKAGE_ROYALTY_CONFIG
             ),
             0u32
         )
-    );
+    )
+;
 SET_COMPONENT_ROYALTY_CONFIG
     Address("${account_address}")
     Tuple(
@@ -364,11 +403,14 @@ SET_COMPONENT_ROYALTY_CONFIG
             "method" => 1u32
         ),
         0u32
-    );
+    )
+;
 CLAIM_PACKAGE_ROYALTY
-    Address("${package_address}");
+    Address("${package_address}")
+;
 CLAIM_COMPONENT_ROYALTY
-    Address("${account_address}");
+    Address("${account_address}")
+;
 "##,
             ),
         );
@@ -388,67 +430,78 @@ SET_METADATA
     "field_name"
     Enum<0u8>(
         "Metadata string value, eg description"
-    );
+    )
+;
 SET_METADATA
     Address("${account_address}")
     "field_name"
     Enum<0u8>(
         "Metadata string value, eg description"
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<0u8>(
         "Metadata string value, eg description"
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<1u8>(
         true
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<2u8>(
         123u8
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<3u8>(
         123u32
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<4u8>(
         123u64
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<5u8>(
         -123i32
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<6u8>(
         -123i64
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<7u8>(
         Decimal("10.5")
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<8u8>(
         Address("${account_address}")
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
@@ -456,37 +509,43 @@ SET_METADATA
         Enum<0u8>(
             Bytes("0000000000000000000000000000000000000000000000000000000000000000ff")
         )
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<10u8>(
         NonFungibleGlobalId("${non_fungible_resource_address}:<some_string>")
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<11u8>(
         NonFungibleLocalId("<some_string>")
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<12u8>(
         10000i64
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<13u8>(
         "https://radixdlt.com/index.html"
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
     Enum<14u8>(
         "https://radixdlt.com"
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
@@ -494,7 +553,8 @@ SET_METADATA
         Enum<0u8>(
             Bytes("0000000000000000000000000000000000000000000000000000000000")
         )
-    );
+    )
+;
 SET_METADATA
     Address("${resource_address}")
     "field_name"
@@ -504,16 +564,20 @@ SET_METADATA
             "another_string",
             "yet_another_string"
         )
-    );
+    )
+;
 REMOVE_METADATA
     Address("${package_address}")
-    "field_name";
+    "field_name"
+;
 REMOVE_METADATA
     Address("${account_address}")
-    "field_name";
+    "field_name"
+;
 REMOVE_METADATA
     Address("${resource_address}")
-    "field_name";
+    "field_name"
+;
 "##,
             ),
         );
@@ -532,7 +596,8 @@ SET_AUTHORITY_ACCESS_RULE
     Address("${resource_address}")
     Enum<0u8>()
     Enum<0u8>()
-    Enum<0u8>();
+    Enum<0u8>()
+;
 "##,
             ),
         );
@@ -553,7 +618,8 @@ SET_AUTHORITY_ACCESS_RULE
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     18u8
     Map<String, Enum>(
@@ -577,11 +643,13 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
             Enum<1u8>()
         )
     )
-    Decimal("12");
+    Decimal("12")
+;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -602,7 +670,8 @@ CALL_METHOD
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CREATE_FUNGIBLE_RESOURCE
     18u8
     Map<String, Enum>(
@@ -625,15 +694,13 @@ CREATE_FUNGIBLE_RESOURCE
             Enum<0u8>(),
             Enum<1u8>()
         )
-    );
+    )
+;
 "##,
             ),
         );
     }
 
-    //FIXME: this test does not work because of decompiler error:
-    // See https://rdxworks.slack.com/archives/C01HK4QFXNY/p1678185923283569?thread_ts=1678184674.780149&cid=C01HK4QFXNY
-    #[ignore]
     #[test]
     fn test_create_non_fungible_resource_with_initial_supply() {
         compile_and_decompile_with_inversion_test(
@@ -651,17 +718,53 @@ CREATE_FUNGIBLE_RESOURCE
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Enum<1u8>()
-    Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum<0u8>( 64u8))
-    Map<String, Enum>("name" => Enum<0u8>("MyResource"), "description" => Enum<0u8>("A very innovative and important resource"))
-    Map<Enum, Tuple>(Enum<4u8>() => Tuple(Enum<0u8>(), Enum<1u8>()), Enum<5u8>() => Tuple(Enum<0u8>(), Enum<1u8>()))
-    Map<NonFungibleLocalId, Array>(NonFungibleLocalId("#12#") => Bytes("5c21020c0b48656c6c6f20576f726c64a00000b0d86b9088a6000000000000000000000000000000000000000000000000"));
+    Tuple(
+        Tuple(
+            Array<Enum>(),
+            Array<Tuple>(),
+            Array<Enum>()
+        ),
+        Enum<0u8>(
+            64u8
+        ),
+        Array<String>()
+    )
+    Map<String, Enum>(
+        "name" => Enum<0u8>(
+            "MyResource"
+        ),
+        "description" => Enum<0u8>(
+            "A very innovative and important resource"
+        )
+    )
+    Map<Enum, Tuple>(
+        Enum<4u8>() => Tuple(
+            Enum<0u8>(),
+            Enum<1u8>()
+        ),
+        Enum<5u8>() => Tuple(
+            Enum<0u8>(),
+            Enum<1u8>()
+        )
+    )
+    Map<NonFungibleLocalId, Tuple>(
+        NonFungibleLocalId("#12#") => Tuple(
+            Tuple(
+                "Hello World",
+                Decimal("12")
+            )
+        )
+    )
+;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -684,7 +787,8 @@ CALL_METHOD
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CREATE_NON_FUNGIBLE_RESOURCE
     Enum<1u8>()
     Tuple(
@@ -715,7 +819,8 @@ CREATE_NON_FUNGIBLE_RESOURCE
             Enum<0u8>(),
             Enum<1u8>()
         )
-    );
+    )
+;
 "##,
             ),
         );
@@ -735,19 +840,23 @@ CREATE_NON_FUNGIBLE_RESOURCE
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CALL_METHOD
     Address("${account_address}")
     "create_proof_of_amount"
     Address("${minter_badge_resource_address}")
-    Decimal("1");
+    Decimal("1")
+;
 MINT_FUNGIBLE
     Address("${mintable_fungible_resource_address}")
-    Decimal("12");
+    Decimal("12")
+;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -767,23 +876,27 @@ CALL_METHOD
 CALL_METHOD
     Address("${account_address}")
     "lock_fee"
-    Decimal("10");
+    Decimal("10")
+;
 CALL_METHOD
     Address("${account_address}")
     "create_proof_of_amount"
     Address("${minter_badge_resource_address}")
-    Decimal("1");
+    Decimal("1")
+;
 MINT_NON_FUNGIBLE
     Address("${mintable_non_fungible_resource_address}")
     Map<NonFungibleLocalId, Tuple>(
         NonFungibleLocalId("${non_fungible_local_id}") => Tuple(
             Tuple()
         )
-    );
+    )
+;
 CALL_METHOD
     Address("${account_address}")
     "deposit_batch"
-    Expression("ENTIRE_WORKTOP");
+    Expression("ENTIRE_WORKTOP")
+;
 "##,
             ),
         );
@@ -799,7 +912,8 @@ CALL_METHOD
             apply_address_replacements(
                 r##"
 CREATE_ACCOUNT_ADVANCED
-    Map<Enum, Tuple>();
+    Map<Enum, Tuple>()
+;
 CREATE_ACCOUNT;
 "##,
             ),
@@ -816,7 +930,8 @@ CREATE_ACCOUNT;
             apply_address_replacements(
                 r##"
 CREATE_VALIDATOR
-    Bytes("02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5");
+    Bytes("02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5")
+;
 "##,
             ),
         );
@@ -832,7 +947,8 @@ CREATE_VALIDATOR
             apply_address_replacements(
                 r##"
 CREATE_IDENTITY_ADVANCED
-    Map<Enum, Tuple>();
+    Map<Enum, Tuple>()
+;
 CREATE_IDENTITY;
 "##,
             ),
@@ -850,7 +966,8 @@ CREATE_IDENTITY;
                 r##"
 TAKE_ALL_FROM_WORKTOP
     Address("${badge_resource_address}")
-    Bucket("bucket1");
+    Bucket("bucket1")
+;
 CREATE_ACCESS_CONTROLLER
     Bucket("bucket1")
     Tuple(
@@ -858,7 +975,8 @@ CREATE_ACCESS_CONTROLLER
         Enum<0u8>(),
         Enum<0u8>()
     )
-    Enum<0u8>();
+    Enum<0u8>()
+;
 "##,
             ),
         );
@@ -872,31 +990,45 @@ CREATE_ACCESS_CONTROLLER
         expected_canonical: impl AsRef<str>,
     ) {
         let original_string = manifest.as_ref();
-        let original_struct = compile(original_string, network, blobs.clone()).unwrap();
-        let original_binary = manifest_encode(&original_struct);
+        let original_compiled = compile(original_string, network, blobs.clone())
+            .expect("Manifest string could not be compiled");
+        let original_binary =
+            manifest_encode(&original_compiled).expect("Compiled manifest could not be encoded");
 
-        let decompiled_string = decompile(&original_struct.instructions, network).unwrap();
-        let decompiled_struct = compile(&decompiled_string, network, blobs.clone()).unwrap();
-        let decompiled_binary = manifest_encode(&decompiled_struct);
+        let original_decompiled = decompile(&original_compiled.instructions, network)
+            .expect("Manifest could not be decompiled");
+        let recompiled = compile(&original_decompiled, network, blobs.clone())
+            .expect("Decompiled manifest could not be recompiled");
+        let recompiled_binary =
+            manifest_encode(&recompiled).expect("Recompiled manifest could not be encoded");
 
-        let recompiled_string = decompile(&decompiled_struct.instructions, network).unwrap();
-        let recompiled_struct = compile(&recompiled_string, network, blobs.clone()).unwrap();
-        let recompiled_binary = manifest_encode(&recompiled_struct);
+        let recompiled_decompiled = decompile(&recompiled.instructions, network)
+            .expect("Recompiled manifest could not be decompiled");
+        let re_recompiled = compile(&recompiled_decompiled, network, blobs.clone())
+            .expect("Decompiled recompiled manifest could not be re-recompiled");
+        let re_recompiled_binary =
+            manifest_encode(&re_recompiled).expect("Re-recompiled manifest could not be encoded");
 
         // If you use the following output for test cases, make sure you've checked the diff
-        println!("{}", recompiled_string);
+        println!("{}", recompiled_decompiled);
         let intent = build_intent(expected_canonical.as_ref(), blobs)
+            .expect("Canonical manifest could not be compiled")
             .to_payload_bytes()
             .unwrap();
         print_blob(name, intent);
 
         // Check round-trip property
-        assert_eq!(original_binary, decompiled_binary);
-        assert_eq!(decompiled_binary, recompiled_binary);
-        assert_eq!(decompiled_string, recompiled_string);
+        assert_eq!(original_binary, recompiled_binary);
+        assert_eq!(recompiled_binary, re_recompiled_binary);
 
-        // Assert with expectation
-        assert_eq!(recompiled_string.trim(), expected_canonical.as_ref().trim());
+        // Check both canonical decompilations are identical
+        assert_eq!(original_decompiled, recompiled_decompiled);
+
+        // Assert that the decompiled matches the expected canonical encoding
+        assert_eq!(
+            original_decompiled.trim(),
+            expected_canonical.as_ref().trim()
+        );
     }
 
     fn print_blob(name: &str, blob: Vec<u8>) {
@@ -913,13 +1045,13 @@ CREATE_ACCESS_CONTROLLER
         println!("];");
     }
 
-    fn build_intent(manifest: &str, blobs: Vec<Vec<u8>>) -> IntentV1 {
+    fn build_intent(manifest: &str, blobs: Vec<Vec<u8>>) -> Result<IntentV1, CompileError> {
         let sk_notary = EddsaEd25519PrivateKey::from_u64(3).unwrap();
 
         let network = NetworkDefinition::simulator();
-        let (instructions, blobs) = compile(manifest, &network, blobs).unwrap().for_intent();
+        let (instructions, blobs) = compile(manifest, &network, blobs)?.for_intent();
 
-        IntentV1 {
+        Ok(IntentV1 {
             header: TransactionHeaderV1 {
                 network_id: network.id,
                 start_epoch_inclusive: 0,
@@ -932,7 +1064,7 @@ CREATE_ACCESS_CONTROLLER
             instructions,
             blobs,
             attachments: AttachmentsV1 {},
-        }
+        })
     }
 
     fn apply_address_replacements(input: impl ToString) -> String {

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -107,7 +107,6 @@ pub enum GeneratorError {
         expected_length: usize,
         actual: usize,
     },
-    OddNumberOfElements,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1150,28 +1149,24 @@ fn generate_singletons(
 }
 
 fn generate_kv_entries(
-    elements: &Vec<ast::Value>,
+    entries: &[(ast::Value, ast::Value)],
     key_value_kind: ManifestValueKind,
     value_value_kind: ManifestValueKind,
     resolver: &mut NameResolver,
     bech32_decoder: &Bech32Decoder,
     blobs: &BTreeMap<Hash, Vec<u8>>,
 ) -> Result<Vec<(ManifestValue, ManifestValue)>, GeneratorError> {
-    if elements.len() % 2 != 0 {
-        return Err(GeneratorError::OddNumberOfElements);
-    }
-
     let mut result = vec![];
-    for i in 0..elements.len() / 2 {
+    for entry in entries {
         let key = generate_value(
-            &elements[i * 2],
+            &entry.0,
             Some(key_value_kind),
             resolver,
             bech32_decoder,
             blobs,
         )?;
         let value = generate_value(
-            &elements[i * 2 + 1],
+            &entry.1,
             Some(value_value_kind),
             resolver,
             bech32_decoder,

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -1460,16 +1460,14 @@ mod tests {
                     Array<String>()
                 )
                 Map<String, Enum>(
-                    "name", Enum<Metadata::String>("Token")
+                    "name" => Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<ResourceMethodAuthKey::Withdraw>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<ResourceMethodAuthKey::Deposit>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Deposit>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     )
@@ -1551,23 +1549,20 @@ mod tests {
                     Array<String>()
                 )
                 Map<String, Enum>(
-                    "name", Enum<Metadata::String>("Token")
+                    "name" => Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<ResourceMethodAuthKey::Withdraw>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<ResourceMethodAuthKey::Deposit>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Deposit>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     )
                 )
                 Map<NonFungibleLocalId, Tuple>(
-                    NonFungibleLocalId("#1#"),
-                    Tuple(
+                    NonFungibleLocalId("#1#") => Tuple(
                         Tuple(
                             "Hello World",
                             Decimal("12")
@@ -1617,16 +1612,18 @@ mod tests {
             r#"CREATE_FUNGIBLE_RESOURCE
                 18u8
                 Map<String, Enum>(
-                    "name", Enum<Metadata::String>("Token")
+                    "name" => Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<ResourceMethodAuthKey::Withdraw>(),
-                    Tuple(Enum<AccessRule::AllowAll>(),
-                    Enum<AccessRule::DenyAll>()
-                ),
-                Enum<ResourceMethodAuthKey::Deposit>(),
-                Tuple(Enum<AccessRule::AllowAll>(),
-                Enum<AccessRule::DenyAll>()))
+                    Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
+                    ),
+                    Enum<ResourceMethodAuthKey::Deposit>() => Tuple(
+                        Enum<AccessRule::AllowAll>(),
+                        Enum<AccessRule::DenyAll>()
+                    )
+                )
             ;"#,
             InstructionV1::CallFunction {
                 package_address: RESOURCE_PACKAGE,
@@ -1659,16 +1656,14 @@ mod tests {
             r#"CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
                 18u8
                 Map<String, Enum>(
-                    "name", Enum<Metadata::String>("Token")
+                    "name" => Enum<Metadata::String>("Token")
                 )
                 Map<Enum, Tuple>(
-                    Enum<ResourceMethodAuthKey::Withdraw>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Withdraw>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     ),
-                    Enum<ResourceMethodAuthKey::Deposit>(),
-                    Tuple(
+                    Enum<ResourceMethodAuthKey::Deposit>() => Tuple(
                         Enum<AccessRule::AllowAll>(),
                         Enum<AccessRule::DenyAll>()
                     )
@@ -1715,7 +1710,7 @@ mod tests {
             r##"
             MINT_NON_FUNGIBLE
                 Address("resource_sim1thvwu8dh6lk4y9mntemkvj25wllq8adq42skzufp4m8wxxuemugnez")
-                Map<NonFungibleLocalId, Tuple>(NonFungibleLocalId("#1#"), Tuple(Tuple("Hello World", Decimal("12"))));
+                Map<NonFungibleLocalId, Tuple>(NonFungibleLocalId("#1#") => Tuple(Tuple("Hello World", Decimal("12"))));
             "##,
             InstructionV1::CallMethod {
                 address: resource_address.into(),

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -2,12 +2,22 @@ use sbor::rust::str::FromStr;
 
 /// The span of tokens. The `start` and `end` are Unicode code points / UTF-32 - as opposed to a
 /// byte-based / UTF-8 index.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Span {
     /// The start of the span, exclusive
-    pub start: usize,
+    pub start: Position,
     /// The end of the span, inclusive
-    pub end: usize,
+    pub end: Position,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    /// A 0-indexed cursor indicating the next unicode char from the start
+    pub full_index: usize,
+    /// A 1-indexed cursor indicating the line number (assuming \n is a line break)
+    pub line_number: usize,
+    /// A 0-indexed cursor indicating the character offset in the line
+    pub line_char_index: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,6 +47,7 @@ pub enum TokenKind {
     GreaterThan,
     Comma,
     Semicolon,
+    FatArrow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,18 +59,18 @@ pub struct Token {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LexerError {
     UnexpectedEof,
-    UnexpectedChar(char, usize),
-    InvalidInteger(String),
-    InvalidUnicode(u32),
-    UnknownIdentifier(String),
+    UnexpectedChar(char, Position),
+    InvalidInteger(String, Position),
+    InvalidUnicode(u32, Position),
+    UnknownIdentifier(String, Position),
 }
 
 #[derive(Debug, Clone)]
 pub struct Lexer {
     /// The input text chars
     text: Vec<char>,
-    /// A 0-indexed cursor indicating the next char
-    current: usize,
+    /// The current position in the text
+    current: Position,
 }
 
 pub fn tokenize(s: &str) -> Result<Vec<Token>, LexerError> {
@@ -79,24 +90,34 @@ impl Lexer {
     pub fn new(text: &str) -> Self {
         Self {
             text: text.chars().collect(),
-            current: 0,
+            current: Position {
+                full_index: 0,
+                line_number: 1,
+                line_char_index: 0,
+            }
         }
     }
 
     pub fn is_eof(&self) -> bool {
-        self.current == self.text.len()
+        self.current.full_index == self.text.len()
     }
 
     fn peek(&self) -> Result<char, LexerError> {
         self.text
-            .get(self.current)
+            .get(self.current.full_index)
             .cloned()
             .ok_or(LexerError::UnexpectedEof)
     }
 
     fn advance(&mut self) -> Result<char, LexerError> {
         let c = self.peek()?;
-        self.current += 1;
+        self.current.full_index += 1;
+        if c == '\n' {
+            self.current.line_number += 1;
+            self.current.line_char_index = 0;
+        } else {
+            self.current.line_char_index += 1;
+        }
         Ok(c)
     }
 
@@ -133,9 +154,9 @@ impl Lexer {
             '-' | '0'..='9' => self.tokenize_number(),
             '"' => self.tokenize_string(),
             'a'..='z' | 'A'..='Z' => self.tokenize_identifier(),
-            '{' | '}' | '(' | ')' | '<' | '>' | ',' | ';' | '&' => self.tokenize_punctuation(),
+            '{' | '}' | '(' | ')' | '<' | '>' | ',' | ';' | '&' | '=' => self.tokenize_punctuation(),
             _ => Err(LexerError::UnexpectedChar(
-                self.text[self.current],
+                self.text[self.current.full_index],
                 self.current,
             )),
         }
@@ -171,41 +192,41 @@ impl Lexer {
             'i' => match self.advance()? {
                 '1' => match self.advance()? {
                     '2' => match self.advance()? {
-                        '8' => Self::parse_int(&s, "i128", TokenKind::I128Literal),
+                        '8' => self.parse_int(&s, "i128", TokenKind::I128Literal),
                         _ => Err(self.unexpected_char()),
                     },
-                    '6' => Self::parse_int(&s, "i16", TokenKind::I16Literal),
+                    '6' => self.parse_int(&s, "i16", TokenKind::I16Literal),
                     _ => Err(self.unexpected_char()),
                 },
                 '3' => match self.advance()? {
-                    '2' => Self::parse_int(&s, "i32", TokenKind::I32Literal),
+                    '2' => self.parse_int(&s, "i32", TokenKind::I32Literal),
                     _ => Err(self.unexpected_char()),
                 },
                 '6' => match self.advance()? {
-                    '4' => Self::parse_int(&s, "i64", TokenKind::I64Literal),
+                    '4' => self.parse_int(&s, "i64", TokenKind::I64Literal),
                     _ => Err(self.unexpected_char()),
                 },
-                '8' => Self::parse_int(&s, "i8", TokenKind::I8Literal),
+                '8' => self.parse_int(&s, "i8", TokenKind::I8Literal),
                 _ => Err(self.unexpected_char()),
             },
             'u' => match self.advance()? {
                 '1' => match self.advance()? {
                     '2' => match self.advance()? {
-                        '8' => Self::parse_int(&s, "u128", TokenKind::U128Literal),
+                        '8' => self.parse_int(&s, "u128", TokenKind::U128Literal),
                         _ => Err(self.unexpected_char()),
                     },
-                    '6' => Self::parse_int(&s, "u16", TokenKind::U16Literal),
+                    '6' => self.parse_int(&s, "u16", TokenKind::U16Literal),
                     _ => Err(self.unexpected_char()),
                 },
                 '3' => match self.advance()? {
-                    '2' => Self::parse_int(&s, "u32", TokenKind::U32Literal),
+                    '2' => self.parse_int(&s, "u32", TokenKind::U32Literal),
                     _ => Err(self.unexpected_char()),
                 },
                 '6' => match self.advance()? {
-                    '4' => Self::parse_int(&s, "u64", TokenKind::U64Literal),
+                    '4' => self.parse_int(&s, "u64", TokenKind::U64Literal),
                     _ => Err(self.unexpected_char()),
                 },
-                '8' => Self::parse_int(&s, "u8", TokenKind::U8Literal),
+                '8' => self.parse_int(&s, "u8", TokenKind::U8Literal),
                 _ => Err(self.unexpected_char()),
             },
             _ => Err(self.unexpected_char()),
@@ -214,13 +235,14 @@ impl Lexer {
     }
 
     fn parse_int<T: FromStr>(
+        &self,
         int: &str,
         ty: &str,
         map: fn(T) -> TokenKind,
     ) -> Result<TokenKind, LexerError> {
         int.parse::<T>()
             .map(map)
-            .map_err(|_| LexerError::InvalidInteger(format!("{}{}", int, ty)))
+            .map_err(|_| LexerError::InvalidInteger(format!("{}{}", int, ty), self.current))
     }
 
     fn tokenize_string(&mut self) -> Result<Token, LexerError> {
@@ -252,7 +274,7 @@ impl Lexer {
                                 return Err(self.unexpected_char());
                             }
                         }
-                        s.push(char::from_u32(unicode).ok_or(LexerError::InvalidUnicode(unicode))?);
+                        s.push(char::from_u32(unicode).ok_or(LexerError::InvalidUnicode(unicode, self.current))?);
                     }
                     _ => {
                         return Err(self.unexpected_char());
@@ -314,6 +336,12 @@ impl Lexer {
             '>' => TokenKind::GreaterThan,
             ',' => TokenKind::Comma,
             ';' => TokenKind::Semicolon,
+            '=' => match self.advance()? {
+                '>' => TokenKind::FatArrow,
+                _ => {
+                    return Err(self.unexpected_char())
+                }
+            },
             _ => {
                 return Err(self.unexpected_char());
             }
@@ -322,7 +350,7 @@ impl Lexer {
         Ok(self.new_token(token_kind, start, self.current))
     }
 
-    fn new_token(&self, kind: TokenKind, start: usize, end: usize) -> Token {
+    fn new_token(&self, kind: TokenKind, start: Position, end: Position) -> Token {
         Token {
             kind,
             span: Span { start, end },
@@ -330,7 +358,7 @@ impl Lexer {
     }
 
     fn unexpected_char(&self) -> LexerError {
-        LexerError::UnexpectedChar(self.text[self.current - 1], self.current - 1)
+        LexerError::UnexpectedChar(self.text[self.current.full_index], self.current)
     }
 }
 

--- a/transaction/src/manifest/lexer.rs
+++ b/transaction/src/manifest/lexer.rs
@@ -94,7 +94,7 @@ impl Lexer {
                 full_index: 0,
                 line_number: 1,
                 line_char_index: 0,
-            }
+            },
         }
     }
 
@@ -154,7 +154,9 @@ impl Lexer {
             '-' | '0'..='9' => self.tokenize_number(),
             '"' => self.tokenize_string(),
             'a'..='z' | 'A'..='Z' => self.tokenize_identifier(),
-            '{' | '}' | '(' | ')' | '<' | '>' | ',' | ';' | '&' | '=' => self.tokenize_punctuation(),
+            '{' | '}' | '(' | ')' | '<' | '>' | ',' | ';' | '&' | '=' => {
+                self.tokenize_punctuation()
+            }
             _ => Err(LexerError::UnexpectedChar(
                 self.text[self.current.full_index],
                 self.current,
@@ -274,7 +276,10 @@ impl Lexer {
                                 return Err(self.unexpected_char());
                             }
                         }
-                        s.push(char::from_u32(unicode).ok_or(LexerError::InvalidUnicode(unicode, self.current))?);
+                        s.push(
+                            char::from_u32(unicode)
+                                .ok_or(LexerError::InvalidUnicode(unicode, self.current))?,
+                        );
                     }
                     _ => {
                         return Err(self.unexpected_char());
@@ -338,9 +343,7 @@ impl Lexer {
             ';' => TokenKind::Semicolon,
             '=' => match self.advance()? {
                 '>' => TokenKind::FatArrow,
-                _ => {
-                    return Err(self.unexpected_char())
-                }
+                _ => return Err(self.unexpected_char()),
             },
             _ => {
                 return Err(self.unexpected_char());

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -959,6 +959,11 @@ mod tests {
             r#"Enum<PublicKey::Secp256k1>()"#,
             Value::Enum(0, Vec::new())
         );
+        // Check we allow trailing commas
+        parse_value_ok!(
+            r#"Enum<0u8>("Hello", 123u8,)"#,
+            Value::Enum(0, vec![Value::String("Hello".into()), Value::U8(123)],)
+        );
     }
 
     #[test]
@@ -967,17 +972,28 @@ mod tests {
             r#"Array<U8>(1u8, 2u8)"#,
             Value::Array(ValueKind::U8, vec![Value::U8(1), Value::U8(2)])
         );
+        parse_value_ok!(r#"Array<U8>()"#, Value::Array(ValueKind::U8, vec![]));
+        // Check we allow trailing commas
+        parse_value_ok!(
+            r#"Array<U8>(1u8, 2u8,)"#,
+            Value::Array(ValueKind::U8, vec![Value::U8(1), Value::U8(2)])
+        );
     }
 
     #[test]
     fn test_tuple() {
+        parse_value_ok!(r#"Tuple()"#, Value::Tuple(vec![]));
         parse_value_ok!(
             r#"Tuple("Hello", 123u8)"#,
             Value::Tuple(vec![Value::String("Hello".into()), Value::U8(123),])
         );
-        parse_value_ok!(r#"Tuple()"#, Value::Tuple(Vec::new()));
         parse_value_ok!(
             r#"Tuple(1u8, 2u8)"#,
+            Value::Tuple(vec![Value::U8(1), Value::U8(2)])
+        );
+        // Check we allow trailing commas
+        parse_value_ok!(
+            r#"Tuple(1u8, 2u8,)"#,
             Value::Tuple(vec![Value::U8(1), Value::U8(2)])
         );
     }
@@ -994,6 +1010,18 @@ mod tests {
         );
         parse_value_ok!(
             r#"Map<String, U8>("Hello" => 123u8, "world!" => 1u8)"#,
+            Value::Map(
+                ValueKind::String,
+                ValueKind::U8,
+                vec![
+                    (Value::String("Hello".into()), Value::U8(123)),
+                    (Value::String("world!".into()), Value::U8(1)),
+                ]
+            )
+        );
+        // Check we allow trailing commas
+        parse_value_ok!(
+            r#"Map<String, U8>("Hello" => 123u8, "world!" => 1u8,)"#,
             Value::Map(
                 ValueKind::String,
                 ValueKind::U8,

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -773,11 +773,7 @@ impl Parser {
             }
         }
         advance_match!(self, TokenKind::CloseParenthesis);
-        Ok(Value::Map(
-            generics[0],
-            generics[1],
-            entries,
-        ))
+        Ok(Value::Map(generics[0], generics[1], entries))
     }
 
     /// Parse a comma-separated value list, enclosed by a pair of marks.
@@ -900,7 +896,7 @@ impl Parser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manifest::lexer::{tokenize, Span, Position};
+    use crate::manifest::lexer::{tokenize, Position, Span};
 
     #[macro_export]
     macro_rules! parse_instruction_ok {


### PR DESCRIPTION
## Summary

Captures two key changes:
* Maps are now written as `Map<X, Y>(x1 => y1, x2 => y2)`
* Canonical decompilation of instructions with arguments puts the `;` on a new line, so it's harder to miss, and less likely to cause issues when extending the argument list.

Also:
* Improves the manifest compiler Span to capture line number and offset, to aid with debugging compilation failures. Compilation may be slightly slower, but compilation is only performed off line, not on-ledger, so it's not a big issue.
* Fixed an ignored test in the e2e.rs, and improved the error messages on failure.

## Update Recommendations
### For dApp Developers

Maps in the manifest are now written like:
```
Map<X, Y>(x1 => y1, x2 => y2)
```
