### PR TITLE
Fixes to let CI be great again

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.69.0
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - uses: radixdlt/criterion-compare-action@update-same-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Check format
       run: bash ./check.sh
   sbor-unit-tests:
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: sbor
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: sbor-tests
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto-tests
@@ -123,7 +123,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Add wasm target (nightly)
@@ -150,7 +150,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Install RocksDB metrics dependency
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -203,7 +203,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -224,7 +224,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -240,7 +240,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -256,7 +256,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: transaction
@@ -270,7 +270,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -304,7 +304,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -332,7 +332,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
 
     - run: |
         sudo apt-get update -qq

--- a/radix-engine-interface/src/blueprints/resource/vault.rs
+++ b/radix-engine-interface/src/blueprints/resource/vault.rs
@@ -3,6 +3,8 @@ use crate::data::scrypto::model::*;
 use crate::data::scrypto::ScryptoCustomTypeKind;
 use crate::data::scrypto::ScryptoCustomValueKind;
 use crate::*;
+#[cfg(feature = "radix_engine_fuzzing")]
+use arbitrary::Arbitrary;
 use radix_engine_common::data::scrypto::*;
 use sbor::rust::prelude::*;
 use sbor::*;
@@ -67,6 +69,7 @@ pub type VaultRecallOutput = Bucket;
 
 pub const VAULT_FREEZE_IDENT: &str = "freeze";
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
 pub struct VaultFreezeInput {}
 
@@ -74,6 +77,7 @@ pub type VaultFreezeOutput = ();
 
 pub const VAULT_UNFREEZE_IDENT: &str = "unfreeze";
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
 pub struct VaultUnfreezeInput {}
 


### PR DESCRIPTION
## Summary

CI fixes:
- added missing instructions to the fuzzer
- pinned rust to `1.69.0`
With the rust 1.70.0 following error is being observed leading to CI failures
```
thread 'can_instantiate_with_preallocated_address' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidWasm(DeserializationError)', /runner/_work/radixdlt-scrypto/radixdlt-scrypto/scrypto-unit/src/test_runner.rs:115:44
```
Error occurs when deserializing the WASM code into a WASM module. The error is:
`UnknownOpcode(192)`

To be reverted as soon as proper fix is implemented
 


