### PR TITLE
Make prices unrealistic before ready

### DIFF
--- a/radix-engine-constants/src/lib.rs
+++ b/radix-engine-constants/src/lib.rs
@@ -72,17 +72,6 @@ pub const DEFAULT_COST_UNIT_LIMIT: u32 = 100_000_000;
 /// The default free credit, for preview only.
 pub const DEFAULT_FREE_CREDIT_IN_XRD: &str = "100";
 
-/// The default cost unit price, in XRD.
-pub const DEFAULT_COST_UNIT_PRICE: &str = "0.000001";
-
-/// The default USD price, in XRD
-/// This is roughly 0.1 USD per XRD
-pub const DEFAULT_USD_PRICE: &str = "10";
-
-/// The default price for adding a single byte to the substate store, in XRD.
-/// This is roughly 0.001 * 0.1 * 1,000,000 = 100 USD per MiB
-pub const DEFAULT_STATE_EXPANSION_PRICE: &str = "0.001";
-
 pub const DEFAULT_MAX_EXECUTION_TRACE_DEPTH: usize = 1;
 
 /// The default max call depth, used by transaction executor.
@@ -100,22 +89,51 @@ pub const DEFAULT_MAX_SUBSTATE_SIZE: usize = 2 * 1024 * 1024;
 /// The default maximum invoke input args size.
 pub const DEFAULT_MAX_INVOKE_INPUT_SIZE: usize = 1 * 1024 * 1024;
 
-/* Fees/tips distribution */
+/// The proposer's share of tips
 pub const TIPS_PROPOSER_SHARE_PERCENTAGE: u8 = 100;
+
+/// The validator set's share of tips
 pub const TIPS_VALIDATOR_SET_SHARE_PERCENTAGE: u8 = 0;
+
+/// The proposer's share of fees (execution and state expansion)
 pub const FEES_PROPOSER_SHARE_PERCENTAGE: u8 = 25;
+
+/// The validator set's share of fees  (execution and state expansion)
 pub const FEES_VALIDATOR_SET_SHARE_PERCENTAGE: u8 = 25;
 
-/* Logs and events */
+/// The max event size
 pub const DEFAULT_MAX_EVENT_SIZE: usize = 64 * 1024;
+
+/// The max log size
 pub const DEFAULT_MAX_LOG_SIZE: usize = 64 * 1024;
+
+/// The max panic message size
 pub const DEFAULT_MAX_PANIC_MESSAGE_SIZE: usize = 64 * 1024;
+
+/// The max number of events
 pub const DEFAULT_MAX_NUMBER_OF_EVENTS: usize = 256;
+
+/// The max number of logs
 pub const DEFAULT_MAX_NUMBER_OF_LOGS: usize = 256;
+
+/// The max SBOR size of metadata key
+pub const DEFAULT_MAX_METADATA_KEY_STRING_LEN: usize = 100;
+
+/// The max SBOR size of metadata value
+pub const DEFAULT_MAX_METADATA_VALUE_SBOR_LEN: usize = 512;
+
+//==========================
+// TO BE DEFINED
+//==========================
+
+/// The default cost unit price, in XRD.
+pub const DEFAULT_COST_UNIT_PRICE: &str = "0.00000001";
+
+/// The default price for adding a single byte to the substate store, in XRD.
+pub const DEFAULT_STATE_EXPANSION_PRICE: &str = "0.00000001";
+
+/// The default USD price, in XRD
+pub const DEFAULT_USD_PRICE: &str = "10";
 
 /// The default maximum that a package or component owner is allowed to set their method royalty to
 pub const DEFAULT_MAX_PER_FUNCTION_ROYALTY_IN_XRD: &str = "150.0";
-
-/* Metadata */
-pub const DEFAULT_MAX_METADATA_KEY_STRING_LEN: usize = 100;
-pub const DEFAULT_MAX_METADATA_VALUE_SBOR_LEN: usize = 512;

--- a/radix-engine-tests/assets/cost_flash_loan.csv
+++ b/radix-engine-tests/assets/cost_flash_loan.csv
@@ -1,8 +1,8 @@
-Total Cost (XRD)                                                           ,    20.61809165,   100.00%
-+ Execution Cost (XRD)                                                     ,      17.714373,    85.92%
-+ Tipping Cost (XRD)                                                       ,     0.88571865,     4.30%
-+ State Expansion Cost (XRD)                                               ,          0.018,     0.09%
-+ Royalty Cost (XRD)                                                       ,              2,     9.70%
+Total Cost (XRD)                                                           ,   2.1860010965,   100.00%
++ Execution Cost (XRD)                                                     ,     0.17714373,     8.10%
++ Tipping Cost (XRD)                                                       ,   0.0088571865,     0.41%
++ State Expansion Cost (XRD)                                               ,     0.00000018,     0.00%
++ Royalty Cost (XRD)                                                       ,              2,    91.49%
 Total Cost Units Consumed                                                  ,       17714373,   100.00%
 AfterInvoke                                                                ,           1948,     0.01%
 AllocateNodeId                                                             ,          26500,     0.15%

--- a/radix-engine-tests/assets/cost_publish_large_package.csv
+++ b/radix-engine-tests/assets/cost_publish_large_package.csv
@@ -1,7 +1,7 @@
-Total Cost (XRD)                                                           ,  2167.92147295,   100.00%
-+ Execution Cost (XRD)                                                     ,      68.751879,     3.17%
-+ Tipping Cost (XRD)                                                       ,     3.43759395,     0.16%
-+ State Expansion Cost (XRD)                                               ,       2095.732,    96.67%
+Total Cost (XRD)                                                           ,   0.7428520495,   100.00%
++ Execution Cost (XRD)                                                     ,     0.68751879,    92.55%
++ Tipping Cost (XRD)                                                       ,   0.0343759395,     4.63%
++ State Expansion Cost (XRD)                                               ,     0.02095732,     2.82%
 + Royalty Cost (XRD)                                                       ,              0,     0.00%
 Total Cost Units Consumed                                                  ,       68751879,   100.00%
 AfterInvoke                                                                ,            402,     0.00%

--- a/radix-engine-tests/assets/cost_radiswap.csv
+++ b/radix-engine-tests/assets/cost_radiswap.csv
@@ -1,8 +1,8 @@
-Total Cost (XRD)                                                           ,    14.97360865,   100.00%
-+ Execution Cost (XRD)                                                     ,      12.153913,    81.17%
-+ Tipping Cost (XRD)                                                       ,     0.60769565,     4.06%
-+ State Expansion Cost (XRD)                                               ,          0.212,     1.42%
-+ Royalty Cost (XRD)                                                       ,              2,    13.36%
+Total Cost (XRD)                                                           ,   2.1276182065,   100.00%
++ Execution Cost (XRD)                                                     ,     0.12153913,     5.71%
++ Tipping Cost (XRD)                                                       ,   0.0060769565,     0.29%
++ State Expansion Cost (XRD)                                               ,     0.00000212,     0.00%
++ Royalty Cost (XRD)                                                       ,              2,    94.00%
 Total Cost Units Consumed                                                  ,       12153913,   100.00%
 AfterInvoke                                                                ,           1300,     0.01%
 AllocateNodeId                                                             ,          15000,     0.12%

--- a/radix-engine-tests/assets/cost_transfer.csv
+++ b/radix-engine-tests/assets/cost_transfer.csv
@@ -1,7 +1,7 @@
-Total Cost (XRD)                                                           ,      5.2065504,   100.00%
-+ Execution Cost (XRD)                                                     ,       4.950048,    95.07%
-+ Tipping Cost (XRD)                                                       ,      0.2475024,     4.75%
-+ State Expansion Cost (XRD)                                               ,          0.009,     0.17%
+Total Cost (XRD)                                                           ,    0.051975594,   100.00%
++ Execution Cost (XRD)                                                     ,     0.04950048,    95.24%
++ Tipping Cost (XRD)                                                       ,    0.002475024,     4.76%
++ State Expansion Cost (XRD)                                               ,     0.00000009,     0.00%
 + Royalty Cost (XRD)                                                       ,              0,     0.00%
 Total Cost Units Consumed                                                  ,        4950048,   100.00%
 AfterInvoke                                                                ,            300,     0.01%

--- a/radix-engine-tests/assets/cost_transfer_to_virtual_account.csv
+++ b/radix-engine-tests/assets/cost_transfer_to_virtual_account.csv
@@ -1,7 +1,7 @@
-Total Cost (XRD)                                                           ,     9.97032075,   100.00%
-+ Execution Cost (XRD)                                                     ,       8.784115,    88.10%
-+ Tipping Cost (XRD)                                                       ,     0.43920575,     4.41%
-+ State Expansion Cost (XRD)                                               ,          0.747,     7.49%
+Total Cost (XRD)                                                           ,   0.0922406775,   100.00%
++ Execution Cost (XRD)                                                     ,     0.08784115,    95.23%
++ Tipping Cost (XRD)                                                       ,   0.0043920575,     4.76%
++ State Expansion Cost (XRD)                                               ,     0.00000747,     0.01%
 + Royalty Cost (XRD)                                                       ,              0,     0.00%
 Total Cost Units Consumed                                                  ,        8784115,   100.00%
 AfterInvoke                                                                ,            886,     0.01%


### PR DESCRIPTION
## Summary

Per team discussion, this PR makes prices unrealistic before they're finalised.

They are
- `COST_UNIT_PRICE`: The price of execution cost units, in XRD
- `STATE_EXPANSION_PRICE`: The price of execution cost units, in XRD
- `USD_PRICE`: The price of USD, in XRD