### PR TITLE
Disable limits module for genesis and system transactions

### DIFF
--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -1662,7 +1662,6 @@ fn low_stakes_should_cause_no_problems() {
     }
 }
 
-
 #[test]
 fn one_hundred_validators_should_work() {
     registered_validator_test(

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -1662,6 +1662,20 @@ fn low_stakes_should_cause_no_problems() {
     }
 }
 
+
+#[test]
+fn one_hundred_validators_should_work() {
+    registered_validator_test(
+        RegisterAndStakeTransactionType::RegisterFirst,
+        100,
+        100,
+        1000000.into(),
+        1100000.into(),
+        true,
+        100,
+    );
+}
+
 #[test]
 fn test_registering_and_staking_many_validators() {
     // Arrange

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -52,11 +52,11 @@ impl EnabledModules {
     /// The difference between genesis transaction and system transaction is "no auth".
     /// TODO: double check if this is the right assumption.
     pub fn for_genesis_transaction() -> Self {
-        Self::LIMITS | Self::NODE_MOVE | Self::TRANSACTION_RUNTIME
+        Self::NODE_MOVE | Self::TRANSACTION_RUNTIME
     }
 
     pub fn for_system_transaction() -> Self {
-        Self::LIMITS | Self::AUTH | Self::NODE_MOVE | Self::TRANSACTION_RUNTIME
+        Self::AUTH | Self::NODE_MOVE | Self::TRANSACTION_RUNTIME
     }
 
     pub fn for_notarized_transaction() -> Self {


### PR DESCRIPTION
## Summary

- Added tests to reproduce Babylon migration error
- Disabled limits module for system and genesis transactions (before Node has better understanding about the bounds).