### PR TITLE
fix: Genesis data chunks are scrypto encodable

### DIFF
--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -32,17 +32,11 @@ fn test_bootstrap_receipt_should_match_constants() {
         xrd_amount: Decimal::one(),
     };
     let genesis_data_chunks = vec![
-        (
-            vec![],
-            GenesisDataChunk::Validators(vec![validator_key.clone().into()]),
-        ),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts: vec![staker_address],
-                allocations: vec![(validator_key, vec![stake])],
-            },
-        ),
+        GenesisDataChunk::Validators(vec![validator_key.clone().into()]),
+        GenesisDataChunk::Stakes {
+            accounts: vec![staker_address],
+            allocations: vec![(validator_key, vec![stake])],
+        },
     ];
 
     let mut bootstrapper = Bootstrapper::new(&mut substate_db, &scrypto_vm, true);
@@ -94,17 +88,11 @@ fn test_bootstrap_receipt_should_have_substate_changes_which_can_be_typed() {
         xrd_amount: Decimal::one(),
     };
     let genesis_data_chunks = vec![
-        (
-            vec![],
-            GenesisDataChunk::Validators(vec![validator_key.clone().into()]),
-        ),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts: vec![staker_address],
-                allocations: vec![(validator_key, vec![stake])],
-            },
-        ),
+        GenesisDataChunk::Validators(vec![validator_key.clone().into()]),
+        GenesisDataChunk::Stakes {
+            accounts: vec![staker_address],
+            allocations: vec![(validator_key, vec![stake])],
+        },
     ];
 
     let mut bootstrapper = Bootstrapper::new(&mut substate_db, &scrypto_vm, true);
@@ -162,10 +150,10 @@ fn test_genesis_xrd_allocation_to_accounts() {
         &PublicKey::Secp256k1(account_public_key.clone()),
     );
     let allocation_amount = dec!("100");
-    let genesis_data_chunks = vec![(
-        vec![],
-        GenesisDataChunk::XrdBalances(vec![(account_component_address, allocation_amount)]),
-    )];
+    let genesis_data_chunks = vec![GenesisDataChunk::XrdBalances(vec![(
+        account_component_address,
+        allocation_amount,
+    )])];
 
     let mut bootstrapper = Bootstrapper::new(&mut substate_db, &scrypto_vm, true);
 
@@ -209,16 +197,12 @@ fn test_genesis_resource_with_initial_allocation() {
         )
         .0,
     );
-    let preallocated_addresses = vec![(
-        BlueprintId::new(&RESOURCE_PACKAGE, FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
-        resource_address.into(),
-    )];
     let resource_owner = ComponentAddress::virtual_account_from_public_key(
         &Secp256k1PrivateKey::from_u64(2).unwrap().public_key(),
     );
     let allocation_amount = dec!("105");
     let genesis_resource = GenesisResource {
-        address_reservation: ManifestAddressReservation(0),
+        reserved_resource_address: resource_address,
         initial_supply: allocation_amount,
         metadata: vec![(
             "symbol".to_string(),
@@ -231,17 +215,11 @@ fn test_genesis_resource_with_initial_allocation() {
         amount: allocation_amount,
     };
     let genesis_data_chunks = vec![
-        (
-            preallocated_addresses,
-            GenesisDataChunk::Resources(vec![genesis_resource]),
-        ),
-        (
-            vec![],
-            GenesisDataChunk::ResourceBalances {
-                accounts: vec![token_holder.clone()],
-                allocations: vec![(resource_address.clone(), vec![resource_allocation])],
-            },
-        ),
+        GenesisDataChunk::Resources(vec![genesis_resource]),
+        GenesisDataChunk::ResourceBalances {
+            accounts: vec![token_holder.clone()],
+            allocations: vec![(resource_address.clone(), vec![resource_allocation])],
+        },
     ];
 
     let mut bootstrapper = Bootstrapper::new(&mut substate_db, &scrypto_vm, true);
@@ -349,23 +327,17 @@ fn test_genesis_stake_allocation() {
         xrd_amount: dec!("1"),
     }];
     let genesis_data_chunks = vec![
-        (
-            vec![],
-            GenesisDataChunk::Validators(vec![
-                validator_0_key.clone().into(),
-                validator_1_key.clone().into(),
-            ]),
-        ),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts: vec![staker_0, staker_1],
-                allocations: vec![
-                    (validator_0_key, validator_0_allocations),
-                    (validator_1_key, validator_1_allocations),
-                ],
-            },
-        ),
+        GenesisDataChunk::Validators(vec![
+            validator_0_key.clone().into(),
+            validator_1_key.clone().into(),
+        ]),
+        GenesisDataChunk::Stakes {
+            accounts: vec![staker_0, staker_1],
+            allocations: vec![
+                (validator_0_key, validator_0_allocations),
+                (validator_1_key, validator_1_allocations),
+            ],
+        },
     ];
 
     let mut bootstrapper = Bootstrapper::new(&mut substate_db, &scrypto_vm, true);

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -65,14 +65,11 @@ fn genesis_epoch_has_correct_initial_validators() {
     }
 
     let genesis_data_chunks = vec![
-        (vec![], GenesisDataChunk::Validators(validators)),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts,
-                allocations: stake_allocations,
-            },
-        ),
+        GenesisDataChunk::Validators(validators),
+        GenesisDataChunk::Stakes {
+            accounts,
+            allocations: stake_allocations,
+        },
     ];
 
     let genesis = CustomGenesis {
@@ -565,14 +562,11 @@ fn validator_set_receives_emissions_proportional_to_stake_on_epoch_change() {
         .map(|validator| validator.owner)
         .collect::<Vec<_>>();
     let genesis_data_chunks = vec![
-        (vec![], GenesisDataChunk::Validators(validators)),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts,
-                allocations,
-            },
-        ),
+        GenesisDataChunk::Validators(validators),
+        GenesisDataChunk::Stakes {
+            accounts,
+            allocations,
+        },
     ];
     let genesis = CustomGenesis {
         genesis_data_chunks,
@@ -1113,15 +1107,12 @@ fn create_custom_genesis(
     }
 
     let genesis_data_chunks = vec![
-        (vec![], GenesisDataChunk::Validators(validators)),
-        (
-            vec![],
-            GenesisDataChunk::Stakes {
-                accounts,
-                allocations: stake_allocations,
-            },
-        ),
-        (vec![], GenesisDataChunk::XrdBalances(xrd_balances)),
+        GenesisDataChunk::Validators(validators),
+        GenesisDataChunk::Stakes {
+            accounts,
+            allocations: stake_allocations,
+        },
+        GenesisDataChunk::XrdBalances(xrd_balances),
     ];
 
     let genesis = CustomGenesis {
@@ -2259,14 +2250,20 @@ fn consensus_manager_create_should_fail_with_supervisor_privilege() {
 
     // Act
     let mut pre_allocated_addresses = vec![];
-    pre_allocated_addresses.push((
-        BlueprintId::new(&CONSENSUS_MANAGER_PACKAGE, CONSENSUS_MANAGER_BLUEPRINT),
-        GlobalAddress::from(CONSENSUS_MANAGER),
-    ));
-    pre_allocated_addresses.push((
-        BlueprintId::new(&RESOURCE_PACKAGE, NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
-        GlobalAddress::from(VALIDATOR_OWNER_BADGE),
-    ));
+    pre_allocated_addresses.push(
+        (
+            BlueprintId::new(&CONSENSUS_MANAGER_PACKAGE, CONSENSUS_MANAGER_BLUEPRINT),
+            GlobalAddress::from(CONSENSUS_MANAGER),
+        )
+            .into(),
+    );
+    pre_allocated_addresses.push(
+        (
+            BlueprintId::new(&RESOURCE_PACKAGE, NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
+            GlobalAddress::from(VALIDATOR_OWNER_BADGE),
+        )
+            .into(),
+    );
     let receipt = test_runner.execute_system_transaction_with_preallocation(
         vec![InstructionV1::CallFunction {
             package_address: CONSENSUS_MANAGER_PACKAGE.into(),
@@ -2301,14 +2298,20 @@ fn consensus_manager_create_should_succeed_with_system_privilege() {
 
     // Act
     let mut pre_allocated_addresses = vec![];
-    pre_allocated_addresses.push((
-        BlueprintId::new(&RESOURCE_PACKAGE, NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
-        GlobalAddress::from(VALIDATOR_OWNER_BADGE),
-    ));
-    pre_allocated_addresses.push((
-        BlueprintId::new(&CONSENSUS_MANAGER_PACKAGE, CONSENSUS_MANAGER_BLUEPRINT),
-        GlobalAddress::from(CONSENSUS_MANAGER),
-    ));
+    pre_allocated_addresses.push(
+        (
+            BlueprintId::new(&RESOURCE_PACKAGE, NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
+            GlobalAddress::from(VALIDATOR_OWNER_BADGE),
+        )
+            .into(),
+    );
+    pre_allocated_addresses.push(
+        (
+            BlueprintId::new(&CONSENSUS_MANAGER_PACKAGE, CONSENSUS_MANAGER_BLUEPRINT),
+            GlobalAddress::from(CONSENSUS_MANAGER),
+        )
+            .into(),
+    );
     let receipt = test_runner.execute_system_transaction_with_preallocation(
         vec![InstructionV1::CallFunction {
             package_address: CONSENSUS_MANAGER_PACKAGE.into(),

--- a/radix-engine-tests/tests/static_dependencies.rs
+++ b/radix-engine-tests/tests/static_dependencies.rs
@@ -105,7 +105,8 @@ fn static_component_should_be_callable() {
         vec![(
             BlueprintId::new(&package_address, "Preallocated"),
             GlobalAddress::new_or_panic(PRE_ALLOCATED),
-        )],
+        )
+            .into()],
         btreeset!(),
     );
     receipt.expect_commit_success();
@@ -171,7 +172,8 @@ fn static_resource_should_be_callable() {
         vec![(
             BlueprintId::new(&RESOURCE_PACKAGE, FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
             GlobalAddress::new_or_panic(PRE_ALLOCATED_RESOURCE),
-        )],
+        )
+            .into()],
         btreeset!(NonFungibleGlobalId::from_public_key(&key)),
     );
     receipt.expect_commit_success();

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -27,6 +27,7 @@ use radix_engine_interface::blueprints::transaction_processor::{
 };
 use resources_tracker_macro::trace_resources;
 use sbor::rust::mem;
+use transaction::prelude::PreAllocatedAddress;
 
 /// Organizes the radix engine stack to make a function entrypoint available for execution
 pub struct KernelBoot<'g, V: SystemCallbackObject, S: SubstateStore> {
@@ -42,7 +43,7 @@ impl<'g, 'h, V: SystemCallbackObject, S: SubstateStore> KernelBoot<'g, V, S> {
         transaction_hash: &'a Hash,
         runtime_validations: &'a [RuntimeValidationRequest],
         manifest_encoded_instructions: &'a [u8],
-        pre_allocated_addresses: &'a Vec<(BlueprintId, GlobalAddress)>,
+        pre_allocated_addresses: &'a Vec<PreAllocatedAddress>,
         references: &'a IndexSet<Reference>,
         blobs: &'a IndexMap<Hash, Vec<u8>>,
     ) -> Result<Vec<u8>, RuntimeError> {
@@ -125,7 +126,11 @@ impl<'g, 'h, V: SystemCallbackObject, S: SubstateStore> KernelBoot<'g, V, S> {
 
         // Allocate global addresses
         let mut global_address_reservations = Vec::new();
-        for (blueprint_id, address) in pre_allocated_addresses {
+        for PreAllocatedAddress {
+            blueprint_id,
+            address,
+        } in pre_allocated_addresses
+        {
             let mut system = SystemService::new(&mut kernel);
             let global_address_reservation =
                 system.prepare_global_address(blueprint_id.clone(), address.clone())?;

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -34,7 +34,7 @@ use radix_engine_store_interface::{
 use transaction::model::{
     BlobsV1, InstructionV1, InstructionsV1, SystemTransactionV1, TransactionPayload,
 };
-use transaction::prelude::BlobV1;
+use transaction::prelude::{BlobV1, PreAllocatedAddress};
 use transaction::validation::ManifestIdAllocator;
 
 const XRD_SYMBOL: &str = "XRD";
@@ -44,7 +44,15 @@ const XRD_URL: &str = "https://tokens.radixdlt.com";
 const XRD_ICON_URL: &str = "https://assets.radixdlt.com/icons/icon-xrd-32x32.png";
 const XRD_MAX_SUPPLY: i128 = 1_000_000_000_000i128;
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+//==========================================================================================
+// GENESIS CHUNK MODELS
+// - These are used by the node (and in Java) so they need to implement ScryptoEncode so
+//   that they can go over the JNI boundary
+// - The models which use ManifestSbor are also included in the transaction itself, and must
+//   match the corresponding models in the `genesis_helper` component
+//==========================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoSbor)]
 pub struct GenesisValidator {
     pub key: Secp256k1PublicKey,
     pub accept_delegated_stake: bool,
@@ -70,27 +78,29 @@ impl From<Secp256k1PublicKey> for GenesisValidator {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoSbor)]
 pub struct GenesisStakeAllocation {
     pub account_index: u32,
     pub xrd_amount: Decimal,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+// Note - this gets mapped into the ManifestGenesisResource by replacing the reservation
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub struct GenesisResource {
-    pub address_reservation: ManifestAddressReservation,
+    pub reserved_resource_address: ResourceAddress,
     pub initial_supply: Decimal,
     pub metadata: Vec<(String, MetadataValue)>,
     pub owner: Option<ComponentAddress>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoSbor)]
 pub struct GenesisResourceAllocation {
     pub account_index: u32,
     pub amount: Decimal,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+// Note - this gets mapped into the ManifestGenesisResource for inclusion in the transaction
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum GenesisDataChunk {
     Validators(Vec<GenesisValidator>),
     Stakes {
@@ -104,6 +114,39 @@ pub enum GenesisDataChunk {
     },
     XrdBalances(Vec<(ComponentAddress, Decimal)>),
 }
+
+//==========================================================================================
+// MANIFEST-SPECIFIC GENESIS CHUNK MODELS
+// - These must match the corresponding models in the `genesis_helper` component
+//==========================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+pub enum ManifestGenesisDataChunk {
+    Validators(Vec<GenesisValidator>),
+    Stakes {
+        accounts: Vec<ComponentAddress>,
+        allocations: Vec<(Secp256k1PublicKey, Vec<GenesisStakeAllocation>)>,
+    },
+    Resources(Vec<ManifestGenesisResource>),
+    ResourceBalances {
+        accounts: Vec<ComponentAddress>,
+        allocations: Vec<(ResourceAddress, Vec<GenesisResourceAllocation>)>,
+    },
+    XrdBalances(Vec<(ComponentAddress, Decimal)>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+pub struct ManifestGenesisResource {
+    pub resource_address_reservation: ManifestAddressReservation,
+    pub initial_supply: Decimal,
+    pub metadata: Vec<(String, MetadataValue)>,
+    pub owner: Option<ComponentAddress>,
+}
+
+//==========================================================================================
+// BOOTSTRAPPER
+// Various helper utilities for constructing and executing genesis
+//==========================================================================================
 
 #[derive(Debug, Clone, ScryptoSbor)]
 pub struct GenesisReceipts {
@@ -162,7 +205,7 @@ where
 
     pub fn bootstrap_with_genesis_data(
         &mut self,
-        genesis_data_chunks: Vec<(Vec<(BlueprintId, GlobalAddress)>, GenesisDataChunk)>,
+        genesis_data_chunks: Vec<GenesisDataChunk>,
         initial_epoch: Epoch,
         initial_config: ConsensusManagerConfig,
         initial_time_ms: i64,
@@ -181,7 +224,7 @@ where
 
             let mut data_ingestion_receipts = vec![];
             for (chunk_index, chunk) in genesis_data_chunks.into_iter().enumerate() {
-                let receipt = self.ingest_genesis_data_chunk(chunk.0, chunk.1, chunk_index);
+                let receipt = self.ingest_genesis_data_chunk(chunk, chunk_index);
                 data_ingestion_receipts.push(receipt);
             }
 
@@ -227,16 +270,11 @@ where
 
     fn ingest_genesis_data_chunk(
         &mut self,
-        pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
         chunk: GenesisDataChunk,
         chunk_number: usize,
     ) -> TransactionReceipt {
-        let transaction = create_genesis_data_ingestion_transaction(
-            pre_allocated_addresses,
-            &GENESIS_HELPER,
-            chunk,
-            chunk_number,
-        );
+        let transaction =
+            create_genesis_data_ingestion_transaction(&GENESIS_HELPER, chunk, chunk_number);
         let receipt = execute_transaction(
             self.substate_db,
             self.scrypto_vm,
@@ -861,19 +899,23 @@ pub fn create_system_bootstrap_transaction(
 
     SystemTransactionV1 {
         instructions: InstructionsV1(instructions),
-        pre_allocated_addresses,
+        pre_allocated_addresses: pre_allocated_addresses
+            .into_iter()
+            .map(|allocation_pair| allocation_pair.into())
+            .collect(),
         blobs: BlobsV1 { blobs },
         hash_for_execution: hash(format!("Genesis Bootstrap")),
     }
 }
 
 pub fn create_genesis_data_ingestion_transaction(
-    pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
     genesis_helper: &ComponentAddress,
     chunk: GenesisDataChunk,
     chunk_number: usize,
 ) -> SystemTransactionV1 {
     let mut instructions = Vec::new();
+
+    let (chunk, pre_allocated_addresses) = map_address_allocations_for_manifest(chunk);
 
     instructions.push(InstructionV1::CallMethod {
         address: genesis_helper.clone().into(),
@@ -886,6 +928,62 @@ pub fn create_genesis_data_ingestion_transaction(
         pre_allocated_addresses,
         blobs: BlobsV1 { blobs: vec![] },
         hash_for_execution: hash(format!("Genesis Data Chunk: {}", chunk_number)),
+    }
+}
+
+fn map_address_allocations_for_manifest(
+    genesis_data_chunk: GenesisDataChunk,
+) -> (ManifestGenesisDataChunk, Vec<PreAllocatedAddress>) {
+    match genesis_data_chunk {
+        GenesisDataChunk::Validators(content) => {
+            (ManifestGenesisDataChunk::Validators(content), vec![])
+        }
+        GenesisDataChunk::Stakes {
+            accounts,
+            allocations,
+        } => (
+            ManifestGenesisDataChunk::Stakes {
+                accounts,
+                allocations,
+            },
+            vec![],
+        ),
+        GenesisDataChunk::Resources(resources) => {
+            let (resources, allocations): (Vec<_>, Vec<_>) = resources
+                .into_iter()
+                .enumerate()
+                .map(|(index, resource)| {
+                    let manifest_resource = ManifestGenesisResource {
+                        resource_address_reservation: ManifestAddressReservation(index as u32),
+                        initial_supply: resource.initial_supply,
+                        metadata: resource.metadata,
+                        owner: resource.owner,
+                    };
+                    let address_allocation = PreAllocatedAddress {
+                        blueprint_id: BlueprintId {
+                            package_address: RESOURCE_PACKAGE,
+                            blueprint_name: FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT.to_string(),
+                        },
+                        address: resource.reserved_resource_address.into(),
+                    };
+                    (manifest_resource, address_allocation)
+                })
+                .unzip();
+            (ManifestGenesisDataChunk::Resources(resources), allocations)
+        }
+        GenesisDataChunk::ResourceBalances {
+            accounts,
+            allocations,
+        } => (
+            ManifestGenesisDataChunk::ResourceBalances {
+                accounts,
+                allocations,
+            },
+            vec![],
+        ),
+        GenesisDataChunk::XrdBalances(content) => {
+            (ManifestGenesisDataChunk::XrdBalances(content), vec![])
+        }
     }
 }
 
@@ -917,10 +1015,10 @@ pub fn create_genesis_wrap_up_transaction() -> SystemTransactionV1 {
 
     SystemTransactionV1 {
         instructions: InstructionsV1(instructions),
-        pre_allocated_addresses: vec![(
-            BlueprintId::new(&FAUCET_PACKAGE, FAUCET_BLUEPRINT),
-            GlobalAddress::from(FAUCET),
-        )],
+        pre_allocated_addresses: vec![PreAllocatedAddress {
+            blueprint_id: BlueprintId::new(&FAUCET_PACKAGE, FAUCET_BLUEPRINT),
+            address: FAUCET.into(),
+        }],
         blobs: BlobsV1 { blobs: vec![] },
         hash_for_execution: hash(format!("Genesis Wrap Up")),
     }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -128,7 +128,7 @@ impl Compile {
 }
 
 pub struct CustomGenesis {
-    pub genesis_data_chunks: Vec<(Vec<(BlueprintId, GlobalAddress)>, GenesisDataChunk)>,
+    pub genesis_data_chunks: Vec<GenesisDataChunk>,
     pub initial_epoch: Epoch,
     pub initial_config: ConsensusManagerConfig,
     pub initial_time_ms: i64,
@@ -171,23 +171,17 @@ impl CustomGenesis {
     ) -> CustomGenesis {
         let genesis_validator: GenesisValidator = validator_public_key.clone().into();
         let genesis_data_chunks = vec![
-            (
-                vec![],
-                GenesisDataChunk::Validators(vec![genesis_validator]),
-            ),
-            (
-                vec![],
-                GenesisDataChunk::Stakes {
-                    accounts: vec![staker_account],
-                    allocations: vec![(
-                        validator_public_key,
-                        vec![GenesisStakeAllocation {
-                            account_index: 0,
-                            xrd_amount: stake_xrd_amount,
-                        }],
-                    )],
-                },
-            ),
+            GenesisDataChunk::Validators(vec![genesis_validator]),
+            GenesisDataChunk::Stakes {
+                accounts: vec![staker_account],
+                allocations: vec![(
+                    validator_public_key,
+                    vec![GenesisStakeAllocation {
+                        account_index: 0,
+                        xrd_amount: stake_xrd_amount,
+                    }],
+                )],
+            },
         ];
         CustomGenesis {
             genesis_data_chunks,
@@ -708,10 +702,10 @@ impl TestRunner {
                     blobs: vec![BlobV1(code)],
                 },
                 hash_for_execution: hash(format!("Test runner txn: {}", nonce)),
-                pre_allocated_addresses: vec![(
-                    BlueprintId::new(&PACKAGE_PACKAGE, PACKAGE_BLUEPRINT),
-                    address.into(),
-                )],
+                pre_allocated_addresses: vec![PreAllocatedAddress {
+                    blueprint_id: BlueprintId::new(&PACKAGE_PACKAGE, PACKAGE_BLUEPRINT),
+                    address: address.into(),
+                }],
             }
             .prepare()
             .expect("expected transaction to be preparable")
@@ -1338,7 +1332,7 @@ impl TestRunner {
         &mut self,
         instructions: Vec<InstructionV1>,
         proofs: BTreeSet<NonFungibleGlobalId>,
-        pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
+        pre_allocated_addresses: Vec<PreAllocatedAddress>,
     ) -> TransactionReceipt {
         let nonce = self.next_transaction_nonce();
 
@@ -1365,7 +1359,7 @@ impl TestRunner {
     pub fn execute_system_transaction_with_preallocated_addresses(
         &mut self,
         instructions: Vec<InstructionV1>,
-        pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
+        pre_allocated_addresses: Vec<PreAllocatedAddress>,
         mut proofs: BTreeSet<NonFungibleGlobalId>,
     ) -> TransactionReceipt {
         let nonce = self.next_transaction_nonce();

--- a/transaction/src/model/v1/system_transaction.rs
+++ b/transaction/src/model/v1/system_transaction.rs
@@ -6,7 +6,7 @@ use crate::model::{AuthZoneParams, Executable};
 pub struct SystemTransactionV1 {
     pub instructions: InstructionsV1,
     pub blobs: BlobsV1,
-    pub pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
+    pub pre_allocated_addresses: Vec<PreAllocatedAddress>,
     pub hash_for_execution: Hash,
 }
 
@@ -16,14 +16,14 @@ impl TransactionPayload for SystemTransactionV1 {
     type Raw = RawSystemTransaction;
 }
 
-type PreparedPreAllocatedIds = SummarizedRawFullBody<Vec<(BlueprintId, GlobalAddress)>>;
+type PreparedPreAllocatedAddresses = SummarizedRawFullBody<Vec<PreAllocatedAddress>>;
 type PreparedHash = SummarizedHash;
 
 pub struct PreparedSystemTransactionV1 {
     pub encoded_instructions: Vec<u8>,
     pub references: IndexSet<Reference>,
     pub blobs: PreparedBlobsV1,
-    pub pre_allocated_addresses: PreparedPreAllocatedIds,
+    pub pre_allocated_addresses: PreparedPreAllocatedAddresses,
     pub hash_for_execution: PreparedHash,
     pub summary: Summary,
 }
@@ -48,7 +48,7 @@ impl TransactionPayloadPreparable for PreparedSystemTransactionV1 {
             ConcatenatedDigest::prepare_from_transaction_payload_enum::<(
                 PreparedInstructionsV1,
                 PreparedBlobsV1,
-                PreparedPreAllocatedIds,
+                PreparedPreAllocatedAddresses,
                 PreparedHash,
             )>(decoder, TransactionDiscriminator::V1System)?;
         Ok(Self {
@@ -68,7 +68,7 @@ impl TransactionFullChildPreparable for PreparedSystemTransactionV1 {
             ConcatenatedDigest::prepare_from_transaction_child_struct::<(
                 PreparedInstructionsV1,
                 PreparedBlobsV1,
-                PreparedPreAllocatedIds,
+                PreparedPreAllocatedAddresses,
                 PreparedHash,
             )>(decoder, TransactionDiscriminator::V1System)?;
         Ok(Self {

--- a/transaction/src/model/versioned.rs
+++ b/transaction/src/model/versioned.rs
@@ -55,7 +55,7 @@ pub enum VersionedTransactionPayload {
     SystemTransactionV1 {
         instructions: InstructionsV1,
         blobs: BlobsV1,
-        pre_allocated_addresses: Vec<(BlueprintId, GlobalAddress)>,
+        pre_allocated_addresses: Vec<PreAllocatedAddress>,
         hash_for_execution: Hash,
     },
 }
@@ -319,10 +319,10 @@ mod tests {
         .unwrap();
         assert_eq!(prepared_blobs_v1.get_summary().hash, expected_blobs_hash);
 
-        let pre_allocated_addresses_v1 = vec![(
-            BlueprintId::new(&RESOURCE_PACKAGE, FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
-            XRD.into(),
-        )];
+        let pre_allocated_addresses_v1 = vec![PreAllocatedAddress {
+            blueprint_id: BlueprintId::new(&RESOURCE_PACKAGE, FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
+            address: XRD.into(),
+        }];
         let expected_preallocated_addresses_hash =
             hash_manifest_encoded_without_prefix_byte(&pre_allocated_addresses_v1);
 


### PR DESCRIPTION
## Summary
Fixes genesis-related issue from #1075 which was blocking merging into the node.

We now map some of the models to their Manifest counterparts, to enable us to pass the non-Manifest models over JNI.

It also improves the abstraction because users can more easily express their intent, and leave the manifest address allocation accounting to the genesis transaction constructor.