### PR TITLE
Update package owner badge to be consistent with other owner badges

### DIFF
--- a/radix-engine-tests/tests/metadata_package.rs
+++ b/radix-engine-tests/tests/metadata_package.rs
@@ -60,8 +60,6 @@ fn can_set_package_metadata_with_owner() {
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     let package_address = receipt.expect_commit(true).new_package_addresses()[0];
-    let vault_id = test_runner.get_component_vaults(account, PACKAGE_OWNER_BADGE)[0];
-    let (_, local_id) = test_runner.inspect_non_fungible_vault(vault_id).unwrap();
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -69,7 +67,7 @@ fn can_set_package_metadata_with_owner() {
         .create_proof_from_account_of_non_fungibles(
             account,
             PACKAGE_OWNER_BADGE,
-            &btreeset!(local_id.unwrap()),
+            &btreeset!(NonFungibleLocalId::bytes(package_address.as_node_id().0).unwrap()),
         )
         .set_metadata(
             package_address,

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -1235,7 +1235,7 @@ impl PackageNativePackage {
                 name: "Package Owner Badge".to_owned(),
                 package: address.try_into().expect("Impossible Case"),
             },
-            None,
+            Some(NonFungibleLocalId::bytes(address.as_node_id().0).unwrap()),
             api,
         )?;
         let metadata = Metadata::create_with_data(metadata_init, api)?;

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -690,7 +690,7 @@ pub fn create_system_bootstrap_transaction(
             args: to_manifest_value_and_unwrap!(
                 &NonFungibleResourceManagerCreateManifestInput {
                     owner_role: OwnerRole::Fixed(rule!(require(global_caller(PACKAGE_PACKAGE)))),
-                    id_type: NonFungibleIdType::RUID,
+                    id_type: NonFungibleIdType::Bytes,
                     track_total_supply: false,
                     non_fungible_schema: NonFungibleDataSchema::new_schema::<PackageOwnerBadgeData>(),
                     resource_roles: NonFungibleResourceRoles {


### PR DESCRIPTION
## Summary

Updates package owner badge to use `NonFungibleIdType::Bytes`, to be consistent with other owner badges.


## Update Recommendations

### For dApp Developers

The non-fungible local id of package owner badge is now `NonFungibleLocalId("[<hex encoded raw bytes of address>]`, instead of RUID.

