### PR TITLE
Feature: Radix Engine WASM Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,6 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Build with resource tracking
       run: cargo build --features resource_tracker
-    - name: Build for WASM target
-      run: cargo build --target wasm32-unknown-unknown --no-default-features --features std,lru
     - name: Build RocksDB metrics test
       run: cargo test -p radix-engine-profiling -p radix-engine-stores --features rocksdb test_store_db --release --no-run -- --nocapture
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Build with resource tracking
       run: cargo build --features resource_tracker
+    - name: Build for WASM target
+      run: cargo build --target wasm32-unknown-unknown --no-default-features --features std,lru
     - name: Build RocksDB metrics test
       run: cargo test -p radix-engine-profiling -p radix-engine-stores --features rocksdb test_store_db --release --no-run -- --nocapture
     - name: Run tests

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = { version = "1.17.1"}
 arbitrary = { version = "1.3.0", features = ["derive"] }
 strum = { version = "0.24.1", default-features = false, features = ["derive"] }
 sbor = { path = "../sbor", default-features = false, features = ["radix_engine_fuzzing"] }
-radix-engine = { path = "../radix-engine", default-features = false, features = ["radix_engine_fuzzing"] }
+radix-engine = { path = "../radix-engine", default-features = false, features = ["radix_engine_fuzzing", "moka"] }
 radix-engine-common = { path = "../radix-engine-common", default-features = false, features = ["radix_engine_fuzzing"] }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false, features = ["radix_engine_fuzzing"]}

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -142,7 +142,7 @@ function fuzzer_simple() {
 
     set -x
     cargo $cmd --release \
-        --no-default-features --features std,simple-fuzzer \
+        --no-default-features --features std,moka,simple-fuzzer \
         --bin $target \
         -- $@
 }

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 sbor = { path = "../sbor", default-features = false }
-radix-engine = { path = "../radix-engine", default-features = false }
+radix-engine = { path = "../radix-engine", default-features = false, features = ["moka"] }
 radix-engine-store-interface = { path = "../radix-engine-store-interface", default-features = false }
 radix-engine-constants = { path = "../radix-engine-constants", default-features = false }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }

--- a/radix-engine-tests/Cargo.toml
+++ b/radix-engine-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 sbor = { path = "../sbor", default-features = false }
-radix-engine = { path = "../radix-engine", default-features = false }
+radix-engine = { path = "../radix-engine", default-features = false, features = ["moka"] }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
 radix-engine-common = { path = "../radix-engine-common", default-features = false }

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -48,9 +48,9 @@ wabt = { version = "0.10.0" }
 
 [features]
 # You should enable either `std` or `alloc`
-default = ["std"]
-std = ["sbor/std", "native-sdk/std", "wasmi/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std", "moka", "serde_json?/std"]
-alloc = ["sbor/alloc", "native-sdk/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc", "lru/hashbrown", "serde_json?/alloc"]
+default = ["std", "moka"]
+std = ["sbor/std", "native-sdk/std", "wasmi/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std", "serde_json?/std"]
+alloc = ["sbor/alloc", "native-sdk/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc", "lru?/hashbrown", "serde_json?/alloc"]
 
 # Enables heap memory and CPU cycles resource tracing - available only for Linux OS on x86 arch.
 # Requires CAP_PERFMON capability for the process (sudo setcap cap_perfmon=eip <exec_file>).
@@ -59,8 +59,10 @@ cpu_ram_metrics = ["std", "dep:perfcnt"]
 # Use `wasmer` as WASM engine, otherwise `wasmi`
 wasmer = ["dep:wasmer", "dep:wasmer-compiler-singlepass"]
 
-# Use moka for caching
+# Two features for the two possible libraries to use for caching. Moka is not WASM friendly while LRU is. One of these
+# two features must be enabled.
 moka = ["dep:moka"]
+lru = ["dep:lru"]
 
 resource_tracker = ["dep:radix-engine-profiling", "resources-tracker-macro/resource_tracker"]
 

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -6,6 +6,11 @@ compile_error!("Either feature `std` or `alloc` must be enabled for this crate."
 #[cfg(all(feature = "std", feature = "alloc"))]
 compile_error!("Feature `std` and `alloc` can't be enabled at the same time.");
 
+#[cfg(not(any(feature = "moka", feature = "lru")))]
+compile_error!("Either feature `moka` or `lru` must be enabled for this crate.");
+#[cfg(all(feature = "moka", feature = "lru"))]
+compile_error!("Feature `moka` and `lru` can't be enabled at the same time.");
+
 /// Radix Engine kernel, defining state, ownership and (low-level) invocation semantics.
 pub mod kernel;
 /// Radix Engine system, defining packages (a.k.a. classes), components (a.k.a. objects) and invocation semantics.

--- a/scrypto-unit/Cargo.toml
+++ b/scrypto-unit/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.0"
 edition = "2021"
 
 [dependencies]
-radix-engine = { path = "../radix-engine", default-features = false }
+radix-engine = { path = "../radix-engine", default-features = false, features = ["moka"] }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
 radix-engine-constants = { path = "../radix-engine-constants" }
 radix-engine-store-interface = { path = "../radix-engine-store-interface", default-features = false }


### PR DESCRIPTION
## Summary

This is a small PR that makes the Radix Engine compile to a `wasm32-unknown-unknown` target which is something that the Radix Engine Toolkit is increasingly needing and relying on more.