### PR TITLE
Feature: Add metadata_locker role

### DIFF
--- a/assets/blueprints/metadata/src/lib.rs
+++ b/assets/blueprints/metadata/src/lib.rs
@@ -11,8 +11,10 @@ mod metadata {
                 .prepare_to_globalize(OwnerRole::None)
                 .metadata(metadata! {
                     roles {
-                        metadata_admin => rule!(allow_all), locked;
-                        metadata_admin_updater => rule!(deny_all), locked;
+                        metadata_setter => rule!(allow_all), locked;
+                        metadata_setter_updater => rule!(deny_all), locked;
+                        metadata_locker => rule!(allow_all), locked;
+                        metadata_locker_updater => rule!(deny_all), locked;
                     },
                     init {
                         "empty_locked" => EMPTY, locked;
@@ -27,8 +29,10 @@ mod metadata {
                 .prepare_to_globalize(OwnerRole::None)
                 .metadata(metadata! {
                     roles {
-                        metadata_admin => rule!(allow_all), locked;
-                        metadata_admin_updater => rule!(deny_all), locked;
+                        metadata_setter => rule!(allow_all), locked;
+                        metadata_setter_updater => rule!(deny_all), locked;
+                        metadata_locker => rule!(allow_all), locked;
+                        metadata_locker_updater => rule!(deny_all), locked;
                     },
                     init {
                         key => value, locked;

--- a/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/metadata/invocations.rs
@@ -288,8 +288,11 @@ impl_metadata_val!(
     METADATA_VALUE_PUBLIC_KEY_HASH_DISCRIMINATOR
 );
 
-pub const METADATA_ADMIN_ROLE: &str = "metadata_admin";
-pub const METADATA_ADMIN_UPDATER_ROLE: &str = "metadata_admin_updater";
+pub const METADATA_SETTER_ROLE: &str = "metadata_setter";
+pub const METADATA_SETTER_UPDATER_ROLE: &str = "metadata_setter_updater";
+
+pub const METADATA_LOCKER_ROLE: &str = "metadata_locker";
+pub const METADATA_LOCKER_UPDATER_ROLE: &str = "metadata_locker_updater";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum MetadataError {

--- a/radix-engine-interface/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource_manager.rs
@@ -3,7 +3,7 @@ use crate::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
 use radix_engine_interface::api::node_modules::metadata::{
-    METADATA_ADMIN_ROLE, METADATA_ADMIN_UPDATER_ROLE,
+    METADATA_SETTER_ROLE, METADATA_SETTER_UPDATER_ROLE,
 };
 use radix_engine_interface::api::ObjectModuleId;
 
@@ -70,7 +70,7 @@ impl ResourceAction {
             Self::Recall => (ObjectModuleId::Main, RoleKey::new(RECALLER_ROLE)),
             Self::Freeze => (ObjectModuleId::Main, RoleKey::new(FREEZER_ROLE)),
 
-            Self::UpdateMetadata => (ObjectModuleId::Metadata, RoleKey::new(METADATA_ADMIN_ROLE)),
+            Self::UpdateMetadata => (ObjectModuleId::Metadata, RoleKey::new(METADATA_SETTER_ROLE)),
         }
     }
 
@@ -89,7 +89,7 @@ impl ResourceAction {
 
             Self::UpdateMetadata => (
                 ObjectModuleId::Metadata,
-                RoleKey::new(METADATA_ADMIN_UPDATER_ROLE),
+                RoleKey::new(METADATA_SETTER_UPDATER_ROLE),
             ),
         }
     }

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -27,7 +27,9 @@ impl Action {
             Action::Recall => (ObjectModuleId::Main, RoleKey::new(RECALLER_ROLE)),
             Action::Freeze => (ObjectModuleId::Main, RoleKey::new(FREEZER_ROLE)),
 
-            Action::UpdateMetadata => (ObjectModuleId::Metadata, RoleKey::new(METADATA_SETTER_ROLE)),
+            Action::UpdateMetadata => {
+                (ObjectModuleId::Metadata, RoleKey::new(METADATA_SETTER_ROLE))
+            }
         }
     }
 }

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use radix_engine::types::*;
-use radix_engine_interface::api::node_modules::metadata::{MetadataValue, METADATA_ADMIN_ROLE};
+use radix_engine_interface::api::node_modules::metadata::{MetadataValue, METADATA_SETTER_ROLE};
 use radix_engine_interface::api::ObjectModuleId;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_unit::*;
@@ -27,7 +27,7 @@ impl Action {
             Action::Recall => (ObjectModuleId::Main, RoleKey::new(RECALLER_ROLE)),
             Action::Freeze => (ObjectModuleId::Main, RoleKey::new(FREEZER_ROLE)),
 
-            Action::UpdateMetadata => (ObjectModuleId::Metadata, RoleKey::new(METADATA_ADMIN_ROLE)),
+            Action::UpdateMetadata => (ObjectModuleId::Metadata, RoleKey::new(METADATA_SETTER_ROLE)),
         }
     }
 }

--- a/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
@@ -11,8 +11,10 @@ mod metadata_component {
                 .prepare_to_globalize(OwnerRole::None)
                 .metadata(metadata! {
                     roles {
-                        metadata_admin => rule!(allow_all), locked;
-                        metadata_admin_updater => rule!(deny_all), locked;
+                        metadata_setter => rule!(allow_all), locked;
+                        metadata_setter_updater => rule!(deny_all), locked;
+                        metadata_locker => rule!(allow_all), locked;
+                        metadata_locker_updater => rule!(deny_all), locked;
                     },
                     init {
                         key.clone() => value.clone(), locked;

--- a/radix-engine/src/blueprints/resource/resource_manager_common.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager_common.rs
@@ -3,7 +3,7 @@ use crate::types::*;
 use native_sdk::modules::access_rules::AccessRules;
 use native_sdk::modules::metadata::Metadata;
 use radix_engine_interface::api::node_modules::metadata::{
-    MetadataInit, METADATA_ADMIN_ROLE, METADATA_ADMIN_UPDATER_ROLE,
+    MetadataInit, METADATA_SETTER_ROLE, METADATA_SETTER_UPDATER_ROLE,
 };
 use radix_engine_interface::api::object_api::ObjectModuleId;
 use radix_engine_interface::api::ClientApi;
@@ -113,9 +113,9 @@ fn build_access_rules(
     let metadata_roles = {
         let mut metadata_roles = Roles::new();
         let locked = update_metadata_mutability.eq(&DenyAll);
-        metadata_roles.define_role(METADATA_ADMIN_ROLE, update_metadata_access_rule, locked);
+        metadata_roles.define_role(METADATA_SETTER_ROLE, update_metadata_access_rule, locked);
         metadata_roles.define_role(
-            METADATA_ADMIN_UPDATER_ROLE,
+            METADATA_SETTER_UPDATER_ROLE,
             update_metadata_mutability,
             locked,
         );

--- a/radix-engine/src/system/node_modules/metadata/package.rs
+++ b/radix-engine/src/system/node_modules/metadata/package.rs
@@ -156,13 +156,15 @@ impl MetadataNativePackage {
                     method_auth: MethodAuthTemplate::StaticRoles(
                         roles_template!(
                             roles {
-                                METADATA_ADMIN_ROLE => updaters: [METADATA_ADMIN_UPDATER_ROLE];
-                                METADATA_ADMIN_UPDATER_ROLE => updaters: [METADATA_ADMIN_UPDATER_ROLE];
+                                METADATA_SETTER_ROLE => updaters: [METADATA_SETTER_UPDATER_ROLE];
+                                METADATA_SETTER_UPDATER_ROLE => updaters: [METADATA_SETTER_UPDATER_ROLE];
+                                METADATA_LOCKER_ROLE => updaters: [METADATA_LOCKER_UPDATER_ROLE];
+                                METADATA_LOCKER_UPDATER_ROLE => updaters: [METADATA_LOCKER_UPDATER_ROLE];
                             },
                             methods {
-                                METADATA_SET_IDENT => [METADATA_ADMIN_ROLE];
-                                METADATA_LOCK_IDENT => [METADATA_ADMIN_ROLE];
-                                METADATA_REMOVE_IDENT => [METADATA_ADMIN_ROLE];
+                                METADATA_SET_IDENT => [METADATA_SETTER_ROLE];
+                                METADATA_REMOVE_IDENT => [METADATA_SETTER_ROLE];
+                                METADATA_LOCK_IDENT => [METADATA_LOCKER_ROLE];
                                 METADATA_GET_IDENT => MethodAccessibility::Public;
                             }
                         ),

--- a/scrypto/src/modules/metadata.rs
+++ b/scrypto/src/modules/metadata.rs
@@ -139,15 +139,19 @@ impl Metadata {
 }
 
 pub struct MetadataRoles<T> {
-    pub metadata_admin: T,
-    pub metadata_admin_updater: T,
+    pub metadata_setter: T,
+    pub metadata_setter_updater: T,
+    pub metadata_locker: T,
+    pub metadata_locker_updater: T,
 }
 
 impl<T> MetadataRoles<T> {
     pub fn list(self) -> Vec<(&'static str, T)> {
         vec![
-            (METADATA_ADMIN_ROLE, self.metadata_admin),
-            (METADATA_ADMIN_UPDATER_ROLE, self.metadata_admin_updater),
+            (METADATA_SETTER_ROLE, self.metadata_setter),
+            (METADATA_SETTER_UPDATER_ROLE, self.metadata_setter_updater),
+            (METADATA_LOCKER_ROLE, self.metadata_locker),
+            (METADATA_LOCKER_UPDATER_ROLE, self.metadata_locker_updater),
         ]
     }
 }

--- a/scrypto/src/resource/resource_manager.rs
+++ b/scrypto/src/resource/resource_manager.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{Global, ObjectStub, ObjectStubHandle, ScryptoEncode};
 use crate::*;
-use radix_engine_interface::api::node_modules::metadata::METADATA_ADMIN_ROLE;
+use radix_engine_interface::api::node_modules::metadata::METADATA_SETTER_ROLE;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::data::scrypto::model::*;
 use radix_engine_interface::data::scrypto::well_known_scrypto_custom_types::resource_address_type_data;
@@ -136,12 +136,12 @@ impl ResourceManager {
 
     pub fn set_updatable_metadata(&self, access_rule: AccessRule) {
         let access_rules = self.0.access_rules();
-        access_rules.set_metadata_role(METADATA_ADMIN_ROLE, access_rule);
+        access_rules.set_metadata_role(METADATA_SETTER_ROLE, access_rule);
     }
 
     pub fn lock_updatable_metadata(&self) {
         let access_rules = self.0.access_rules();
-        access_rules.lock_metadata_role(METADATA_ADMIN_ROLE);
+        access_rules.lock_metadata_role(METADATA_SETTER_ROLE);
     }
 }
 


### PR DESCRIPTION
## Summary
Add more granular roles to Metadata

## Details
Set the roles of metadata to be:
```
metadata_setter
metadata_setter_updater
metadata_locker
metadata_locker_updater
```


## Update Recommendations

### For dApp Developers
If setting roles for metadata, users must now specify 4 different roles
