### PR TITLE
Feature: distribute fees and tips to validators

### DIFF
--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "utils",
  "wasm-instrument",
  "wasmi",
- "wasmi-validation",
+ "wasmparser-nostd 0.100.1",
 ]
 
 [[package]]
@@ -1334,16 +1334,7 @@ dependencies = [
  "spin",
  "wasmi_arena",
  "wasmi_core",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
-dependencies = [
- "parity-wasm",
+ "wasmparser-nostd 0.91.0",
 ]
 
 [[package]]
@@ -1367,6 +1358,15 @@ name = "wasmparser-nostd"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+dependencies = [
+ "indexmap-nostd",
+]
+
+[[package]]
+name = "wasmparser-nostd"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
 dependencies = [
  "indexmap-nostd",
 ]

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -97,3 +97,9 @@ pub const DEFAULT_MAX_SUBSTATE_SIZE: usize = 4 * 1024 * 1024;
 
 /// The default maximum invoke input args size.
 pub const DEFAULT_MAX_INVOKE_INPUT_SIZE: usize = 4 * 1024 * 1024;
+
+/* Fees/tips distribution */
+pub const TIPS_PROPOSER_SHARE_PERCENTAGE: u8 = 100;
+pub const TIPS_VALIDATOR_SET_SHARE_PERCENTAGE: u8 = 0;
+pub const FEES_PROPOSER_SHARE_PERCENTAGE: u8 = 25;
+pub const FEES_VALIDATOR_SET_SHARE_PERCENTAGE: u8 = 25;

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -21,6 +21,7 @@ pub struct ConsensusManagerCreateInput {
     pub initial_epoch: Epoch,
     pub initial_config: ConsensusManagerConfig,
     pub initial_time_ms: i64,
+    pub initial_current_leader: Option<ValidatorIndex>,
 }
 
 #[derive(Debug, Eq, PartialEq, ManifestSbor)]
@@ -30,6 +31,7 @@ pub struct ConsensusManagerCreateManifestInput {
     pub initial_epoch: Epoch,
     pub initial_config: ConsensusManagerConfig,
     pub initial_time_ms: i64,
+    pub initial_current_leader: Option<ValidatorIndex>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -346,6 +346,18 @@ pub struct ValidatorApplyEmissionInput {
 
 pub type ValidatorApplyEmissionOutput = ();
 
+pub const VALIDATOR_APPLY_REWARD_IDENT: &str = "apply_reward";
+
+#[derive(Debug, Eq, PartialEq, ScryptoSbor)]
+pub struct ValidatorApplyRewardInput {
+    /// A bucket with the rewarded XRDs (from transaction fees) for this validator.
+    pub xrd_bucket: Bucket,
+    /// The *concluded* epoch's number. Informational-only.
+    pub epoch: Epoch,
+}
+
+pub type ValidatorApplyRewardOutput = ();
+
 pub const VALIDATOR_LOCK_OWNER_STAKE_UNITS_IDENT: &str = "lock_owner_stake_units";
 
 #[derive(Debug, Eq, PartialEq, ScryptoSbor)]

--- a/radix-engine-interface/src/types/node_layout.rs
+++ b/radix-engine-interface/src/types/node_layout.rs
@@ -126,6 +126,7 @@ impl TryFrom<u8> for ConsensusManagerPartitionOffset {
 pub enum ConsensusManagerField {
     Config,
     ConsensusManager,
+    ValidatorRewards,
     CurrentValidatorSet,
     CurrentProposalStatistic,
     CurrentTimeRoundedToMinutes,

--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -398,6 +398,7 @@ pub enum TypedNonFungibleVaultFieldValue {
 pub enum TypedConsensusManagerFieldValue {
     Config(ConsensusManagerConfigSubstate),
     ConsensusManager(ConsensusManagerSubstate),
+    ValidatorRewards(ValidatorRewardsSubstate),
     CurrentValidatorSet(CurrentValidatorSetSubstate),
     CurrentProposalStatistic(CurrentProposalStatisticSubstate),
     CurrentTimeRoundedToMinutes(ProposerMinuteTimestampSubstate),
@@ -565,6 +566,9 @@ fn to_typed_object_substate_value(
                 }
                 ConsensusManagerField::ConsensusManager => {
                     TypedConsensusManagerFieldValue::ConsensusManager(scrypto_decode(data)?)
+                }
+                ConsensusManagerField::ValidatorRewards => {
+                    TypedConsensusManagerFieldValue::ValidatorRewards(scrypto_decode(data)?)
                 }
                 ConsensusManagerField::CurrentValidatorSet => {
                     TypedConsensusManagerFieldValue::CurrentValidatorSet(scrypto_decode(data)?)

--- a/radix-engine-tests/tests/balance_changes.rs
+++ b/radix-engine-tests/tests/balance_changes.rs
@@ -76,6 +76,9 @@ fn test_balance_changes_when_success() {
             ),
             account.into() => indexmap!(
                 RADIX_TOKEN => BalanceChange::Fungible(dec!("-1"))
+            ),
+            CONSENSUS_MANAGER.into() => indexmap!(
+                RADIX_TOKEN => BalanceChange::Fungible(result.fee_summary.expected_reward_if_single_validator())
             )
         )
     );
@@ -146,6 +149,9 @@ fn test_balance_changes_when_failure() {
         &indexmap!(
             test_runner.faucet_component().into() => indexmap!(
                 RADIX_TOKEN => BalanceChange::Fungible(-(result.fee_summary.total_execution_cost_xrd + result.fee_summary.total_royalty_cost_xrd))
+            ),
+            CONSENSUS_MANAGER.into() => indexmap!(
+                RADIX_TOKEN => BalanceChange::Fungible(result.fee_summary.expected_reward_if_single_validator())
             )
         )
     )
@@ -188,6 +194,9 @@ fn test_balance_changes_when_recall() {
             other_account.into() => indexmap!(
                 recallable_token => BalanceChange::Fungible(dec!("1"))
             ),
+            CONSENSUS_MANAGER.into() => indexmap!(
+                RADIX_TOKEN => BalanceChange::Fungible(result.fee_summary.expected_reward_if_single_validator())
+            )
         )
     );
     assert_eq!(
@@ -234,7 +243,8 @@ fn test_balance_changes_when_transferring_non_fungibles() {
         hashset![
             account.into(),
             other_account.into(),
-            test_runner.faucet_component().into()
+            test_runner.faucet_component().into(),
+            CONSENSUS_MANAGER.into(),
         ]
     );
 
@@ -257,7 +267,9 @@ fn test_balance_changes_when_transferring_non_fungibles() {
         result.fee_summary.total_execution_cost_xrd + result.fee_summary.total_royalty_cost_xrd;
     assert_eq!(
         faucet_changes,
-        &indexmap!(RADIX_TOKEN => BalanceChange::Fungible(-total_cost_xrd)),
+        &indexmap!(
+            RADIX_TOKEN => BalanceChange::Fungible(-total_cost_xrd),
+        ),
     );
 
     assert!(result.direct_vault_updates().is_empty())

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -51,6 +51,7 @@ fn test_bootstrap_receipt_should_match_constants() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             1,
+            Some(0),
         )
         .unwrap();
 
@@ -107,6 +108,7 @@ fn test_bootstrap_receipt_should_have_substate_changes_which_can_be_typed() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             1,
+            Some(0),
         )
         .unwrap();
 
@@ -166,6 +168,7 @@ fn test_genesis_xrd_allocation_to_accounts() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             1,
+            Some(0),
         )
         .unwrap();
 
@@ -233,6 +236,7 @@ fn test_genesis_resource_with_initial_allocation() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             1,
+            Some(0),
         )
         .unwrap();
 
@@ -351,6 +355,7 @@ fn test_genesis_stake_allocation() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             1,
+            Some(0),
         )
         .unwrap();
 
@@ -436,6 +441,7 @@ fn test_genesis_time() {
             Epoch::of(1),
             CustomGenesis::default_consensus_manager_config(),
             123 * 60 * 1000 + 22, // 123 full minutes + 22 ms (which should be rounded down)
+            Some(0),
         )
         .unwrap();
 

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -2256,7 +2256,11 @@ fn unstaked_validator_gets_less_stake_on_epoch_change() {
             .get(&validator_address)
             .unwrap()
             .stake,
-        Decimal::from(9) + result1.fee_summary.expected_reward_if_single_validator()
+        // The validator isn't eligible for the validator set rewards because it's `reliability_factor` is zero.
+        Decimal::from(9)
+            + result1
+                .fee_summary
+                .expected_reward_as_proposer_if_single_validator()
     );
 }
 

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -78,6 +78,7 @@ fn genesis_epoch_has_correct_initial_validators() {
         initial_config: CustomGenesis::default_consensus_manager_config()
             .with_max_validators(max_validators),
         initial_time_ms: 1,
+        initial_current_leader: Some(0),
     };
 
     // Act
@@ -579,6 +580,7 @@ fn validator_set_receives_emissions_proportional_to_stake_on_epoch_change() {
             })
             .with_total_emission_xrd_per_epoch(epoch_emissions_xrd),
         initial_time_ms: 1,
+        initial_current_leader: Some(0),
     };
 
     // Act
@@ -818,6 +820,14 @@ fn validator_receives_no_emission_when_too_many_proposals_missed() {
     );
 }
 
+macro_rules! assert_close_to {
+    ($a:expr, $b:expr) => {
+        if ($a - $b).abs() > dec!("0.0001") {
+            panic!("{} is not close to {}", $a, $b);
+        }
+    };
+}
+
 #[test]
 fn decreasing_validator_fee_takes_effect_during_next_epoch() {
     // Arrange
@@ -853,20 +863,19 @@ fn decreasing_validator_fee_takes_effect_during_next_epoch() {
             manifest_args!(next_epoch_fee_factor),
         )
         .build();
-    test_runner
-        .execute_manifest(
-            manifest,
-            vec![NonFungibleGlobalId::from_public_key(&validator_key)],
-        )
-        .expect_commit_success();
+    let receipt1 = test_runner.execute_manifest(
+        manifest,
+        vec![NonFungibleGlobalId::from_public_key(&validator_key)],
+    );
+    let result1 = receipt1.expect_commit_success();
 
     // Act: change epoch
-    let receipt = test_runner.advance_to_round(Round::of(1));
+    let receipt2 = test_runner.advance_to_round(Round::of(1));
 
     // Assert: no change yet (the default `fee_factor = 1.0` was effective during that epoch)
-    let result = receipt.expect_commit_success();
+    let result2 = receipt2.expect_commit_success();
     assert_eq!(
-        test_runner.extract_events_of_type::<ValidatorEmissionAppliedEvent>(result),
+        test_runner.extract_events_of_type::<ValidatorEmissionAppliedEvent>(result2),
         vec![ValidatorEmissionAppliedEvent {
             epoch: initial_epoch,
             starting_stake_pool_xrd: initial_stake_amount,
@@ -877,52 +886,62 @@ fn decreasing_validator_fee_takes_effect_during_next_epoch() {
             proposals_missed: 0,
         },]
     );
-    let first_epoch_fee_xrd = emission_xrd_per_epoch; // the entire emission was raked...
+    let emission_and_tx1_rewards =
+        emission_xrd_per_epoch + result1.fee_summary.expected_reward_if_single_validator();
     let validator_substate = test_runner.get_active_validator_info_by_key(&validator_key);
-    assert_eq!(
-        test_runner.inspect_vault_balance(validator_substate.stake_xrd_vault_id.0),
-        Some(initial_stake_amount + first_epoch_fee_xrd) // ... and it also was auto-staked...
+    assert_close_to!(
+        test_runner
+            .inspect_vault_balance(validator_substate.stake_xrd_vault_id.0)
+            .unwrap(),
+        initial_stake_amount + emission_and_tx1_rewards
     );
-    assert_eq!(
-        test_runner.inspect_vault_balance(validator_substate.locked_owner_stake_unit_vault_id.0),
-        Some(first_epoch_fee_xrd) // ... and locked in the internal owner's vault
+    assert_close_to!(
+        test_runner
+            .inspect_vault_balance(validator_substate.locked_owner_stake_unit_vault_id.0)
+            .unwrap(),
+        emission_and_tx1_rewards
     );
 
     // Act: change epoch
-    let receipt = test_runner.advance_to_round(Round::of(1));
+    let receipt3 = test_runner.advance_to_round(Round::of(1));
 
     // Assert: during that next epoch, the `next_epoch_fee_factor` was already effective
-    let result = receipt.expect_commit_success();
-    let next_epoch_start_stake_xrd = initial_stake_amount + emission_xrd_per_epoch;
+    let result3 = receipt3.expect_commit_success();
+    let next_epoch_start_stake_xrd = initial_stake_amount + emission_and_tx1_rewards;
     let next_epoch_fee_xrd = emission_xrd_per_epoch * next_epoch_fee_factor;
     let next_epoch_net_emission_xrd = emission_xrd_per_epoch - next_epoch_fee_xrd;
-    assert_eq!(
-        test_runner.extract_events_of_type::<ValidatorEmissionAppliedEvent>(result),
-        vec![ValidatorEmissionAppliedEvent {
-            epoch: initial_epoch.next(),
-            starting_stake_pool_xrd: next_epoch_start_stake_xrd,
-            stake_pool_added_xrd: next_epoch_net_emission_xrd,
-            total_stake_unit_supply: next_epoch_start_stake_xrd, // we auto-staked 100%, so the rate is still 1:1
-            validator_fee_xrd: next_epoch_fee_xrd,
-            proposals_made: 1,
-            proposals_missed: 0,
-        },]
-    );
+    let event = test_runner
+        .extract_events_of_type::<ValidatorEmissionAppliedEvent>(result3)
+        .pop()
+        .unwrap();
+    assert_eq!(event.epoch, initial_epoch.next());
+    assert_close_to!(event.starting_stake_pool_xrd, next_epoch_start_stake_xrd);
+    assert_close_to!(event.stake_pool_added_xrd, next_epoch_net_emission_xrd);
+    assert_close_to!(event.total_stake_unit_supply, next_epoch_start_stake_xrd); // we auto-staked 100%, so the rate is still 1 ,1
+    assert_close_to!(event.validator_fee_xrd, next_epoch_fee_xrd);
+    assert_eq!(event.proposals_made, 1);
+    assert_eq!(event.proposals_missed, 0,);
+
     let validator_substate = test_runner.get_active_validator_info_by_key(&validator_key);
-    assert_eq!(
-        test_runner.inspect_vault_balance(validator_substate.stake_xrd_vault_id.0),
-        Some(initial_stake_amount + dec!("2") * emission_xrd_per_epoch) // everything still goes into stake, by various means
+    assert_close_to!(
+        test_runner
+            .inspect_vault_balance(validator_substate.stake_xrd_vault_id.0)
+            .unwrap(),
+        initial_stake_amount
+            + result1.fee_summary.expected_reward_if_single_validator()
+            + result2.fee_summary.expected_reward_if_single_validator()
+            + dec!("2") * emission_xrd_per_epoch // everything still goes into stake, by various means
     );
     // the new fee goes into internal owner's vault (as stake units)
-    let stake_unit_exchange_rate =
-        next_epoch_start_stake_xrd / (next_epoch_start_stake_xrd + next_epoch_net_emission_xrd);
-    assert_eq!(
-        precise_enough(
-            test_runner
-                .inspect_vault_balance(validator_substate.locked_owner_stake_unit_vault_id.0)
-                .unwrap()
-        ),
-        precise_enough(first_epoch_fee_xrd + next_epoch_fee_xrd * stake_unit_exchange_rate)
+    let stake_unit_exchange_rate = event.starting_stake_pool_xrd
+        / (event.starting_stake_pool_xrd + next_epoch_net_emission_xrd);
+    assert_close_to!(
+        test_runner
+            .inspect_vault_balance(validator_substate.locked_owner_stake_unit_vault_id.0)
+            .unwrap(),
+        emission_and_tx1_rewards
+            + (result2.fee_summary.expected_reward_if_single_validator() + next_epoch_fee_xrd)
+                * stake_unit_exchange_rate
     );
 }
 
@@ -958,7 +977,10 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
         .0;
 
     // we have to first request some fee decrease...
-    test_runner
+    let mut total_rewards = Decimal::ZERO;
+    let mut last_reward;
+
+    last_reward = test_runner
         .execute_manifest(
             ManifestBuilder::new()
                 .lock_fee(test_runner.faucet_component(), 10.into())
@@ -971,16 +993,22 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&validator_key)],
         )
-        .expect_commit_success();
+        .expect_commit_success()
+        .fee_summary
+        .expected_reward_if_single_validator();
+    total_rewards += last_reward;
 
     // ... and wait 1 epoch to make it effective
-    test_runner
+    last_reward = test_runner
         .advance_to_round(Round::of(1))
-        .expect_commit_success();
+        .expect_commit_success()
+        .fee_summary
+        .expected_reward_if_single_validator();
+    total_rewards += last_reward;
     let current_epoch = initial_epoch.next();
 
     // Act: request the fee increase
-    test_runner
+    last_reward = test_runner
         .execute_manifest(
             ManifestBuilder::new()
                 .lock_fee(test_runner.faucet_component(), 10.into())
@@ -993,29 +1021,32 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&validator_key)],
         )
-        .expect_commit_success();
+        .expect_commit_success()
+        .fee_summary
+        .expected_reward_if_single_validator();
+    total_rewards += last_reward;
     let increase_effective_at_epoch = current_epoch.after(fee_increase_delay_epochs);
 
     // advance a few epochs (just 1 short of the increase being effective)
     // Note: we deliberately do not use `set_current_epoch()`, since we want the "next epoch" engine logic to execute
     for _ in current_epoch.number()..increase_effective_at_epoch.number() {
-        test_runner
+        last_reward = test_runner
             .advance_to_round(Round::of(1))
-            .expect_commit_success();
+            .expect_commit_success()
+            .fee_summary
+            .expected_reward_if_single_validator();
+        total_rewards += last_reward;
     }
 
     // Assert: no change yet (the default `fee_factor = 1.0` was effective during all these epochs)
     let num_epochs_with_default_fee = increase_effective_at_epoch.number() - initial_epoch.number();
-    assert_eq!(
-        precise_enough(
-            test_runner
-                .inspect_vault_balance(stake_xrd_vault_id)
-                .unwrap()
-        ),
-        precise_enough(
-            initial_stake_amount
-                + Decimal::from(num_epochs_with_default_fee) * emission_xrd_per_epoch
-        )
+    let starting_stake_pool = test_runner
+        .inspect_vault_balance(stake_xrd_vault_id)
+        .unwrap();
+    assert_close_to!(
+        starting_stake_pool,
+        initial_stake_amount + total_rewards - last_reward
+            + Decimal::from(num_epochs_with_default_fee) * emission_xrd_per_epoch
     );
 
     // Act: advance one more epoch
@@ -1023,36 +1054,23 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
 
     // Assert: during that next epoch, the `increased_fee_factor` was already effective
     let result = receipt.expect_commit_success();
+    last_reward = result.fee_summary.expected_reward_if_single_validator();
+    total_rewards += last_reward;
     let event = test_runner
         .extract_events_of_type::<ValidatorEmissionAppliedEvent>(result)
         .remove(0);
-    let rounded_amounts_event = ValidatorEmissionAppliedEvent {
-        epoch: event.epoch,
-        starting_stake_pool_xrd: precise_enough(event.starting_stake_pool_xrd),
-        stake_pool_added_xrd: precise_enough(event.stake_pool_added_xrd),
-        total_stake_unit_supply: precise_enough(event.total_stake_unit_supply),
-        validator_fee_xrd: precise_enough(event.validator_fee_xrd),
-        proposals_made: event.proposals_made,
-        proposals_missed: event.proposals_missed,
-    };
-    assert_eq!(
-        rounded_amounts_event,
-        ValidatorEmissionAppliedEvent {
-            epoch: increase_effective_at_epoch,
-            starting_stake_pool_xrd: precise_enough(
-                initial_stake_amount
-                    + Decimal::from(num_epochs_with_default_fee) * emission_xrd_per_epoch
-            ),
-            stake_pool_added_xrd: precise_enough(
-                emission_xrd_per_epoch * (Decimal::one() - increased_fee_factor)
-            ),
-            // note: we staked (i.e. minted stake units) only during the first round; later a fee of 0% was effective, until now
-            total_stake_unit_supply: precise_enough(initial_stake_amount + emission_xrd_per_epoch),
-            validator_fee_xrd: precise_enough(emission_xrd_per_epoch * increased_fee_factor),
-            proposals_made: 1,
-            proposals_missed: 0,
-        }
+    assert_eq!(event.epoch, increase_effective_at_epoch);
+    assert_close_to!(event.starting_stake_pool_xrd, starting_stake_pool);
+    assert_close_to!(
+        event.stake_pool_added_xrd,
+        emission_xrd_per_epoch * (Decimal::one() - increased_fee_factor)
     );
+    assert_close_to!(
+        event.validator_fee_xrd,
+        emission_xrd_per_epoch * increased_fee_factor
+    );
+    assert_eq!(event.proposals_made, 1);
+    assert_eq!(event.proposals_missed, 0);
 }
 
 fn create_custom_genesis(
@@ -1126,6 +1144,7 @@ fn create_custom_genesis(
                 target_duration_millis: 0,
             }),
         initial_time_ms: 1,
+        initial_current_leader: Some(0),
     };
 
     (genesis, pub_key_accounts)
@@ -2217,29 +2236,27 @@ fn unstaked_validator_gets_less_stake_on_epoch_change() {
             manifest_args!(ManifestExpression::EntireWorktop),
         )
         .build();
-    let receipt = test_runner.execute_manifest(
+    let receipt1 = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&account_pub_key)],
     );
-    receipt.expect_commit_success();
+    let result1 = receipt1.expect_commit_success();
 
     // Act
-    let receipt = test_runner.advance_to_round(Round::of(rounds_per_epoch));
+    let receipt2 = test_runner.advance_to_round(Round::of(rounds_per_epoch));
 
     // Assert
-    let result = receipt.expect_commit_success();
-    let next_epoch = result.next_epoch().expect("Should have next epoch");
+    let result2 = receipt2.expect_commit_success();
+    let next_epoch = result2.next_epoch().expect("Should have next epoch");
     assert_eq!(next_epoch.epoch, initial_epoch.next());
-    assert_eq!(
+    assert_close_to!(
         next_epoch
             .validator_set
             .validators_by_stake_desc
             .get(&validator_address)
-            .unwrap(),
-        &Validator {
-            key: validator_pub_key,
-            stake: Decimal::from(9),
-        }
+            .unwrap()
+            .stake,
+        Decimal::from(9) + result1.fee_summary.expected_reward_if_single_validator()
     );
 }
 
@@ -2323,6 +2340,7 @@ fn consensus_manager_create_should_succeed_with_system_privilege() {
                 initial_epoch: Epoch::of(1),
                 initial_config: CustomGenesis::default_consensus_manager_config(),
                 initial_time_ms: 120000i64,
+                initial_current_leader: Some(0),
             }),
         }],
         btreeset![AuthAddresses::system_role()],
@@ -2339,10 +2357,4 @@ fn extract_emitter_node_id(event_type_id: &EventTypeIdentifier) -> NodeId {
         Emitter::Method(node_id, _) => node_id,
     }
     .clone()
-}
-
-/// Applies an arbitrary rounding of the given decimal, so that simple `==` comparison is meaningful
-/// enough for test purposes.
-fn precise_enough(exact: Decimal) -> Decimal {
-    exact.round(15, RoundingMode::AwayFromZero)
 }

--- a/radix-engine-tests/tests/wasm_non_mvp.rs
+++ b/radix-engine-tests/tests/wasm_non_mvp.rs
@@ -29,6 +29,8 @@ macro_rules! assert_sign_extensions {
                         .replace("${value_kind}", &value_kind)
                         .replace("${slice_len}", &slice_len));
 
+                assert!(WasmModule::init(&code).unwrap().contains_sign_ext_ops());
+
                 let mut test_runner = TestRunner::builder().build();
                 let package_address = test_runner.publish_package(
                     code,
@@ -55,14 +57,6 @@ assert_sign_extensions!(i32, "extend16_s", 0x44332211, 0x2211);
 assert_sign_extensions!(i64, "extend8_s", 0x665544332211, 0x11);
 assert_sign_extensions!(i64, "extend16_s", 0x665544332211, 0x2211);
 assert_sign_extensions!(i64, "extend32_s", 0x665544332211, 0x44332211);
-
-#[test]
-fn test_wasm_non_mvp_expect_sign_ext_from_rust_code() {
-    // Arrange
-    let (code, _) = Compile::compile("./tests/blueprints/wasm_non_mvp");
-
-    assert!(WasmModule::init(&code).unwrap().contains_sign_ext_ops())
-}
 
 #[test]
 fn test_wasm_non_mvp_mutable_globals_import() {

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -755,7 +755,7 @@ impl ConsensusManagerBlueprint {
             let reward_amount = from_pool + from_self;
 
             // Note that dusted xrd (due to rounding) are kept in the vault and will
-            // become retrievable next epoch.
+            // become retrievable next time.
             let xrd_bucket = validator_rewards.rewards_vault.take(reward_amount, api)?;
 
             api.call_method(

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -45,6 +45,22 @@ pub struct CurrentValidatorSetSubstate {
     pub validator_set: ActiveValidatorSet,
 }
 
+#[derive(Debug, PartialEq, Eq, ScryptoSbor)]
+pub struct ValidatorRewardsSubstate {
+    /// Transaction fees that are awarded to individual validators.
+    pub individual_validator_rewards: BTreeMap<ComponentAddress, Vault>,
+    /// Transaction fees that are distributed to the active validator set.
+    pub shared_validator_rewards: Vault,
+    /// At the end of a notarized transaction, the proposer portion of transaction fees is temporarily
+    /// accounted here and moved to `individual_validator_rewards` at `next_round` time.
+    ///
+    /// ```text
+    /// Tips: 100% proposer
+    /// Fees: 25% proposer, 25% validator set, 50% burnt
+    /// ```
+    pub proposer_rewards: Vault,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 #[sbor(transparent)]
 pub struct ActiveValidatorSet {

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -240,7 +240,7 @@ impl ConsensusManagerBlueprint {
                 current_leader: initial_current_leader,
             };
             let validator_rewards = ValidatorRewardsSubstate {
-                proposer_rewards: IndexMap::new(),
+                proposer_rewards: index_map_new(),
                 rewards_vault: Vault::create(RADIX_TOKEN, api)?,
             };
             let current_validator_set = CurrentValidatorSetSubstate {

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -758,6 +758,9 @@ impl ConsensusManagerBlueprint {
                 .unwrap_or_default();
             let from_pool = validator_info.effective_stake_xrd * reward_per_staked_xrd;
             let reward_amount = from_self + from_pool;
+            if reward_amount.is_zero() {
+                continue;
+            }
 
             // Note that dusted xrd (due to rounding) are kept in the vault and will
             // become retrievable next time.

--- a/radix-engine/src/blueprints/consensus_manager/events/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/events/validator.rs
@@ -57,3 +57,11 @@ pub struct ValidatorEmissionAppliedEvent {
     /// A number of proposals missed by this validator during the emission period.
     pub proposals_missed: u64,
 }
+
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
+pub struct ValidatorRewardAppliedEvent {
+    /// An epoch number of the *concluded* epoch (i.e. for which this reward applies).
+    pub epoch: Epoch,
+    /// The reward amount
+    pub amount: Decimal,
+}

--- a/radix-engine/src/blueprints/consensus_manager/package.rs
+++ b/radix-engine/src/blueprints/consensus_manager/package.rs
@@ -42,6 +42,9 @@ impl ConsensusManagerNativePackage {
             aggregator.add_child_type_and_descendents::<ConsensusManagerSubstate>(),
         ));
         fields.push(FieldSchema::normal(
+            aggregator.add_child_type_and_descendents::<ValidatorRewardsSubstate>(),
+        ));
+        fields.push(FieldSchema::normal(
             aggregator.add_child_type_and_descendents::<CurrentValidatorSetSubstate>(),
         ));
         fields.push(FieldSchema::normal(

--- a/radix-engine/src/blueprints/consensus_manager/package.rs
+++ b/radix-engine/src/blueprints/consensus_manager/package.rs
@@ -399,6 +399,7 @@ impl ConsensusManagerNativePackage {
                     input.initial_epoch,
                     input.initial_config,
                     input.initial_time_ms,
+                    input.initial_current_leader,
                     api,
                 )?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -830,11 +830,10 @@ impl ValidatorBlueprint {
         let mut stake_xrd_vault = Vault(substate.stake_xrd_vault_id);
         let starting_stake_pool_xrd = stake_xrd_vault.amount(api)?;
         let mut stake_unit_resman = ResourceManager(substate.stake_unit_resource);
-        let post_reward_stake_pool_xrd = starting_stake_pool_xrd + total_reward_xrd;
         let total_stake_unit_supply = stake_unit_resman.total_supply(api)?.unwrap();
         let stake_unit_mint_amount = Self::calculate_stake_unit_amount(
             total_reward_xrd,
-            post_reward_stake_pool_xrd,
+            starting_stake_pool_xrd,
             total_stake_unit_supply,
         );
         let new_stake_unit_bucket = stake_unit_resman.mint_fungible(stake_unit_mint_amount, api)?;

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -229,6 +229,9 @@ pub enum SystemError {
     BlueprintDoesNotExist(BlueprintId),
     InvalidDropNodeAccess(Box<InvalidDropNodeAccess>),
     InvalidScryptoValue(DecodeError),
+    CostingModuleNotEnabled,
+    AuthModuleNotEnabled,
+    TransactionRuntimeModuleNotEnabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -200,6 +200,7 @@ where
                 num_fee_increase_delay_epochs: 1,
             },
             1,
+            Some(0),
         )
     }
 
@@ -209,6 +210,7 @@ where
         initial_epoch: Epoch,
         initial_config: ConsensusManagerConfig,
         initial_time_ms: i64,
+        initial_current_leader: Option<ValidatorIndex>,
     ) -> Option<GenesisReceipts> {
         let xrd_info = self
             .substate_db
@@ -219,8 +221,12 @@ where
             );
 
         if xrd_info.is_none() {
-            let system_bootstrap_receipt =
-                self.execute_system_bootstrap(initial_epoch, initial_config, initial_time_ms);
+            let system_bootstrap_receipt = self.execute_system_bootstrap(
+                initial_epoch,
+                initial_config,
+                initial_time_ms,
+                initial_current_leader,
+            );
 
             let mut data_ingestion_receipts = vec![];
             for (chunk_index, chunk) in genesis_data_chunks.into_iter().enumerate() {
@@ -245,9 +251,14 @@ where
         initial_epoch: Epoch,
         initial_config: ConsensusManagerConfig,
         initial_time_ms: i64,
+        initial_current_leader: Option<ValidatorIndex>,
     ) -> TransactionReceipt {
-        let transaction =
-            create_system_bootstrap_transaction(initial_epoch, initial_config, initial_time_ms);
+        let transaction = create_system_bootstrap_transaction(
+            initial_epoch,
+            initial_config,
+            initial_time_ms,
+            initial_current_leader,
+        );
 
         let receipt = execute_transaction(
             self.substate_db,
@@ -319,6 +330,7 @@ pub fn create_system_bootstrap_transaction(
     initial_epoch: Epoch,
     initial_config: ConsensusManagerConfig,
     initial_time_ms: i64,
+    initial_current_leader: Option<ValidatorIndex>,
 ) -> SystemTransactionV1 {
     // NOTES
     // * Create resources before packages to avoid circular dependencies.
@@ -867,6 +879,7 @@ pub fn create_system_bootstrap_transaction(
                 initial_epoch,
                 initial_config,
                 initial_time_ms,
+                initial_current_leader,
             }),
         });
     }

--- a/radix-engine/src/system/module_mixer.rs
+++ b/radix-engine/src/system/module_mixer.rs
@@ -83,21 +83,25 @@ impl EnabledModules {
     }
 }
 
+// TODO: use option instead of defaults?
+#[allow(dead_code)]
 pub struct SystemModuleMixer {
     /* flags */
-    pub enabled_modules: EnabledModules,
+    // TODO: check if the original assumption is still true.
+    // The reason for using bit flags, rather than Option<T>, was to improve method dispatching performance.
+    enabled_modules: EnabledModules,
 
     /* states */
-    pub kernel_trace: KernelDebugModule,
-    pub costing: CostingModule,
-    pub node_move: NodeMoveModule,
-    pub auth: AuthModule,
-    pub logger: LoggerModule,
-    pub transaction_runtime: TransactionRuntimeModule,
-    pub execution_trace: ExecutionTraceModule,
-    pub transaction_limits: TransactionLimitsModule,
-    pub events: EventsModule,
-    pub virtualization: VirtualizationModule,
+    kernel_trace: KernelDebugModule,
+    costing: CostingModule,
+    node_move: NodeMoveModule,
+    auth: AuthModule,
+    logger: LoggerModule,
+    transaction_runtime: TransactionRuntimeModule,
+    execution_trace: ExecutionTraceModule,
+    transaction_limits: TransactionLimitsModule,
+    events: EventsModule,
+    virtualization: VirtualizationModule,
 }
 
 // Macro generates default modules dispatches call based on passed function name and arguments.
@@ -181,6 +185,89 @@ impl SystemModuleMixer {
             events: EventsModule::default(),
             virtualization: VirtualizationModule,
         }
+    }
+
+    pub fn costing_module(&mut self) -> Option<&mut CostingModule> {
+        if self.enabled_modules.contains(EnabledModules::COSTING) {
+            Some(&mut self.costing)
+        } else {
+            None
+        }
+    }
+
+    pub fn events_module(&mut self) -> Option<&mut EventsModule> {
+        if self.enabled_modules.contains(EnabledModules::EVENTS) {
+            Some(&mut self.events)
+        } else {
+            None
+        }
+    }
+
+    pub fn logger_module(&mut self) -> Option<&mut LoggerModule> {
+        if self.enabled_modules.contains(EnabledModules::LOGGER) {
+            Some(&mut self.logger)
+        } else {
+            None
+        }
+    }
+
+    pub fn auth_module(&mut self) -> Option<&mut AuthModule> {
+        if self.enabled_modules.contains(EnabledModules::AUTH) {
+            Some(&mut self.auth)
+        } else {
+            None
+        }
+    }
+
+    pub fn execution_trace_module(&mut self) -> Option<&mut ExecutionTraceModule> {
+        if self
+            .enabled_modules
+            .contains(EnabledModules::EXECUTION_TRACE)
+        {
+            Some(&mut self.execution_trace)
+        } else {
+            None
+        }
+    }
+
+    pub fn transaction_runtime_module(&mut self) -> Option<&mut TransactionRuntimeModule> {
+        if self
+            .enabled_modules
+            .contains(EnabledModules::TRANSACTION_RUNTIME)
+        {
+            Some(&mut self.transaction_runtime)
+        } else {
+            None
+        }
+    }
+
+    pub fn transaction_limits_module(&mut self) -> Option<&mut TransactionLimitsModule> {
+        if self
+            .enabled_modules
+            .contains(EnabledModules::TRANSACTION_LIMITS)
+        {
+            Some(&mut self.transaction_limits)
+        } else {
+            None
+        }
+    }
+
+    pub fn unpack(
+        self,
+    ) -> (
+        CostingModule,
+        EventsModule,
+        LoggerModule,
+        ExecutionTraceModule,
+        TransactionLimitsModule,
+    ) {
+        (
+            self.costing,
+            self.events,
+            self.logger,
+            self.execution_trace,
+            self.transaction_limits,
+        )
     }
 }
 

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -485,10 +485,8 @@ impl<C: SystemCallbackObject> KernelCallbackObject for SystemConfig<C> {
         if let Some(auth_zone_id) = api
             .kernel_get_system()
             .modules
-            .auth
-            .auth_zone_stack
-            .last()
-            .cloned()
+            .auth_module()
+            .and_then(|auth| auth.auth_zone_stack.last().cloned())
         {
             let handle = api.kernel_lock_substate(
                 &auth_zone_id,

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -299,7 +299,13 @@ impl AuthModule {
         V: SystemCallbackObject,
         Y: KernelApi<SystemConfig<V>>,
     {
-        if let Some(auth_zone_id) = api.kernel_get_system().modules.auth.last_auth_zone() {
+        if let Some(auth_zone_id) = api
+            .kernel_get_system()
+            .modules
+            .auth_module()
+            .unwrap()
+            .last_auth_zone()
+        {
             let mut system = SystemService::new(api);
 
             // Decide `authorization`, `barrier_crossing_allowed`, and `tip_auth_zone_id`
@@ -362,7 +368,7 @@ impl AuthModule {
         let is_barrier = callee.is_barrier();
         let is_transaction_processor = callee.is_transaction_processor();
         let (virtual_resources, virtual_non_fungibles) = if is_transaction_processor {
-            let auth_module = &api.kernel_get_system().modules.auth;
+            let auth_module = &api.kernel_get_system().modules.auth_module().unwrap();
             (
                 auth_module.params.virtual_resources.clone(),
                 auth_module.params.initial_proofs.clone(),
@@ -373,7 +379,8 @@ impl AuthModule {
         let parent = api
             .kernel_get_system()
             .modules
-            .auth
+            .auth_module()
+            .unwrap()
             .auth_zone_stack
             .last()
             .map(|x| Reference(x.clone().into()));
@@ -413,7 +420,8 @@ impl AuthModule {
         // Update auth zone stack
         api.kernel_get_system()
             .modules
-            .auth
+            .auth_module()
+            .unwrap()
             .auth_zone_stack
             .push(auth_zone_node_id);
 
@@ -437,7 +445,12 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for AuthModule {
         _dropped_actor: &Actor,
     ) -> Result<(), RuntimeError> {
         // update internal state
-        api.kernel_get_system().modules.auth.auth_zone_stack.pop();
+        api.kernel_get_system()
+            .modules
+            .auth_module()
+            .unwrap()
+            .auth_zone_stack
+            .pop();
         Ok(())
     }
 }

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -147,7 +147,8 @@ fn apply_royalty_cost<Y: KernelApi<SystemConfig<V>>, V: SystemCallbackObject>(
 ) -> Result<(), RuntimeError> {
     api.kernel_get_system()
         .modules
-        .costing
+        .costing_module()
+        .unwrap()
         .fee_reserve
         .consume_royalty(royalty_amount, recipient, recipient_vault_id)
         .map_err(|e| {
@@ -159,7 +160,7 @@ fn apply_royalty_cost<Y: KernelApi<SystemConfig<V>>, V: SystemCallbackObject>(
 
 impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
     fn on_init<Y: KernelApi<SystemConfig<V>>>(api: &mut Y) -> Result<(), RuntimeError> {
-        let costing = &mut api.kernel_get_system().modules.costing;
+        let costing = &mut api.kernel_get_system().modules.costing_module().unwrap();
         let fee_reserve = &mut costing.fee_reserve;
         let fee_table = &costing.fee_table;
 
@@ -191,7 +192,14 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         invocation: &KernelInvocation,
     ) -> Result<(), RuntimeError> {
         let current_depth = api.kernel_get_current_depth();
-        if current_depth == api.kernel_get_system().modules.costing.max_call_depth {
+        if current_depth
+            == api
+                .kernel_get_system()
+                .modules
+                .costing_module()
+                .unwrap()
+                .max_call_depth
+        {
             return Err(RuntimeError::SystemModuleError(
                 SystemModuleError::CostingError(CostingError::MaxCallDepthLimitReached),
             ));
@@ -200,7 +208,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         if current_depth > 0 {
             api.kernel_get_system()
                 .modules
-                .costing
+                .costing_module()
+                .unwrap()
                 .apply_execution_cost(
                     CostingReason::Invoke,
                     |fee_table| {
@@ -337,7 +346,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::CreateNode,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::CreateNode { node_id }),
@@ -346,14 +356,16 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::CreateNode, store_access)
     }
 
     fn after_drop_node<Y: KernelApi<SystemConfig<V>>>(api: &mut Y) -> Result<(), RuntimeError> {
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::DropNode,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::DropNode),
@@ -371,7 +383,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::LockSubstate,
                 |fee_table| {
@@ -394,7 +407,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::LockSubstate, store_access)
     }
 
@@ -407,7 +421,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part + value size costing
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::ReadSubstate,
                 |fee_table| {
@@ -420,7 +435,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::ReadSubstate, store_access)
     }
 
@@ -433,7 +449,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part + value size costing
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::WriteSubstate,
                 |fee_table| {
@@ -446,7 +463,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::WriteSubstate, store_access)
     }
 
@@ -458,7 +476,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::DropLock,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::DropLock),
@@ -467,7 +486,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::DropLock, store_access)
     }
 
@@ -478,7 +498,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::ScanSubstate,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::ScanSubstate),
@@ -487,7 +508,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::ScanSubstate, store_access)
     }
 
@@ -498,7 +520,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::SetSubstate,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::SetSubstate),
@@ -507,7 +530,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::SetSubstate, store_access)
     }
 
@@ -518,7 +542,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // CPU execution part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::TakeSubstate,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::TakeSubstate),
@@ -527,7 +552,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
         // Storage usage part
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_access_store_costs(CostingReason::TakeSubstate, store_access)
     }
 
@@ -537,7 +563,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system()
             .modules
-            .costing
+            .costing_module()
+            .unwrap()
             .apply_execution_cost(
                 CostingReason::AllocateNodeId,
                 |fee_table| fee_table.kernel_api_cost(CostingEntry::AllocateNodeId),

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -488,7 +488,7 @@ impl FinalizingFeeReserve for SystemLoanFeeReserve {
         // Sanity check
         assert_eq!(
             total_execution_cost_xrd,
-            fee_summary.fee_to_distribute() + fee_summary.tips_to_distribute()
+            fee_summary.fees_to_handle() + fee_summary.tips_to_handle()
         );
         fee_summary
     }

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -472,7 +472,7 @@ impl FinalizingFeeReserve for SystemLoanFeeReserve {
         let royalty_cost_breakdown = self.royalty_cost();
         let total_royalty_cost_xrd = royalty_cost_breakdown.values().map(|x| x.1).sum();
 
-        FeeSummary {
+        let fee_summary = FeeSummary {
             cost_unit_limit: self.cost_unit_limit,
             cost_unit_price: transmute_u128_as_decimal(self.cost_unit_price),
             tip_percentage: self.tip_percentage,
@@ -483,7 +483,14 @@ impl FinalizingFeeReserve for SystemLoanFeeReserve {
             execution_cost_breakdown,
             execution_cost_sum: self.execution_committed_sum,
             royalty_cost_breakdown,
-        }
+        };
+
+        // Sanity check
+        assert_eq!(
+            total_execution_cost_xrd,
+            fee_summary.fee_to_distribute() + fee_summary.tips_to_distribute()
+        );
+        fee_summary
     }
 }
 

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -488,7 +488,7 @@ impl FinalizingFeeReserve for SystemLoanFeeReserve {
         // Sanity check
         assert_eq!(
             total_execution_cost_xrd,
-            fee_summary.fees_to_handle() + fee_summary.tips_to_handle()
+            fee_summary.fees_to_distribute() + fee_summary.tips_to_distribute()
         );
         fee_summary
     }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -32,11 +32,11 @@ impl FeeSummary {
         self.total_bad_debt_xrd == 0.into()
     }
 
-    pub fn fee_to_distribute(&self) -> Decimal {
+    pub fn fees_to_handle(&self) -> Decimal {
         self.cost_unit_price * Decimal::from(self.execution_cost_sum)
     }
 
-    pub fn tips_to_distribute(&self) -> Decimal {
+    pub fn tips_to_handle(&self) -> Decimal {
         (self.cost_unit_price * Decimal::from(self.tip_percentage) / Decimal::from(100u32))
             * Decimal::from(self.execution_cost_sum)
     }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -43,11 +43,15 @@ impl FeeSummary {
 
     // For testing only
     pub fn expected_reward_if_single_validator(&self) -> Decimal {
-        self.tips_to_distribute()
-            * (TIPS_PROPOSER_SHARE_PERCENTAGE + TIPS_VALIDATOR_SET_SHARE_PERCENTAGE)
-            / dec!(100)
-            + self.fees_to_distribute()
-                * (FEES_PROPOSER_SHARE_PERCENTAGE + FEES_VALIDATOR_SET_SHARE_PERCENTAGE)
-                / dec!(100)
+        self.expected_reward_as_proposer_if_single_validator()
+            + self.expected_reward_as_active_validator_if_single_validator()
+    }
+    pub fn expected_reward_as_proposer_if_single_validator(&self) -> Decimal {
+        self.tips_to_distribute() * (TIPS_PROPOSER_SHARE_PERCENTAGE) / dec!(100)
+            + self.fees_to_distribute() * (FEES_PROPOSER_SHARE_PERCENTAGE) / dec!(100)
+    }
+    pub fn expected_reward_as_active_validator_if_single_validator(&self) -> Decimal {
+        self.tips_to_distribute() * (TIPS_VALIDATOR_SET_SHARE_PERCENTAGE) / dec!(100)
+            + self.fees_to_distribute() * (FEES_VALIDATOR_SET_SHARE_PERCENTAGE) / dec!(100)
     }
 }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -32,11 +32,11 @@ impl FeeSummary {
         self.total_bad_debt_xrd == 0.into()
     }
 
-    pub fn fees_to_handle(&self) -> Decimal {
+    pub fn fees_to_distribute(&self) -> Decimal {
         self.cost_unit_price * Decimal::from(self.execution_cost_sum)
     }
 
-    pub fn tips_to_handle(&self) -> Decimal {
+    pub fn tips_to_distribute(&self) -> Decimal {
         (self.cost_unit_price * Decimal::from(self.tip_percentage) / Decimal::from(100u32))
             * Decimal::from(self.execution_cost_sum)
     }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -31,4 +31,13 @@ impl FeeSummary {
     pub fn loan_fully_repaid(&self) -> bool {
         self.total_bad_debt_xrd == 0.into()
     }
+
+    pub fn fee_to_distribute(&self) -> Decimal {
+        self.cost_unit_price * Decimal::from(self.execution_cost_sum)
+    }
+
+    pub fn tips_to_distribute(&self) -> Decimal {
+        (self.cost_unit_price * Decimal::from(self.tip_percentage) / Decimal::from(100u32))
+            * Decimal::from(self.execution_cost_sum)
+    }
 }

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -40,4 +40,14 @@ impl FeeSummary {
         (self.cost_unit_price * Decimal::from(self.tip_percentage) / Decimal::from(100u32))
             * Decimal::from(self.execution_cost_sum)
     }
+
+    // For testing only
+    pub fn expected_reward_if_single_validator(&self) -> Decimal {
+        self.tips_to_distribute()
+            * (TIPS_PROPOSER_SHARE_PERCENTAGE + TIPS_VALIDATOR_SET_SHARE_PERCENTAGE)
+            / dec!(100)
+            + self.fees_to_distribute()
+                * (FEES_PROPOSER_SHARE_PERCENTAGE + FEES_VALIDATOR_SET_SHARE_PERCENTAGE)
+                / dec!(100)
+    }
 }

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -296,7 +296,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         api.kernel_get_system_state()
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_before_create_node();
         Ok(())
     }
@@ -312,7 +313,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         system_state
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_after_create_node(system_state.current, current_depth, resource_summary);
         Ok(())
     }
@@ -325,7 +327,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         api.kernel_get_system_state()
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_before_drop_node(resource_summary);
         Ok(())
     }
@@ -336,7 +339,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         system_state
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_after_drop_node(system_state.current, current_depth);
         Ok(())
     }
@@ -352,7 +356,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         system_state
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_before_push_frame(system_state.current, callee, resource_summary);
         Ok(())
     }
@@ -371,7 +376,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for ExecutionTraceMo
         system_state
             .system
             .modules
-            .execution_trace
+            .execution_trace_module()
+            .unwrap()
             .handle_on_execution_finish(
                 system_state.current,
                 current_depth,

--- a/radix-engine/src/system/system_modules/transaction_limits/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_limits/module.rs
@@ -225,7 +225,11 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for TransactionLimit
         api: &mut Y,
         invocation: &KernelInvocation,
     ) -> Result<(), RuntimeError> {
-        let tlimit = &mut api.kernel_get_system().modules.transaction_limits;
+        let tlimit = &mut api
+            .kernel_get_system()
+            .modules
+            .transaction_limits_module()
+            .unwrap();
         let input_size = invocation.len();
         if input_size > tlimit.invoke_payload_max_size {
             tlimit.invoke_payload_max_size = input_size;
@@ -251,7 +255,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for TransactionLimit
         // push new empty wasm memory value refencing current call frame to internal stack
         api.kernel_get_system()
             .modules
-            .transaction_limits
+            .transaction_limits_module()
+            .unwrap()
             .call_frames_stack
             .push(CallFrameLimitInfo::default());
         Ok(())
@@ -264,7 +269,8 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for TransactionLimit
         // pop from internal stack
         api.kernel_get_system()
             .modules
-            .transaction_limits
+            .transaction_limits_module()
+            .unwrap()
             .call_frames_stack
             .pop();
         Ok(())
@@ -276,7 +282,11 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for TransactionLimit
         value_size: usize,
         _store_access: &StoreAccessInfo,
     ) -> Result<(), RuntimeError> {
-        let tlimit = &mut api.kernel_get_system().modules.transaction_limits;
+        let tlimit = &mut api
+            .kernel_get_system()
+            .modules
+            .transaction_limits_module()
+            .unwrap();
 
         // Increase read coutner.
         tlimit.substate_db_read_count += 1;
@@ -294,7 +304,11 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for TransactionLimit
         value_size: usize,
         _store_access: &StoreAccessInfo,
     ) -> Result<(), RuntimeError> {
-        let tlimit = &mut api.kernel_get_system().modules.transaction_limits;
+        let tlimit = &mut api
+            .kernel_get_system()
+            .modules
+            .transaction_limits_module()
+            .unwrap();
 
         // Increase write coutner.
         tlimit.substate_db_write_count += 1;

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -625,7 +625,7 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
         let rewards = tips_to_distribute * TIPS_PROPOSER_SHARE_PERCENTAGE / dec!(100)
             + fees_to_distribute * FEES_PROPOSER_SHARE_PERCENTAGE / dec!(100);
         substate
-            .individual_validator_rewards
+            .proposer_rewards
             .entry(current_leader)
             .or_default()
             .add_assign(rewards);
@@ -633,10 +633,11 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
     } else {
         Decimal::ZERO
     };
-    let validator_set_rewards = tips_to_distribute * TIPS_VALIDATOR_SET_SHARE_PERCENTAGE
-        / dec!(100)
-        + fees_to_distribute * FEES_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100);
-    let vault_node_id = substate.validator_rewards.0 .0;
+    let validator_set_rewards = {
+        tips_to_distribute * TIPS_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100)
+            + fees_to_distribute * FEES_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100)
+    };
+    let vault_node_id = substate.rewards_vault.0 .0;
     track.update_substate(handle, IndexedScryptoValue::from_typed(&substate));
     track.release_lock(handle);
 

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -592,9 +592,8 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
         };
     }
 
-    // TODO: burn and update validator rewards substate
-    let tips_to_handle = fee_summary.tips_to_handle();
-    let fees_to_handle = fee_summary.fees_to_handle();
+    let tips_to_distribute = fee_summary.tips_to_distribute();
+    let fees_to_distribute = fee_summary.fees_to_distribute();
 
     // Fetch current leader
     // TODO: maybe we should move current leader into validator rewards?
@@ -623,8 +622,8 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
         .0;
     let mut substate: ValidatorRewardsSubstate = track.read_substate(handle).0.as_typed().unwrap();
     let proposer_rewards = if let Some(current_leader) = current_leader {
-        let rewards = tips_to_handle * TIPS_PROPOSER_SHARE_PERCENTAGE / dec!(100)
-            + fees_to_handle * FEES_PROPOSER_SHARE_PERCENTAGE / dec!(100);
+        let rewards = tips_to_distribute * TIPS_PROPOSER_SHARE_PERCENTAGE / dec!(100)
+            + fees_to_distribute * FEES_PROPOSER_SHARE_PERCENTAGE / dec!(100);
         substate
             .individual_validator_rewards
             .entry(current_leader)
@@ -634,8 +633,9 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
     } else {
         Decimal::ZERO
     };
-    let validator_set_rewards = tips_to_handle * TIPS_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100)
-        + fees_to_handle * FEES_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100);
+    let validator_set_rewards = tips_to_distribute * TIPS_VALIDATOR_SET_SHARE_PERCENTAGE
+        / dec!(100)
+        + fees_to_distribute * FEES_VALIDATOR_SET_SHARE_PERCENTAGE / dec!(100);
     let vault_node_id = substate.validator_rewards.0 .0;
     track.update_substate(handle, IndexedScryptoValue::from_typed(&substate));
     track.release_lock(handle);

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -589,6 +589,9 @@ fn distribute_fees<S: SubstateDatabase, M: DatabaseKeyMapper>(
         };
     }
 
-    // TODO: distribute fees
+    // TODO: burn and update validator rewards substate
+    let _fees_to_handle = fee_summary.fees_to_handle();
+    let _tips_to_handle = fee_summary.tips_to_handle();
+
     (fee_summary, fee_payments)
 }

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -192,6 +192,47 @@ impl CustomGenesis {
             initial_current_leader: Some(0),
         }
     }
+
+    pub fn two_validators_and_single_staker(
+        validator1_public_key: Secp256k1PublicKey,
+        validator2_public_key: Secp256k1PublicKey,
+        stake_xrd_amount: (Decimal, Decimal),
+        staker_account: ComponentAddress,
+        initial_epoch: Epoch,
+        initial_config: ConsensusManagerConfig,
+    ) -> CustomGenesis {
+        let genesis_validator1: GenesisValidator = validator1_public_key.clone().into();
+        let genesis_validator2: GenesisValidator = validator2_public_key.clone().into();
+        let genesis_data_chunks = vec![
+            GenesisDataChunk::Validators(vec![genesis_validator1, genesis_validator2]),
+            GenesisDataChunk::Stakes {
+                accounts: vec![staker_account],
+                allocations: vec![
+                    (
+                        validator1_public_key,
+                        vec![GenesisStakeAllocation {
+                            account_index: 0,
+                            xrd_amount: stake_xrd_amount.0,
+                        }],
+                    ),
+                    (
+                        validator2_public_key,
+                        vec![GenesisStakeAllocation {
+                            account_index: 0,
+                            xrd_amount: stake_xrd_amount.1,
+                        }],
+                    ),
+                ],
+            },
+        ];
+        CustomGenesis {
+            genesis_data_chunks,
+            initial_epoch,
+            initial_config,
+            initial_time_ms: 0,
+            initial_current_leader: Some(0),
+        }
+    }
 }
 
 pub struct TestRunnerBuilder {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -132,6 +132,7 @@ pub struct CustomGenesis {
     pub initial_epoch: Epoch,
     pub initial_config: ConsensusManagerConfig,
     pub initial_time_ms: i64,
+    pub initial_current_leader: Option<ValidatorIndex>,
 }
 
 impl CustomGenesis {
@@ -188,6 +189,7 @@ impl CustomGenesis {
             initial_epoch,
             initial_config,
             initial_time_ms: 0,
+            initial_current_leader: Some(0),
         }
     }
 }
@@ -232,6 +234,7 @@ impl TestRunnerBuilder {
                     custom_genesis.initial_epoch,
                     custom_genesis.initial_config,
                     custom_genesis.initial_time_ms,
+                    custom_genesis.initial_current_leader,
                 )
                 .unwrap(),
             None => bootstrapper.bootstrap_test_default().unwrap(),

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -488,6 +488,7 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
             epoch: Epoch::zero(),
             epoch_start_milli: 0,
             round: Round::zero(),
+            current_leader: Some(0),
         });
 
     consensus_manager_substate.epoch = epoch;


### PR DESCRIPTION
## Summary

This PR implements fees and tips distribution, and fixes issues with system modules (deeper refactor required though).
```
Tips: 100% proposer,
Fees: 25% proposer, 25% validator set, 50% burnt
```

Note that `proposer` and `validator set` refer to the validator owners.

These rewards are auto-staked at the end of an epoch into "owner stake units".

## Testing

New tests added

## Update Recommendations

- A new field `current_leader: Option<ValidatorIndex` is added to `ConsensusManager` substate;
- A new substate `ValidatorRewardsSubstate` is added. 
