### PR TITLE
feat: Allow FlashReceipt to be converted to TransactionReceipt

### DIFF
--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -17,8 +17,8 @@ use crate::system::node_modules::royalty::RoyaltyNativePackage;
 use crate::system::node_modules::type_info::TypeInfoSubstate;
 use crate::track::SystemUpdates;
 use crate::transaction::{
-    execute_transaction, ExecutionConfig, FeeReserveConfig, StateUpdateSummary, TransactionReceipt,
-    TransactionResult,
+    execute_transaction, CommitResult, ExecutionConfig, FeeReserveConfig, StateUpdateSummary,
+    TransactionOutcome, TransactionReceipt, TransactionResult,
 };
 use crate::types::*;
 use crate::vm::wasm::WasmEngine;
@@ -170,14 +170,22 @@ pub struct FlashReceipt {
     pub state_update_summary: StateUpdateSummary,
 }
 
+impl From<FlashReceipt> for TransactionReceipt {
+    fn from(value: FlashReceipt) -> Self {
+        // This is used by the node for allowing the flash to execute before the
+        // genesis bootstrap transaction
+        let commit_result = CommitResult::empty_with_outcome(TransactionOutcome::Success(vec![]));
+        let mut transaction_receipt = TransactionReceipt::empty_with_commit(commit_result);
+        value.merge_genesis_flash_into_transaction_receipt(&mut transaction_receipt);
+        transaction_receipt
+    }
+}
+
 impl FlashReceipt {
     // Merge system_flash_receipt into system_bootstrap_receipt
     // This is currently a necessary hack in order to not change GenesisReceipt with
     // the addition of a new system_flash_receipt.
-    pub fn merge_genesis_flash_into_system_bootstrap_receipt(
-        self,
-        receipt: &mut TransactionReceipt,
-    ) {
+    pub fn merge_genesis_flash_into_transaction_receipt(self, receipt: &mut TransactionReceipt) {
         match &mut receipt.transaction_result {
             TransactionResult::Commit(result) => {
                 let mut new_packages = self.state_update_summary.new_packages;
@@ -294,7 +302,7 @@ where
             );
 
             flash_receipt
-                .merge_genesis_flash_into_system_bootstrap_receipt(&mut system_bootstrap_receipt);
+                .merge_genesis_flash_into_transaction_receipt(&mut system_bootstrap_receipt);
 
             let mut data_ingestion_receipts = vec![];
             for (chunk_index, chunk) in genesis_data_chunks.into_iter().enumerate() {

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -3,7 +3,7 @@ use crate::types::*;
 use radix_engine_interface::blueprints::resource::LiquidFungibleResource;
 use sbor::rust::collections::*;
 
-#[derive(Debug, Clone, ScryptoSbor)]
+#[derive(Default, Debug, Clone, ScryptoSbor)]
 pub struct FeeSummary {
     /// The cost unit price in XRD.
     pub cost_unit_price: Decimal,

--- a/radix-engine/src/track/track.rs
+++ b/radix-engine/src/track/track.rs
@@ -15,7 +15,7 @@ use sbor::rust::collections::btree_map::Entry;
 use sbor::rust::iter::empty;
 use sbor::rust::mem;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct StateUpdates {
     pub database_updates: DatabaseUpdates,
     pub system_updates: SystemUpdates,

--- a/radix-engine/src/transaction/state_update_summary.rs
+++ b/radix-engine/src/transaction/state_update_summary.rs
@@ -14,7 +14,7 @@ use sbor::rust::prelude::*;
 use crate::system::node_modules::type_info::TypeInfoSubstate;
 use crate::track::{TrackedKey, TrackedNode, Write};
 
-#[derive(Debug, Clone, ScryptoSbor)]
+#[derive(Default, Debug, Clone, ScryptoSbor)]
 pub struct StateUpdateSummary {
     pub new_packages: Vec<PackageAddress>,
     pub new_components: Vec<ComponentAddress>,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -99,6 +99,19 @@ pub struct CommitResult {
 }
 
 impl CommitResult {
+    pub fn empty_with_outcome(outcome: TransactionOutcome) -> Self {
+        Self {
+            state_updates: Default::default(),
+            state_update_summary: Default::default(),
+            outcome,
+            fee_summary: Default::default(),
+            application_events: Default::default(),
+            application_logs: Default::default(),
+            execution_metrics: Default::default(),
+            execution_trace: Default::default(),
+        }
+    }
+
     pub fn next_epoch(&self) -> Option<EpochChangeEvent> {
         // Note: Node should use a well-known index id
         for (ref event_type_id, ref event_data) in self.application_events.iter() {
@@ -219,6 +232,14 @@ pub struct TransactionReceipt {
 }
 
 impl TransactionReceipt {
+    /// An empty receipt for merging changes into.
+    pub fn empty_with_commit(commit_result: CommitResult) -> Self {
+        Self {
+            transaction_result: TransactionResult::Commit(commit_result),
+            resources_usage: Default::default(),
+        }
+    }
+
     pub fn is_commit_success(&self) -> bool {
         matches!(
             self.transaction_result,


### PR DESCRIPTION
## Summary
To enable us to handle it separately in the node, as it turns out that is the easier approach.