### PR TITLE
Use fixed size WASM cache replacing the wasm length based cache

### DIFF
--- a/radix-engine-tests/tests/cached_wasm_limits.rs
+++ b/radix-engine-tests/tests/cached_wasm_limits.rs
@@ -1,0 +1,64 @@
+use radix_engine::vm::wasm::DEFAULT_CACHE_SIZE;
+use radix_engine::{types::*, vm::wasm::WASM_MEMORY_PAGE_SIZE};
+use radix_engine_constants::DEFAULT_MAX_WASM_MEM_PER_CALL_FRAME;
+use radix_engine_interface::blueprints::package::PackageDefinition;
+use scrypto_unit::*;
+use transaction::builder::ManifestBuilder;
+
+/// Long running test which verifies that the Wasm cache is properly evicting entries
+/// Ignored for day-to-day unit testing as it takes a long while to execute
+#[test]
+#[ignore]
+fn publishing_many_packages_should_not_cause_system_failure() {
+    // Arrange
+    let mut test_runner = TestRunner::builder().build();
+    let code = wat2wasm(&format!(
+        r#"
+                (module
+                    (data (i32.const 0) "{}")
+                    (memory $0 64)
+                    (func $Test_f (param $0 i64) (result i64)
+                      ;; Encode () in SBOR at address 0x0
+                      (i32.const 0)
+                      (i32.const 92)  ;; prefix
+                      (i32.store8)
+                      (i32.const 1)
+                      (i32.const 33)  ;; tuple value kind
+                      (i32.store8)
+                      (i32.const 2)
+                      (i32.const 0)  ;; tuple length
+                      (i32.store8)
+
+                      ;; Return slice (ptr = 0, len = 3)
+                      (i64.const 3)
+                    )
+                    (export "memory" (memory $0))
+                    (export "Test_f" (func $Test_f))
+                )
+            "#,
+        "i".repeat(DEFAULT_MAX_INVOKE_INPUT_SIZE - 1024)
+    ));
+
+    // Act
+    for _ in 0..(DEFAULT_CACHE_SIZE + 200) {
+        let manifest = ManifestBuilder::new()
+            .lock_fee(test_runner.faucet_component(), 100.into())
+            .publish_package_advanced(
+                code.clone(),
+                single_function_package_definition("Test", "f"),
+                BTreeMap::new(),
+                OwnerRole::None,
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+        let result = receipt.expect_commit_success();
+        let package_address = result.new_package_addresses()[0];
+
+        let manifest = ManifestBuilder::new()
+            .lock_fee(test_runner.faucet_component(), 100.into())
+            .call_function(package_address, "Test", "f", manifest_args!())
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+        receipt.expect_commit_success();
+    }
+}

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -6,6 +6,7 @@ use crate::types::*;
 use crate::vm::wasm::constants::*;
 use crate::vm::wasm::errors::*;
 use crate::vm::wasm::traits::*;
+use crate::vm::wasm::DEFAULT_CACHE_SIZE;
 use sbor::rust::sync::{Arc, Mutex};
 use wasmer::{
     imports, Function, HostEnvInitError, Instance, LazyInit, Module, RuntimeError, Store,
@@ -780,13 +781,13 @@ impl WasmInstance for WasmerInstance {
 
 #[derive(Debug, Clone)]
 pub struct EngineOptions {
-    max_cache_size_bytes: usize,
+    max_cache_size: usize,
 }
 
 impl Default for WasmerEngine {
     fn default() -> Self {
         Self::new(EngineOptions {
-            max_cache_size_bytes: 200 * 1024 * 1024,
+            max_cache_size: DEFAULT_CACHE_SIZE,
         })
     }
 }
@@ -797,20 +798,20 @@ impl WasmerEngine {
 
         #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
         let modules_cache = RefCell::new(lru::LruCache::new(
-            NonZeroUsize::new(options.max_cache_size_bytes / (1024 * 1024)).unwrap(),
+            NonZeroUsize::new(options.max_cache_size).unwrap(),
         ));
         #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
         let modules_cache = moka::sync::Cache::builder()
             .weigher(
-                |_metered_code_key: &MeteredCodeKey, value: &Arc<WasmerModule>| -> u32 {
-                    // Approximate the module entry size by the code size
-                    value.code_size_bytes.try_into().unwrap_or(u32::MAX)
+                |_metered_code_key: &MeteredCodeKey, _value: &Arc<WasmerModule>| -> u32 {
+                    // No sophisticated weighing mechanism, just keep a fixed size cache
+                    1u32
                 },
             )
-            .max_capacity(options.max_cache_size_bytes as u64)
+            .max_capacity(options.max_cache_size as u64)
             .build();
         #[cfg(feature = "radix_engine_fuzzing")]
-        let modules_cache = options.max_cache_size_bytes;
+        let modules_cache = options.max_cache_size;
 
         Self {
             store: Store::new(&Universal::new(compiler).engine()),

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -15,7 +15,7 @@ use crate::types::*;
 use crate::vm::wasm::constants::*;
 use crate::vm::wasm::errors::*;
 use crate::vm::wasm::traits::*;
-use crate::vm::wasm::WasmEngine;
+use crate::vm::wasm::{WasmEngine, DEFAULT_CACHE_SIZE};
 
 type FakeHostState = FakeWasmiInstanceEnv;
 type HostState = WasmiInstanceEnv;
@@ -1212,7 +1212,7 @@ impl WasmInstance for WasmiInstance {
 
 #[derive(Debug, Clone)]
 pub struct EngineOptions {
-    max_cache_size_bytes: usize,
+    max_cache_size: usize,
 }
 
 pub struct WasmiEngine {
@@ -1229,7 +1229,7 @@ pub struct WasmiEngine {
 impl Default for WasmiEngine {
     fn default() -> Self {
         Self::new(EngineOptions {
-            max_cache_size_bytes: 200 * 1024 * 1024,
+            max_cache_size: DEFAULT_CACHE_SIZE,
         })
     }
 }
@@ -1238,18 +1238,18 @@ impl WasmiEngine {
     pub fn new(options: EngineOptions) -> Self {
         #[cfg(all(not(feature = "radix_engine_fuzzing"), not(feature = "moka")))]
         let modules_cache = RefCell::new(lru::LruCache::new(
-            NonZeroUsize::new(options.max_cache_size_bytes / (1024 * 1024)).unwrap(),
+            NonZeroUsize::new(options.max_cache_size).unwrap(),
         ));
         #[cfg(all(not(feature = "radix_engine_fuzzing"), feature = "moka"))]
         let modules_cache = moka::sync::Cache::builder()
-            .weigher(|_key: &MeteredCodeKey, value: &Arc<WasmiModule>| -> u32 {
-                // Approximate the module entry size by the code size
-                value.code_size_bytes.try_into().unwrap_or(u32::MAX)
+            .weigher(|_key: &MeteredCodeKey, _value: &Arc<WasmiModule>| -> u32 {
+                // No sophisticated weighing mechanism, just keep a fixed size cache
+                1u32
             })
-            .max_capacity(options.max_cache_size_bytes as u64)
+            .max_capacity(options.max_cache_size as u64)
             .build();
         #[cfg(feature = "radix_engine_fuzzing")]
-        let modules_cache = options.max_cache_size_bytes;
+        let modules_cache = options.max_cache_size;
 
         Self { modules_cache }
     }


### PR DESCRIPTION
## Summary
Use a fixed size cache (1000 as default) for both WASM instrumenter and WASM module caches

## Details
Using a fixed size cache simplifies the caching algorithm and prevents cache bugs with the current WASM-size based cache which does not capture all resources used by the WASM module/instrumenter.

## Testing
Added a `publishing_many_packages_should_not_cause_system_failure` which attempts to publish many packages.