### PR TITLE
fix: Fix the resource role definitions mutable_mutable

### DIFF
--- a/radix-engine-interface/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource_manager.rs
@@ -28,7 +28,6 @@ pub const UPDATE_NON_FUNGIBLE_DATA_UPDATE_ROLE: &str = "update_non_fungible_data
 pub const SET_METADATA_ROLE: &str = "set_metadata";
 pub const SET_METADATA_UPDATE_ROLE: &str = "set_metadata_update";
 
-// TODO: Remove?
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, ScryptoSbor, ManifestSbor)]
 pub enum ResourceMethodAuthKey {
@@ -41,6 +40,48 @@ pub enum ResourceMethodAuthKey {
     Recall,
     Freeze,
     Unfreeze,
+}
+
+pub const ALL_RESOURCE_AUTH_KEYS: [ResourceMethodAuthKey; 9] = [
+    ResourceMethodAuthKey::Mint,
+    ResourceMethodAuthKey::Burn,
+    ResourceMethodAuthKey::UpdateNonFungibleData,
+    ResourceMethodAuthKey::UpdateMetadata,
+    ResourceMethodAuthKey::Withdraw,
+    ResourceMethodAuthKey::Deposit,
+    ResourceMethodAuthKey::Recall,
+    ResourceMethodAuthKey::Freeze,
+    ResourceMethodAuthKey::Unfreeze,
+];
+
+impl ResourceMethodAuthKey {
+    pub fn action_role_key(&self) -> RoleKey {
+        match self {
+            Self::Mint => RoleKey::new(MINT_ROLE),
+            Self::Burn => RoleKey::new(BURN_ROLE),
+            Self::UpdateNonFungibleData => RoleKey::new(UPDATE_NON_FUNGIBLE_DATA_ROLE),
+            Self::UpdateMetadata => RoleKey::new(SET_METADATA_ROLE),
+            Self::Withdraw => RoleKey::new(WITHDRAW_ROLE),
+            Self::Deposit => RoleKey::new(DEPOSIT_ROLE),
+            Self::Recall => RoleKey::new(RECALL_ROLE),
+            Self::Freeze => RoleKey::new(FREEZE_ROLE),
+            Self::Unfreeze => RoleKey::new(UNFREEZE_ROLE),
+        }
+    }
+
+    pub fn updater_role_key(&self) -> RoleKey {
+        match self {
+            Self::Mint => RoleKey::new(MINT_UPDATE_ROLE),
+            Self::Burn => RoleKey::new(BURN_UPDATE_ROLE),
+            Self::UpdateNonFungibleData => RoleKey::new(UPDATE_NON_FUNGIBLE_DATA_UPDATE_ROLE),
+            Self::UpdateMetadata => RoleKey::new(SET_METADATA_UPDATE_ROLE),
+            Self::Withdraw => RoleKey::new(WITHDRAW_UPDATE_ROLE),
+            Self::Deposit => RoleKey::new(DEPOSIT_UPDATE_ROLE),
+            Self::Recall => RoleKey::new(RECALL_UPDATE_ROLE),
+            Self::Freeze => RoleKey::new(FREEZE_UPDATE_ROLE),
+            Self::Unfreeze => RoleKey::new(UNFREEZE_UPDATE_ROLE),
+        }
+    }
 }
 
 pub const RESOURCE_MANAGER_BURN_IDENT: &str = "burn";

--- a/radix-engine-tests/tests/auth_mutability.rs
+++ b/radix-engine-tests/tests/auth_mutability.rs
@@ -1,231 +1,162 @@
 extern crate core;
 
-use radix_engine::errors::{RuntimeError, SystemModuleError};
-use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
 
-enum ResourceAuth {
-    Mint,
-    Burn,
-    Withdraw,
-    Deposit,
-    Recall,
-    UpdateMetadata,
+#[test]
+fn test_all_resource_roles_have_immutable_updater() {
+    for key in ALL_RESOURCE_AUTH_KEYS {
+        ensure_auth_updater_is_immutable(key);
+    }
 }
 
-fn lock_resource_auth_and_try_update(action: ResourceAuth, lock: bool) -> TransactionReceipt {
-    // Arrange
+fn ensure_auth_updater_is_immutable(action: ResourceMethodAuthKey) {
+    // Arrange 1
+    let mut test_runner = TestRunner::builder().build();
+    let resource_address = test_runner.create_everything_allowed_non_fungible_resource();
+
+    // Act - check that despite everything being allowed, you cannot update the role mutability
+    // In other words, both roles are always set to have mutability always be the updater role
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .update_role_mutability(
+                    resource_address.into(),
+                    action.action_role_key(),
+                    (RoleList::none(), false),
+                )
+                .build(),
+            vec![],
+        )
+        .expect_auth_failure();
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .update_role_mutability(
+                    resource_address.into(),
+                    action.updater_role_key(),
+                    (RoleList::none(), false),
+                )
+                .build(),
+            vec![],
+        )
+        .expect_auth_failure();
+}
+
+#[test]
+fn test_locked_resource_auth_cannot_be_updated() {
+    for key in ALL_RESOURCE_AUTH_KEYS {
+        assert_locked_auth_can_no_longer_be_updated(key);
+    }
+}
+
+pub fn assert_locked_auth_can_no_longer_be_updated(action: ResourceMethodAuthKey) {
+    // Arrange 1
     let mut test_runner = TestRunner::builder().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let (token_address, _, _, _, _, _, _, _, admin_auth) =
-        test_runner.create_restricted_token(account);
-    let (_, updated_auth) = test_runner.create_restricted_burn_token(account);
+    let token_address = test_runner.create_everything_allowed_non_fungible_resource();
+    let admin_auth = test_runner.create_non_fungible_resource(account);
 
-    let role_key = match action {
-        ResourceAuth::Mint => RoleKey::new(MINT_ROLE),
-        ResourceAuth::Burn => RoleKey::new(BURN_ROLE),
-        ResourceAuth::UpdateMetadata => RoleKey::new(SET_METADATA_ROLE),
-        ResourceAuth::Withdraw => RoleKey::new(WITHDRAW_ROLE),
-        ResourceAuth::Deposit => RoleKey::new(DEPOSIT_ROLE),
-        ResourceAuth::Recall => RoleKey::new(RECALL_ROLE),
-    };
+    // Act 1 - Show that updating the action auth is initially possible
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.action_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
+        )
+        .expect_commit_success();
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.updater_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
+        )
+        .expect_commit_success();
+
+    // Act 2 - Double check that the previous updating the action auth still lets us update
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.action_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
+        )
+        .expect_commit_success();
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.updater_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
+        )
+        .expect_commit_success();
+
+    // Arrange - We now use the updater role to update the updater role to DenyAll
     {
-        let manifest = ManifestBuilder::new()
-            .lock_fee(test_runner.faucet_component(), 100u32.into())
-            .create_proof_from_account(account, admin_auth)
-            .update_role_mutability(token_address.into(), role_key, (RoleList::none(), false))
-            .build();
         test_runner
-            .execute_manifest(
-                manifest,
+            .execute_manifest_ignoring_fee(
+                ManifestBuilder::new()
+                    .create_proof_from_account(account, admin_auth)
+                    .update_role(
+                        token_address.into(),
+                        action.updater_role_key(),
+                        AccessRule::DenyAll,
+                    )
+                    .build(),
                 vec![NonFungibleGlobalId::from_public_key(&public_key)],
             )
             .expect_commit_success();
     }
 
-    // Act
-    let mut builder = ManifestBuilder::new();
-    builder
-        .lock_fee(test_runner.faucet_component(), 100u32.into())
-        .create_proof_from_account(account, admin_auth);
-
-    let role_key = match action {
-        ResourceAuth::Mint => RoleKey::new(MINT_ROLE),
-        ResourceAuth::Burn => RoleKey::new(BURN_ROLE),
-        ResourceAuth::UpdateMetadata => RoleKey::new(SET_METADATA_ROLE),
-        ResourceAuth::Withdraw => RoleKey::new(WITHDRAW_ROLE),
-        ResourceAuth::Deposit => RoleKey::new(DEPOSIT_ROLE),
-        ResourceAuth::Recall => RoleKey::new(RECALL_ROLE),
-    };
-
-    let builder = if lock {
-        builder.update_role_mutability(
-            token_address.into(),
-            role_key.clone(),
-            (RoleList::none(), false),
+    // Act 3 - After locking, now attempting to update the action or updater role should fail
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.action_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
         )
-    } else {
-        builder.update_role(token_address.into(), role_key, rule!(require(updated_auth)))
-    };
-
-    let manifest = builder
-        .call_method(
-            account,
-            "try_deposit_batch_or_abort",
-            manifest_args!(ManifestExpression::EntireWorktop),
+        .expect_auth_failure();
+    test_runner
+        .execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_proof_from_account(account, admin_auth)
+                .update_role(
+                    token_address.into(),
+                    action.updater_role_key(),
+                    rule!(require(admin_auth)),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&public_key)],
         )
-        .build();
-    let receipt = test_runner.execute_manifest(
-        manifest,
-        vec![NonFungibleGlobalId::from_public_key(&public_key)],
-    );
-
-    receipt
-}
-
-#[test]
-fn locked_mint_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Mint, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_mint_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Mint, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_burn_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Burn, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_burn_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Burn, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_withdraw_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Withdraw, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_withdraw_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Withdraw, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_deposit_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Deposit, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_deposit_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Deposit, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_recall_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Recall, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_recall_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::Recall, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_update_metadata_auth_cannot_be_updated() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::UpdateMetadata, false);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
-}
-
-#[test]
-fn locked_update_metadata_auth_cannot_be_relocked() {
-    let receipt = lock_resource_auth_and_try_update(ResourceAuth::UpdateMetadata, true);
-    // Assert
-    receipt.expect_specific_failure(|e| {
-        matches!(
-            e,
-            RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
-        )
-    })
+        .expect_auth_failure();
 }

--- a/radix-engine-tests/tests/auth_mutability.rs
+++ b/radix-engine-tests/tests/auth_mutability.rs
@@ -59,7 +59,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: ResourceMethodAuthKey
     let token_address = test_runner.create_everything_allowed_non_fungible_resource();
     let admin_auth = test_runner.create_non_fungible_resource(account);
 
-    // Act 1 - Show that updating the action auth is initially possible
+    // Act 1 - Show that updating both the action_role_key and updater_role_key is initially possible
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
@@ -69,14 +69,6 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: ResourceMethodAuthKey
                     action.action_role_key(),
                     rule!(require(admin_auth)),
                 )
-                .build(),
-            vec![NonFungibleGlobalId::from_public_key(&public_key)],
-        )
-        .expect_commit_success();
-    test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
-                .create_proof_from_account(account, admin_auth)
                 .update_role(
                     token_address.into(),
                     action.updater_role_key(),
@@ -97,14 +89,6 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: ResourceMethodAuthKey
                     action.action_role_key(),
                     rule!(require(admin_auth)),
                 )
-                .build(),
-            vec![NonFungibleGlobalId::from_public_key(&public_key)],
-        )
-        .expect_commit_success();
-    test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
-                .create_proof_from_account(account, admin_auth)
                 .update_role(
                     token_address.into(),
                     action.updater_role_key(),
@@ -115,7 +99,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: ResourceMethodAuthKey
         )
         .expect_commit_success();
 
-    // Arrange - We now use the updater role to update the updater role to DenyAll
+    // Arrange - We now use the updater role to update the updater role's rule to DenyAll
     {
         test_runner
             .execute_manifest_ignoring_fee(

--- a/radix-engine/src/blueprints/resource/resource_manager_common.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager_common.rs
@@ -32,11 +32,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 MINT_UPDATE_ROLE,
-                RoleEntry::new(mint_mutability, [MINT_UPDATE_ROLE], true),
+                RoleEntry::new(mint_mutability, [MINT_UPDATE_ROLE], false),
             );
             roles.define_role(
                 MINT_ROLE,
-                RoleEntry::new(mint_access_rule, [MINT_UPDATE_ROLE], true),
+                RoleEntry::new(mint_access_rule, [MINT_UPDATE_ROLE], false),
             );
         }
 
@@ -47,11 +47,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 BURN_UPDATE_ROLE,
-                RoleEntry::new(burn_mutability, [BURN_UPDATE_ROLE], true),
+                RoleEntry::new(burn_mutability, [BURN_UPDATE_ROLE], false),
             );
             roles.define_role(
                 BURN_ROLE,
-                RoleEntry::new(burn_access_rule, [BURN_UPDATE_ROLE], true),
+                RoleEntry::new(burn_access_rule, [BURN_UPDATE_ROLE], false),
             );
         }
 
@@ -66,7 +66,7 @@ fn build_access_rules(
                 RoleEntry::new(
                     update_non_fungible_data_mutability,
                     [UPDATE_NON_FUNGIBLE_DATA_UPDATE_ROLE],
-                    true,
+                    false,
                 ),
             );
 
@@ -75,7 +75,7 @@ fn build_access_rules(
                 RoleEntry::new(
                     update_non_fungible_data_access_rule,
                     [UPDATE_NON_FUNGIBLE_DATA_UPDATE_ROLE],
-                    true,
+                    false,
                 ),
             );
         }
@@ -87,7 +87,7 @@ fn build_access_rules(
         {
             roles.define_role(
                 SET_METADATA_UPDATE_ROLE,
-                RoleEntry::new(update_metadata_mutability, [SET_METADATA_UPDATE_ROLE], true),
+                RoleEntry::new(update_metadata_mutability, [SET_METADATA_UPDATE_ROLE], false),
             );
 
             roles.define_role(
@@ -95,7 +95,7 @@ fn build_access_rules(
                 RoleEntry::new(
                     update_metadata_access_rule,
                     [SET_METADATA_UPDATE_ROLE],
-                    true,
+                    false,
                 ),
             );
         }
@@ -107,11 +107,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 WITHDRAW_ROLE,
-                RoleEntry::new(withdraw_access_rule, [WITHDRAW_UPDATE_ROLE], true),
+                RoleEntry::new(withdraw_access_rule, [WITHDRAW_UPDATE_ROLE], false),
             );
             roles.define_role(
                 WITHDRAW_UPDATE_ROLE,
-                RoleEntry::new(withdraw_mutability, [WITHDRAW_UPDATE_ROLE], true),
+                RoleEntry::new(withdraw_mutability, [WITHDRAW_UPDATE_ROLE], false),
             );
         }
 
@@ -122,11 +122,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 RECALL_ROLE,
-                RoleEntry::new(recall_access_rule, [RECALL_UPDATE_ROLE], true),
+                RoleEntry::new(recall_access_rule, [RECALL_UPDATE_ROLE], false),
             );
             roles.define_role(
                 RECALL_UPDATE_ROLE,
-                RoleEntry::new(recall_mutability, [RECALL_UPDATE_ROLE], true),
+                RoleEntry::new(recall_mutability, [RECALL_UPDATE_ROLE], false),
             );
         }
 
@@ -137,11 +137,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 FREEZE_ROLE,
-                RoleEntry::new(freeze_access_rule, [FREEZE_UPDATE_ROLE], true),
+                RoleEntry::new(freeze_access_rule, [FREEZE_UPDATE_ROLE], false),
             );
             roles.define_role(
                 FREEZE_UPDATE_ROLE,
-                RoleEntry::new(freeze_mutability, [FREEZE_UPDATE_ROLE], true),
+                RoleEntry::new(freeze_mutability, [FREEZE_UPDATE_ROLE], false),
             );
         }
 
@@ -152,11 +152,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 UNFREEZE_ROLE,
-                RoleEntry::new(unfreeze_access_rule, [UNFREEZE_UPDATE_ROLE], true),
+                RoleEntry::new(unfreeze_access_rule, [UNFREEZE_UPDATE_ROLE], false),
             );
             roles.define_role(
                 UNFREEZE_UPDATE_ROLE,
-                RoleEntry::new(unfreeze_mutability, [UNFREEZE_UPDATE_ROLE], true),
+                RoleEntry::new(unfreeze_mutability, [UNFREEZE_UPDATE_ROLE], false),
             );
         }
 
@@ -167,11 +167,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 DEPOSIT_ROLE,
-                RoleEntry::new(deposit_access_rule, [DEPOSIT_UPDATE_ROLE], true),
+                RoleEntry::new(deposit_access_rule, [DEPOSIT_UPDATE_ROLE], false),
             );
             roles.define_role(
                 DEPOSIT_UPDATE_ROLE,
-                RoleEntry::new(deposit_mutability, [DEPOSIT_UPDATE_ROLE], true),
+                RoleEntry::new(deposit_mutability, [DEPOSIT_UPDATE_ROLE], false),
             );
         }
     }

--- a/radix-engine/src/blueprints/resource/resource_manager_common.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager_common.rs
@@ -87,7 +87,11 @@ fn build_access_rules(
         {
             roles.define_role(
                 SET_METADATA_UPDATE_ROLE,
-                RoleEntry::new(update_metadata_mutability, [SET_METADATA_UPDATE_ROLE], false),
+                RoleEntry::new(
+                    update_metadata_mutability,
+                    [SET_METADATA_UPDATE_ROLE],
+                    false,
+                ),
             );
 
             roles.define_role(

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -335,6 +335,15 @@ impl TransactionReceipt {
             );
         }
     }
+
+    pub fn expect_auth_failure(&self) {
+        self.expect_specific_failure(|e| {
+            matches!(
+                e,
+                RuntimeError::SystemModuleError(SystemModuleError::AuthError(..))
+            )
+        })
+    }
 }
 
 macro_rules! prefix {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -1094,6 +1094,28 @@ impl TestRunner {
         )
     }
 
+    pub fn create_everything_allowed_non_fungible_resource(&mut self) -> ResourceAddress {
+        let mut access_rules: BTreeMap<ResourceMethodAuthKey, (AccessRule, AccessRule)> =
+            BTreeMap::new();
+        for key in ALL_RESOURCE_AUTH_KEYS {
+            access_rules.insert(key, (rule!(allow_all), rule!(allow_all)));
+        }
+
+        let receipt = self.execute_manifest_ignoring_fee(
+            ManifestBuilder::new()
+                .create_non_fungible_resource::<_, Vec<_>, ()>(
+                    NonFungibleIdType::Integer,
+                    false,
+                    BTreeMap::new(),
+                    access_rules,
+                    None,
+                )
+                .build(),
+            vec![],
+        );
+        receipt.expect_commit(true).new_resource_addresses()[0]
+    }
+
     pub fn create_freezeable_token(&mut self, account: ComponentAddress) -> ResourceAddress {
         let mut access_rules = BTreeMap::new();
         access_rules.insert(Withdraw, (rule!(allow_all), LOCKED));


### PR DESCRIPTION
## Summary
Previously the `RoleEntry`s on the resource manager were set to "mutable mutable". This meant that you could change eg the `MINT_ROLE` to be updatable by the `BURN_ROLE` instead of by the `MINT_UPDATE_ROLE`.

This breaks common sense / invariants that callers would expect.

So this PR disables the `mutable mutable` flag, and updates the relevant tests.