### PR TITLE
Disable bench on push commits

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,14 +1,6 @@
 name: Benchmark PR
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - docs
-      - alphanet
-      - betanet
-      - release\/*
   pull_request:
     # Run on PR against any branch
 


### PR DESCRIPTION
## Summary

Disable bench on push commits. It's been failing all the time, because there is no target to compare against.