### PR TITLE
Remove serde derives from tx models

### DIFF
--- a/radix-engine-common/src/types/consensus.rs
+++ b/radix-engine-common/src/types/consensus.rs
@@ -10,6 +10,11 @@ use sbor::Sbor;
 pub type ValidatorIndex = u8;
 
 /// A type-safe consensus epoch number.
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(transparent)
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Sbor)]
 #[sbor(transparent)]
 pub struct Epoch(u64);

--- a/transaction/src/model/v1/header.rs
+++ b/transaction/src/model/v1/header.rs
@@ -3,7 +3,6 @@ use radix_engine_common::{crypto::PublicKey, ManifestSbor};
 
 use crate::model::SummarizedRawFullBody;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct TransactionHeaderV1 {
     pub network_id: u8,

--- a/transaction/src/model/v1/intent.rs
+++ b/transaction/src/model/v1/intent.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct IntentV1 {
     pub header: TransactionHeaderV1,
@@ -21,7 +20,6 @@ impl TransactionPayload for IntentV1 {
     type Raw = RawIntent;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedIntentV1 {
     pub header: PreparedTransactionHeaderV1,

--- a/transaction/src/model/v1/notarized_transaction.rs
+++ b/transaction/src/model/v1/notarized_transaction.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct NotarizedTransactionV1 {
     pub signed_intent: SignedIntentV1,
@@ -19,7 +18,6 @@ impl TransactionPayload for NotarizedTransactionV1 {
     type Raw = RawNotarizedTransaction;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedNotarizedTransactionV1 {
     pub signed_intent: PreparedSignedIntentV1,

--- a/transaction/src/model/v1/signed_intent.rs
+++ b/transaction/src/model/v1/signed_intent.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct SignedIntentV1 {
     pub intent: IntentV1,
@@ -19,7 +18,6 @@ impl TransactionPayload for SignedIntentV1 {
     type Raw = RawSignedIntent;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedSignedIntentV1 {
     pub intent: PreparedIntentV1,


### PR DESCRIPTION
This PR removes the feature-gated `serde::Serialize` and `serde::Deserialize` derives from a number of types which prevented certain crates from compiling when the `serde` feature is enabled.

The reason why compilation failed is because some of the types used in these structs were not serializable and deserializable, namely `Epoch` and `InstructionV1`. `Epoch` can derive the serde traits with no issues but `InstructionV1` is a bigger problem where we get into Bech32 stuff and network dependence. 