### PR TITLE
fix: Fix all (glob import) compiler warnings for Rust 1.70

### DIFF
--- a/fuzz-tests/src/fuzz_tx.rs
+++ b/fuzz-tests/src/fuzz_tx.rs
@@ -1,5 +1,5 @@
 use arbitrary::{Arbitrary, Unstructured};
-use radix_engine::types::blueprints::package::*;
+use radix_engine_interface::blueprints::package::*;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::*;
 use radix_engine_interface::api::node_modules::metadata::*;

--- a/radix-engine-common/src/data/manifest/custom_extension.rs
+++ b/radix-engine-common/src/data/manifest/custom_extension.rs
@@ -1,7 +1,4 @@
-use super::*;
-use crate::data::scrypto::*;
-use crate::*;
-use sbor::rust::prelude::*;
+use crate::internal_prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum ManifestCustomExtension {}

--- a/radix-engine-common/src/data/manifest/custom_formatting.rs
+++ b/radix-engine-common/src/data/manifest/custom_formatting.rs
@@ -1,10 +1,6 @@
 use super::converter::*;
 use super::model::*;
-use super::*;
-use crate::*;
-use sbor::representations::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::*;
+use crate::internal_prelude::*;
 
 impl<'a> CustomDisplayContext<'a> for ManifestValueDisplayContext<'a> {
     type CustomExtension = ManifestCustomExtension;

--- a/radix-engine-common/src/data/manifest/custom_payload_wrappers.rs
+++ b/radix-engine-common/src/data/manifest/custom_payload_wrappers.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::internal_prelude::*;
 
 pub type ManifestRawPayload<'a> = RawPayload<'a, ManifestCustomExtension>;
 pub type ManifestOwnedRawPayload = RawPayload<'static, ManifestCustomExtension>;

--- a/radix-engine-common/src/data/manifest/custom_serde.rs
+++ b/radix-engine-common/src/data/manifest/custom_serde.rs
@@ -1,10 +1,7 @@
 use super::converter::*;
 use super::model::*;
 use super::*;
-use crate::*;
-use sbor::representations::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::*;
+use crate::internal_prelude::*;
 
 impl SerializableCustomExtension for ManifestCustomExtension {
     fn map_value_for_serialization<'s, 'de, 'a, 't, 's1, 's2>(

--- a/radix-engine-common/src/data/manifest/custom_traversal.rs
+++ b/radix-engine-common/src/data/manifest/custom_traversal.rs
@@ -1,8 +1,4 @@
-use sbor::decoder::*;
-use sbor::traversal::*;
-use sbor::value_kind::*;
-
-use super::*;
+use crate::internal_prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManifestCustomTerminalValueRef(pub ManifestCustomValue);

--- a/radix-engine-common/src/data/manifest/custom_validation.rs
+++ b/radix-engine-common/src/data/manifest/custom_validation.rs
@@ -1,11 +1,8 @@
-use super::model::ManifestExpression;
-use super::*;
+use super::model::*;
 use crate::data::scrypto::{
     ReferenceValidation, ScryptoCustomTypeKind, ScryptoCustomTypeValidation,
 };
-use crate::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::TerminalValueRef;
+use crate::internal_prelude::*;
 
 impl<'a> ValidatableCustomExtension<()> for ManifestCustomExtension {
     fn apply_validation_for_custom_value<'de>(
@@ -117,7 +114,7 @@ impl<'a> ValidatableCustomExtension<()> for ManifestCustomExtension {
                         reference_validation,
                     )) => {
                         let is_valid = match address {
-                            model::ManifestAddress::Static(node_id) => match reference_validation {
+                            ManifestAddress::Static(node_id) => match reference_validation {
                                 ReferenceValidation::IsGlobal => node_id.is_global(),
                                 ReferenceValidation::IsGlobalPackage => node_id.is_global_package(),
                                 ReferenceValidation::IsGlobalComponent => {
@@ -130,7 +127,7 @@ impl<'a> ValidatableCustomExtension<()> for ManifestCustomExtension {
                                 ReferenceValidation::IsInternal => node_id.is_internal(),
                                 ReferenceValidation::IsInternalTyped(_, _) => node_id.is_internal(), // Assume yes
                             },
-                            model::ManifestAddress::Named(_) => {
+                            ManifestAddress::Named(_) => {
                                 reference_validation.could_match_manifest_address()
                             }
                         };
@@ -228,15 +225,14 @@ impl<'a> ValidatableCustomExtension<()> for ManifestCustomExtension {
 
 #[cfg(test)]
 mod tests {
-    use crate::data::manifest::model::*;
+    use super::*;
+
     use crate::data::scrypto::model::NonFungibleLocalId;
     use crate::data::scrypto::{well_known_scrypto_custom_types, ScryptoValue};
     use crate::data::scrypto::{ScryptoCustomSchema, ScryptoDescribe};
     use crate::math::{Decimal, PreciseDecimal};
     use crate::native_addresses::*;
     use crate::types::{PackageAddress, ResourceAddress};
-
-    use super::*;
 
     pub struct Bucket;
 

--- a/radix-engine-common/src/data/manifest/custom_value.rs
+++ b/radix-engine-common/src/data/manifest/custom_value.rs
@@ -1,5 +1,6 @@
 use crate::data::manifest::model::*;
-use crate::data::manifest::*;
+use crate::internal_prelude::*;
+
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
 

--- a/radix-engine-common/src/data/manifest/custom_value_kind.rs
+++ b/radix-engine-common/src/data/manifest/custom_value_kind.rs
@@ -1,16 +1,16 @@
+use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
-use sbor::*;
 
-pub const VALUE_KIND_ADDRESS: u8 = 0x80;
-pub const VALUE_KIND_BUCKET: u8 = 0x81;
-pub const VALUE_KIND_PROOF: u8 = 0x82;
-pub const VALUE_KIND_EXPRESSION: u8 = 0x83;
-pub const VALUE_KIND_BLOB: u8 = 0x84;
-pub const VALUE_KIND_DECIMAL: u8 = 0x85;
-pub const VALUE_KIND_PRECISE_DECIMAL: u8 = 0x86;
-pub const VALUE_KIND_NON_FUNGIBLE_LOCAL_ID: u8 = 0x87;
-pub const VALUE_KIND_ADDRESS_RESERVATION: u8 = 0x88;
+pub const MANIFEST_VALUE_KIND_ADDRESS: u8 = 0x80;
+pub const MANIFEST_VALUE_KIND_BUCKET: u8 = 0x81;
+pub const MANIFEST_VALUE_KIND_PROOF: u8 = 0x82;
+pub const MANIFEST_VALUE_KIND_EXPRESSION: u8 = 0x83;
+pub const MANIFEST_VALUE_KIND_BLOB: u8 = 0x84;
+pub const MANIFEST_VALUE_KIND_DECIMAL: u8 = 0x85;
+pub const MANIFEST_VALUE_KIND_PRECISE_DECIMAL: u8 = 0x86;
+pub const MANIFEST_VALUE_KIND_NON_FUNGIBLE_LOCAL_ID: u8 = 0x87;
+pub const MANIFEST_VALUE_KIND_ADDRESS_RESERVATION: u8 = 0x88;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[cfg_attr(
@@ -40,29 +40,33 @@ impl From<ManifestCustomValueKind> for ValueKind<ManifestCustomValueKind> {
 impl CustomValueKind for ManifestCustomValueKind {
     fn as_u8(&self) -> u8 {
         match self {
-            Self::Address => VALUE_KIND_ADDRESS,
-            Self::Bucket => VALUE_KIND_BUCKET,
-            Self::Proof => VALUE_KIND_PROOF,
-            Self::Expression => VALUE_KIND_EXPRESSION,
-            Self::Blob => VALUE_KIND_BLOB,
-            Self::Decimal => VALUE_KIND_DECIMAL,
-            Self::PreciseDecimal => VALUE_KIND_PRECISE_DECIMAL,
-            Self::NonFungibleLocalId => VALUE_KIND_NON_FUNGIBLE_LOCAL_ID,
-            Self::AddressReservation => VALUE_KIND_ADDRESS_RESERVATION,
+            Self::Address => MANIFEST_VALUE_KIND_ADDRESS,
+            Self::Bucket => MANIFEST_VALUE_KIND_BUCKET,
+            Self::Proof => MANIFEST_VALUE_KIND_PROOF,
+            Self::Expression => MANIFEST_VALUE_KIND_EXPRESSION,
+            Self::Blob => MANIFEST_VALUE_KIND_BLOB,
+            Self::Decimal => MANIFEST_VALUE_KIND_DECIMAL,
+            Self::PreciseDecimal => MANIFEST_VALUE_KIND_PRECISE_DECIMAL,
+            Self::NonFungibleLocalId => MANIFEST_VALUE_KIND_NON_FUNGIBLE_LOCAL_ID,
+            Self::AddressReservation => MANIFEST_VALUE_KIND_ADDRESS_RESERVATION,
         }
     }
 
     fn from_u8(id: u8) -> Option<Self> {
         match id {
-            VALUE_KIND_ADDRESS => Some(ManifestCustomValueKind::Address),
-            VALUE_KIND_BUCKET => Some(ManifestCustomValueKind::Bucket),
-            VALUE_KIND_PROOF => Some(ManifestCustomValueKind::Proof),
-            VALUE_KIND_EXPRESSION => Some(ManifestCustomValueKind::Expression),
-            VALUE_KIND_BLOB => Some(ManifestCustomValueKind::Blob),
-            VALUE_KIND_DECIMAL => Some(ManifestCustomValueKind::Decimal),
-            VALUE_KIND_PRECISE_DECIMAL => Some(ManifestCustomValueKind::PreciseDecimal),
-            VALUE_KIND_NON_FUNGIBLE_LOCAL_ID => Some(ManifestCustomValueKind::NonFungibleLocalId),
-            VALUE_KIND_ADDRESS_RESERVATION => Some(ManifestCustomValueKind::AddressReservation),
+            MANIFEST_VALUE_KIND_ADDRESS => Some(ManifestCustomValueKind::Address),
+            MANIFEST_VALUE_KIND_BUCKET => Some(ManifestCustomValueKind::Bucket),
+            MANIFEST_VALUE_KIND_PROOF => Some(ManifestCustomValueKind::Proof),
+            MANIFEST_VALUE_KIND_EXPRESSION => Some(ManifestCustomValueKind::Expression),
+            MANIFEST_VALUE_KIND_BLOB => Some(ManifestCustomValueKind::Blob),
+            MANIFEST_VALUE_KIND_DECIMAL => Some(ManifestCustomValueKind::Decimal),
+            MANIFEST_VALUE_KIND_PRECISE_DECIMAL => Some(ManifestCustomValueKind::PreciseDecimal),
+            MANIFEST_VALUE_KIND_NON_FUNGIBLE_LOCAL_ID => {
+                Some(ManifestCustomValueKind::NonFungibleLocalId)
+            }
+            MANIFEST_VALUE_KIND_ADDRESS_RESERVATION => {
+                Some(ManifestCustomValueKind::AddressReservation)
+            }
             _ => None,
         }
     }

--- a/radix-engine-common/src/data/manifest/definitions.rs
+++ b/radix-engine-common/src/data/manifest/definitions.rs
@@ -1,0 +1,150 @@
+use crate::internal_prelude::*;
+
+pub use radix_engine_constants::MANIFEST_SBOR_V1_PAYLOAD_PREFIX;
+pub const MANIFEST_SBOR_V1_MAX_DEPTH: usize = 24;
+
+pub type ManifestEncoder<'a> = VecEncoder<'a, ManifestCustomValueKind>;
+pub type ManifestDecoder<'a> = VecDecoder<'a, ManifestCustomValueKind>;
+pub type ManifestValueKind = ValueKind<ManifestCustomValueKind>;
+pub type ManifestValue = Value<ManifestCustomValueKind, ManifestCustomValue>;
+pub type ManifestEnumVariantValue = EnumVariantValue<ManifestCustomValueKind, ManifestCustomValue>;
+pub type ManifestTraverser<'a> = VecTraverser<'a, ManifestCustomTraversal>;
+
+pub trait ManifestCategorize: Categorize<ManifestCustomValueKind> {}
+impl<T: Categorize<ManifestCustomValueKind> + ?Sized> ManifestCategorize for T {}
+
+pub trait ManifestSborEnum: SborEnum<ManifestCustomValueKind> {}
+impl<T: SborEnum<ManifestCustomValueKind> + ?Sized> ManifestSborEnum for T {}
+
+pub trait ManifestSborTuple: SborTuple<ManifestCustomValueKind> {}
+impl<T: SborTuple<ManifestCustomValueKind> + ?Sized> ManifestSborTuple for T {}
+
+pub trait ManifestDecode: for<'a> Decode<ManifestCustomValueKind, ManifestDecoder<'a>> {}
+impl<T: for<'a> Decode<ManifestCustomValueKind, ManifestDecoder<'a>>> ManifestDecode for T {}
+
+pub trait ManifestEncode: for<'a> Encode<ManifestCustomValueKind, ManifestEncoder<'a>> {}
+impl<T: for<'a> Encode<ManifestCustomValueKind, ManifestEncoder<'a>> + ?Sized> ManifestEncode
+    for T
+{
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RustToManifestValueError {
+    DecodeError(DecodeError),
+    EncodeError(EncodeError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestToRustValueError {
+    DecodeError(DecodeError),
+    EncodeError(EncodeError),
+}
+
+pub fn manifest_encode<T: ManifestEncode + ?Sized>(value: &T) -> Result<Vec<u8>, EncodeError> {
+    let mut buf = Vec::with_capacity(512);
+    let encoder = ManifestEncoder::new(&mut buf, MANIFEST_SBOR_V1_MAX_DEPTH);
+    encoder.encode_payload(value, MANIFEST_SBOR_V1_PAYLOAD_PREFIX)?;
+    Ok(buf)
+}
+
+pub fn manifest_decode<T: ManifestDecode>(buf: &[u8]) -> Result<T, DecodeError> {
+    ManifestDecoder::new(buf, MANIFEST_SBOR_V1_MAX_DEPTH)
+        .decode_payload(MANIFEST_SBOR_V1_PAYLOAD_PREFIX)
+}
+
+pub fn to_manifest_value<T: ManifestEncode + ?Sized>(
+    value: &T,
+) -> Result<ManifestValue, RustToManifestValueError> {
+    let encoded = manifest_encode(value).map_err(RustToManifestValueError::EncodeError)?;
+
+    manifest_decode(&encoded).map_err(RustToManifestValueError::DecodeError)
+}
+
+pub fn from_manifest_value<T: ManifestDecode>(
+    manifest_value: &ManifestValue,
+) -> Result<T, ManifestToRustValueError> {
+    let encoded = manifest_encode(manifest_value).map_err(ManifestToRustValueError::EncodeError)?;
+
+    manifest_decode(&encoded).map_err(ManifestToRustValueError::DecodeError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manifest_value_conversions() {
+        let invalid_value = ManifestValue::Tuple {
+            fields: vec![ManifestValue::Array {
+                element_value_kind: ValueKind::U8,
+                elements: vec![
+                    ManifestValue::U8 { value: 1 },
+                    ManifestValue::U16 { value: 2 },
+                ],
+            }],
+        };
+        assert!(matches!(
+            to_manifest_value(&invalid_value),
+            Err(RustToManifestValueError::EncodeError(
+                EncodeError::MismatchingArrayElementValueKind { .. }
+            ))
+        ));
+
+        let invalid_value = ManifestValue::Map {
+            key_value_kind: ValueKind::U8,
+            value_value_kind: ValueKind::I8,
+            entries: vec![(
+                ManifestValue::U16 { value: 1 },
+                ManifestValue::I8 { value: 1 },
+            )],
+        };
+        assert!(matches!(
+            to_manifest_value(&invalid_value),
+            Err(RustToManifestValueError::EncodeError(
+                EncodeError::MismatchingMapKeyValueKind { .. }
+            ))
+        ));
+
+        let invalid_value = ManifestValue::Map {
+            key_value_kind: ValueKind::U8,
+            value_value_kind: ValueKind::I8,
+            entries: vec![(
+                ManifestValue::U8 { value: 1 },
+                ManifestValue::I16 { value: 1 },
+            )],
+        };
+        assert!(matches!(
+            to_manifest_value(&invalid_value),
+            Err(RustToManifestValueError::EncodeError(
+                EncodeError::MismatchingMapValueValueKind { .. }
+            ))
+        ));
+
+        let too_deep_tuple = get_tuple_of_depth(MANIFEST_SBOR_V1_MAX_DEPTH + 1).unwrap();
+        assert!(matches!(
+            to_manifest_value(&too_deep_tuple),
+            Err(RustToManifestValueError::EncodeError(
+                EncodeError::MaxDepthExceeded { .. }
+            ))
+        ));
+
+        let fine_tuple = get_tuple_of_depth(MANIFEST_SBOR_V1_MAX_DEPTH).unwrap();
+        assert!(to_manifest_value(&fine_tuple).is_ok());
+    }
+
+    pub fn get_tuple_of_depth(depth: usize) -> Option<ManifestValue> {
+        // Minimum tuple depth is 2
+        if depth <= 1 {
+            None
+        } else if depth <= 2 {
+            Some(ManifestValue::Tuple {
+                fields: vec![ManifestValue::U8 { value: 1 }],
+            })
+        } else {
+            let value = get_tuple_of_depth(depth - 1).unwrap();
+            Some(ManifestValue::Tuple {
+                fields: vec![value],
+            })
+        }
+    }
+}

--- a/radix-engine-common/src/data/manifest/mod.rs
+++ b/radix-engine-common/src/data/manifest/mod.rs
@@ -1,20 +1,20 @@
-use sbor::rust::vec::Vec;
-use sbor::traversal::VecTraverser;
-use sbor::*;
+// Modules that should appear explicitly under manifest::
+pub mod converter;
+pub mod model;
 
+// Modules which should appear part of `manifest`
 mod custom_extension;
 mod custom_formatting;
 mod custom_payload_wrappers;
 #[cfg(feature = "serde")]
 mod custom_serde;
 mod custom_traversal;
+mod custom_validation;
 mod custom_value;
 mod custom_value_kind;
+mod definitions;
 mod display_context;
 
-pub mod converter;
-mod custom_validation;
-pub mod model;
 pub use custom_extension::*;
 pub use custom_formatting::*;
 pub use custom_payload_wrappers::*;
@@ -23,153 +23,25 @@ pub use custom_serde::*;
 pub use custom_traversal::*;
 pub use custom_value::*;
 pub use custom_value_kind::*;
+pub use definitions::*;
 pub use display_context::*;
 
-pub use radix_engine_constants::MANIFEST_SBOR_V1_PAYLOAD_PREFIX;
-pub const MANIFEST_SBOR_V1_MAX_DEPTH: usize = 24;
+// Prelude:
+// This exposes all the types/traits directly, without exposing the module
+// names. These module names can clash with other preludes so get excluded.
+pub mod prelude {
+    // Public modules to include in prelude
+    pub use super::model::*;
 
-pub type ManifestEncoder<'a> = VecEncoder<'a, ManifestCustomValueKind>;
-pub type ManifestDecoder<'a> = VecDecoder<'a, ManifestCustomValueKind>;
-pub type ManifestValueKind = ValueKind<ManifestCustomValueKind>;
-pub type ManifestValue = Value<ManifestCustomValueKind, ManifestCustomValue>;
-pub type ManifestEnumVariantValue = EnumVariantValue<ManifestCustomValueKind, ManifestCustomValue>;
-pub type ManifestTraverser<'a> = VecTraverser<'a, ManifestCustomTraversal>;
-
-pub trait ManifestCategorize: Categorize<ManifestCustomValueKind> {}
-impl<T: Categorize<ManifestCustomValueKind> + ?Sized> ManifestCategorize for T {}
-
-pub trait ManifestSborEnum: SborEnum<ManifestCustomValueKind> {}
-impl<T: SborEnum<ManifestCustomValueKind> + ?Sized> ManifestSborEnum for T {}
-
-pub trait ManifestSborTuple: SborTuple<ManifestCustomValueKind> {}
-impl<T: SborTuple<ManifestCustomValueKind> + ?Sized> ManifestSborTuple for T {}
-
-pub trait ManifestDecode: for<'a> Decode<ManifestCustomValueKind, ManifestDecoder<'a>> {}
-impl<T: for<'a> Decode<ManifestCustomValueKind, ManifestDecoder<'a>>> ManifestDecode for T {}
-
-pub trait ManifestEncode: for<'a> Encode<ManifestCustomValueKind, ManifestEncoder<'a>> {}
-impl<T: for<'a> Encode<ManifestCustomValueKind, ManifestEncoder<'a>> + ?Sized> ManifestEncode
-    for T
-{
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RustToManifestValueError {
-    DecodeError(DecodeError),
-    EncodeError(EncodeError),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ManifestToRustValueError {
-    DecodeError(DecodeError),
-    EncodeError(EncodeError),
-}
-
-pub fn manifest_encode<T: ManifestEncode + ?Sized>(value: &T) -> Result<Vec<u8>, EncodeError> {
-    let mut buf = Vec::with_capacity(512);
-    let encoder = ManifestEncoder::new(&mut buf, MANIFEST_SBOR_V1_MAX_DEPTH);
-    encoder.encode_payload(value, MANIFEST_SBOR_V1_PAYLOAD_PREFIX)?;
-    Ok(buf)
-}
-
-pub fn manifest_decode<T: ManifestDecode>(buf: &[u8]) -> Result<T, DecodeError> {
-    ManifestDecoder::new(buf, MANIFEST_SBOR_V1_MAX_DEPTH)
-        .decode_payload(MANIFEST_SBOR_V1_PAYLOAD_PREFIX)
-}
-
-pub fn to_manifest_value<T: ManifestEncode + ?Sized>(
-    value: &T,
-) -> Result<ManifestValue, RustToManifestValueError> {
-    let encoded = manifest_encode(value).map_err(RustToManifestValueError::EncodeError)?;
-
-    manifest_decode(&encoded).map_err(RustToManifestValueError::DecodeError)
-}
-
-pub fn from_manifest_value<T: ManifestDecode>(
-    manifest_value: &ManifestValue,
-) -> Result<T, ManifestToRustValueError> {
-    let encoded = manifest_encode(manifest_value).map_err(ManifestToRustValueError::EncodeError)?;
-
-    manifest_decode(&encoded).map_err(ManifestToRustValueError::DecodeError)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_manifest_value_conversions() {
-        let invalid_value = ManifestValue::Tuple {
-            fields: vec![ManifestValue::Array {
-                element_value_kind: ValueKind::U8,
-                elements: vec![
-                    ManifestValue::U8 { value: 1 },
-                    ManifestValue::U16 { value: 2 },
-                ],
-            }],
-        };
-        assert!(matches!(
-            to_manifest_value(&invalid_value),
-            Err(RustToManifestValueError::EncodeError(
-                EncodeError::MismatchingArrayElementValueKind { .. }
-            ))
-        ));
-
-        let invalid_value = ManifestValue::Map {
-            key_value_kind: ValueKind::U8,
-            value_value_kind: ValueKind::I8,
-            entries: vec![(
-                ManifestValue::U16 { value: 1 },
-                ManifestValue::I8 { value: 1 },
-            )],
-        };
-        assert!(matches!(
-            to_manifest_value(&invalid_value),
-            Err(RustToManifestValueError::EncodeError(
-                EncodeError::MismatchingMapKeyValueKind { .. }
-            ))
-        ));
-
-        let invalid_value = ManifestValue::Map {
-            key_value_kind: ValueKind::U8,
-            value_value_kind: ValueKind::I8,
-            entries: vec![(
-                ManifestValue::U8 { value: 1 },
-                ManifestValue::I16 { value: 1 },
-            )],
-        };
-        assert!(matches!(
-            to_manifest_value(&invalid_value),
-            Err(RustToManifestValueError::EncodeError(
-                EncodeError::MismatchingMapValueValueKind { .. }
-            ))
-        ));
-
-        let too_deep_tuple = get_tuple_of_depth(MANIFEST_SBOR_V1_MAX_DEPTH + 1).unwrap();
-        assert!(matches!(
-            to_manifest_value(&too_deep_tuple),
-            Err(RustToManifestValueError::EncodeError(
-                EncodeError::MaxDepthExceeded { .. }
-            ))
-        ));
-
-        let fine_tuple = get_tuple_of_depth(MANIFEST_SBOR_V1_MAX_DEPTH).unwrap();
-        assert!(to_manifest_value(&fine_tuple).is_ok());
-    }
-
-    pub fn get_tuple_of_depth(depth: usize) -> Option<ManifestValue> {
-        // Minimum tuple depth is 2
-        if depth <= 1 {
-            None
-        } else if depth <= 2 {
-            Some(ManifestValue::Tuple {
-                fields: vec![ManifestValue::U8 { value: 1 }],
-            })
-        } else {
-            let value = get_tuple_of_depth(depth - 1).unwrap();
-            Some(ManifestValue::Tuple {
-                fields: vec![value],
-            })
-        }
-    }
+    // Private modules to include in prelude
+    pub use super::custom_extension::*;
+    pub use super::custom_formatting::*;
+    pub use super::custom_payload_wrappers::*;
+    #[cfg(feature = "serde")]
+    pub use super::custom_serde::*;
+    pub use super::custom_traversal::*;
+    pub use super::custom_value::*;
+    pub use super::custom_value_kind::*;
+    pub use super::definitions::*;
+    pub use super::display_context::*;
 }

--- a/radix-engine-common/src/data/manifest/model/manifest_non_fungible_local_id.rs
+++ b/radix-engine-common/src/data/manifest/model/manifest_non_fungible_local_id.rs
@@ -9,7 +9,7 @@ use crate::*;
 
 // NOTE: redundant code to `NonFungibleLocalId` in favor of minimum dependency
 
-pub const NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH: usize = 64;
+pub const MANIFEST_NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH: usize = 64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ManifestNonFungibleLocalId {
@@ -20,7 +20,7 @@ pub enum ManifestNonFungibleLocalId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ContentValidationError {
+pub enum ManifestNonFungibleLocalIdValidationError {
     TooLong,
     Empty,
     ContainsBadCharacter(char),
@@ -28,31 +28,31 @@ pub enum ContentValidationError {
 }
 
 impl ManifestNonFungibleLocalId {
-    pub fn string(s: String) -> Result<Self, ContentValidationError> {
+    pub fn string(s: String) -> Result<Self, ManifestNonFungibleLocalIdValidationError> {
         if s.len() == 0 {
-            return Err(ContentValidationError::Empty);
+            return Err(ManifestNonFungibleLocalIdValidationError::Empty);
         }
-        if s.len() > NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH {
-            return Err(ContentValidationError::TooLong);
+        if s.len() > MANIFEST_NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH {
+            return Err(ManifestNonFungibleLocalIdValidationError::TooLong);
         }
         for char in s.chars() {
             if !matches!(char, '0'..='9' | 'A'..='Z' | 'a'..='z' | '_') {
-                return Err(ContentValidationError::ContainsBadCharacter(char));
+                return Err(ManifestNonFungibleLocalIdValidationError::ContainsBadCharacter(char));
             }
         }
         Ok(Self::String(s))
     }
 
-    pub fn integer(s: u64) -> Result<Self, ContentValidationError> {
+    pub fn integer(s: u64) -> Result<Self, ManifestNonFungibleLocalIdValidationError> {
         Ok(Self::Integer(s))
     }
 
-    pub fn bytes(s: Vec<u8>) -> Result<Self, ContentValidationError> {
+    pub fn bytes(s: Vec<u8>) -> Result<Self, ManifestNonFungibleLocalIdValidationError> {
         if s.len() == 0 {
-            return Err(ContentValidationError::Empty);
+            return Err(ManifestNonFungibleLocalIdValidationError::Empty);
         }
-        if s.len() > NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH {
-            return Err(ContentValidationError::TooLong);
+        if s.len() > MANIFEST_NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH {
+            return Err(ManifestNonFungibleLocalIdValidationError::TooLong);
         }
         Ok(Self::Bytes(s))
     }
@@ -72,7 +72,7 @@ impl<'a> Arbitrary<'a> for ManifestNonFungibleLocalId {
                         .chars()
                         .collect();
                 let len: u8 = u
-                    .int_in_range(1..=NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH as u8)
+                    .int_in_range(1..=MANIFEST_NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH as u8)
                     .unwrap();
                 let s = (0..len).map(|_| *u.choose(&charset[..]).unwrap()).collect();
                 Self::String(s)
@@ -83,7 +83,7 @@ impl<'a> Arbitrary<'a> for ManifestNonFungibleLocalId {
             }
             2 => {
                 let len: u8 = u
-                    .int_in_range(1..=NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH as u8)
+                    .int_in_range(1..=MANIFEST_NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH as u8)
                     .unwrap();
                 let bytes = (0..len).map(|_| u8::arbitrary(u).unwrap()).collect();
                 Self::Bytes(bytes)

--- a/radix-engine-common/src/data/scrypto/custom_extension.rs
+++ b/radix-engine-common/src/data/scrypto/custom_extension.rs
@@ -1,7 +1,4 @@
-use super::*;
-use crate::*;
-use sbor::rust::prelude::*;
-use sbor::*;
+use crate::internal_prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ScryptoCustomExtension {}

--- a/radix-engine-common/src/data/scrypto/custom_formatting.rs
+++ b/radix-engine-common/src/data/scrypto/custom_formatting.rs
@@ -1,10 +1,4 @@
-use super::*;
-use crate::address::Bech32Encoder;
-use crate::*;
-use sbor::representations::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::*;
-use utils::ContextualDisplay;
+use crate::internal_prelude::*;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ScryptoValueDisplayContext<'a> {

--- a/radix-engine-common/src/data/scrypto/custom_payload_wrappers.rs
+++ b/radix-engine-common/src/data/scrypto/custom_payload_wrappers.rs
@@ -1,5 +1,4 @@
-use super::*;
-use sbor::*;
+use crate::internal_prelude::*;
 
 pub type ScryptoRawPayload<'a> = RawPayload<'a, ScryptoCustomExtension>;
 pub type ScryptoOwnedRawPayload = RawPayload<'static, ScryptoCustomExtension>;

--- a/radix-engine-common/src/data/scrypto/custom_schema.rs
+++ b/radix-engine-common/src/data/scrypto/custom_schema.rs
@@ -1,8 +1,4 @@
-use super::*;
-use crate::types::PackageAddress;
-use crate::*;
-use sbor::rust::prelude::*;
-use sbor::*;
+use crate::internal_prelude::*;
 
 pub type ScryptoTypeKind<L> = TypeKind<ScryptoCustomTypeKind, L>;
 pub type ScryptoSchema = Schema<ScryptoCustomSchema>;

--- a/radix-engine-common/src/data/scrypto/custom_serde.rs
+++ b/radix-engine-common/src/data/scrypto/custom_serde.rs
@@ -1,10 +1,4 @@
-use super::*;
-use crate::*;
-use sbor::representations::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::*;
-use sbor::*;
-use utils::ContextualDisplay;
+use crate::internal_prelude::*;
 
 impl SerializableCustomExtension for ScryptoCustomExtension {
     fn map_value_for_serialization<'s, 'de, 'a, 't, 's1, 's2>(

--- a/radix-engine-common/src/data/scrypto/custom_traversal.rs
+++ b/radix-engine-common/src/data/scrypto/custom_traversal.rs
@@ -1,8 +1,4 @@
-use sbor::decoder::*;
-use sbor::traversal::*;
-use sbor::value_kind::*;
-
-use super::*;
+use crate::internal_prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScryptoCustomTerminalValueRef(pub ScryptoCustomValue);

--- a/radix-engine-common/src/data/scrypto/custom_validation.rs
+++ b/radix-engine-common/src/data/scrypto/custom_validation.rs
@@ -1,8 +1,4 @@
-use super::*;
-use crate::*;
-use sbor::rust::prelude::*;
-use sbor::traversal::TerminalValueRef;
-use sbor::*;
+use crate::internal_prelude::*;
 
 //=======================================================================================================
 // NOTE:

--- a/radix-engine-common/src/data/scrypto/custom_value.rs
+++ b/radix-engine-common/src/data/scrypto/custom_value.rs
@@ -1,10 +1,6 @@
-use crate::data::scrypto::model::*;
-use crate::data::scrypto::*;
-use crate::math::{Decimal, PreciseDecimal};
+use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
-use sbor::value_kind::*;
-use sbor::*;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/radix-engine-common/src/data/scrypto/custom_value_kind.rs
+++ b/radix-engine-common/src/data/scrypto/custom_value_kind.rs
@@ -1,6 +1,6 @@
+use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
-use sbor::*;
 
 pub const VALUE_KIND_REFERENCE: u8 = 0x80;
 pub const VALUE_KIND_OWN: u8 = 0x90;

--- a/radix-engine-common/src/data/scrypto/definitions.rs
+++ b/radix-engine-common/src/data/scrypto/definitions.rs
@@ -1,0 +1,56 @@
+use crate::internal_prelude::*;
+
+pub use radix_engine_constants::SCRYPTO_SBOR_V1_PAYLOAD_PREFIX;
+pub const SCRYPTO_SBOR_V1_MAX_DEPTH: usize = 64;
+
+pub type ScryptoEncoder<'a> = VecEncoder<'a, ScryptoCustomValueKind>;
+pub type ScryptoDecoder<'a> = VecDecoder<'a, ScryptoCustomValueKind>;
+pub type ScryptoTraverser<'a> = VecTraverser<'a, ScryptoCustomTraversal>;
+pub type ScryptoValueKind = ValueKind<ScryptoCustomValueKind>;
+pub type ScryptoValue = Value<ScryptoCustomValueKind, ScryptoCustomValue>;
+
+// The following trait "aliases" are to be used in parameters.
+//
+// They are much nicer to read than the underlying traits, but because they are "new", and are defined
+// via blanket impls, they can only be used for parameters, but cannot be used for implementations.
+//
+// Implementations should instead implement the underlying traits:
+// * Categorize<ScryptoCustomValueKind>
+// * Encode<ScryptoCustomValueKind, E> (impl over all E: Encoder<ScryptoCustomValueKind>)
+// * Decode<ScryptoCustomValueKind, D> (impl over all D: Decoder<ScryptoCustomValueKind>)
+//
+// TODO: Change these to be Trait aliases once stable in rust: https://github.com/rust-lang/rust/issues/41517
+pub trait ScryptoCategorize: Categorize<ScryptoCustomValueKind> {}
+impl<T: Categorize<ScryptoCustomValueKind> + ?Sized> ScryptoCategorize for T {}
+
+pub trait ScryptoSborEnum: SborEnum<ScryptoCustomValueKind> {}
+impl<T: SborEnum<ScryptoCustomValueKind> + ?Sized> ScryptoSborEnum for T {}
+
+pub trait ScryptoSborTuple: SborTuple<ScryptoCustomValueKind> {}
+impl<T: SborTuple<ScryptoCustomValueKind> + ?Sized> ScryptoSborTuple for T {}
+
+pub trait ScryptoDecode: for<'a> Decode<ScryptoCustomValueKind, ScryptoDecoder<'a>> {}
+impl<T: for<'a> Decode<ScryptoCustomValueKind, ScryptoDecoder<'a>>> ScryptoDecode for T {}
+
+pub trait ScryptoEncode: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> {}
+impl<T: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> + ?Sized> ScryptoEncode for T {}
+
+pub trait ScryptoDescribe: Describe<ScryptoCustomTypeKind> {}
+impl<T: Describe<ScryptoCustomTypeKind>> ScryptoDescribe for T {}
+
+pub trait ScryptoSbor: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe {}
+impl<T: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe> ScryptoSbor for T {}
+
+/// Encodes a data structure into byte array.
+pub fn scrypto_encode<T: ScryptoEncode + ?Sized>(value: &T) -> Result<Vec<u8>, EncodeError> {
+    let mut buf = Vec::with_capacity(512);
+    let encoder = ScryptoEncoder::new(&mut buf, SCRYPTO_SBOR_V1_MAX_DEPTH);
+    encoder.encode_payload(value, SCRYPTO_SBOR_V1_PAYLOAD_PREFIX)?;
+    Ok(buf)
+}
+
+/// Decodes a data structure from a byte array.
+pub fn scrypto_decode<T: ScryptoDecode>(buf: &[u8]) -> Result<T, DecodeError> {
+    ScryptoDecoder::new(buf, SCRYPTO_SBOR_V1_MAX_DEPTH)
+        .decode_payload(SCRYPTO_SBOR_V1_PAYLOAD_PREFIX)
+}

--- a/radix-engine-common/src/data/scrypto/mod.rs
+++ b/radix-engine-common/src/data/scrypto/mod.rs
@@ -1,3 +1,8 @@
+// Modules that should appear explicitly under the scrypto module
+pub mod model;
+
+// Modules which should appear part of the scrypto module
+
 /// Defines the full Scrypto extension.
 mod custom_extension;
 mod custom_formatting;
@@ -16,10 +21,10 @@ mod custom_value;
 mod custom_value_kind;
 /// Defines the scrypto custom well known types.
 mod custom_well_known_types;
+/// Defines the core traits and methods for scrypto SBOR encoding
+mod definitions;
 /// Defines a way to uniquely identify an element within a Scrypto schema type.
 mod schema_path;
-
-pub mod model;
 
 pub use custom_extension::*;
 pub use custom_formatting::*;
@@ -32,63 +37,28 @@ pub use custom_validation::*;
 pub use custom_value::*;
 pub use custom_value_kind::*;
 pub use custom_well_known_types::*;
+pub use definitions::*;
 pub use schema_path::*;
 
-use sbor::rust::vec::Vec;
-use sbor::traversal::VecTraverser;
-use sbor::*;
+// Prelude:
+// This exposes all the types/traits directly, without exposing the module
+// names. These module names can clash with other preludes so get excluded.
+pub mod prelude {
+    // Public modules to include in prelude
+    pub use super::model::*;
 
-pub use radix_engine_constants::SCRYPTO_SBOR_V1_PAYLOAD_PREFIX;
-pub const SCRYPTO_SBOR_V1_MAX_DEPTH: usize = 64;
-
-pub type ScryptoEncoder<'a> = VecEncoder<'a, ScryptoCustomValueKind>;
-pub type ScryptoDecoder<'a> = VecDecoder<'a, ScryptoCustomValueKind>;
-pub type ScryptoTraverser<'a> = VecTraverser<'a, ScryptoCustomTraversal>;
-pub type ScryptoValueKind = ValueKind<ScryptoCustomValueKind>;
-pub type ScryptoValue = Value<ScryptoCustomValueKind, ScryptoCustomValue>;
-
-// The following trait "aliases" are to be used in parameters.
-//
-// They are much nicer to read than the underlying traits, but because they are "new", and are defined
-// via blanket impls, they can only be used for parameters, but cannot be used for implementations.
-//
-// Implementations should instead implement the underlying traits:
-// * Categorize<ScryptoCustomValueKind>
-// * Encode<ScryptoCustomValueKind, E> (impl over all E: Encoder<ScryptoCustomValueKind>)
-// * Decode<ScryptoCustomValueKind, D> (impl over all D: Decoder<ScryptoCustomValueKind>)
-//
-// TODO: Change these to be Trait aliases once stable in rust: https://github.com/rust-lang/rust/issues/41517
-pub trait ScryptoCategorize: Categorize<ScryptoCustomValueKind> {}
-impl<T: Categorize<ScryptoCustomValueKind> + ?Sized> ScryptoCategorize for T {}
-
-pub trait ScryptoSborEnum: SborEnum<ScryptoCustomValueKind> {}
-impl<T: SborEnum<ScryptoCustomValueKind> + ?Sized> ScryptoSborEnum for T {}
-
-pub trait ScryptoSborTuple: SborTuple<ScryptoCustomValueKind> {}
-impl<T: SborTuple<ScryptoCustomValueKind> + ?Sized> ScryptoSborTuple for T {}
-
-pub trait ScryptoDecode: for<'a> Decode<ScryptoCustomValueKind, ScryptoDecoder<'a>> {}
-impl<T: for<'a> Decode<ScryptoCustomValueKind, ScryptoDecoder<'a>>> ScryptoDecode for T {}
-
-pub trait ScryptoEncode: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> {}
-impl<T: for<'a> Encode<ScryptoCustomValueKind, ScryptoEncoder<'a>> + ?Sized> ScryptoEncode for T {}
-
-pub trait ScryptoDescribe: Describe<ScryptoCustomTypeKind> {}
-impl<T: Describe<ScryptoCustomTypeKind>> ScryptoDescribe for T {}
-
-pub trait ScryptoSbor: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe {}
-impl<T: ScryptoCategorize + ScryptoDecode + ScryptoEncode + ScryptoDescribe> ScryptoSbor for T {}
-
-/// Encodes a data structure into byte array.
-pub fn scrypto_encode<T: ScryptoEncode + ?Sized>(value: &T) -> Result<Vec<u8>, EncodeError> {
-    let mut buf = Vec::with_capacity(512);
-    let encoder = ScryptoEncoder::new(&mut buf, SCRYPTO_SBOR_V1_MAX_DEPTH);
-    encoder.encode_payload(value, SCRYPTO_SBOR_V1_PAYLOAD_PREFIX)?;
-    Ok(buf)
-}
-
-/// Decodes a data structure from a byte array.
-pub fn scrypto_decode<T: ScryptoDecode>(buf: &[u8]) -> Result<T, DecodeError> {
-    ScryptoDecoder::new(buf, SCRYPTO_SBOR_V1_MAX_DEPTH)
-        .decode_payload(SCRYPTO_SBOR_V1_PAYLOAD_PREFIX)
+    // Private modules to include in prelude
+    pub use super::custom_extension::*;
+    pub use super::custom_formatting::*;
+    pub use super::custom_payload_wrappers::*;
+    pub use super::custom_schema::*;
+    #[cfg(feature = "serde")]
+    pub use super::custom_serde::*;
+    pub use super::custom_traversal::*;
+    pub use super::custom_validation::*;
+    pub use super::custom_value::*;
+    pub use super::custom_value_kind::*;
+    pub use super::custom_well_known_types::*;
+    pub use super::definitions::*;
+    pub use super::schema_path::*;
 }

--- a/radix-engine-common/src/lib.rs
+++ b/radix-engine-common/src/lib.rs
@@ -49,6 +49,7 @@ pub extern crate self as radix_engine_common;
 /// This makes refactors easier, and makes integration into the node less painful.
 pub mod prelude {
     // Exports from upstream libaries
+    pub use radix_engine_constants::*;
     pub use radix_engine_derive::{
         ManifestCategorize, ManifestDecode, ManifestEncode, ManifestSbor, ScryptoCategorize,
         ScryptoDecode, ScryptoEncode, ScryptoEvent, ScryptoSbor,
@@ -59,13 +60,22 @@ pub mod prelude {
     // Exports from this crate
     pub use super::address::*;
     pub use super::crypto::*;
-    pub use super::data::manifest::*;
-    pub use super::data::scrypto::model::*;
-    pub use super::data::scrypto::*;
+    pub use super::data::manifest::prelude::*;
+    pub use super::data::scrypto::prelude::*;
     pub use super::macros::*;
+    pub use super::math::*;
     pub use super::native_addresses::*;
     pub use super::network::*;
     pub use super::time::*;
     pub use super::types::*;
-    pub use crate::{dec, define_wrapped_hash, manifest_args, pdec, scrypto_args};
+    pub use crate::{
+        dec, define_wrapped_hash, manifest_args, pdec, scrypto_args, to_manifest_value_and_unwrap,
+    };
+}
+
+pub(crate) mod internal_prelude {
+    pub use super::prelude::*;
+    pub use sbor::representations::*;
+    pub use sbor::traversal::*;
+    pub use sbor::*;
 }

--- a/radix-engine-common/tests/manifest_codec.rs
+++ b/radix-engine-common/tests/manifest_codec.rs
@@ -1,7 +1,6 @@
 use radix_engine_common::address::test_addresses::*;
 use radix_engine_common::data::manifest::model::*;
-use radix_engine_common::data::manifest::*;
-use radix_engine_common::*;
+use radix_engine_common::prelude::*;
 
 #[derive(ManifestSbor, PartialEq, Eq, Debug)]
 struct TestStruct {

--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -7,12 +7,15 @@
 // In order to distinguish payloads, all of these should be distinct!
 // This is particularly important for payloads which will be signed (Transaction / ROLA)
 
-/// 0x5b for [5b]or - (90 in decimal)
-pub const BASIC_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5b; // Duplicated due to dependency issues
+// 0x5b for [5b]or - (90 in decimal)
+// The following is exported from the sbor repo, but commented out here to avoid import clashes:
+// pub const BASIC_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5b;
+
 /// 0x5c for [5c]rypto - (91 in decimal)
 pub const SCRYPTO_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x5c;
 /// 0x4d = M in ASCII for Manifest - (77 in decimal)
 pub const MANIFEST_SBOR_V1_PAYLOAD_PREFIX: u8 = 0x4d;
+
 /// The ROLA hash which is signed is created as `hash(ROLA_HASHABLE_PAYLOAD_PREFIX || ..)`
 ///
 /// 0x52 = R in ASCII for ROLA - (82 in decimal)

--- a/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -1,13 +1,8 @@
 use crate::blueprints::resource::*;
-use crate::data::scrypto::model::*;
 use crate::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::{Arbitrary, Result, Unstructured};
-use radix_engine_common::data::manifest::model::ManifestAddressReservation;
-use radix_engine_common::data::manifest::ManifestValue;
-use radix_engine_common::data::scrypto::{ScryptoCustomTypeKind, ScryptoSchema, ScryptoValue};
-use radix_engine_common::prelude::replace_self_package_address;
-use radix_engine_common::types::*;
+use radix_engine_common::prelude::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::types::NonFungibleData;
 use sbor::rust::collections::{BTreeMap, BTreeSet};

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -39,15 +39,18 @@ pub extern crate self as radix_engine_interface;
 /// The idea is that we can just include the current crate's prelude and avoid messing around with tons of includes.
 /// This makes refactors easier, and makes integration into the node less painful.
 pub mod prelude {
+    // Extern crates for the purposes of EG being visible from
+    // scrypto macros
+    pub extern crate radix_engine_common;
+
     // Exports from upstream crates
     pub use radix_engine_common::prelude::*;
 
     // Exports from this crate
     pub use crate::blueprints::resource::NonFungibleGlobalId;
-    pub use crate::data::manifest::model::*;
-    pub use crate::data::manifest::*;
-    pub use crate::data::scrypto::model::*;
-    pub use crate::data::scrypto::*;
     pub use crate::macros::*;
+    pub use crate::schema::*;
+    pub use crate::traits::*;
     pub use crate::types::*;
+    pub use crate::{access_and_or, access_rule_node, role_entry, roles2, rule};
 }

--- a/radix-engine-queries/src/typed_substate_layout.rs
+++ b/radix-engine-queries/src/typed_substate_layout.rs
@@ -1,15 +1,14 @@
 use radix_engine::blueprints::transaction_tracker::TransactionTrackerSubstate;
 use radix_engine::types::*;
-use sbor::rust::prelude::*;
 
 // Import and re-export these types so they are available easily with a single import
 pub use radix_engine::blueprints::access_controller::*;
 pub use radix_engine::blueprints::account::*;
 pub use radix_engine::blueprints::consensus_manager::*;
 pub use radix_engine::blueprints::package::*;
-pub use radix_engine::blueprints::pool::multi_resource_pool::*;
-pub use radix_engine::blueprints::pool::one_resource_pool::*;
-pub use radix_engine::blueprints::pool::two_resource_pool::*;
+pub use radix_engine::blueprints::pool::multi_resource_pool;
+pub use radix_engine::blueprints::pool::one_resource_pool;
+pub use radix_engine::blueprints::pool::two_resource_pool;
 pub use radix_engine::blueprints::resource::*;
 pub use radix_engine::system::node_modules::access_rules::*;
 pub use radix_engine::system::node_modules::metadata::*;
@@ -526,17 +525,17 @@ pub enum TypedAccountFieldValue {
 
 #[derive(Debug, Clone)]
 pub enum TypedOneResourcePoolFieldValue {
-    OneResourcePool(OneResourcePoolSubstate),
+    OneResourcePool(one_resource_pool::OneResourcePoolSubstate),
 }
 
 #[derive(Debug, Clone)]
 pub enum TypedTwoResourcePoolFieldValue {
-    TwoResourcePool(TwoResourcePoolSubstate),
+    TwoResourcePool(two_resource_pool::TwoResourcePoolSubstate),
 }
 
 #[derive(Debug, Clone)]
 pub enum TypedMultiResourcePoolFieldValue {
-    MultiResourcePool(MultiResourcePoolSubstate),
+    MultiResourcePool(multi_resource_pool::MultiResourcePoolSubstate),
 }
 
 #[derive(Debug, Clone)]

--- a/radix-engine-tests/tests/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/account_deposit_modes.rs
@@ -4,7 +4,6 @@ use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_queries::typed_substate_layout::AccountError;
-use scrypto::prelude::*;
 use scrypto_unit::TestRunner;
 use transaction::builder::{ManifestBuilder, TransactionManifestV1};
 use transaction::signing::secp256k1::Secp256k1PrivateKey;

--- a/radix-engine-tests/tests/multi_resource_pool.rs
+++ b/radix-engine-tests/tests/multi_resource_pool.rs
@@ -5,7 +5,6 @@ use radix_engine::{
     types::*,
 };
 use radix_engine_interface::blueprints::pool::*;
-use scrypto::prelude::*;
 use scrypto_unit::{is_auth_error, TestRunner};
 use transaction::prelude::{ManifestBuilder, TransactionManifestV1};
 

--- a/radix-engine-tests/tests/one_resource_pool.rs
+++ b/radix-engine-tests/tests/one_resource_pool.rs
@@ -3,7 +3,6 @@ use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::pool::*;
-use scrypto::prelude::*;
 use scrypto_unit::*;
 use transaction::builder::*;
 

--- a/radix-engine-tests/tests/two_resource_pool.rs
+++ b/radix-engine-tests/tests/two_resource_pool.rs
@@ -3,7 +3,6 @@ use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::pool::*;
-use scrypto::prelude::*;
 use scrypto_unit::*;
 use transaction::builder::*;
 

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -604,7 +604,7 @@ impl PackageNativePackage {
         functions.insert(
             PACKAGE_CLAIM_ROYALTIES_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<PackageClaimRoyaltiesInput>(),
                 ),

--- a/radix-engine/src/blueprints/transaction_tracker/package.rs
+++ b/radix-engine/src/blueprints/transaction_tracker/package.rs
@@ -50,7 +50,7 @@ impl TransactionTrackerNativePackage {
         let mut collections: Vec<BlueprintCollectionSchema<TypeRef<LocalTypeIndex>>> = vec![];
         for _ in PARTITION_RANGE_START..=PARTITION_RANGE_END {
             collections.push(BlueprintCollectionSchema::KeyValueStore(
-                schema::BlueprintKeyValueStoreSchema {
+                BlueprintKeyValueStoreSchema {
                     key: TypeRef::Static(key_type_index),
                     value: TypeRef::Static(value_type_index),
                     can_own: false,

--- a/radix-engine/src/system/node_modules/access_rules/package.rs
+++ b/radix-engine/src/system/node_modules/access_rules/package.rs
@@ -72,7 +72,7 @@ impl AccessRulesNativePackage {
         functions.insert(
             ACCESS_RULES_UPDATE_ROLE_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<AccessRulesUpdateRoleInput>(),
                 ),
@@ -85,7 +85,7 @@ impl AccessRulesNativePackage {
         functions.insert(
             ACCESS_RULES_GET_ROLE_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<AccessRulesGetRoleInput>(),
                 ),

--- a/radix-engine/src/system/node_modules/metadata/package.rs
+++ b/radix-engine/src/system/node_modules/metadata/package.rs
@@ -73,7 +73,7 @@ impl MetadataNativePackage {
         functions.insert(
             METADATA_SET_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<MetadataSetInput>(),
                 ),
@@ -86,7 +86,7 @@ impl MetadataNativePackage {
         functions.insert(
             METADATA_GET_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref()),
+                receiver: Some(ReceiverInfo::normal_ref()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<MetadataGetInput>(),
                 ),
@@ -99,7 +99,7 @@ impl MetadataNativePackage {
         functions.insert(
             METADATA_REMOVE_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<MetadataRemoveInput>(),
                 ),

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -61,7 +61,7 @@ impl RoyaltyNativePackage {
         functions.insert(
             COMPONENT_ROYALTY_SET_ROYALTY_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<ComponentSetRoyaltyInput>(),
                 ),
@@ -74,7 +74,7 @@ impl RoyaltyNativePackage {
         functions.insert(
             COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT.to_string(),
             FunctionSchemaInit {
-                receiver: Some(schema::ReceiverInfo::normal_ref_mut()),
+                receiver: Some(ReceiverInfo::normal_ref_mut()),
                 input: TypeRef::Static(
                     aggregator.add_child_type_and_descendents::<ComponentClaimRoyaltiesInput>(),
                 ),

--- a/radix-engine/src/types.rs
+++ b/radix-engine/src/types.rs
@@ -4,38 +4,14 @@ pub use radix_engine_interface::address::{
 };
 pub use radix_engine_interface::blueprints::resource::*;
 pub use radix_engine_interface::constants::*;
-pub use radix_engine_interface::crypto::*;
-pub use radix_engine_interface::data::manifest::model::*;
-pub use radix_engine_interface::data::manifest::*;
-pub use radix_engine_interface::data::scrypto::model::*;
-pub use radix_engine_interface::data::scrypto::*;
-pub use radix_engine_interface::dec;
-pub use radix_engine_interface::math::*;
-pub use radix_engine_interface::network::*;
-pub use radix_engine_interface::time::*;
-pub use radix_engine_interface::traits::*;
-pub use radix_engine_interface::types::*;
-pub use radix_engine_interface::*;
-pub use sbor::rust::borrow::ToOwned;
-pub use sbor::rust::boxed::Box;
-pub use sbor::rust::cell::{Ref, RefCell, RefMut};
-pub use sbor::rust::collections::*;
-pub use sbor::rust::fmt;
-pub use sbor::rust::fmt::Debug;
-pub use sbor::rust::format;
-pub use sbor::rust::marker::PhantomData;
+pub use radix_engine_interface::prelude::*;
+pub mod blueprints {
+    pub use radix_engine_interface::blueprints::*;
+}
 pub use sbor::rust::num::NonZeroU32;
 pub use sbor::rust::num::NonZeroUsize;
 pub use sbor::rust::ops::AddAssign;
 pub use sbor::rust::ops::SubAssign;
-pub use sbor::rust::ptr;
-pub use sbor::rust::rc::Rc;
-pub use sbor::rust::str::FromStr;
-pub use sbor::rust::string::String;
-pub use sbor::rust::string::ToString;
-pub use sbor::rust::sync;
-pub use sbor::rust::vec;
-pub use sbor::rust::vec::Vec;
 pub use sbor::*;
 #[cfg(feature = "std")]
 pub use std::alloc;

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -5,10 +5,10 @@ use crate::system::system::KeyValueEntrySubstate;
 use crate::system::system_callback::{SystemConfig, SystemLockData};
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::types::*;
-use crate::vm::vm::api::ClientApi;
 use crate::vm::wasm::WasmEngine;
 use crate::vm::{NativeVm, ScryptoVm};
 use radix_engine_interface::api::field_lock_api::LockFlags;
+use radix_engine_interface::api::ClientApi;
 use radix_engine_interface::blueprints::package::*;
 
 pub struct Vm<'g, W: WasmEngine> {

--- a/sbor/src/representations/display/nested_string.rs
+++ b/sbor/src/representations/display/nested_string.rs
@@ -71,7 +71,7 @@ pub(crate) fn format_partial_payload_as_nested_string<
     Ok(())
 }
 
-pub fn consume_end_event<E: FormattableCustomExtension>(
+fn consume_end_event<E: FormattableCustomExtension>(
     traverser: &mut TypedTraverser<E>,
 ) -> Result<(), FormattingError> {
     traverser.consume_end_event().map_err(FormattingError::Sbor)

--- a/sbor/src/representations/display/rustlike_string.rs
+++ b/sbor/src/representations/display/rustlike_string.rs
@@ -64,7 +64,7 @@ pub(crate) fn format_partial_payload_as_rustlike_value<
     Ok(())
 }
 
-pub fn consume_end_event<E: FormattableCustomExtension>(
+fn consume_end_event<E: FormattableCustomExtension>(
     traverser: &mut TypedTraverser<E>,
 ) -> Result<(), FormattingError> {
     traverser.consume_end_event().map_err(FormattingError::Sbor)

--- a/sbor/src/value.rs
+++ b/sbor/src/value.rs
@@ -349,9 +349,9 @@ impl<X: CustomValueKind, Y: CustomValue<X>, C: CustomTypeKind<GlobalTypeId>> Des
     }
 }
 
-///==============================================
-/// ENUMS
-///==============================================
+//==============================================
+// ENUMS
+//==============================================
 
 pub struct EnumVariantValue<X: CustomValueKind, Y: CustomValue<X>> {
     pub discriminator: u8,

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -24,13 +24,9 @@ pub use num_traits::{
     sign::Signed,
 };
 pub use radix_engine_interface::blueprints::resource::*;
-pub use radix_engine_interface::constants::*;
 pub use radix_engine_interface::crypto::*;
-pub use radix_engine_interface::data::manifest::model::*;
-pub use radix_engine_interface::data::manifest::*;
-pub use radix_engine_interface::data::scrypto::model::*;
-pub use radix_engine_interface::data::scrypto::*;
 pub use radix_engine_interface::math::*;
+pub use radix_engine_interface::prelude::*;
 pub use radix_engine_interface::time::*;
 pub use radix_engine_interface::traits::*;
 pub use radix_engine_interface::types::*;

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -83,7 +83,6 @@ use radix_engine_store_interface::{
     interface::SubstateDatabase,
 };
 use radix_engine_stores::rocks_db::RocksdbSubstateStore;
-use sbor::rust::prelude::*;
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/transaction/src/signing/secp256k1/signature.rs
+++ b/transaction/src/signing/secp256k1/signature.rs
@@ -40,23 +40,6 @@ impl TryFrom<&[u8]> for Secp256k1Signature {
 // error
 //======
 
-/// Represents an error when parsing an ECDSA Secp256k1 public key from hex.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ParseSecp256k1PublicKeyError {
-    InvalidHex(String),
-    InvalidLength(usize),
-}
-
-#[cfg(not(feature = "alloc"))]
-impl std::error::Error for ParseSecp256k1PublicKeyError {}
-
-#[cfg(not(feature = "alloc"))]
-impl fmt::Display for ParseSecp256k1PublicKeyError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseSecp256k1SignatureError {
     InvalidHex(String),

--- a/utils/src/rust.rs
+++ b/utils/src/rust.rs
@@ -4,6 +4,7 @@ pub mod prelude {
     // std::prelude::v1
     pub use super::borrow::ToOwned;
     pub use super::boxed::Box;
+    pub use super::cell::RefCell;
     pub use super::clone::Clone;
     pub use super::cmp::{Eq, Ord, PartialEq, PartialOrd};
     pub use super::convert::{AsMut, AsRef, From, Into};


### PR DESCRIPTION
## Summary
A mindless PR to resolve all the conflicting glob imports in scrypto.
