### PR TITLE
Fix simple fuzzer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,9 @@ jobs:
     - name: Setup AFL
       run: bash ./install_afl.sh
       working-directory: fuzz-tests
+    - name: Build simple fuzzer
+      run: bash ./fuzz.sh simple build
+      working-directory: fuzz-tests
     - name: Build AFL fuzzer
       run: bash ./fuzz.sh afl build
       working-directory: fuzz-tests

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -142,7 +142,7 @@ function fuzzer_simple() {
 
     set -x
     cargo $cmd --release \
-        --no-default-features --features std,moka,simple-fuzzer \
+        --no-default-features --features std,simple-fuzzer \
         --bin $target \
         -- $@
 }


### PR DESCRIPTION
## Summary

Fix simple fuzzer build. This build is used for inspecting crashes discovered during fuzzing campaign.

## Testing

Added simple fuzzer build to the CI.