### PR TITLE
Fix failing CI for birch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.69.0
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
       - uses: radixdlt/criterion-compare-action@update-same-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Check format
       run: bash ./check.sh
   sbor-unit-tests:
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: sbor
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: sbor-tests
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto-tests
@@ -123,7 +123,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Add wasm target (nightly)
@@ -150,7 +150,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -178,7 +178,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -199,7 +199,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -220,7 +220,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -236,7 +236,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -252,7 +252,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Run tests
       run: cargo test
       working-directory: transaction
@@ -266,7 +266,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -300,7 +300,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -328,7 +328,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Setup AFL

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.69.0
 
     - run: |
         sudo apt-get update -qq


### PR DESCRIPTION
## Summary

Pinned rust to `1.69.0`
With the rust `1.70.0` following error is being observed leading to CI failures
```
thread 'can_instantiate_with_preallocated_address' panicked at 'called `Result::unwrap()` on an `Err` value: InvalidWasm(DeserializationError)', /runner/_work/radixdlt-scrypto/radixdlt-scrypto/scrypto-unit/src/test_runner.rs:115:44
```
Error occurs when deserializing the WASM code into a WASM module. The error is:
UnknownOpcode(192)

To be reverted as soon as proper fix is implemented

NOTE! Change ported from https://github.com/radixdlt/radixdlt-scrypto/pull/1083