### PR TITLE
Fix build and test script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ echo "Building the simulator packages..."
 
 echo "Building the engine in different configurations..."
 
-(set -x; cd radix-engine; cargo build --no-default-features --features alloc)
+(set -x; cd radix-engine; cargo build --no-default-features --features alloc,moka)
 (set -x; cd radix-engine; cargo build --features wasmer,resource_tracker)
 
 # We use a globally loaded scrypto CLI so that this script works even if the code doesn't compile at present

--- a/test_utils.sh
+++ b/test_utils.sh
@@ -33,7 +33,15 @@ test_crates_features() {
     cargo $test_runner $crates $args
 
     if [ $doc_test_separately -eq 1 ] ; then
-        cargo test $crates --doc $args
+        tmpfile=$(mktemp)
+        # this is to skip error in case of bin target
+        #   https://github.com/rust-lang/rust/issues/50784
+        if ! cargo test $crates --doc $args 2>$tmpfile ; then
+            if ! grep -q 'error: no library targets found in package' $tmpfile ; then
+                cat $tmpfile
+                exit 1
+            fi
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary

Minor fixes for locally used scripts:
- build.sh
after merging https://github.com/radixdlt/radixdlt-scrypto/pull/1084  `moka` (or `lru`) feature shall be explicitly specified if building with  `no-default-featues`
- test_utils.sh
`test_crates_features` for fuzz-tests were returning error due to failing doctests. 