### PR TITLE
Bugfix: Serde Serialization

### DIFF
--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -150,7 +150,7 @@ fn do_swap(
 ) -> TransactionReceipt {
     // Validate
     let validated = NotarizedTransactionValidator::new(ValidationConfig::simulator())
-        .validate_from_raw(transaction_payload)
+        .validate_from_payload_bytes(transaction_payload)
         .unwrap();
 
     let mut executable = validated.get_executable();

--- a/radix-engine-tests/benches/validation.rs
+++ b/radix-engine-tests/benches/validation.rs
@@ -83,7 +83,13 @@ fn bench_transaction_validation(c: &mut Criterion) {
     let validator = NotarizedTransactionValidator::new(ValidationConfig::simulator());
 
     c.bench_function("Validation::validate_manifest", |b| {
-        b.iter(|| black_box(validator.validate_from_raw(&transaction_bytes).unwrap()))
+        b.iter(|| {
+            black_box(
+                validator
+                    .validate_from_payload_bytes(&transaction_bytes)
+                    .unwrap(),
+            )
+        })
     });
 }
 

--- a/transaction/src/model/v1/header.rs
+++ b/transaction/src/model/v1/header.rs
@@ -3,7 +3,6 @@ use radix_engine_common::{crypto::PublicKey, ManifestSbor};
 
 use crate::model::SummarizedRawFullBody;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct TransactionHeaderV1 {
     pub network_id: u8,

--- a/transaction/src/model/v1/intent.rs
+++ b/transaction/src/model/v1/intent.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct IntentV1 {
     pub header: TransactionHeaderV1,
@@ -21,7 +20,6 @@ impl TransactionPayload for IntentV1 {
     type Raw = RawIntent;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedIntentV1 {
     pub header: PreparedTransactionHeaderV1,

--- a/transaction/src/model/v1/notarized_transaction.rs
+++ b/transaction/src/model/v1/notarized_transaction.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct NotarizedTransactionV1 {
     pub signed_intent: SignedIntentV1,
@@ -19,7 +18,6 @@ impl TransactionPayload for NotarizedTransactionV1 {
     type Raw = RawNotarizedTransaction;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedNotarizedTransactionV1 {
     pub signed_intent: PreparedSignedIntentV1,

--- a/transaction/src/model/v1/signed_intent.rs
+++ b/transaction/src/model/v1/signed_intent.rs
@@ -6,7 +6,6 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 pub struct SignedIntentV1 {
     pub intent: IntentV1,
@@ -19,7 +18,6 @@ impl TransactionPayload for SignedIntentV1 {
     type Raw = RawSignedIntent;
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // For toolkit
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedSignedIntentV1 {
     pub intent: PreparedIntentV1,


### PR DESCRIPTION
This PR removes the feature-gated `serde::Serialize` and `serde::Deserialize` derives from a number of types which prevented certain crates from compiling when the `serde` feature is enabled.

The reason why compilation failed is because some of the types used in these structs were not serializable and deserializable, namely `Epoch` and `InstructionV1`. `Epoch` can derive the serde traits with no issues but `InstructionV1` is a bigger problem where we get into Bech32 stuff and network dependence. 

**Note**: The benchmark that's failing is not failing due to anything in this PR, this PR actually fixes the issue in benchmarks so that it works. It's failing since it's trying to benchmark this PR against the last commit in the `release/birch` branch where the benchmarks appear to be broken. It is safe to merge this PR with the one failing benchmark job.