### PR TITLE
Feature/SCRY-450 add scrypto instructions

### DIFF
--- a/fuzz-tests/src/fuzz_tx.rs
+++ b/fuzz-tests/src/fuzz_tx.rs
@@ -230,19 +230,23 @@ impl TxFuzzer {
                         resource_address,
                     })
                 }
+                // AssertWorktopContainsAny
+                2 => Some(InstructionV1::AssertWorktopContainsAny {
+                        resource_address,
+                    }),
                 // AssertWorktopContainsNonFungibles
-                2 => Some(InstructionV1::AssertWorktopContainsNonFungibles {
+                3 => Some(InstructionV1::AssertWorktopContainsNonFungibles {
                     resource_address,
                     ids: non_fungible_ids.clone(),
                 }),
                 // BurnResource
-                3 => {
+                4 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::BurnResource { bucket_id })
                 }
                 // CallAccessRulesMethod
-                4 => {
+                5 => {
                     // TODO - fuzz more methods
                     global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
@@ -258,22 +262,22 @@ impl TxFuzzer {
                     }
                 }
                 // CallFunction
-                5 => {
-                    // TODO
-                    None
-                }
-                // CallMetadataMethod
                 6 => {
                     // TODO
                     None
                 }
-                // CallMethod
+                // CallMetadataMethod
                 7 => {
                     // TODO
                     None
                 }
+                // CallMethod
+                8 => {
+                    // TODO
+                    None
+                }
                 // CallRoyaltyMethod
-                8 =>
+                9 =>
                 // TODO - fuzz more methods
                 {
                     Some(InstructionV1::CallRoyaltyMethod {
@@ -283,13 +287,13 @@ impl TxFuzzer {
                     })
                 }
                 // ClaimComponentRoyalty
-                9 => Some(InstructionV1::CallRoyaltyMethod {
+                10 => Some(InstructionV1::CallRoyaltyMethod {
                     address: component_address.into(),
                     method_name: COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT.to_string(),
                     args: manifest_args!(),
                 }),
                 // ClaimPackageRoyalty
-                10 => {
+                11 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     Some(InstructionV1::CallMethod {
@@ -299,17 +303,17 @@ impl TxFuzzer {
                     })
                 }
                 // ClearAuthZone
-                11 => Some(InstructionV1::ClearAuthZone),
+                12 => Some(InstructionV1::ClearAuthZone),
                 // ClearSignatureProofs
-                12 => Some(InstructionV1::ClearSignatureProofs),
+                13 => Some(InstructionV1::ClearSignatureProofs),
                 // CloneProof
-                13 => {
+                14 => {
                     let proof_id = *unstructured.choose(&proof_ids[..]).unwrap();
 
                     Some(InstructionV1::CloneProof { proof_id })
                 }
                 // CreateAccessController
-                14 => {
+                15 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
@@ -325,7 +329,7 @@ impl TxFuzzer {
                     })
                 }
                 // CreateAccount
-                15 => {
+                16 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = AccountCreateInput::arbitrary(&mut unstructured).unwrap();
@@ -341,7 +345,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateAccountAdvanced
-                16 => {
+                17 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = AccountCreateAdvancedInput::arbitrary(&mut unstructured).unwrap();
@@ -357,7 +361,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateFungibleResource
-                17 => {
+                18 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input =
@@ -374,7 +378,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateFungibleResourceWithInitialSupply
-                18 => {
+                19 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = FungibleResourceManagerCreateWithInitialSupplyManifestInput::arbitrary(
@@ -395,7 +399,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateIdentity
-                19 => {
+                20 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = IdentityCreateInput::arbitrary(&mut unstructured).unwrap();
@@ -411,7 +415,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateIdentityAdvanced
-                20 => {
+                21 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = IdentityCreateAdvancedInput::arbitrary(&mut unstructured).unwrap();
@@ -427,7 +431,7 @@ impl TxFuzzer {
                     }
                 }
                 // CreateNonFungibleResource
-                21 => {
+                22 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input = NonFungibleResourceManagerCreateManifestInput::arbitrary(&mut unstructured)
@@ -445,7 +449,7 @@ impl TxFuzzer {
                 }
 
                 // CreateNonFungibleResourceWithInitialSupply
-                22 => {
+                23 => {
                     package_addresses.push(PackageAddress::arbitrary(&mut unstructured).unwrap());
                     let package_address = *unstructured.choose(&package_addresses[..]).unwrap();
                     let input =
@@ -467,11 +471,11 @@ impl TxFuzzer {
                     }
                 }
                 // CreateProofFromAuthZone
-                23 => Some(InstructionV1::CreateProofFromAuthZone { resource_address }),
+                24 => Some(InstructionV1::CreateProofFromAuthZone { resource_address }),
                 // CreateProofFromAuthZoneofAll
-                24 => Some(InstructionV1::CreateProofFromAuthZoneOfAll { resource_address }),
+                25 => Some(InstructionV1::CreateProofFromAuthZoneOfAll { resource_address }),
                 // CreateProofFromAuthZoneOfAmount
-                25 => {
+                26 => {
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::CreateProofFromAuthZoneOfAmount {
@@ -480,38 +484,38 @@ impl TxFuzzer {
                     })
                 }
                 // CreateProofFromAuthZoneOfNonFungibles
-                26 => Some(InstructionV1::CreateProofFromAuthZoneOfNonFungibles {
+                27 => Some(InstructionV1::CreateProofFromAuthZoneOfNonFungibles {
                     ids: non_fungible_ids.clone(),
                     resource_address,
                 }),
                 // CreateProofFromBucket
-                27 => {
+                28 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::CreateProofFromBucket { bucket_id })
                 }
                 // CreateProofFromBucketOfAll
-                28 => {
+                29 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::CreateProofFromBucketOfAll { bucket_id })
                 }
                 // CreateProofFromBucketOfAmount
-                29 => {
+                30 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::CreateProofFromBucketOfAmount { bucket_id, amount })
                 }
                 // CreateProofFromBucketOfNonFungibles
-                30 => {
+                31 => {
                     let ids = non_fungible_ids.clone();
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::CreateProofFromBucketOfNonFungibles { bucket_id, ids })
                 }
                 // CreateValidator
-                31 => {
+                32 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     let input = ConsensusManagerCreateValidatorManifestInput {
@@ -530,15 +534,15 @@ impl TxFuzzer {
                     }
                 }
                 // DropAllProofs
-                32 => Some(InstructionV1::DropAllProofs),
+                33 => Some(InstructionV1::DropAllProofs),
                 // DropProof
-                33 => {
+                34 => {
                     let proof_id = *unstructured.choose(&proof_ids[..]).unwrap();
 
                     Some(InstructionV1::DropProof { proof_id })
                 }
                 // FreezeVault
-                34 => {
+                35 => {
                     let vault_id = {
                         let vaults = self
                             .runner
@@ -562,8 +566,60 @@ impl TxFuzzer {
                         Err(_) => None,
                     }
                 }
+                // LockComponentRoyalty
+                36 => {
+                    let method = String::arbitrary(&mut unstructured).unwrap();
+
+                    Some(InstructionV1::CallRoyaltyMethod {
+                        address: component_address.into(),
+                        method_name: COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT.to_string(),
+                        args: manifest_args!(method),
+                    })
+                }
+                // LockMetadata
+                37 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let key = String::arbitrary(&mut unstructured).unwrap();
+
+                    Some(InstructionV1::CallMetadataMethod {
+                        address: address.into(),
+                        method_name: METADATA_LOCK_IDENT.to_string(),
+                        args: manifest_args!(key),
+                    })
+                }
+                // LockOwnerRole
+                38 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let input = AccessRulesLockOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_LOCK_OWNER_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
+                // LockRole
+                39 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let input = AccessRulesLockRoleInput::arbitrary(&mut unstructured).unwrap();
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_LOCK_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
                 // MintFungible
-                35 => {
+                40 => {
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::CallMethod {
@@ -573,7 +629,7 @@ impl TxFuzzer {
                     })
                 }
                 // MintNonFungible
-                36 => {
+                41 => {
                     let input =
                         NonFungibleResourceManagerMintManifestInput::arbitrary(&mut unstructured)
                             .unwrap();
@@ -588,7 +644,7 @@ impl TxFuzzer {
                     }
                 }
                 // MintRuidNonFungible
-                37 => {
+                42 => {
                     let input = NonFungibleResourceManagerMintRuidManifestInput::arbitrary(
                         &mut unstructured,
                     )
@@ -604,9 +660,9 @@ impl TxFuzzer {
                     }
                 }
                 // PopFromAuthZone
-                38 => Some(InstructionV1::PopFromAuthZone {}),
+                43 => Some(InstructionV1::PopFromAuthZone {}),
                 // PublishPackage | PublishPackageAdvanced
-                39 | 40 => {
+                44 | 45 => {
                     // Publishing package involves a compilation by scrypto compiler.
                     // In case of AFL invoking external tool breaks fuzzing.
                     // For now we skip this step
@@ -615,13 +671,13 @@ impl TxFuzzer {
                     None
                 }
                 // PushToAuthZone
-                41 => {
+                46 => {
                     let proof_id = *unstructured.choose(&proof_ids[..]).unwrap();
 
                     Some(InstructionV1::PushToAuthZone { proof_id })
                 }
                 // RecallFromVault
-                42 => {
+                47 => {
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
                     let vault_id = {
                         let vaults = self
@@ -642,8 +698,23 @@ impl TxFuzzer {
                         args: manifest_args!(amount),
                     })
                 }
+                // RecallNonFungiblesFromVault
+                48 => {
+                    let input = NonFungibleVaultRecallNonFungiblesInput {
+                        non_fungible_local_ids: BTreeSet::from_iter(non_fungible_ids.clone().into_iter()),
+                    };
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallMethod {
+                            address: resource_address.into(),
+                            method_name: NON_FUNGIBLE_VAULT_RECALL_NON_FUNGIBLES_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
                 // RemoveMetadata
-                43 => {
+                49 => {
                     global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let key = String::arbitrary(&mut unstructured).unwrap();
@@ -655,13 +726,43 @@ impl TxFuzzer {
                     })
                 }
                 // ReturnToWorktop
-                44 => {
+                50 => {
                     let bucket_id = *unstructured.choose(&buckets[..]).unwrap();
 
                     Some(InstructionV1::ReturnToWorktop { bucket_id })
                 }
+                // SetAndLockOnwerRole
+                51 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let input = AccessRulesSetAndLockOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_SET_AND_LOCK_OWNER_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
+                // SetAndLockRole
+                52 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let input = AccessRulesSetAndLockRoleInput::arbitrary(&mut unstructured).unwrap();
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_SET_AND_LOCK_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
                 // SetComponentRoyalty
-                45 => {
+                53 => {
                     let method = String::arbitrary(&mut unstructured).unwrap();
                     let amount = RoyaltyAmount::arbitrary(&mut unstructured).unwrap();
 
@@ -671,18 +772,8 @@ impl TxFuzzer {
                         args: manifest_args!(method, amount),
                     })
                 }
-                // LockComponentRoyalty
-                46 => {
-                    let method = String::arbitrary(&mut unstructured).unwrap();
-
-                    Some(InstructionV1::CallRoyaltyMethod {
-                        address: component_address.into(),
-                        method_name: COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT.to_string(),
-                        args: manifest_args!(method),
-                    })
-                }
                 // SetMetadata
-                47 => {
+                54 => {
                     global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
                     let key = String::arbitrary(&mut unstructured).unwrap();
@@ -694,22 +785,40 @@ impl TxFuzzer {
                         args: manifest_args!(key, value),
                     })
                 }
-                // LockMetadata
-                48 => {
+                // SetOwnerRole
+                55 => {
                     global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
                     let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let key = String::arbitrary(&mut unstructured).unwrap();
+                    let input = AccessRulesSetOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
 
-                    Some(InstructionV1::CallMetadataMethod {
-                        address: address.into(),
-                        method_name: METADATA_LOCK_IDENT.to_string(),
-                        args: manifest_args!(key),
-                    })
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_SET_OWNER_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
+                }
+                // SetRole
+                56 => {
+                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
+                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
+                    let input = AccessRulesSetRoleInput::arbitrary(&mut unstructured).unwrap();
+
+                    match to_manifest_value(&input) {
+                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
+                            address: address.into(),
+                            method_name: ACCESS_RULES_SET_ROLE_IDENT.to_string(),
+                            args,
+                        }),
+                        Err(_) => None,
+                    }
                 }
                 // TakeAllFromWorktop
-                49 => Some(InstructionV1::TakeAllFromWorktop { resource_address }),
+                57 => Some(InstructionV1::TakeAllFromWorktop { resource_address }),
                 // TakeFromWorktop
-                50 => {
+                58 => {
                     let amount = Decimal::arbitrary(&mut unstructured).unwrap();
 
                     Some(InstructionV1::TakeFromWorktop {
@@ -718,12 +827,12 @@ impl TxFuzzer {
                     })
                 }
                 // TakeNonFungiblesFromWorktop
-                51 => Some(InstructionV1::TakeNonFungiblesFromWorktop {
+                59 => Some(InstructionV1::TakeNonFungiblesFromWorktop {
                     ids: non_fungible_ids.clone(),
                     resource_address,
                 }),
                 // UnfreezeVault
-                52 => {
+                60 => {
                     let vault_id = {
                         let vaults = self
                             .runner
@@ -747,96 +856,12 @@ impl TxFuzzer {
                         Err(_) => None,
                     }
                 }
-                // SetOwnerRole
-                53 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesSetOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_SET_OWNER_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
-                // LockRole
-                54 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesLockOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_LOCK_OWNER_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
-                // SetAndLockRole
-                55 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesSetAndLockOwnerRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_SET_AND_LOCK_OWNER_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
-                // SetRole
-                56 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesSetRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_SET_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
-                // LockRole
-                57 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesLockRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_LOCK_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
-                // SetAndLockRole
-                58 => {
-                    global_addresses.push(GlobalAddress::arbitrary(&mut unstructured).unwrap());
-                    let address = *unstructured.choose(&global_addresses[..]).unwrap();
-                    let input = AccessRulesSetAndLockRoleInput::arbitrary(&mut unstructured).unwrap();
-
-                    match to_manifest_value(&input) {
-                        Ok(args) => Some(InstructionV1::CallAccessRulesMethod {
-                            address: address.into(),
-                            method_name: ACCESS_RULES_SET_AND_LOCK_ROLE_IDENT.to_string(),
-                            args,
-                        }),
-                        Err(_) => None,
-                    }
-                }
+                
+                
+                
+                
+                
+                
                 // If you encounter below error you can check what are the current instructions
                 // using below command:
                 //   cat transaction/src/manifest/ast.rs | awk '/pub enum Instruction/,/^}/ {print $0}' | grep -E "^[ ]*[A-Z][a-zA-Z]*" | sed -E "s/[ ,\{\}]//g" | sort | awk '{print NR-1"\t"$0}'

--- a/radix-engine-tests/benches/transaction_decompilation.rs
+++ b/radix-engine-tests/benches/transaction_decompilation.rs
@@ -10,7 +10,7 @@ use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::resource::RolesInit;
 use radix_engine_interface::blueprints::resource::{NonFungibleResourceRoles, OwnerRole};
 use radix_engine_interface::{metadata, metadata_init, ScryptoSbor};
-use scrypto::prelude::{AccessRule, ComponentAddress};
+use scrypto::prelude::ComponentAddress;
 use scrypto::NonFungibleData;
 use transaction::builder::{ManifestBuilder, TransactionBuilder};
 use transaction::manifest::{compile, decompile, BlobProvider};

--- a/transaction/examples/resources/recall_non_fungibles.rtm
+++ b/transaction/examples/resources/recall_non_fungibles.rtm
@@ -1,0 +1,1 @@
+RECALL_NON_FUNGIBLES_FROM_VAULT Address("${vault_address}") Array<NonFungibleLocalId>(NonFungibleLocalId("#123#"), NonFungibleLocalId("#456#"));

--- a/transaction/examples/resources/worktop.rtm
+++ b/transaction/examples/resources/worktop.rtm
@@ -7,6 +7,7 @@ CALL_METHOD Address("${account_address}") "withdraw" Address("${xrd_resource_add
 # Buy GUM with XRD
 TAKE_FROM_WORKTOP Address("${xrd_resource_address}") Decimal("2.0") Bucket("xrd");
 CALL_METHOD Address("${component_address}") "buy_gumball" Bucket("xrd");
+ASSERT_WORKTOP_CONTAINS_ANY Address("${gumball_resource_address}");
 ASSERT_WORKTOP_CONTAINS Address("${gumball_resource_address}") Decimal("3.0");
 
 # Create a proof from bucket, clone it and drop both

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -158,6 +158,10 @@ pub enum Instruction {
         vault_id: Value,
         args: Vec<Value>,
     },
+    RecallNonFungiblesFromVault {
+        vault_id: Value,
+        args: Vec<Value>,
+    },
 
     /* Call function aliases */
     PublishPackage {

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -36,6 +36,10 @@ pub enum Instruction {
         ids: Value,
     },
 
+    AssertWorktopContainsAny {
+        resource_address: Value,
+    },
+
     PopFromAuthZone {
         new_proof: Value,
     },

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -38,7 +38,8 @@ use radix_engine_interface::blueprints::resource::{
     NON_FUNGIBLE_RESOURCE_MANAGER_CREATE_IDENT,
     NON_FUNGIBLE_RESOURCE_MANAGER_CREATE_WITH_INITIAL_SUPPLY_IDENT,
     NON_FUNGIBLE_RESOURCE_MANAGER_MINT_IDENT, NON_FUNGIBLE_RESOURCE_MANAGER_MINT_RUID_IDENT,
-    VAULT_FREEZE_IDENT, VAULT_RECALL_IDENT, VAULT_UNFREEZE_IDENT,
+    NON_FUNGIBLE_VAULT_RECALL_NON_FUNGIBLES_IDENT, VAULT_FREEZE_IDENT, VAULT_RECALL_IDENT,
+    VAULT_UNFREEZE_IDENT,
 };
 use radix_engine_interface::constants::{
     ACCESS_CONTROLLER_PACKAGE, ACCOUNT_PACKAGE, IDENTITY_PACKAGE, RESOURCE_PACKAGE,
@@ -607,6 +608,10 @@ pub fn decompile_instruction<F: fmt::Write>(
                 VAULT_UNFREEZE_IDENT => {
                     fields.push(to_manifest_value(vault_id)?);
                     "UNFREEZE_VAULT"
+                }
+                NON_FUNGIBLE_VAULT_RECALL_NON_FUNGIBLES_IDENT => {
+                    fields.push(to_manifest_value(vault_id)?);
+                    "RECALL_NON_FUNGIBLES_FROM_VAULT"
                 }
                 /* Default */
                 _ => {

--- a/transaction/src/manifest/decompiler.rs
+++ b/transaction/src/manifest/decompiler.rs
@@ -210,10 +210,6 @@ pub fn decompile_instruction<F: fmt::Write>(
         InstructionV1::ReturnToWorktop { bucket_id } => {
             ("RETURN_TO_WORKTOP", to_manifest_value(&(bucket_id,))?)
         }
-        InstructionV1::AssertWorktopContainsAny { resource_address } => (
-            "ASSERT_WORKTOP_CONTAINS_ANY",
-            to_manifest_value(&(resource_address))?,
-        ),
         InstructionV1::AssertWorktopContains {
             amount,
             resource_address,
@@ -227,6 +223,10 @@ pub fn decompile_instruction<F: fmt::Write>(
         } => (
             "ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES",
             to_manifest_value(&(resource_address, ids))?,
+        ),
+        InstructionV1::AssertWorktopContainsAny { resource_address } => (
+            "ASSERT_WORKTOP_CONTAINS_ANY",
+            to_manifest_value(&(resource_address,))?,
         ),
         InstructionV1::PopFromAuthZone => {
             let proof = context.new_proof();

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -111,6 +111,9 @@ CALL_METHOD
     "buy_gumball"
     Bucket("bucket1")
 ;
+ASSERT_WORKTOP_CONTAINS_ANY
+    Address("${gumball_resource_address}")
+;
 ASSERT_WORKTOP_CONTAINS
     Address("${gumball_resource_address}")
     Decimal("3")

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -341,6 +341,29 @@ CALL_FUNCTION
     }
 
     #[test]
+    fn test_resource_recall_nonfungibles() {
+        compile_and_decompile_with_inversion_test(
+            "resource_recall_nonfungibles",
+            apply_address_replacements(include_str!(
+                "../../examples/resources/recall_non_fungibles.rtm"
+            )),
+            &NetworkDefinition::simulator(),
+            vec![],
+            apply_address_replacements(
+                r##"
+RECALL_NON_FUNGIBLES_FROM_VAULT
+    Address("${vault_address}")
+    Array<NonFungibleLocalId>(
+        NonFungibleLocalId("#123#"),
+        NonFungibleLocalId("#456#")
+    )
+;
+"##,
+            ),
+        );
+    }
+
+    #[test]
     fn test_call_method() {
         compile_and_decompile_with_inversion_test(
             "call_method",

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -630,6 +630,13 @@ where
                 args: generate_args(args, resolver, address_bech32_decoder, blobs)?,
             }
         }
+        ast::Instruction::RecallNonFungiblesFromVault { vault_id, args } => {
+            InstructionV1::CallDirectVaultMethod {
+                address: generate_local_address(vault_id, address_bech32_decoder)?,
+                method_name: NON_FUNGIBLE_VAULT_RECALL_NON_FUNGIBLES_IDENT.to_string(),
+                args: generate_args(args, resolver, address_bech32_decoder, blobs)?,
+            }
+        }
 
         /* call function aliases */
         ast::Instruction::PublishPackage { args } => InstructionV1::CallFunction {

--- a/transaction/src/manifest/generator.rs
+++ b/transaction/src/manifest/generator.rs
@@ -329,6 +329,14 @@ where
             resource_address: generate_resource_address(resource_address, address_bech32_decoder)?,
             ids: generate_non_fungible_local_ids(ids)?,
         },
+        ast::Instruction::AssertWorktopContainsAny { resource_address } => {
+            InstructionV1::AssertWorktopContainsAny {
+                resource_address: generate_resource_address(
+                    resource_address,
+                    address_bech32_decoder,
+                )?,
+            }
+        }
         ast::Instruction::PopFromAuthZone { new_proof } => {
             let proof_id = id_validator
                 .new_proof(ProofKind::AuthZoneProof)

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -37,6 +37,7 @@ pub enum InstructionIdent {
     ReturnToWorktop,
     AssertWorktopContains,
     AssertWorktopContainsNonFungibles,
+    AssertWorktopContainsAny,
 
     PopFromAuthZone,
     PushToAuthZone,
@@ -124,6 +125,7 @@ impl InstructionIdent {
             "ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES" => {
                 InstructionIdent::AssertWorktopContainsNonFungibles
             }
+            "ASSERT_WORKTOP_CONTAINS_ANY" => InstructionIdent::AssertWorktopContainsAny,
 
             "POP_FROM_AUTH_ZONE" => InstructionIdent::PopFromAuthZone,
             "PUSH_TO_AUTH_ZONE" => InstructionIdent::PushToAuthZone,
@@ -517,6 +519,9 @@ impl Parser {
                     ids: self.parse_value()?,
                 }
             }
+            InstructionIdent::AssertWorktopContainsAny => Instruction::AssertWorktopContainsAny {
+                resource_address: self.parse_value()?,
+            },
             InstructionIdent::PopFromAuthZone => Instruction::PopFromAuthZone {
                 new_proof: self.parse_value()?,
             },

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -67,6 +67,7 @@ pub enum InstructionIdent {
     RecallFromVault,
     FreezeVault,
     UnfreezeVault,
+    RecallNonFungiblesFromVault,
 
     // ==============
     // Call function aliases
@@ -163,6 +164,7 @@ impl InstructionIdent {
             "RECALL_FROM_VAULT" => InstructionIdent::RecallFromVault,
             "FREEZE_VAULT" => InstructionIdent::FreezeVault,
             "UNFREEZE_VAULT" => InstructionIdent::UnfreezeVault,
+            "RECALL_NON_FUNGIBLES_FROM_VAULT" => InstructionIdent::RecallNonFungiblesFromVault,
 
             // ==============
             // Call function aliases
@@ -630,6 +632,12 @@ impl Parser {
                 vault_id: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,
             },
+            InstructionIdent::RecallNonFungiblesFromVault => {
+                Instruction::RecallNonFungiblesFromVault {
+                    vault_id: self.parse_value()?,
+                    args: self.parse_values_till_semicolon()?,
+                }
+            }
 
             /* Call function aliases */
             InstructionIdent::PublishPackage => Instruction::PublishPackage {


### PR DESCRIPTION
## Summary
Added missing Scrypto instructions: `RECALL_NON_FUNGIBLES_FROM_VAULT` and `ASSERT_CONTAINS_ANY`.

## Testing
Added test to cover these new instructions.
