### PR TITLE
tests: Add metadata encode/decode tests

### DIFF
--- a/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
@@ -103,22 +103,29 @@ pub const METADATA_VALUE_URL_DISCRIMINATOR: u8 = 13u8;
 pub const METADATA_VALUE_ORIGIN_DISCRIMINATOR: u8 = 14u8;
 pub const METADATA_VALUE_PUBLIC_KEY_HASH_DISCRIMINATOR: u8 = 15u8;
 
-pub const METADATA_VALUE_STRING_ARRAY_DISCRIMINATOR: u8 = 0x80 + 0u8;
-pub const METADATA_VALUE_BOOLEAN_ARRAY_DISCRIMINATOR: u8 = 0x80 + 1u8;
-pub const METADATA_VALUE_U8_ARRAY_DISCRIMINATOR: u8 = 0x80 + 2u8;
-pub const METADATA_VALUE_U32_ARRAY_DISCRIMINATOR: u8 = 0x80 + 3u8;
-pub const METADATA_VALUE_U64_ARRAY_DISCRIMINATOR: u8 = 0x80 + 4u8;
-pub const METADATA_VALUE_I32_ARRAY_DISCRIMINATOR: u8 = 0x80 + 5u8;
-pub const METADATA_VALUE_I64_ARRAY_DISCRIMINATOR: u8 = 0x80 + 6u8;
-pub const METADATA_VALUE_DECIMAL_ARRAY_DISCRIMINATOR: u8 = 0x80 + 7u8;
-pub const METADATA_VALUE_GLOBAL_ADDRESS_ARRAY_DISCRIMINATOR: u8 = 0x80 + 8u8;
-pub const METADATA_VALUE_PUBLIC_KEY_ARRAY_DISCRIMINATOR: u8 = 0x80 + 9u8;
-pub const METADATA_VALUE_NON_FUNGIBLE_GLOBAL_ID_ARRAY_DISCRIMINATOR: u8 = 0x80 + 10u8;
-pub const METADATA_VALUE_NON_FUNGIBLE_LOCAL_ID_ARRAY_DISCRIMINATOR: u8 = 0x80 + 11u8;
-pub const METADATA_VALUE_INSTANT_ARRAY_DISCRIMINATOR: u8 = 0x80 + 12u8;
-pub const METADATA_VALUE_URL_ARRAY_DISCRIMINATOR: u8 = 0x80 + 13u8;
-pub const METADATA_VALUE_ORIGIN_ARRAY_DISCRIMINATOR: u8 = 0x80 + 14u8;
-pub const METADATA_VALUE_PUBLIC_KEY_HASH_ARRAY_DISCRIMINATOR: u8 = 0x80 + 15u8;
+pub const METADATA_DISCRIMINATOR_ARRAY_BASE: u8 = 0x80;
+
+pub const METADATA_VALUE_STRING_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 0u8;
+pub const METADATA_VALUE_BOOLEAN_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 1u8;
+pub const METADATA_VALUE_U8_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 2u8;
+pub const METADATA_VALUE_U32_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 3u8;
+pub const METADATA_VALUE_U64_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 4u8;
+pub const METADATA_VALUE_I32_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 5u8;
+pub const METADATA_VALUE_I64_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 6u8;
+pub const METADATA_VALUE_DECIMAL_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 7u8;
+pub const METADATA_VALUE_GLOBAL_ADDRESS_ARRAY_DISCRIMINATOR: u8 =
+    METADATA_DISCRIMINATOR_ARRAY_BASE + 8u8;
+pub const METADATA_VALUE_PUBLIC_KEY_ARRAY_DISCRIMINATOR: u8 =
+    METADATA_DISCRIMINATOR_ARRAY_BASE + 9u8;
+pub const METADATA_VALUE_NON_FUNGIBLE_GLOBAL_ID_ARRAY_DISCRIMINATOR: u8 =
+    METADATA_DISCRIMINATOR_ARRAY_BASE + 10u8;
+pub const METADATA_VALUE_NON_FUNGIBLE_LOCAL_ID_ARRAY_DISCRIMINATOR: u8 =
+    METADATA_DISCRIMINATOR_ARRAY_BASE + 11u8;
+pub const METADATA_VALUE_INSTANT_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 12u8;
+pub const METADATA_VALUE_URL_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 13u8;
+pub const METADATA_VALUE_ORIGIN_ARRAY_DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + 14u8;
+pub const METADATA_VALUE_PUBLIC_KEY_HASH_ARRAY_DISCRIMINATOR: u8 =
+    METADATA_DISCRIMINATOR_ARRAY_BASE + 15u8;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
@@ -138,8 +145,16 @@ pub trait MetadataVal: ScryptoEncode + ScryptoDecode {
     fn from_metadata_value(entry: MetadataValue) -> Result<Self, MetadataError>;
 }
 
+pub trait SingleMetadataVal: MetadataVal {
+    fn to_array_metadata_value(vec: Vec<Self>) -> MetadataValue;
+
+    fn from_array_metadata_value(entry: MetadataValue) -> Result<Vec<Self>, MetadataError>;
+}
+
+pub trait ArrayMetadataVal: MetadataVal {}
+
 macro_rules! impl_metadata_val {
-    ($rust_type:ty, $metadata_type:tt, $type_id:expr) => {
+    ($rust_type:ty, $metadata_type:tt, $metadata_array_type:tt, $type_id:expr) => {
         impl MetadataVal for $rust_type {
             const DISCRIMINATOR: u8 = $type_id;
 
@@ -151,7 +166,7 @@ macro_rules! impl_metadata_val {
                 match entry {
                     MetadataValue::$metadata_type(x) => Ok(x),
                     _ => Err(MetadataError::UnexpectedType {
-                        expected_type_id: $type_id,
+                        expected_type_id: Self::DISCRIMINATOR,
                         actual_type_id: SborEnum::<ScryptoCustomValueKind>::get_discriminator(
                             &entry,
                         ),
@@ -159,86 +174,102 @@ macro_rules! impl_metadata_val {
                 }
             }
         }
+
+        impl SingleMetadataVal for $rust_type {
+            fn to_array_metadata_value(vec: Vec<Self>) -> MetadataValue {
+                vec.to_metadata_value()
+            }
+
+            fn from_array_metadata_value(entry: MetadataValue) -> Result<Vec<Self>, MetadataError> {
+                Vec::<Self>::from_metadata_value(entry)
+            }
+        }
+
+        impl MetadataVal for Vec<$rust_type> {
+            const DISCRIMINATOR: u8 = METADATA_DISCRIMINATOR_ARRAY_BASE + $type_id;
+
+            fn to_metadata_value(self) -> MetadataValue {
+                MetadataValue::$metadata_array_type(self)
+            }
+
+            fn from_metadata_value(entry: MetadataValue) -> Result<Self, MetadataError> {
+                match entry {
+                    MetadataValue::$metadata_array_type(x) => Ok(x),
+                    _ => Err(MetadataError::UnexpectedType {
+                        expected_type_id: Self::DISCRIMINATOR,
+                        actual_type_id: SborEnum::<ScryptoCustomValueKind>::get_discriminator(
+                            &entry,
+                        ),
+                    }),
+                }
+            }
+        }
+
+        impl ArrayMetadataVal for Vec<$rust_type> {}
     };
 }
 
-impl_metadata_val!(String, String, METADATA_VALUE_STRING_DISCRIMINATOR);
-impl_metadata_val!(bool, Bool, METADATA_VALUE_BOOLEAN_DISCRIMINATOR);
-impl_metadata_val!(u8, U8, METADATA_VALUE_U8_DISCRIMINATOR);
-impl_metadata_val!(u32, U32, METADATA_VALUE_U32_DISCRIMINATOR);
-impl_metadata_val!(u64, U64, METADATA_VALUE_U64_DISCRIMINATOR);
-impl_metadata_val!(i32, I32, METADATA_VALUE_I32_DISCRIMINATOR);
-impl_metadata_val!(i64, I64, METADATA_VALUE_I64_DISCRIMINATOR);
-impl_metadata_val!(Decimal, Decimal, METADATA_VALUE_DECIMAL_DISCRIMINATOR);
+impl_metadata_val!(
+    String,
+    String,
+    StringArray,
+    METADATA_VALUE_STRING_DISCRIMINATOR
+);
+impl_metadata_val!(bool, Bool, BoolArray, METADATA_VALUE_BOOLEAN_DISCRIMINATOR);
+impl_metadata_val!(u8, U8, U8Array, METADATA_VALUE_U8_DISCRIMINATOR);
+impl_metadata_val!(u32, U32, U32Array, METADATA_VALUE_U32_DISCRIMINATOR);
+impl_metadata_val!(u64, U64, U64Array, METADATA_VALUE_U64_DISCRIMINATOR);
+impl_metadata_val!(i32, I32, I32Array, METADATA_VALUE_I32_DISCRIMINATOR);
+impl_metadata_val!(i64, I64, I64Array, METADATA_VALUE_I64_DISCRIMINATOR);
+impl_metadata_val!(
+    Decimal,
+    Decimal,
+    DecimalArray,
+    METADATA_VALUE_DECIMAL_DISCRIMINATOR
+);
 impl_metadata_val!(
     GlobalAddress,
     GlobalAddress,
+    GlobalAddressArray,
     METADATA_VALUE_GLOBAL_ADDRESS_DISCRIMINATOR
 );
 impl_metadata_val!(
     PublicKey,
     PublicKey,
+    PublicKeyArray,
     METADATA_VALUE_PUBLIC_KEY_DISCRIMINATOR
 );
 impl_metadata_val!(
     NonFungibleGlobalId,
     NonFungibleGlobalId,
+    NonFungibleGlobalIdArray,
     METADATA_VALUE_PUBLIC_KEY_DISCRIMINATOR
 );
 impl_metadata_val!(
     NonFungibleLocalId,
     NonFungibleLocalId,
+    NonFungibleLocalIdArray,
     METADATA_VALUE_NON_FUNGIBLE_LOCAL_ID_DISCRIMINATOR
 );
-impl_metadata_val!(Instant, Instant, METADATA_VALUE_INSTANT_DISCRIMINATOR);
-impl_metadata_val!(Url, Url, METADATA_VALUE_URL_DISCRIMINATOR);
-
 impl_metadata_val!(
-    Vec<String>,
-    StringArray,
-    METADATA_VALUE_STRING_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<bool>,
-    BoolArray,
-    METADATA_VALUE_BOOLEAN_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(Vec<u8>, U8Array, METADATA_VALUE_U8_ARRAY_DISCRIMINATOR);
-impl_metadata_val!(Vec<u32>, U32Array, METADATA_VALUE_U32_ARRAY_DISCRIMINATOR);
-impl_metadata_val!(Vec<u64>, U64Array, METADATA_VALUE_U64_ARRAY_DISCRIMINATOR);
-impl_metadata_val!(Vec<i32>, I32Array, METADATA_VALUE_I32_ARRAY_DISCRIMINATOR);
-impl_metadata_val!(Vec<i64>, I64Array, METADATA_VALUE_I64_ARRAY_DISCRIMINATOR);
-impl_metadata_val!(
-    Vec<Decimal>,
-    DecimalArray,
-    METADATA_VALUE_DECIMAL_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<GlobalAddress>,
-    GlobalAddressArray,
-    METADATA_VALUE_GLOBAL_ADDRESS_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<PublicKey>,
-    PublicKeyArray,
-    METADATA_VALUE_PUBLIC_KEY_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<NonFungibleGlobalId>,
-    NonFungibleGlobalIdArray,
-    METADATA_VALUE_PUBLIC_KEY_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<NonFungibleLocalId>,
-    NonFungibleLocalIdArray,
-    METADATA_VALUE_NON_FUNGIBLE_LOCAL_ID_ARRAY_DISCRIMINATOR
-);
-impl_metadata_val!(
-    Vec<Instant>,
+    Instant,
+    Instant,
     InstantArray,
-    METADATA_VALUE_INSTANT_ARRAY_DISCRIMINATOR
+    METADATA_VALUE_INSTANT_DISCRIMINATOR
 );
-impl_metadata_val!(Vec<Url>, UrlArray, METADATA_VALUE_URL_ARRAY_DISCRIMINATOR);
+impl_metadata_val!(Url, Url, UrlArray, METADATA_VALUE_URL_DISCRIMINATOR);
+impl_metadata_val!(
+    Origin,
+    Origin,
+    OriginArray,
+    METADATA_VALUE_ORIGIN_DISCRIMINATOR
+);
+impl_metadata_val!(
+    PublicKeyHash,
+    PublicKeyHash,
+    PublicKeyHashArray,
+    METADATA_VALUE_PUBLIC_KEY_HASH_DISCRIMINATOR
+);
 
 pub const METADATA_ADMIN_ROLE: &str = "metadata_admin";
 pub const METADATA_ADMIN_UPDATER_ROLE: &str = "metadata_admin_updater";
@@ -305,3 +336,62 @@ pub struct MetadataRemoveInput {
 }
 
 pub type MetadataRemoveOutput = bool;
+
+#[cfg(test)]
+mod tests {
+    use radix_engine_common::prelude::*;
+
+    use super::*;
+
+    #[test]
+    pub fn can_encode_and_decode_all_metadata_values() {
+        encode_decode(&["Hello".to_string(), "world!".to_string()]);
+        encode_decode(&[true, false]);
+        encode_decode(&[1u8, 2u8]);
+        encode_decode(&[2u32, 3u32]);
+        encode_decode(&[3u64, 4u64]);
+        encode_decode(&[4i32, 5i32]);
+        encode_decode(&[5i64, 6i64]);
+        encode_decode(&[dec!("1"), dec!("2.1")]);
+        encode_decode(&[GlobalAddress::from(XRD)]);
+        encode_decode(&[
+            PublicKey::Ed25519(Ed25519PublicKey([0; Ed25519PublicKey::LENGTH])),
+            PublicKey::Secp256k1(Secp256k1PublicKey([0; Secp256k1PublicKey::LENGTH])),
+        ]);
+        encode_decode(&[NonFungibleGlobalId::package_of_direct_caller_badge(
+            POOL_PACKAGE,
+        )]);
+        encode_decode(&[
+            NonFungibleLocalId::String(
+                StringNonFungibleLocalId::new("Hello_world".to_owned()).unwrap(),
+            ),
+            NonFungibleLocalId::Integer(IntegerNonFungibleLocalId::new(42)),
+            NonFungibleLocalId::Bytes(BytesNonFungibleLocalId::new(vec![1u8]).unwrap()),
+            NonFungibleLocalId::RUID(RUIDNonFungibleLocalId::new([1; 32])),
+        ]);
+        encode_decode(&[Instant {
+            seconds_since_unix_epoch: 1687446137,
+        }]);
+        encode_decode(&[Url("https://www.radixdlt.com".to_owned())]);
+        encode_decode(&[Origin("www.radixdlt.com".to_owned())]);
+        encode_decode(&[
+            PublicKeyHash::Ed25519(Ed25519PublicKey([0; Ed25519PublicKey::LENGTH]).get_hash()),
+            PublicKeyHash::Secp256k1(
+                Secp256k1PublicKey([0; Secp256k1PublicKey::LENGTH]).get_hash(),
+            ),
+        ]);
+    }
+
+    fn encode_decode<T: SingleMetadataVal + Clone>(values: &[T]) {
+        check_can_encode_decode(values[0].clone().to_metadata_value());
+        check_can_encode_decode(T::to_array_metadata_value(values.to_vec()));
+    }
+
+    fn check_can_encode_decode(value: MetadataValue) {
+        let bytes = scrypto_encode(&value).unwrap();
+        // The outputting of bytes is for test vectors for other impls (eg the Gateway)
+        println!("{}", hex::encode(&bytes));
+        let decoded_value: MetadataValue = scrypto_decode(&bytes).unwrap();
+        assert_eq!(decoded_value, value);
+    }
+}


### PR DESCRIPTION
## Summary
Minor PR tweaking `MetadataVal` and adding some encode/decode tests.

Ideally would add transaction scenario/s for this too, but these can come later.
