### PR TITLE
Tweak/finalize epoch constants

### DIFF
--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -50,7 +50,8 @@ pub const DEFAULT_MIN_TIP_PERCENTAGE: u16 = 0;
 pub const DEFAULT_MAX_TIP_PERCENTAGE: u16 = u16::MAX;
 
 /// The max epoch range
-pub const DEFAULT_MAX_EPOCH_RANGE: u64 = 100;
+/// Should be ~ 1 month. The below is ~30 days given 5 minute epochs.
+pub const DEFAULT_MAX_EPOCH_RANGE: u64 = 12 * 24 * 30;
 
 /// The max transaction size
 pub const DEFAULT_MAX_TRANSACTION_SIZE: usize = 1 * 1024 * 1024;

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -122,6 +122,10 @@ impl EpochChangeCondition {
         round: Round,
     ) -> EpochChangeOutcome {
         let epoch_duration_millis =
+            // The application invariants in `check_non_decreasing_and_update_timestamps`
+            // ensures that current_time > effective_start, and genesis should ensure
+            // effective_start > 0.
+            // This is just a sanity-check to avoid overflow if something invaraint fails.
             if current_time >= 0 && effective_start >= 0 && current_time > effective_start {
                 (current_time - effective_start) as u64
             } else {

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -105,16 +105,67 @@ pub struct EpochChangeCondition {
     pub target_duration_millis: u64,
 }
 
+pub enum EpochChangeOutcome {
+    NoChange,
+    Change {
+        next_epoch_effective_start_millis: i64,
+    },
+}
+
 impl EpochChangeCondition {
     /// Determines whether this condition is met by the given actual state.
     /// See the condition's field definitions for exact rules.
-    pub fn is_met(&self, duration_millis: i64, round: Round) -> bool {
+    pub fn should_epoch_change(
+        &self,
+        effective_start: i64,
+        current_time: i64,
+        round: Round,
+    ) -> EpochChangeOutcome {
+        let epoch_duration_millis =
+            if current_time >= 0 && effective_start >= 0 && current_time > effective_start {
+                (current_time - effective_start) as u64
+            } else {
+                0
+            };
+        if self.is_change_criterion_met(epoch_duration_millis, round) {
+            // The following aims to prevent small systematic drift in the epoch length each epoch,
+            // due to overheads / time noticing end of epoch.
+            // If the actual epoch length is sufficiently close to the target epoch length, we just
+            // pretend the effective epoch length was actually the target epoch length.
+            let next_epoch_effective_start_millis =
+                if self.is_actual_duration_close_to_target(epoch_duration_millis) {
+                    effective_start.saturating_add_unsigned(self.target_duration_millis)
+                } else {
+                    current_time
+                };
+            EpochChangeOutcome::Change {
+                next_epoch_effective_start_millis,
+            }
+        } else {
+            EpochChangeOutcome::NoChange
+        }
+    }
+
+    fn is_actual_duration_close_to_target(&self, actual_duration_millis: u64) -> bool {
+        let bounds_are_compatible_with_calculation =
+            actual_duration_millis >= 1000 && self.target_duration_millis >= 1000;
+        if !bounds_are_compatible_with_calculation {
+            // Need to avoid issues with divide by zero etc
+            return false;
+        }
+        let proportion_difference = (Decimal::from(actual_duration_millis)
+            - Decimal::from(self.target_duration_millis))
+            / Decimal::from(self.target_duration_millis);
+        proportion_difference <= dec!("0.1")
+    }
+
+    fn is_change_criterion_met(&self, duration_millis: u64, round: Round) -> bool {
         if round.number() >= self.max_round_count {
             true
         } else if round.number() < self.min_round_count {
             false
         } else {
-            duration_millis >= 0 && (duration_millis as u64) >= self.target_duration_millis
+            duration_millis >= self.target_duration_millis
         }
     }
 }

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -232,31 +232,109 @@ fn next_round_causes_epoch_change_on_reaching_max_rounds() {
 }
 
 #[test]
-fn next_round_causes_epoch_change_on_reaching_target_duration() {
+fn next_round_causes_epoch_change_on_reaching_target_duration_with_sensible_epoch_length_normalization(
+) {
     // Arrange
     let initial_epoch = Epoch::of(5);
     let rounds_per_epoch = 100;
-    let epoch_duration_millis = 1000;
+    let target_epoch_duration_millis = 1000;
+    let genesis_start_time_millis: i64 = 0;
     let genesis = CustomGenesis::default(
         initial_epoch,
         CustomGenesis::default_consensus_manager_config().with_epoch_change_condition(
             EpochChangeCondition {
                 min_round_count: 0,
                 max_round_count: rounds_per_epoch,
-                target_duration_millis: epoch_duration_millis,
+                target_duration_millis: target_epoch_duration_millis,
             },
         ),
     );
     let mut test_runner = TestRunner::builder().with_custom_genesis(genesis).build();
 
-    // Act
-    let receipt =
-        test_runner.advance_to_round_at_timestamp(Round::of(1), epoch_duration_millis as i64);
+    // Prepare for first epoch
+    let current_epoch = initial_epoch;
+    let expected_next_epoch_change_time =
+        genesis_start_time_millis + (target_epoch_duration_millis as i64);
 
-    // Assert
+    // Act 1 - not quite there
+    let next_round = Round::of(1);
+    let next_timestamp = expected_next_epoch_change_time - 1;
+    let receipt = test_runner.advance_to_round_at_timestamp(next_round, next_timestamp);
+
+    // Assert 1
+    let result = receipt.expect_commit_success();
+    assert!(result.next_epoch().is_none());
+
+    // Act 2 - slightly over the time change - should trigger
+    let next_round = Round::of(2);
+    let next_timestamp = expected_next_epoch_change_time + 1;
+    let receipt = test_runner.advance_to_round_at_timestamp(next_round, next_timestamp);
+
+    // Assert 2
     let result = receipt.expect_commit_success();
     let next_epoch = result.next_epoch().expect("Should have next epoch");
-    assert_eq!(next_epoch.epoch, initial_epoch.next());
+    assert_eq!(next_epoch.epoch, current_epoch.next());
+    let state = test_runner.get_consensus_manager_state();
+    assert_eq!(state.actual_epoch_start_milli, next_timestamp);
+    assert_eq!(
+        state.effective_epoch_start_milli,
+        expected_next_epoch_change_time
+    );
+
+    // Prepare for next epoch
+    let current_epoch = current_epoch.next();
+    let expected_next_epoch_change_time =
+        genesis_start_time_millis + 2 * (target_epoch_duration_millis as i64);
+
+    // Act 3 - In next epoch, not quite enough for another change
+    let next_round = Round::of(1);
+    let next_timestamp = expected_next_epoch_change_time - 1;
+    let receipt = test_runner.advance_to_round_at_timestamp(next_round, next_timestamp);
+
+    // Assert 3
+    let result = receipt.expect_commit_success();
+    assert!(result.next_epoch().is_none());
+
+    // Act 4 - In next epoch, exactly on expected time change
+    // Because of the epoch normalization, this epoch length is only 999 milliseconds
+    // but we catch back up with where we're expecting to be
+    let next_round = Round::of(2);
+    let next_timestamp = expected_next_epoch_change_time;
+    let receipt = test_runner.advance_to_round_at_timestamp(next_round, next_timestamp);
+
+    // Assert 4
+    let result = receipt.expect_commit_success();
+    let next_epoch = result.next_epoch().expect("Should have next epoch");
+    assert_eq!(next_epoch.epoch, current_epoch.next());
+    let state = test_runner.get_consensus_manager_state();
+    assert_eq!(
+        state.actual_epoch_start_milli,
+        expected_next_epoch_change_time
+    );
+    assert_eq!(
+        state.effective_epoch_start_milli,
+        expected_next_epoch_change_time
+    );
+
+    // Prepare for next epoch
+    let current_epoch = current_epoch.next();
+    let expected_next_epoch_change_time =
+        genesis_start_time_millis + 3 * (target_epoch_duration_millis as i64);
+
+    // Act 5
+    let next_round = Round::of(1);
+    // This round lasts much longer than planned
+    let next_timestamp = expected_next_epoch_change_time + (target_epoch_duration_millis as i64);
+    let receipt = test_runner.advance_to_round_at_timestamp(next_round, next_timestamp);
+
+    // Assert 5
+    // Therefore the effective start isn't normalized, and is equal to actual start
+    let result = receipt.expect_commit_success();
+    let next_epoch = result.next_epoch().expect("Should have next epoch");
+    assert_eq!(next_epoch.epoch, current_epoch.next());
+    let state = test_runner.get_consensus_manager_state();
+    assert_eq!(state.actual_epoch_start_milli, next_timestamp);
+    assert_eq!(state.effective_epoch_start_milli, next_timestamp);
 }
 
 #[test]

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -522,7 +522,8 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
         )
         .unwrap_or_else(|| ConsensusManagerSubstate {
             epoch: Epoch::zero(),
-            epoch_start_milli: 0,
+            effective_epoch_start_milli: 0,
+            actual_epoch_start_milli: 0,
             round: Round::zero(),
             current_leader: Some(0),
         });

--- a/transaction/src/validation/transaction_validator.rs
+++ b/transaction/src/validation/transaction_validator.rs
@@ -471,7 +471,13 @@ mod tests {
             TransactionValidationError::HeaderValidationError(
                 HeaderValidationError::EpochRangeTooLarge
             ),
-            (Epoch::zero(), Epoch::of(1000), 5, vec![1], 2)
+            (
+                Epoch::zero(),
+                Epoch::of(DEFAULT_MAX_EPOCH_RANGE + 1),
+                5,
+                vec![1],
+                2
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
Three parts:
* Fix `DEFAULT_MAX_EPOCH_RANGE` for a transaction to be ~1 month
* Tweak the consensus manager epoch change logic to not be prone to systematic drift - this means we can avoid handling / second-guessing this in our constants on the node side.
* Ensure the proposer timestamp is non-decreasing. This formalizes an invariant that an honest validator set is required to maintain.