### PR TITLE
Fuzzing updates and some tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,8 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Setup AFL
@@ -340,4 +342,7 @@ jobs:
       working-directory: fuzz-tests
     - name: Build AFL fuzzer
       run: bash ./fuzz.sh afl build
+      working-directory: fuzz-tests
+    - name: Check fuzzed instructions coverage
+      run: cargo nextest run test_check_fuzzed_instruction_coverage
       working-directory: fuzz-tests

--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a66412baacf51dfc30a1e220bc7cc947001e8c47e3716468a3857f98887a7f3"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a66412baacf51dfc30a1e220bc7cc947001e8c47e3716468a3857f98887a7f3"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -699,6 +699,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix-engine-profiling"
+version = "0.9.0"
+dependencies = [
+ "fixedstr",
+]
+
+[[package]]
 name = "radix-engine-queries"
 version = "0.10.0"
 dependencies = [
@@ -721,6 +728,7 @@ dependencies = [
  "itertools",
  "radix-engine-common",
  "radix-engine-derive",
+ "radix-engine-interface",
  "sbor",
  "utils",
 ]
@@ -736,13 +744,6 @@ dependencies = [
  "radix-engine-store-interface",
  "sbor",
  "utils",
-]
-
-[[package]]
-name = "radix-engine-utils"
-version = "0.9.0"
-dependencies = [
- "fixedstr",
 ]
 
 [[package]]
@@ -810,7 +811,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-utils",
+ "radix-engine-profiling",
  "syn",
 ]
 
@@ -896,6 +897,7 @@ name = "scrypto"
 version = "0.10.0"
 dependencies = [
  "bech32",
+ "const-sha1",
  "hex",
  "num-bigint",
  "num-traits",

--- a/examples/no-std/Cargo.lock
+++ b/examples/no-std/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a66412baacf51dfc30a1e220bc7cc947001e8c47e3716468a3857f98887a7f3"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -351,6 +351,7 @@ name = "scrypto"
 version = "0.10.0"
 dependencies = [
  "bech32",
+ "const-sha1",
  "hex",
  "num-bigint",
  "num-traits",

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -35,9 +35,6 @@ scrypto-unit = { path = "../scrypto-unit", default-features = false }
 # More details: https://github.com/rust-fuzz/afl.rs#lazy_static-variables
 lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs", rev = "c5eb91f2bde4c2f70092d1574f7145cb33ff0922" }
 
-# Use forked repo for bnum with Arbitrary traits supported
-bnum = { git = "https://github.com/radixdlt/bnum.git", rev = "ecc77523b5a4b93554bd58c7611999fa65a9448c" }
-
 [workspace]
 members = ["."]
 

--- a/fuzz-tests/group_crashes.sh
+++ b/fuzz-tests/group_crashes.sh
@@ -25,19 +25,38 @@ function summarize_crashes {
 
 function process_crashes {
     local crash_inventories=$@
+    # Parse crash inventory file to get following information:
+    # - event info (crash kind or timeout)
+    # - location in sources (in case of crash)
+    # - number of such events
+    # - name of the file including the list of the crash files causing this event
 
-    echo "Crash types"
+    # Exemplary entries in crash inventory file depending on event type:
+    # - Crash
+    #   column  #1                                                                                #16                                                                      Last (NF in awk)
+    #           panic   : thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: MismatchingMapKeyValueKind { key_value_kind: 2, actual_value_kind: 1 }', /home/radixdlt/_work/radixdlt-scrypto/radixdlt-scrypto/radix-engine-common/src/data/manifest/mod.rs:62:45
+    #           count   : 2
+    #           list    : 00b8778915d6dd5b50f2da62eb9d8c89054d5b0ad84f099f0a645ee85e7aa503.panic
+    # - Timeout
+    #       panic   :
+    #       count   : 2
+    #       list    : 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b.panic
+
+    # Generate intermediate file for easier further processing
     cat $crash_inventories | \
         awk -F'\\(| ' '
             ($1 == "panic" && NF >= 16) { print $16"\n"$NF};
-            ($1 == "panic" && NF < 16) { print "Timeout\n"$NF};
+            ($1 == "panic" && NF < 16) { print "Timeout\nUnknown"};
             $1 == "count" {print $NF};
             $1 == "list" {print $NF}
             ' | \
         paste - - - - > $crash_types_file
+
+    # Summarize collected information
+    echo "# Crash types"
     cat $crash_types_file | summarize_crashes
 
-    printf "\nCrash types per location\n"
+    printf "\n# Crash types per location\n"
     locations=$(cat $crash_types_file | awk '{print $2}' | sort | uniq)
     for l in $locations ; do
         printf "location:    %s\n" $l

--- a/fuzz-tests/src/common.rs
+++ b/fuzz-tests/src/common.rs
@@ -1,0 +1,52 @@
+use radix_engine::types::*;
+use radix_engine_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
+use radix_engine_store_interface::interface::ListableSubstateDatabase;
+use radix_engine_store_interface::interface::SubstateDatabase;
+use radix_engine_stores::memory_db::InMemorySubstateDatabase;
+
+pub fn get_ledger_entries(
+    substate_db: &InMemorySubstateDatabase,
+) -> (
+    Vec<PackageAddress>,
+    Vec<ComponentAddress>,
+    Vec<ResourceAddress>,
+    Vec<ResourceAddress>,
+) {
+    let mut packages: Vec<PackageAddress> = vec![];
+    let mut components: Vec<ComponentAddress> = vec![];
+    let mut resources_fungible: Vec<ResourceAddress> = vec![];
+    let mut resources_non_fungible: Vec<ResourceAddress> = vec![];
+
+    for key in substate_db.list_partition_keys() {
+        let _entries = substate_db.list_entries(&key);
+        let (node_id, _) = SpreadPrefixKeyMapper::from_db_partition_key(&key);
+        if let Ok(address) = PackageAddress::try_from(node_id.as_ref()) {
+            if !packages.contains(&address) {
+                packages.push(address);
+            }
+        } else if let Ok(address) = ComponentAddress::try_from(node_id.as_ref()) {
+            if !components.contains(&address) {
+                components.push(address);
+            }
+        } else if let Ok(address) = ResourceAddress::try_from(node_id.as_ref()) {
+            let resources = {
+                if address.as_node_id().is_global_fungible_resource_manager() {
+                    &mut resources_fungible
+                } else {
+                    &mut resources_non_fungible
+                }
+            };
+
+            if !resources.contains(&address) {
+                resources.push(address);
+            }
+        }
+    }
+
+    (
+        packages,
+        components,
+        resources_fungible,
+        resources_non_fungible,
+    )
+}

--- a/fuzz-tests/src/fuzz_tx.rs
+++ b/fuzz-tests/src/fuzz_tx.rs
@@ -222,15 +222,16 @@ impl TxFuzzer {
                 0 => {
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
 
-                    Some(InstructionV1::AssertWorktopContains { amount, resource_address })
-                },
-                // AssertWorktopContainsNonFungibles
-                1 => {
-                    Some(InstructionV1::AssertWorktopContainsNonFungibles {
+                    Some(InstructionV1::AssertWorktopContains {
+                        amount,
                         resource_address,
-                        ids: non_fungible_ids.clone(),
                     })
                 }
+                // AssertWorktopContainsNonFungibles
+                1 => Some(InstructionV1::AssertWorktopContainsNonFungibles {
+                    resource_address,
+                    ids: non_fungible_ids.clone(),
+                }),
                 // BurnResource
                 2 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
@@ -240,8 +241,7 @@ impl TxFuzzer {
                 // CallAccessRulesMethod
                 3 => {
                     // TODO - fuzz more methods
-                    global_addresses.push(
-                        GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let input = AccessRulesCreateInput::arbitrary(&mut unstructured).unwrap();
 
@@ -250,7 +250,7 @@ impl TxFuzzer {
                         method_name: ACCESS_RULES_CREATE_IDENT.to_string(),
                         args: to_manifest_value(&input),
                     })
-                },
+                }
                 // CallFunction
                 4 => {
                     // TODO
@@ -268,28 +268,29 @@ impl TxFuzzer {
                 }
                 // CallRoyaltyMethod
                 7 =>
-                    // TODO - fuzz more methods
+                // TODO - fuzz more methods
+                {
                     Some(InstructionV1::CallRoyaltyMethod {
-                    address: component_address.into(),
-                    method_name: COMPONENT_ROYALTY_CLAIM_ROYALTY_IDENT.to_string(),
-                    args: manifest_args!(),
-                }),
+                        address: component_address.into(),
+                        method_name: COMPONENT_ROYALTY_CLAIM_ROYALTY_IDENT.to_string(),
+                        args: manifest_args!(),
+                    })
+                }
                 // ClaimComponentRoyalty
                 8 => Some(InstructionV1::CallRoyaltyMethod {
                     address: component_address.into(),
                     method_name: COMPONENT_ROYALTY_CLAIM_ROYALTY_IDENT.to_string(),
-                    args: manifest_args!()
+                    args: manifest_args!(),
                 }),
                 // ClaimPackageRoyalty
                 9 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
 
                     Some(InstructionV1::CallMethod {
                         address: package_address.into(),
                         method_name: PACKAGE_CLAIM_ROYALTY_IDENT.to_string(),
-                        args: manifest_args!()
+                        args: manifest_args!(),
                     })
                 }
                 // ClearAuthZone
@@ -304,8 +305,7 @@ impl TxFuzzer {
                 }
                 // CreateAccessController
                 13 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
                     let rule_set = RuleSet::arbitrary(&mut unstructured).unwrap();
@@ -321,8 +321,7 @@ impl TxFuzzer {
                 }
                 // CreateAccount
                 14 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
 
                     Some(InstructionV1::CallFunction {
@@ -336,8 +335,7 @@ impl TxFuzzer {
                 }
                 // CreateAccountAdvanced
                 15 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = AccountCreateAdvancedInput::arbitrary(&mut unstructured).unwrap();
 
@@ -350,8 +348,7 @@ impl TxFuzzer {
                 }
                 // CreateFungibleResource
                 16 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input =
                         FungibleResourceManagerCreateInput::arbitrary(&mut unstructured).unwrap();
@@ -365,8 +362,7 @@ impl TxFuzzer {
                 }
                 // CreateFungibleResourceWithInitialSupply
                 17 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = FungibleResourceManagerCreateWithInitialSupplyInput::arbitrary(
                         &mut unstructured,
@@ -383,8 +379,7 @@ impl TxFuzzer {
                 }
                 // CreateIdentity
                 18 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = IdentityCreateInput::arbitrary(&mut unstructured).unwrap();
 
@@ -397,8 +392,7 @@ impl TxFuzzer {
                 }
                 // CreateIdentityAdvanced
                 19 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = IdentityCreateAdvancedInput::arbitrary(&mut unstructured).unwrap();
 
@@ -411,8 +405,7 @@ impl TxFuzzer {
                 }
                 // CreateNonFungibleResource
                 20 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = NonFungibleResourceManagerCreateInput::arbitrary(&mut unstructured)
                         .unwrap();
@@ -427,8 +420,7 @@ impl TxFuzzer {
 
                 // CreateNonFungibleResourceWithInitialSupply
                 21 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input =
                         &NonFungibleResourceManagerCreateWithInitialSupplyManifestInput::arbitrary(
@@ -484,7 +476,7 @@ impl TxFuzzer {
                 }
                 // CreateProofFromBucketOfNonFungibles
                 29 => {
-                    let ids =  non_fungible_ids.clone();
+                    let ids = non_fungible_ids.clone();
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::CreateProofFromBucketOfNonFungibles { bucket_id, ids })
@@ -514,7 +506,7 @@ impl TxFuzzer {
                     Some(InstructionV1::CallMethod {
                         address: resource_address.into(),
                         method_name: FUNGIBLE_RESOURCE_MANAGER_MINT_IDENT.to_string(),
-                        args: manifest_args!(amount)
+                        args: manifest_args!(amount),
                     })
                 }
                 // MintNonFungible
@@ -569,7 +561,9 @@ impl TxFuzzer {
                         if !vaults.is_empty() {
                             *unstructured.choose(&vaults[..]).unwrap()
                         } else {
-                            InternalAddress::arbitrary(&mut unstructured).unwrap().into()
+                            InternalAddress::arbitrary(&mut unstructured)
+                                .unwrap()
+                                .into()
                         }
                     };
 
@@ -580,15 +574,14 @@ impl TxFuzzer {
                 }
                 // RemoveMetadata
                 41 => {
-                    global_addresses.push(
-                        GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let key = String::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::CallMetadataMethod {
                         address,
                         method_name: METADATA_REMOVE_IDENT.to_string(),
-                        args: manifest_args!(key)
+                        args: manifest_args!(key),
                     })
                 }
                 // ReturnToWorktop
@@ -604,13 +597,12 @@ impl TxFuzzer {
                     Some(InstructionV1::CallRoyaltyMethod {
                         address: component_address.into(),
                         method_name: COMPONENT_ROYALTY_SET_ROYALTY_CONFIG_IDENT.to_string(),
-                        args: manifest_args!(royalty_config)
+                        args: manifest_args!(royalty_config),
                     })
                 }
                 // SetMetadata
                 44 => {
-                    global_addresses.push(
-                        GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let key = String::arbitrary(&mut unstructured).unwrap();
                     let value = MetadataValue::arbitrary(&mut unstructured).unwrap();
@@ -618,15 +610,15 @@ impl TxFuzzer {
                     Some(InstructionV1::CallMetadataMethod {
                         address,
                         method_name: METADATA_SET_IDENT.to_string(),
-                        args: manifest_args!(key, value)
+                        args: manifest_args!(key, value),
                     })
                 }
                 // SetPackageRoyaltyConfig
                 45 => {
-                    package_addresses
-                        .push(PackageAddress::arbitrary(&mut unstructured).unwrap());
+                    package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
-                    let royalty_config = BTreeMap::<String, RoyaltyConfig>::arbitrary(&mut unstructured).unwrap();
+                    let royalty_config =
+                        BTreeMap::<String, RoyaltyConfig>::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::CallMethod {
                         address: package_address.into(),
@@ -652,8 +644,7 @@ impl TxFuzzer {
                 }),
                 // UpdateRole
                 49 => {
-                    global_addresses.push(
-                        GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let input = AccessRulesUpdateRoleInput::arbitrary(&mut unstructured).unwrap();
 
@@ -671,8 +662,9 @@ impl TxFuzzer {
                 // - enumerated monotonically and no gaps between numbers
                 // Please keep that in mind when playing with the instructions.
                 _ => unreachable!(
-                    "Not all instructions (current count is {}) covered by this match, current instruction {}",
-                    ast::Instruction::COUNT, next
+                    "Not covered instruction {} (current instruction count {})",
+                    next,
+                    ast::Instruction::COUNT
                 ),
             };
             if let Some(instruction) = instruction {
@@ -730,6 +722,32 @@ pub enum TxStatus {
     // Transaction manifest parse error
     #[allow(unused)]
     DecodeError,
+}
+
+#[test]
+fn test_check_fuzzed_instruction_coverage() {
+    use rand::{Rng, RngCore};
+    use rand_chacha::rand_core::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    let mut rng = ChaCha8Rng::seed_from_u64(1234);
+    let mut fuzzer = TxFuzzer::new();
+    for _ in 0..5000 {
+        let len = rng.gen_range(0..1024);
+        let mut bytes: Vec<u8> = (0..len).map(|_| rng.gen_range(0..u8::MAX)).collect();
+        rng.fill_bytes(&mut bytes[..]);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            fuzzer.reset_runner();
+            fuzzer.build_manifest(&bytes[..])
+        }));
+        if let Err(err) = result {
+            let err_msg = err.downcast::<String>().unwrap();
+            if err_msg.contains("Not covered instruction") {
+                panic!("Found not covered instruction");
+            }
+        }
+    }
 }
 
 // This test tries is supposed to generate fuzz input data.

--- a/fuzz-tests/src/transaction.rs
+++ b/fuzz-tests/src/transaction.rs
@@ -16,6 +16,8 @@ mod simple_fuzzer;
 mod fuzz_tx;
 use fuzz_tx::*;
 
+mod common;
+
 // Fuzzer entry points
 #[cfg(feature = "libfuzzer-sys")]
 fuzz_target!(|data: &[u8]| {

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -14,7 +14,7 @@ hex = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
-bnum = { version = "0.6.0", default-features = false, features = ["numtraits"] }
+bnum = { version = "0.7.0", default-features = false, features = ["numtraits"] }
 bech32 = { version = "0.9.0", default-features = false }
 paste = { version = "1.0.7"}
 blake2 = { version = "0.10.6", default-features = false }
@@ -48,7 +48,7 @@ alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", 
 
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work
-radix_engine_fuzzing = ["arbitrary"]
+radix_engine_fuzzing = ["arbitrary", "bnum/arbitrary"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]

--- a/radix-engine-interface/src/api/node_modules/auth/access_rules/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/auth/access_rules/invocations.rs
@@ -1,5 +1,7 @@
 use crate::blueprints::resource::*;
 use crate::*;
+#[cfg(feature = "radix_engine_fuzzing")]
+use arbitrary::Arbitrary;
 use radix_engine_common::data::scrypto::model::Own;
 use sbor::rust::fmt::Debug;
 use sbor::rust::prelude::*;
@@ -8,6 +10,7 @@ pub const ACCESS_RULES_BLUEPRINT: &str = "AccessRules";
 
 pub const ACCESS_RULES_CREATE_IDENT: &str = "create";
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
@@ -19,6 +22,7 @@ pub type AccessRulesCreateOutput = Own;
 
 pub const ACCESS_RULES_UPDATE_ROLE_IDENT: &str = "update_role";
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
@@ -32,6 +36,7 @@ pub type AccessRulesUpdateRoleOutput = ();
 
 pub const ACCESS_RULES_GET_ROLE_IDENT: &str = "get_role";
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a66412baacf51dfc30a1e220bc7cc947001e8c47e3716468a3857f98887a7f3"
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/test.sh
+++ b/test.sh
@@ -42,6 +42,15 @@ test_benchmark  \
     "sbor-tests \
     radix-engine-tests"
 
+echo "Checking fuzzer..."
+(
+    cd fuzz-tests;
+    # specifying empty package list, as fuzz-tests workspace has no packages
+    test_crates_features \
+        "" \
+        test_check_fuzzed_instruction_coverage
+)
+
 ./check_stack_usage.sh
 
 echo "Congrats! All tests passed."


### PR DESCRIPTION
## Summary

* Align fuzzed instructions with current `develop` branch
* Add test to detect not covered instructions
* Get rid of some hardcoded values by getting entries from DB
* Some code cleanup 

## Details
The test `test_check_fuzzed_instruction_coverage` checks for uncovered instructions.
If it finds such it panics with message `Found not covered instruction`. In such case please follow below guidelines to add support for the uncovered instructions.

For easier maintenance instructions in the huge match in `build_manifest()` are
- ordered alphabetically
- enumerated monotonically and no gaps between numbers

In order to get the list of the currently supported instructions below command might be used:
`cat transaction/src/manifest/ast.rs | awk '/pub enum Instruction/,/^}/ {print $0}' | grep -E "^[ ]*[A-Z][a-zA-Z]*" | sed -E "s/[ ,\{\}]//g" | sort | awk '{print NR-1"\t"$0}'`

