### PR TITLE
Feature/typed native events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Check format
       run: bash ./check.sh
   sbor-unit-tests:
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: sbor
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: sbor-tests
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto-tests
@@ -123,7 +123,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Add wasm target (nightly)
@@ -153,7 +153,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Install RocksDB metrics dependency
@@ -185,7 +185,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -206,7 +206,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -227,7 +227,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -243,7 +243,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -259,7 +259,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: transaction
@@ -287,7 +287,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -321,7 +321,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -349,7 +349,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target

--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "ppv-lite86"
@@ -630,9 +630,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -688,7 +688,7 @@ dependencies = [
  "resources-tracker-macro",
  "sbor",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "transaction",
  "utils",
  "wasm-instrument",
@@ -713,7 +713,7 @@ dependencies = [
  "radix-engine-derive",
  "sbor",
  "serde",
- "strum",
+ "strum 0.24.1",
  "utils",
 ]
 
@@ -728,7 +728,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sbor-derive-common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ dependencies = [
  "sbor",
  "scrypto-schema",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "utils",
 ]
 
@@ -762,11 +762,13 @@ version = "0.10.0"
 dependencies = [
  "hex",
  "itertools",
+ "paste",
  "radix-engine",
  "radix-engine-constants",
  "radix-engine-interface",
  "radix-engine-store-interface",
  "sbor",
+ "strum 0.25.0",
  "transaction",
  "utils",
 ]
@@ -863,7 +865,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "radix-engine-profiling",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -925,7 +927,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -960,7 +962,7 @@ dependencies = [
  "scrypto-derive",
  "scrypto-schema",
  "serde",
- "strum",
+ "strum 0.24.1",
  "utils",
 ]
 
@@ -975,7 +977,7 @@ dependencies = [
  "scrypto-schema",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1051,7 +1053,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1117,7 +1119,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.1",
 ]
 
 [[package]]
@@ -1130,7 +1141,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1151,6 +1175,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,7 +1193,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -1199,7 +1234,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1488,6 +1523,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -16,7 +16,7 @@ num-integer = { version = "0.1.45", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 bnum = { version = "0.7.0", default-features = false, features = ["numtraits"] }
 bech32 = { version = "0.9.0", default-features = false }
-paste = { version = "1.0.7"}
+paste = { version = "1.0.13" }
 blake2 = { version = "0.10.6", default-features = false }
 lazy_static = "1.4.0"
 strum = { version = "0.24", default-features = false, features = ["derive"] }

--- a/radix-engine-common/tests/scrypto_codec.rs
+++ b/radix-engine-common/tests/scrypto_codec.rs
@@ -1,3 +1,6 @@
+// This test module fails to compile if we do not increase the recursion limit.
+#![recursion_limit = "256"] 
+
 use radix_engine_common::data::scrypto::model::NonFungibleLocalId;
 use radix_engine_common::data::scrypto::*;
 use radix_engine_common::*;

--- a/radix-engine-common/tests/scrypto_codec.rs
+++ b/radix-engine-common/tests/scrypto_codec.rs
@@ -1,5 +1,5 @@
 // This test module fails to compile if we do not increase the recursion limit.
-#![recursion_limit = "256"] 
+#![recursion_limit = "256"]
 
 use radix_engine_common::data::scrypto::model::NonFungibleLocalId;
 use radix_engine_common::data::scrypto::*;

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { version = "1.0", default-features = false }
 lazy_static = "1.4.0"
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
-paste = { version = "1.0.12" }
+paste = { version = "1.0.13" }
 
 [features]
 # You should enable either `std` or `alloc`

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -13,12 +13,14 @@ transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false }
 itertools = { version = "0.10.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
+strum = { version = "0.25.0", features = ["derive"] }
+paste = "1.0.13"
 
 [features]
 # You should enable either `std` or `alloc`
 default = ["std", "moka"]
-std = ["hex/std", "sbor/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std"]
-alloc = ["hex/alloc", "sbor/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc"]
+std = ["radix-engine/std", "hex/std", "sbor/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std"]
+alloc = ["radix-engine/alloc", "hex/alloc", "sbor/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc"]
 
 moka = ["radix-engine/moka"]
 lru = ["radix-engine/lru"]

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -13,7 +13,6 @@ transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false }
 itertools = { version = "0.10.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-strum = { version = "0.25.0", features = ["derive"] }
 paste = "1.0.13"
 
 [features]

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -13,7 +13,7 @@ transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false }
 itertools = { version = "0.10.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-paste = "1.0.13"
+paste = { version = "1.0.13" }
 
 [features]
 # You should enable either `std` or `alloc`

--- a/radix-engine-queries/src/lib.rs
+++ b/radix-engine-queries/src/lib.rs
@@ -6,4 +6,5 @@ compile_error!("Either feature `std` or `alloc` must be enabled for this crate."
 compile_error!("Feature `std` and `alloc` can't be enabled at the same time.");
 
 pub mod query;
+pub mod typed_native_events;
 pub mod typed_substate_layout;

--- a/radix-engine-queries/src/typed_native_events.rs
+++ b/radix-engine-queries/src/typed_native_events.rs
@@ -471,7 +471,7 @@ macro_rules! define_structure {
                         )*
                     }
 
-                    impl std::str::FromStr for [< Typed $blueprint_ident BlueprintEventKey >] {
+                    impl sbor::prelude::FromStr for [< Typed $blueprint_ident BlueprintEventKey >] {
                         type Err = TypedNativeEventError;
 
                         fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/radix-engine-queries/src/typed_native_events.rs
+++ b/radix-engine-queries/src/typed_native_events.rs
@@ -15,6 +15,13 @@ use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::consensus_manager::*;
 use radix_engine_interface::blueprints::identity::*;
 
+/// Given an [`EventTypeIdentifier`] and the raw event data, this function attempts to convert the
+/// event data into a structured model provided that the event is registered to a native blueprint.
+///
+/// # Panics
+///
+/// This function panics if the even't [`TypePointer`] is of variant [`TypePointer::Instance`] as
+/// generics are not supported in events.
 pub fn to_typed_native_event(
     event_type_identifier: &EventTypeIdentifier,
     event_data: &[u8],
@@ -29,7 +36,7 @@ fn resolve_typed_event_key_from_event_type_identifier(
 ) -> Result<TypedNativeEventKey, TypedNativeEventError> {
     let local_type_index = match event_type_identifier.1 {
         TypePointer::Package(_, x) => x,
-        _ => panic!(""),
+        TypePointer::Instance(..) => panic!("An event can not be generic"),
     };
 
     match &event_type_identifier.0 {

--- a/radix-engine-queries/src/typed_native_events.rs
+++ b/radix-engine-queries/src/typed_native_events.rs
@@ -1,0 +1,320 @@
+//! This module contains the code and models that are required to convert native events into a typed
+//! model based on the [`EventTypeIdentifier`] and the raw SBOR bytes of the event. This is used in
+//! the toolkit and consumed by the gateway for some of its internal operations.
+
+use crate::typed_substate_layout::*;
+use radix_engine::blueprints::native_schema::*;
+use radix_engine::blueprints::pool::multi_resource_pool::*;
+use radix_engine::blueprints::pool::one_resource_pool::*;
+use radix_engine::blueprints::pool::two_resource_pool::*;
+use radix_engine::types::*;
+use radix_engine_interface::api::node_modules::auth::*;
+use radix_engine_interface::api::*;
+use radix_engine_interface::blueprints::access_controller::*;
+use radix_engine_interface::blueprints::account::*;
+use radix_engine_interface::blueprints::consensus_manager::*;
+use radix_engine_interface::blueprints::identity::*;
+
+pub fn to_typed_native_event(
+    event_type_identifier: &EventTypeIdentifier,
+    event_data: &[u8],
+) -> Result<TypedNativeEvent, TypedNativeEventError> {
+    todo!()
+}
+
+define_structure! {
+    /* Native Packages */
+    AccessController => {
+        AccessController => [
+            InitiateRecoveryEvent,
+            InitiateBadgeWithdrawAttemptEvent,
+            RuleSetUpdateEvent,
+            BadgeWithdrawEvent,
+            CancelRecoveryProposalEvent,
+            CancelBadgeWithdrawAttemptEvent,
+            LockPrimaryRoleEvent,
+            UnlockPrimaryRoleEvent,
+            StopTimedRecoveryEvent,
+        ],
+    },
+    Account => {
+        Account => []
+    },
+    Identity => {
+        Identity => []
+    },
+    Package => {
+        Package => []
+    },
+    ConsensusManager => {
+        ConsensusManager => [
+            RoundChangeEvent,
+            EpochChangeEvent
+        ],
+        Validator => [
+            RegisterValidatorEvent,
+            UnregisterValidatorEvent,
+            StakeEvent,
+            UnstakeEvent,
+            ClaimXrdEvent,
+            UpdateAcceptingStakeDelegationStateEvent,
+            ProtocolUpdateReadinessSignalEvent,
+            ValidatorEmissionAppliedEvent,
+            ValidatorRewardAppliedEvent,
+        ],
+    },
+    Pool => {
+        OneResourcePool => [
+            OneResourcePoolContributionEvent,
+            OneResourcePoolRedemptionEvent,
+            OneResourcePoolWithdrawEvent,
+            OneResourcePoolDepositEvent,
+        ],
+        TwoResourcePool => [
+            TwoResourcePoolContributionEvent,
+            TwoResourcePoolRedemptionEvent,
+            TwoResourcePoolWithdrawEvent,
+            TwoResourcePoolDepositEvent,
+        ],
+        MultiResourcePool => [
+            MultiResourcePoolContributionEvent,
+            MultiResourcePoolRedemptionEvent,
+            MultiResourcePoolWithdrawEvent,
+            MultiResourcePoolDepositEvent,
+        ],
+    },
+    Resource => {
+        FungibleVault => [
+            LockFeeEvent,
+            WithdrawResourceEvent,
+            DepositResourceEvent,
+            RecallResourceEvent,
+        ],
+        NonFungibleVault => [
+            LockFeeEvent,
+            WithdrawResourceEvent,
+            DepositResourceEvent,
+            RecallResourceEvent,
+        ],
+        FungibleResourceManager => [
+            VaultCreationEvent,
+            MintFungibleResourceEvent,
+            BurnFungibleResourceEvent,
+        ],
+        NonFungibleResourceManager => [
+            VaultCreationEvent,
+            MintNonFungibleResourceEvent,
+            BurnNonFungibleResourceEvent,
+        ]
+    },
+    TransactionProcessor => {
+        TransactionProcessor => []
+    },
+    TransactionTracker => {
+        TransactionTracker => []
+    },
+
+    /* Node Module Packages */
+    AccessRules => {
+        AccessRules => [
+            SetRoleEvent,
+            LockRoleEvent,
+            SetAndLockRoleEvent,
+            SetOwnerRoleEvent,
+            LockOwnerRoleEvent,
+            SetAndLockOwnerRoleEvent,
+        ]
+    },
+    Metadata => {
+        Metadata => [
+            SetMetadataEvent,
+            RemoveMetadataEvent,
+        ]
+    },
+    Royalty => {
+        Royalty => []
+    },
+}
+
+// Type aliases for events with the same name in order not to cause use collision issues.
+type OneResourcePoolContributionEvent = one_resource_pool::ContributionEvent;
+type OneResourcePoolRedemptionEvent = one_resource_pool::RedemptionEvent;
+type OneResourcePoolWithdrawEvent = one_resource_pool::WithdrawEvent;
+type OneResourcePoolDepositEvent = one_resource_pool::DepositEvent;
+
+type TwoResourcePoolContributionEvent = two_resource_pool::ContributionEvent;
+type TwoResourcePoolRedemptionEvent = two_resource_pool::RedemptionEvent;
+type TwoResourcePoolWithdrawEvent = two_resource_pool::WithdrawEvent;
+type TwoResourcePoolDepositEvent = two_resource_pool::DepositEvent;
+
+type MultiResourcePoolContributionEvent = multi_resource_pool::ContributionEvent;
+type MultiResourcePoolRedemptionEvent = multi_resource_pool::RedemptionEvent;
+type MultiResourcePoolWithdrawEvent = multi_resource_pool::WithdrawEvent;
+type MultiResourcePoolDepositEvent = multi_resource_pool::DepositEvent;
+
+//========
+// Macros
+//========
+
+/// This enum uses some special syntax to define the structure of events. This makes the code for
+/// model definitions very compact, allows for very easy addition of more packages, blueprints or
+/// events in the future, keeps various models all in sync, and implements various functions and
+/// methods on appropriate types.
+///
+/// The syntax allowed for by this macro looks like the following:
+/// ```no_run
+/// define_structure! {
+///     package_name1 => {
+///         blueprint_name1 => [
+///             Event1,
+///             Event2,
+///             Event3,
+///         ],
+///         blueprint_name2 => [
+///             Event1,
+///         ]
+///     },
+///     package_name2 => {
+///         blueprint_name1 => [
+///             Event1,
+///         ],
+///         blueprint_name2 => [
+///             Event1,
+///             Event2,
+///         ]
+///     }
+/// }
+/// ```
+macro_rules! define_structure {
+    (
+        $(
+            $package_ident: ident => {
+                $(
+                    $blueprint_ident: ident => [
+                        $($event_ty: ty $(as event_ident: ident)?),* $(,)?
+                    ]
+                ),* $(,)?
+            }
+        ),* $(,)?
+    ) => {
+        paste::paste! {
+            // Defining the top-level type which will be of all of the packages and their blueprints.
+            pub enum TypedNativeEvent {
+                $(
+                    $package_ident([< Typed $package_ident PackageEvent >]),
+                )*
+            }
+
+            // Define a type for the package - this should be an enum of all of the blueprints that
+            // the package has.
+            $(
+                pub enum [< Typed $package_ident PackageEvent >] {
+                    $(
+                        $blueprint_ident([< Typed $blueprint_ident BlueprintEvent >]),
+                    )*
+                }
+
+                $(
+                    #[derive(radix_engine_interface::prelude::ScryptoSbor)]
+                    pub enum [< Typed $blueprint_ident BlueprintEvent >] {
+                        $(
+                            $event_ty ($event_ty),
+                        )*
+                    }
+                )*
+            )*
+
+            // Defining the event key types which are the same as above but do not have any event
+            // data inside of them.
+            pub enum TypedNativeEventKey {
+                $(
+                    $package_ident([< Typed $package_ident PackageEventKey >]),
+                )*
+            }
+
+            $(
+                pub enum [< Typed $package_ident PackageEventKey >] {
+                    $(
+                        $blueprint_ident([< Typed $blueprint_ident BlueprintEventKey >]),
+                    )*
+                }
+
+                $(
+                    #[derive(radix_engine_interface::prelude::ScryptoSbor)]
+                    pub enum [< Typed $blueprint_ident BlueprintEventKey >] {
+                        $(
+                            $event_ty,
+                        )*
+                    }
+
+                    impl std::str::FromStr for [< Typed $blueprint_ident BlueprintEventKey >] {
+                        type Err = TypedNativeEventError;
+
+                        fn from_str(s: &str) -> Result<Self, Self::Err> {
+                            match s {
+                                $(
+                                    _ if <$event_ty as radix_engine_interface::prelude::ScryptoEvent>::event_name() == s => Ok(Self::$event_ty),
+                                )*
+                                _ => Err(Self::Err::BlueprintEventKeyParseError {
+                                    blueprint_event_key: stringify!([< Typed $blueprint_ident BlueprintEventKey >]).to_string(),
+                                    event_name: s.to_string()
+                                })
+                            }
+                        }
+                    }
+                )*
+            )*
+
+            // The implementation of a function that converts any `TypedNativeEventKey` + raw SBOR
+            // bytes to the appropriate typed event type.
+            #[allow(dead_code)] // TODO: Remove
+            fn typed_event_with_event_key(
+                event_key: &TypedNativeEventKey,
+                data: &[u8]
+            ) -> Result<TypedNativeEvent, TypedNativeEventError> {
+                match event_key {
+                    $(
+                        $(
+                            $(
+                                TypedNativeEventKey::$package_ident(
+                                    [< Typed $package_ident PackageEventKey >]::$blueprint_ident(
+                                        [< Typed $blueprint_ident BlueprintEventKey >]::$event_ty
+                                    )
+                                ) => Ok(TypedNativeEvent::$package_ident(
+                                    [< Typed $package_ident PackageEvent >]::$blueprint_ident(
+                                        [< Typed $blueprint_ident BlueprintEvent >]::$event_ty(
+                                            radix_engine_interface::prelude::scrypto_decode(data)?
+                                        )
+                                    )
+                                )),
+                            )*
+                        )*
+                    )*
+
+                    // The following panic needs to be included to allow blueprints with no events
+                    // to work with no issues. It's impossible for us to get to this point here!
+                    _ => panic!("Illegal State! Matching over enum was not exhaustive.")
+                }
+            }
+        }
+    };
+}
+use define_structure;
+
+pub enum TypedNativeEventError {
+    EventNameIsInvalidForBlueprint {
+        event_name: String,
+        blueprint_name: String,
+    },
+    BlueprintEventKeyParseError {
+        blueprint_event_key: String,
+        event_name: String,
+    },
+    DecodeError(DecodeError),
+}
+
+impl From<DecodeError> for TypedNativeEventError {
+    fn from(value: DecodeError) -> Self {
+        Self::DecodeError(value)
+    }
+}

--- a/radix-engine-tests/Cargo.toml
+++ b/radix-engine-tests/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0.144", default-features = false }
 serde_json = { version = "1.0.81", default-features = false }
 crossbeam = { version = "0.8.2" }
 walkdir = { version = "2.3.3" }
-paste = { version = "1.0.12" }
+paste = { version = "1.0.13" }
 
 
 [[bench]]

--- a/radix-engine-tests/tests/blueprints/events/src/scrypto_events.rs
+++ b/radix-engine-tests/tests/blueprints/events/src/scrypto_events.rs
@@ -1,11 +1,11 @@
 use scrypto::prelude::*;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 struct RegisteredEvent {
     number: u64,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 struct UnregisteredEvent {
     number: u64,
 }

--- a/radix-engine-tests/tests/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/typed_substate_layout.rs
@@ -1,3 +1,4 @@
+use radix_engine::blueprints::native_schema::*;
 use radix_engine::system::bootstrap::{
     Bootstrapper, GenesisDataChunk, GenesisReceipts, GenesisStakeAllocation,
 };
@@ -5,10 +6,13 @@ use radix_engine::transaction::{CommitResult, TransactionResult};
 use radix_engine::types::*;
 use radix_engine::vm::wasm::DefaultWasmEngine;
 use radix_engine::vm::*;
-use radix_engine_queries::typed_native_events::to_typed_native_event;
-use radix_engine_queries::typed_substate_layout::{to_typed_substate_key, to_typed_substate_value};
+use radix_engine_queries::typed_native_events::{to_typed_native_event, TypedNativeEvent};
+use radix_engine_queries::typed_substate_layout::{
+    to_typed_substate_key, to_typed_substate_value,
+};
 use radix_engine_store_interface::interface::DatabaseUpdate;
 use radix_engine_stores::memory_db::InMemorySubstateDatabase;
+use sbor::rust::ops::Deref;
 use scrypto_unit::{CustomGenesis, TestRunner};
 use transaction::signing::secp256k1::Secp256k1PrivateKey;
 use transaction_scenarios::scenario::{NextAction, ScenarioCore};
@@ -144,7 +148,7 @@ fn test_all_scenario_commit_receipts_should_have_substate_changes_which_can_be_t
 #[test]
 fn test_all_scenario_commit_receipts_should_have_events_that_can_be_typed() {
     let network = NetworkDefinition::simulator();
-    let mut test_runner = TestRunner::builder().without_trace().build();
+    let mut test_runner = TestRunner::builder().build();
 
     let mut next_nonce: u32 = 0;
     for scenario_builder in get_builder_for_every_scenario() {
@@ -174,6 +178,60 @@ fn test_all_scenario_commit_receipts_should_have_events_that_can_be_typed() {
                     break;
                 }
             }
+        }
+    }
+}
+
+/// We need to ensure that all of the events registered to native events are included in the typed
+/// native event model. This test checks that the events in `typed_native_events.rs` module all
+/// exist in the blueprint schema.
+#[test]
+fn typed_native_event_type_contains_all_native_events() {
+    // Arrange
+    let package_name_definition_mapping = hashmap! {
+        "ConsensusManager" => CONSENSUS_MANAGER_PACKAGE_DEFINITION.deref(),
+        "Account" => ACCOUNT_PACKAGE_DEFINITION.deref(),
+        "Identity" => IDENTITY_PACKAGE_DEFINITION.deref(),
+        "AccessController" => ACCESS_CONTROLLER_PACKAGE_DEFINITION.deref(),
+        "Pool" => POOL_PACKAGE_DEFINITION.deref(),
+        "TransactionTracker" => TRANSACTION_TRACKER_PACKAGE_DEFINITION.deref(),
+        "Resource" => RESOURCE_PACKAGE_DEFINITION.deref(),
+        "Package" => PACKAGE_PACKAGE_DEFINITION.deref(),
+        "TransactionProcessor" => TRANSACTION_PROCESSOR_PACKAGE_DEFINITION.deref(),
+        "Metadata" => METADATA_PACKAGE_DEFINITION.deref(),
+        "Royalty" => ROYALTY_PACKAGE_DEFINITION.deref(),
+        "AccessRules" => ACCESS_RULES_PACKAGE_DEFINITION.deref(),
+    };
+
+    // Act
+    let registered_events = TypedNativeEvent::registered_events();
+
+    // Assert
+    for (package_name, package_blueprints) in registered_events.into_iter() {
+        let package_definition = package_name_definition_mapping.get(package_name.as_str()).expect(
+            format!("No package definition found for a package with the name: \"{package_name}\"")
+                .as_str(),
+        );
+        for (blueprint_name, blueprint_events) in package_blueprints.into_iter() {
+            let blueprint_definition = package_definition.blueprints.get(&blueprint_name).expect(
+                format!(
+                    "Package named \"{package_name}\" has no blueprint named \"{blueprint_name}\""
+                )
+                .as_str(),
+            );
+            let actual_blueprint_events = blueprint_definition
+                .schema
+                .events
+                .event_schema
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            assert_eq!(
+                blueprint_events, 
+                actual_blueprint_events, 
+                "There is a difference between the actual blueprint events and the ones registered in the typed model. Package name: \"{package_name}\", Blueprint name: \"{blueprint_name}\""
+            )
         }
     }
 }

--- a/radix-engine-tests/tests/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/typed_substate_layout.rs
@@ -7,9 +7,7 @@ use radix_engine::types::*;
 use radix_engine::vm::wasm::DefaultWasmEngine;
 use radix_engine::vm::*;
 use radix_engine_queries::typed_native_events::{to_typed_native_event, TypedNativeEvent};
-use radix_engine_queries::typed_substate_layout::{
-    to_typed_substate_key, to_typed_substate_value,
-};
+use radix_engine_queries::typed_substate_layout::{to_typed_substate_key, to_typed_substate_value};
 use radix_engine_store_interface::interface::DatabaseUpdate;
 use radix_engine_stores::memory_db::InMemorySubstateDatabase;
 use sbor::rust::ops::Deref;
@@ -208,10 +206,14 @@ fn typed_native_event_type_contains_all_native_events() {
 
     // Assert
     for (package_name, package_blueprints) in registered_events.into_iter() {
-        let package_definition = package_name_definition_mapping.get(package_name.as_str()).expect(
-            format!("No package definition found for a package with the name: \"{package_name}\"")
+        let package_definition = package_name_definition_mapping
+            .get(package_name.as_str())
+            .expect(
+                format!(
+                    "No package definition found for a package with the name: \"{package_name}\""
+                )
                 .as_str(),
-        );
+            );
         for (blueprint_name, blueprint_events) in package_blueprints.into_iter() {
             let blueprint_definition = package_definition.blueprints.get(&blueprint_name).expect(
                 format!(
@@ -228,8 +230,8 @@ fn typed_native_event_type_contains_all_native_events() {
                 .collect::<HashSet<_>>();
 
             assert_eq!(
-                blueprint_events, 
-                actual_blueprint_events, 
+                blueprint_events,
+                actual_blueprint_events,
                 "There is a difference between the actual blueprint events and the ones registered in the typed model. Package name: \"{package_name}\", Blueprint name: \"{blueprint_name}\""
             )
         }

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -22,7 +22,7 @@ strum = { version = "0.24", default-features = false, features = ["derive"] }
 perfcnt = { version = "0.8.0", optional = true }
 radix-engine-profiling = { path = "../radix-engine-profiling", optional = true, features = ["resource_tracker"] }
 resources-tracker-macro = { path = "../radix-engine-profiling/resources-tracker-macro" }
-paste = "1.0.12"
+paste = { version = "1.0.13" }
 
 # WASM de-/serialization
 parity-wasm = { version = "0.42.2", features = ["sign_ext"] }

--- a/radix-engine/src/blueprints/access_controller/events.rs
+++ b/radix-engine/src/blueprints/access_controller/events.rs
@@ -1,43 +1,43 @@
 use crate::types::*;
 use radix_engine_interface::blueprints::access_controller::{Proposer, RecoveryProposal};
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct InitiateRecoveryEvent {
     pub proposer: Proposer,
     pub proposal: RecoveryProposal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct InitiateBadgeWithdrawAttemptEvent {
     pub proposer: Proposer,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct RuleSetUpdateEvent {
     pub proposer: Proposer,
     pub proposal: RecoveryProposal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct BadgeWithdrawEvent {
     pub proposer: Proposer,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct CancelRecoveryProposalEvent {
     pub proposer: Proposer,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct CancelBadgeWithdrawAttemptEvent {
     pub proposer: Proposer,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct LockPrimaryRoleEvent;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct UnlockPrimaryRoleEvent;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct StopTimedRecoveryEvent;

--- a/radix-engine/src/blueprints/consensus_manager/events/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/events/validator.rs
@@ -1,33 +1,33 @@
 use crate::types::*;
 use radix_engine_interface::math::Decimal;
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct RegisterValidatorEvent;
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct UnregisterValidatorEvent;
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct StakeEvent {
     pub xrd_staked: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct UnstakeEvent {
     pub stake_units: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct ClaimXrdEvent {
     pub claimed_xrd: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct UpdateAcceptingStakeDelegationStateEvent {
     pub accepts_delegation: bool,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct ProtocolUpdateReadinessSignalEvent {
     pub protocol_version_name: String,
 }

--- a/radix-engine/src/blueprints/native_schema.rs
+++ b/radix-engine/src/blueprints/native_schema.rs
@@ -34,7 +34,7 @@ lazy_static! {
         TransactionProcessorNativePackage::definition();
     pub static ref METADATA_PACKAGE_DEFINITION: PackageDefinition =
         MetadataNativePackage::definition();
-    pub static ref ROYALTIES_PACKAGE_DEFINITION: PackageDefinition =
+    pub static ref ROYALTY_PACKAGE_DEFINITION: PackageDefinition =
         RoyaltyNativePackage::definition();
     pub static ref ACCESS_RULES_PACKAGE_DEFINITION: PackageDefinition =
         AccessRulesNativePackage::definition();

--- a/radix-engine/src/blueprints/pool/multi_resource_pool/events.rs
+++ b/radix-engine/src/blueprints/pool/multi_resource_pool/events.rs
@@ -3,25 +3,25 @@ use radix_engine_common::math::Decimal;
 use radix_engine_common::{ScryptoEvent, ScryptoSbor};
 use sbor::rust::prelude::*;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct ContributionEvent {
     pub contributed_resources: BTreeMap<ResourceAddress, Decimal>,
     pub pool_units_minted: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct RedemptionEvent {
     pub pool_unit_tokens_redeemed: Decimal,
     pub redeemed_resources: BTreeMap<ResourceAddress, Decimal>,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct WithdrawEvent {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct DepositEvent {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,

--- a/radix-engine/src/blueprints/pool/one_resource_pool/events.rs
+++ b/radix-engine/src/blueprints/pool/one_resource_pool/events.rs
@@ -2,24 +2,24 @@ use crate::types::*;
 use radix_engine_common::math::Decimal;
 use radix_engine_common::{ScryptoEvent, ScryptoSbor};
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct ContributionEvent {
     pub amount_of_resources_contributed: Decimal,
     pub pool_units_minted: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct RedemptionEvent {
     pub pool_unit_tokens_redeemed: Decimal,
     pub redeemed_amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct WithdrawEvent {
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct DepositEvent {
     pub amount: Decimal,
 }

--- a/radix-engine/src/blueprints/pool/two_resource_pool/events.rs
+++ b/radix-engine/src/blueprints/pool/two_resource_pool/events.rs
@@ -3,25 +3,25 @@ use radix_engine_common::math::Decimal;
 use radix_engine_common::{ScryptoEvent, ScryptoSbor};
 use sbor::rust::prelude::*;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct ContributionEvent {
     pub contributed_resources: BTreeMap<ResourceAddress, Decimal>,
     pub pool_units_minted: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct RedemptionEvent {
     pub pool_unit_tokens_redeemed: Decimal,
     pub redeemed_resources: BTreeMap<ResourceAddress, Decimal>,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct WithdrawEvent {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct DepositEvent {
     pub resource_address: ResourceAddress,
     pub amount: Decimal,

--- a/radix-engine/src/blueprints/resource/events/resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/events/resource_manager.rs
@@ -1,6 +1,6 @@
 use crate::types::*;
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct VaultCreationEvent {
     pub vault_id: NodeId,
 }
@@ -10,17 +10,17 @@ pub struct MintFungibleResourceEvent {
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct BurnFungibleResourceEvent {
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct MintNonFungibleResourceEvent {
     pub ids: BTreeSet<NonFungibleLocalId>,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct BurnNonFungibleResourceEvent {
     pub ids: BTreeSet<NonFungibleLocalId>,
 }

--- a/radix-engine/src/blueprints/resource/events/vault.rs
+++ b/radix-engine/src/blueprints/resource/events/vault.rs
@@ -1,11 +1,11 @@
 use crate::types::*;
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub struct LockFeeEvent {
     pub amount: Decimal,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub enum WithdrawResourceEvent {
     Amount(Decimal),
     Ids(BTreeSet<NonFungibleLocalId>),
@@ -17,7 +17,7 @@ pub enum DepositResourceEvent {
     Ids(BTreeSet<NonFungibleLocalId>),
 }
 
-#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq)]
+#[derive(ScryptoSbor, ScryptoEvent, PartialEq, Eq, Debug)]
 pub enum RecallResourceEvent {
     Amount(Decimal),
     Ids(BTreeSet<NonFungibleLocalId>),

--- a/radix-engine/src/system/node_modules/access_rules/events.rs
+++ b/radix-engine/src/system/node_modules/access_rules/events.rs
@@ -1,32 +1,32 @@
 use crate::types::*;
 use radix_engine_interface::blueprints::resource::AccessRule;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct SetRoleEvent {
     pub role_key: RoleKey,
     pub rule: AccessRule,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct LockRoleEvent {
     pub role_key: RoleKey,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct SetAndLockRoleEvent {
     pub role_key: RoleKey,
     pub rule: AccessRule,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct SetOwnerRoleEvent {
     pub rule: AccessRule,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct LockOwnerRoleEvent {}
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct SetAndLockOwnerRoleEvent {
     pub rule: AccessRule,
 }

--- a/radix-engine/src/system/node_modules/metadata/events.rs
+++ b/radix-engine/src/system/node_modules/metadata/events.rs
@@ -1,13 +1,13 @@
 use crate::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct SetMetadataEvent {
     pub key: String,
     pub value: MetadataValue,
 }
 
-#[derive(ScryptoSbor, ScryptoEvent)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug)]
 pub struct RemoveMetadataEvent {
     pub key: String,
 }

--- a/radix-engine/src/utils/native_blueprint_call_validator.rs
+++ b/radix-engine/src/utils/native_blueprint_call_validator.rs
@@ -183,7 +183,7 @@ fn get_arguments_schema<'s>(
                 .map(Some)?
         }
         Invocation::Function(package_address @ ROYALTY_MODULE_PACKAGE, ref blueprint, _) => {
-            get_blueprint_schema(&ROYALTIES_PACKAGE_DEFINITION, package_address, blueprint)
+            get_blueprint_schema(&ROYALTY_PACKAGE_DEFINITION, package_address, blueprint)
                 .map(Some)?
         }
         Invocation::Function(package_address @ ACCESS_RULES_MODULE_PACKAGE, ref blueprint, _) => {
@@ -259,7 +259,7 @@ fn get_arguments_schema<'s>(
         Invocation::Method(_, ObjectModuleId::AccessRules, _) => ACCESS_RULES_PACKAGE_DEFINITION
             .blueprints
             .get(ACCESS_RULES_BLUEPRINT),
-        Invocation::Method(_, ObjectModuleId::Royalty, _) => ROYALTIES_PACKAGE_DEFINITION
+        Invocation::Method(_, ObjectModuleId::Royalty, _) => ROYALTY_PACKAGE_DEFINITION
             .blueprints
             .get(COMPONENT_ROYALTY_BLUEPRINT),
     };

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -10,7 +10,7 @@ sbor-derive = { path = "../sbor-derive" }
 serde = { version = "1.0.137", default-features = false, optional = true, features=["derive"] }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
 lazy_static = "1.4.0"
-paste = { version = "1.0.7" }
+paste = { version = "1.0.13" }
 arbitrary = { version = "1.3.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -15,7 +15,7 @@ sbor = { path = "../sbor", default-features = false }
 scrypto-schema = { path = "../scrypto-schema", default-features = false }
 scrypto-derive = { path = "../scrypto-derive", default-features = false }
 utils = { path = "../utils", default-features = false }
-paste = { version = "1.0.7"}
+paste = { version = "1.0.13" }
 serde = { version = "1.0.144", default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "peeking_take_while"
@@ -805,7 +805,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -869,7 +869,7 @@ dependencies = [
  "resources-tracker-macro",
  "sbor",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "transaction",
  "utils",
  "wasm-instrument",
@@ -893,7 +893,7 @@ dependencies = [
  "radix-engine-constants",
  "radix-engine-derive",
  "sbor",
- "strum",
+ "strum 0.24.1",
  "utils",
 ]
 
@@ -908,7 +908,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sbor-derive-common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -925,7 +925,7 @@ dependencies = [
  "sbor",
  "scrypto-schema",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "utils",
 ]
 
@@ -942,11 +942,13 @@ version = "0.10.0"
 dependencies = [
  "hex",
  "itertools",
+ "paste",
  "radix-engine",
  "radix-engine-constants",
  "radix-engine-interface",
  "radix-engine-store-interface",
  "sbor",
+ "strum 0.25.0",
  "transaction",
  "utils",
 ]
@@ -1102,7 +1104,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "radix-engine-profiling",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1180,7 +1182,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1252,7 +1254,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1355,7 +1357,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.1",
 ]
 
 [[package]]
@@ -1368,7 +1379,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1389,6 +1413,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,7 +1431,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -1461,7 +1496,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1741,7 +1776,7 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
  "version_check",
 ]
 
@@ -869,7 +869,7 @@ dependencies = [
  "resources-tracker-macro",
  "sbor",
  "serde_json",
- "strum 0.24.1",
+ "strum",
  "transaction",
  "utils",
  "wasm-instrument",
@@ -893,7 +893,7 @@ dependencies = [
  "radix-engine-constants",
  "radix-engine-derive",
  "sbor",
- "strum 0.24.1",
+ "strum",
  "utils",
 ]
 
@@ -908,7 +908,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sbor-derive-common",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -925,7 +925,7 @@ dependencies = [
  "sbor",
  "scrypto-schema",
  "serde_json",
- "strum 0.24.1",
+ "strum",
  "utils",
 ]
 
@@ -948,7 +948,6 @@ dependencies = [
  "radix-engine-interface",
  "radix-engine-store-interface",
  "sbor",
- "strum 0.25.0",
  "transaction",
  "utils",
 ]
@@ -1104,7 +1103,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "radix-engine-profiling",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -1182,7 +1181,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -1254,7 +1253,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -1357,16 +1356,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.1",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1379,20 +1369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.25",
+ "syn",
 ]
 
 [[package]]
@@ -1413,17 +1390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,7 +1397,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1496,7 +1462,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
 ]
 
 [[package]]
@@ -1776,7 +1742,7 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn",
  "synstructure",
 ]
 


### PR DESCRIPTION
## Summary

This PR adds typed models for native events. This allows clients with an `EventTypeIdentifier` and some raw SBOR bytes to decode the events to a typed `TypedNativeEvent` model.

In much of a similar way to the other typed models, this is implemented in the `radix-engine-queries` crate. This will be used by the toolkit and eventually exposed to the gateway.

## Testing 

* Test that all events emitted at genesis can be typed.
* Test that all scenario events can be typed.
* Test that the events registered in the `TypedNativeEvent` are not missing any events by cross checking against the package schema.