### PR TITLE
Feature/clean revert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Check format
       run: bash ./check.sh
   sbor-unit-tests:
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: sbor
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: sbor-tests
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: scrypto-tests
@@ -123,7 +123,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Add wasm target (nightly)
@@ -153,7 +153,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install dependency
       run: sudo apt-get -y update && sudo apt-get -y install pkg-config libfreetype6-dev libfontconfig1-dev
     - name: Build with resource tracking
@@ -172,7 +172,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -219,7 +219,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target
@@ -240,7 +240,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -256,7 +256,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Add wasm target
       run: rustup target add wasm32-unknown-unknown
     - name: Run bench
@@ -272,7 +272,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Run tests
       run: cargo test
       working-directory: transaction
@@ -300,7 +300,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -334,7 +334,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - uses: radixdlt/rust-cache@allow_registry_src_caching
       with:
         prefix-key: ""
@@ -362,7 +362,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.70.0
     - name: Install nextest
       uses: taiki-e/install-action@nextest
     - name: Add wasm target

--- a/fuzz-tests/src/fuzz_tx.rs
+++ b/fuzz-tests/src/fuzz_tx.rs
@@ -1,5 +1,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::*;
 use radix_engine_interface::api::node_modules::royalty::{
     COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT, COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT,
@@ -14,7 +15,7 @@ use radix_engine_interface::blueprints::resource::{FromPublicKey, NonFungibleGlo
 #[cfg(feature = "dummy_fuzzing")]
 use radix_engine_interface::data::manifest::manifest_decode;
 use radix_engine_store_interface::db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper};
-use scrypto_unit::{DefaultTestRunner, TestRunnerBuilder, TestRunnerSnapshot};
+use scrypto_unit::{TestRunner, TestRunnerBuilder, TestRunnerSnapshot};
 #[cfg(test)]
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use strum::EnumCount;
@@ -51,7 +52,7 @@ struct Account {
 }
 
 pub struct TxFuzzer {
-    runner: DefaultTestRunner,
+    runner: TestRunner<NoExtension>,
     snapshot: TestRunnerSnapshot,
     accounts: Vec<Account>,
     #[allow(unused)]

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -86,7 +86,7 @@ impl ListableSubstateDatabase for RocksdbSubstateStore {
     }
 }
 
-pub fn encode_to_rocksdb_bytes(partition_key: &DbPartitionKey, sort_key: &DbSortKey) -> Vec<u8> {
+fn encode_to_rocksdb_bytes(partition_key: &DbPartitionKey, sort_key: &DbSortKey) -> Vec<u8> {
     let mut buffer = Vec::new();
     buffer.extend(u32::try_from(partition_key.0.len()).unwrap().to_be_bytes());
     buffer.extend(partition_key.0.clone());
@@ -94,7 +94,7 @@ pub fn encode_to_rocksdb_bytes(partition_key: &DbPartitionKey, sort_key: &DbSort
     buffer
 }
 
-pub fn decode_from_rocksdb_bytes(buffer: &[u8]) -> DbSubstateKey {
+fn decode_from_rocksdb_bytes(buffer: &[u8]) -> DbSubstateKey {
     let partition_key_len =
         usize::try_from(u32::from_be_bytes(copy_u8_array(&buffer[..4]))).unwrap();
     let sort_key_offset = 4 + partition_key_len;

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -11,8 +11,8 @@ use rocksdb::{
 };
 use sbor::rust::prelude::*;
 use std::path::PathBuf;
+use utils::copy_u8_array;
 mod state_tree;
-use crate::rocks_db::{decode_from_rocksdb_bytes, encode_to_rocksdb_bytes};
 use state_tree::*;
 
 const META_CF: &str = "meta";
@@ -25,12 +25,6 @@ pub struct RocksDBWithMerkleTreeSubstateStore {
 }
 
 impl RocksDBWithMerkleTreeSubstateStore {
-    pub fn clear(root: PathBuf) -> Self {
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::remove_dir_all(&root).unwrap();
-        Self::standard(root)
-    }
-
     pub fn standard(root: PathBuf) -> Self {
         let mut options = Options::default();
         options.create_if_missing(true);
@@ -194,6 +188,23 @@ impl<P: Payload> ReadableTreeStore<P> for RocksDBWithMerkleTreeSubstateStore {
             .unwrap()
             .map(|bytes| scrypto_decode(&bytes).unwrap())
     }
+}
+
+fn encode_to_rocksdb_bytes(partition_key: &DbPartitionKey, sort_key: &DbSortKey) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    buffer.extend(u32::try_from(partition_key.0.len()).unwrap().to_be_bytes());
+    buffer.extend(partition_key.0.clone());
+    buffer.extend(sort_key.0.clone());
+    buffer
+}
+
+fn decode_from_rocksdb_bytes(buffer: &[u8]) -> DbSubstateKey {
+    let partition_key_len =
+        usize::try_from(u32::from_be_bytes(copy_u8_array(&buffer[..4]))).unwrap();
+    let sort_key_offset = 4 + partition_key_len;
+    let partition_key = DbPartitionKey(buffer[4..sort_key_offset].to_vec());
+    let sort_key = DbSortKey(buffer[sort_key_offset..].to_vec());
+    (partition_key, sort_key)
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, ScryptoSbor)]

--- a/radix-engine-tests/tests/access_controller.rs
+++ b/radix-engine-tests/tests/access_controller.rs
@@ -6,8 +6,9 @@ use radix_engine::errors::SystemModuleError;
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::access_controller::*;
-use scrypto_unit::{CustomGenesis, DefaultTestRunner, TestRunnerBuilder};
+use scrypto_unit::{CustomGenesis, TestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
 
 #[test]
@@ -1634,7 +1635,7 @@ fn is_drop_non_empty_bucket_error(error: &RuntimeError) -> bool {
 
 #[allow(dead_code)]
 struct AccessControllerTestRunner {
-    pub test_runner: DefaultTestRunner,
+    pub test_runner: TestRunner<NoExtension>,
 
     pub account: (ComponentAddress, PublicKey),
 

--- a/radix-engine-tests/tests/access_rules.rs
+++ b/radix-engine-tests/tests/access_rules.rs
@@ -2,6 +2,7 @@ use radix_engine::errors::{RuntimeError, SystemError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::api::ObjectModuleId;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
@@ -322,7 +323,7 @@ fn change_lock_owner_role_rules() {
 }
 
 struct MutableAccessRulesTestRunner {
-    test_runner: DefaultTestRunner,
+    test_runner: TestRunner<NoExtension>,
     component_address: ComponentAddress,
     initial_proofs: BTreeSet<NonFungibleGlobalId>,
 }
@@ -332,7 +333,7 @@ impl MutableAccessRulesTestRunner {
 
     pub fn create_component(
         roles: RolesInit,
-        test_runner: &mut DefaultTestRunner,
+        test_runner: &mut TestRunner<NoExtension>,
     ) -> TransactionReceipt {
         let package_address = test_runner.compile_and_publish("./tests/blueprints/access_rules");
 
@@ -349,7 +350,7 @@ impl MutableAccessRulesTestRunner {
 
     pub fn create_component_with_owner(
         owner_role: OwnerRole,
-        test_runner: &mut DefaultTestRunner,
+        test_runner: &mut TestRunner<NoExtension>,
     ) -> TransactionReceipt {
         let package_address = test_runner.compile_and_publish("./tests/blueprints/access_rules");
 

--- a/radix-engine-tests/tests/account.rs
+++ b/radix-engine-tests/tests/account.rs
@@ -3,6 +3,7 @@ use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::BalanceChange;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::blueprints::account::{AccountSecurifyInput, ACCOUNT_SECURIFY_IDENT};
 use radix_engine_interface::blueprints::resource::FromPublicKey;
@@ -77,7 +78,7 @@ fn can_withdraw_from_my_virtual_account() {
 
 fn can_withdraw_from_my_account_internal<F>(new_account: F)
 where
-    F: FnOnce(&mut DefaultTestRunner) -> (Secp256k1PublicKey, ComponentAddress),
+    F: FnOnce(&mut TestRunner<NoExtension>) -> (Secp256k1PublicKey, ComponentAddress),
 {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();

--- a/radix-engine-tests/tests/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/account_deposit_modes.rs
@@ -2,9 +2,10 @@ use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_queries::typed_substate_layout::AccountError;
-use scrypto_unit::{DefaultTestRunner, TestRunnerBuilder};
+use scrypto_unit::{TestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
 use transaction::signing::secp256k1::Secp256k1PrivateKey;
 
@@ -440,7 +441,7 @@ fn disallow_all_permits_deposit_of_resource_in_allow_list() {
 }
 
 struct AccountDepositModesTestRunner {
-    test_runner: DefaultTestRunner,
+    test_runner: TestRunner<NoExtension>,
     public_key: PublicKey,
     component_address: ComponentAddress,
 }

--- a/radix-engine-tests/tests/auth_account.rs
+++ b/radix-engine-tests/tests/auth_account.rs
@@ -1,13 +1,14 @@
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::system::node_modules::royalty::ComponentRoyaltyError;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::rule;
 use scrypto_unit::*;
 use transaction::prelude::*;
 
 fn test_auth_rule(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     auth_rule: &AccessRule,
     signer_public_keys: &[PublicKey],
     should_succeed: bool,

--- a/radix-engine-tests/tests/auth_component.rs
+++ b/radix-engine-tests/tests/auth_component.rs
@@ -1,11 +1,12 @@
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use radix_engine_interface::rule;
 use scrypto_unit::*;
 use transaction::prelude::*;
 
 fn create_secured_component(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     auth: NonFungibleGlobalId,
     package_address: PackageAddress,
 ) -> ComponentAddress {
@@ -24,7 +25,7 @@ fn create_secured_component(
 }
 
 fn create_resource_secured_component(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     account: ComponentAddress,
     package_address: PackageAddress,
 ) -> (ComponentAddress, NonFungibleGlobalId) {
@@ -37,7 +38,7 @@ fn create_resource_secured_component(
 }
 
 fn create_component(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     package_address: PackageAddress,
 ) -> ComponentAddress {
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -5,6 +5,7 @@ use radix_engine::blueprints::resource::BucketError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::bootstrap::*;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::blueprints::consensus_manager::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
@@ -1566,7 +1567,7 @@ fn register_and_stake_new_validator(
     pub_key: Secp256k1PublicKey,
     account_address: ComponentAddress,
     stake_amount: Decimal,
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
 ) -> ComponentAddress {
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account_address);
 

--- a/radix-engine-tests/tests/data_validation.rs
+++ b/radix-engine-tests/tests/data_validation.rs
@@ -1,3 +1,4 @@
+use radix_engine::vm::NoExtension;
 use radix_engine::{
     errors::{CallFrameError, KernelError, RuntimeError},
     kernel::call_frame::PassMessageError,
@@ -6,7 +7,7 @@ use radix_engine::{
 use scrypto_unit::*;
 use transaction::prelude::*;
 
-fn setup_component(test_runner: &mut DefaultTestRunner) -> ComponentAddress {
+fn setup_component(test_runner: &mut TestRunner<NoExtension>) -> ComponentAddress {
     let package_address = test_runner.compile_and_publish("./tests/blueprints/data_validation");
 
     let setup_manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -9,6 +9,7 @@ use radix_engine::errors::{
 };
 use radix_engine::system::node_modules::metadata::SetMetadataEvent;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::{RoleDefinition, ToRoleEntry};
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::api::node_modules::ModuleConfig;
@@ -1600,7 +1601,7 @@ fn is_decoded_equal<T: ScryptoDecode + PartialEq>(expected: &T, actual: &[u8]) -
     scrypto_decode::<T>(&actual).unwrap() == *expected
 }
 
-fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceAddress {
+fn create_all_allowed_resource(test_runner: &mut TestRunner<NoExtension>) -> ResourceAddress {
     let manifest = ManifestBuilder::new()
         .create_fungible_resource(
             OwnerRole::Fixed(AccessRule::AllowAll),

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -6,6 +6,7 @@ use radix_engine::kernel::heap::HeapOpenSubstateError;
 use radix_engine::track::interface::AcquireLockError;
 use radix_engine::transaction::{FeeLocks, TransactionReceipt};
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
 use transaction::prelude::PreviewFlags;
@@ -23,7 +24,7 @@ where
     test_runner.execute_manifest(manifest, vec![])
 }
 
-fn setup_test_runner() -> (DefaultTestRunner, ComponentAddress) {
+fn setup_test_runner() -> (TestRunner<NoExtension>, ComponentAddress) {
     // Basic setup
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -1,6 +1,7 @@
 use radix_engine::system::system_modules::costing::FeeSummary;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto::api::node_modules::ModuleConfig;
 use scrypto::prelude::metadata;
@@ -88,7 +89,7 @@ fn test_mint_small_size_nfts_from_manifest() {
 
 #[cfg(feature = "std")]
 fn execute_with_time_logging(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     manifest: TransactionManifestV1,
     proofs: Vec<NonFungibleGlobalId>,
 ) -> (TransactionReceipt, u32) {
@@ -104,7 +105,7 @@ fn execute_with_time_logging(
 
 #[cfg(feature = "alloc")]
 fn execute_with_time_logging(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     manifest: TransactionManifestV1,
     proofs: Vec<NonFungibleGlobalId>,
 ) -> (TransactionReceipt, u32) {
@@ -637,7 +638,7 @@ fn should_be_able_to_generate_5_proofs_and_then_lock_fee() {
     receipt.expect_commit(true);
 }
 
-fn setup_test_runner_with_fee_blueprint_component() -> (DefaultTestRunner, ComponentAddress) {
+fn setup_test_runner_with_fee_blueprint_component() -> (TestRunner<NoExtension>, ComponentAddress) {
     // Basic setup
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();

--- a/radix-engine-tests/tests/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/pool_multi_resource.rs
@@ -1,4 +1,5 @@
 use radix_engine::errors::{SystemError, SystemModuleError};
+use radix_engine::vm::NoExtension;
 use radix_engine::{
     blueprints::pool::multi_resource_pool::*,
     errors::{ApplicationError, RuntimeError},
@@ -7,7 +8,7 @@ use radix_engine::{
 };
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::blueprints::pool::*;
-use scrypto_unit::{is_auth_error, DefaultTestRunner, TestRunnerBuilder};
+use scrypto_unit::{is_auth_error, TestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
 
 #[test]
@@ -744,7 +745,7 @@ fn cant_withdraw_without_proper_signature() {
 }
 
 struct TestEnvironment<const N: usize> {
-    test_runner: DefaultTestRunner,
+    test_runner: TestRunner<NoExtension>,
 
     pool_component_address: ComponentAddress,
     pool_unit_resource_address: ResourceAddress,

--- a/radix-engine-tests/tests/pool_one_resource.rs
+++ b/radix-engine-tests/tests/pool_one_resource.rs
@@ -2,6 +2,7 @@ use radix_engine::blueprints::pool::one_resource_pool::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::blueprints::pool::*;
 use scrypto_unit::*;
@@ -612,7 +613,7 @@ pub fn owner_can_update_pool_metadata() {
 //===================================
 
 struct TestEnvironment {
-    test_runner: DefaultTestRunner,
+    test_runner: TestRunner<NoExtension>,
     pool_component_address: ComponentAddress,
     pool_unit_resource_address: ResourceAddress,
     resource_address: ResourceAddress,

--- a/radix-engine-tests/tests/pool_two_resource.rs
+++ b/radix-engine-tests/tests/pool_two_resource.rs
@@ -2,6 +2,7 @@ use radix_engine::blueprints::pool::two_resource_pool::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::blueprints::pool::*;
 use scrypto_unit::*;
@@ -898,7 +899,7 @@ pub fn contribute_fails_without_proper_authority_present() {
 }
 
 struct TestEnvironment {
-    test_runner: DefaultTestRunner,
+    test_runner: TestRunner<NoExtension>,
 
     pool_component_address: ComponentAddress,
     pool_unit_resource_address: ResourceAddress,

--- a/radix-engine-tests/tests/preview.rs
+++ b/radix-engine-tests/tests/preview.rs
@@ -1,6 +1,7 @@
 use radix_engine::transaction::ExecutionConfig;
 use radix_engine::transaction::FeeReserveConfig;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::rule;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -86,7 +87,7 @@ fn test_assume_all_signature_proofs_flag_method_authorization() {
 }
 
 fn prepare_matching_test_tx_and_preview_intent(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     network: &NetworkDefinition,
     manifest: TransactionManifestV1,
     flags: &PreviewFlags,

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -2,6 +2,7 @@ use radix_engine::blueprints::package::PackageError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::system::node_modules::royalty::ComponentRoyaltyError;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -459,7 +460,7 @@ fn cannot_set_royalty_after_locking() {
 }
 
 fn set_up_package_and_component() -> (
-    DefaultTestRunner,
+    TestRunner<NoExtension>,
     ComponentAddress,
     Secp256k1PublicKey,
     PackageAddress,

--- a/radix-engine-tests/tests/royalty_auth.rs
+++ b/radix-engine-tests/tests/royalty_auth.rs
@@ -1,4 +1,5 @@
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -169,7 +170,7 @@ fn non_component_owner_cannot_claim_royalty() {
 }
 
 fn set_up_package_and_component() -> (
-    DefaultTestRunner,
+    TestRunner<NoExtension>,
     ComponentAddress,
     Secp256k1PublicKey,
     PackageAddress,

--- a/radix-engine-tests/tests/system_global_address.rs
+++ b/radix-engine-tests/tests/system_global_address.rs
@@ -42,9 +42,9 @@ fn global_address_access_from_frame_owned_object_should_not_succeed() {
             }
         }
     }
-    let mut test_runner = TestRunnerBuilder::new()
-        .with_custom_extension(OverridePackageCode::new(CUSTOM_PACKAGE_CODE_ID, TestInvoke))
-        .build();
+    let mut test_runner = TestRunnerBuilder::new().build_with_native_vm_extension(
+        OverridePackageCode::new(CUSTOM_PACKAGE_CODE_ID, TestInvoke),
+    );
     let package_address = test_runner.publish_native_package(
         CUSTOM_PACKAGE_CODE_ID,
         PackageDefinition::new_test_definition(
@@ -110,12 +110,11 @@ fn global_address_access_from_direct_access_methods_should_fail_even_with_borrow
             ResourceNativePackage::invoke_export(export_name, input, api)
         }
     }
-    let mut test_runner = TestRunnerBuilder::new()
-        .with_custom_extension(OverridePackageCode::new(
+    let mut test_runner =
+        TestRunnerBuilder::new().build_with_native_vm_extension(OverridePackageCode::new(
             RESOURCE_CODE_ID,
             ResourceOverride(resource_direct_access_methods),
-        ))
-        .build();
+        ));
 
     let (public_key, _, account) = test_runner.new_allocated_account();
 

--- a/radix-engine-tests/tests/vault.rs
+++ b/radix-engine-tests/tests/vault.rs
@@ -4,6 +4,7 @@ use radix_engine::errors::{
 };
 use radix_engine::kernel::call_frame::{CloseSubstateError, CreateNodeError, TakeNodeError};
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::{metadata, metadata_init};
 use scrypto::prelude::FromPublicKey;
@@ -688,7 +689,7 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
 }
 
 fn get_vault_id(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     component_address: ComponentAddress,
 ) -> NodeId {
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/vault_burn.rs
+++ b/radix-engine-tests/tests/vault_burn.rs
@@ -1,6 +1,7 @@
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
+use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::{metadata, metadata_init};
 use scrypto::NonFungibleData;
@@ -1028,7 +1029,7 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
 }
 
 fn get_vault_id(
-    test_runner: &mut DefaultTestRunner,
+    test_runner: &mut TestRunner<NoExtension>,
     component_address: ComponentAddress,
 ) -> NodeId {
     let manifest = ManifestBuilder::new()

--- a/scrypto-unit/src/basic_rocksdb_test_runner.rs
+++ b/scrypto-unit/src/basic_rocksdb_test_runner.rs
@@ -1,0 +1,275 @@
+use crate::Compile;
+use radix_engine::system::bootstrap::Bootstrapper;
+use radix_engine::transaction::{
+    execute_transaction, ExecutionConfig, FeeReserveConfig, TransactionReceipt, TransactionResult,
+};
+use radix_engine::types::*;
+use radix_engine::vm::wasm::DefaultWasmEngine;
+use radix_engine::vm::wasm::WasmValidatorConfigV1;
+use radix_engine::vm::DefaultNativeVm;
+use radix_engine::vm::ScryptoVm;
+use radix_engine::vm::Vm;
+use radix_engine_interface::blueprints::package::PackageDefinition;
+use radix_engine_interface::rule;
+use radix_engine_store_interface::interface::CommittableSubstateDatabase;
+use radix_engine_stores::rocks_db_with_merkle_tree::RocksDBWithMerkleTreeSubstateStore;
+use scrypto::api::node_modules::ModuleConfig;
+use scrypto::prelude::metadata;
+use scrypto::prelude::metadata_init;
+use std::path::{Path, PathBuf};
+use transaction::model::{Executable, TestTransaction};
+use transaction::prelude::*;
+use transaction::signing::secp256k1::Secp256k1PrivateKey;
+
+// Basic RocksDB test runner for benchmark purpose.
+pub struct BasicRocksdbTestRunner {
+    scrypto_vm: ScryptoVm<DefaultWasmEngine>,
+    native_vm: DefaultNativeVm,
+    substate_db: RocksDBWithMerkleTreeSubstateStore,
+    next_private_key: u64,
+    next_transaction_nonce: u32,
+    trace: bool,
+}
+
+impl BasicRocksdbTestRunner {
+    pub fn new(root: PathBuf, trace: bool) -> Self {
+        let mut substate_db = RocksDBWithMerkleTreeSubstateStore::standard(root);
+        let scrypto_vm = ScryptoVm {
+            wasm_engine: DefaultWasmEngine::default(),
+            wasm_validator_config: WasmValidatorConfigV1::new(),
+        };
+        let native_vm = DefaultNativeVm::new();
+        let vm = Vm::new(&scrypto_vm, native_vm.clone());
+        let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, false);
+        bootstrapper.bootstrap_test_default().unwrap();
+
+        Self {
+            scrypto_vm,
+            native_vm,
+            substate_db,
+            next_private_key: 1,
+            next_transaction_nonce: 1,
+            trace,
+        }
+    }
+
+    pub fn faucet_component(&self) -> GlobalAddress {
+        FAUCET.clone().into()
+    }
+
+    pub fn substate_db(&self) -> &RocksDBWithMerkleTreeSubstateStore {
+        &self.substate_db
+    }
+
+    pub fn substate_db_mut(&mut self) -> &mut RocksDBWithMerkleTreeSubstateStore {
+        &mut self.substate_db
+    }
+
+    pub fn next_private_key(&mut self) -> u64 {
+        self.next_private_key += 1;
+        self.next_private_key - 1
+    }
+
+    pub fn next_transaction_nonce(&mut self) -> u32 {
+        self.next_transaction_nonce += 1;
+        self.next_transaction_nonce - 1
+    }
+
+    pub fn new_key_pair(&mut self) -> (Secp256k1PublicKey, Secp256k1PrivateKey) {
+        let private_key = Secp256k1PrivateKey::from_u64(self.next_private_key()).unwrap();
+        let public_key = private_key.public_key();
+
+        (public_key, private_key)
+    }
+
+    pub fn new_key_pair_with_auth_address(
+        &mut self,
+    ) -> (Secp256k1PublicKey, Secp256k1PrivateKey, NonFungibleGlobalId) {
+        let key_pair = self.new_allocated_account();
+        (
+            key_pair.0,
+            key_pair.1,
+            NonFungibleGlobalId::from_public_key(&key_pair.0),
+        )
+    }
+
+    pub fn load_account_from_faucet(&mut self, account_address: ComponentAddress) {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .get_free_xrd_from_faucet()
+            .take_all_from_worktop(XRD, "free_xrd")
+            .try_deposit_or_abort(account_address, "free_xrd")
+            .build();
+
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit_success();
+    }
+
+    pub fn new_account_advanced(&mut self, owner_role: OwnerRole) -> ComponentAddress {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .new_account_advanced(owner_role)
+            .build();
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit_success();
+
+        let account = receipt.expect_commit(true).new_component_addresses()[0];
+
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .get_free_xrd_from_faucet()
+            .try_deposit_batch_or_abort(account)
+            .build();
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit_success();
+
+        account
+    }
+
+    pub fn new_virtual_account(
+        &mut self,
+    ) -> (Secp256k1PublicKey, Secp256k1PrivateKey, ComponentAddress) {
+        let (pub_key, priv_key) = self.new_key_pair();
+        let account = ComponentAddress::virtual_account_from_public_key(&PublicKey::Secp256k1(
+            pub_key.clone(),
+        ));
+        self.load_account_from_faucet(account);
+        (pub_key, priv_key, account)
+    }
+
+    pub fn new_allocated_account(
+        &mut self,
+    ) -> (Secp256k1PublicKey, Secp256k1PrivateKey, ComponentAddress) {
+        let key_pair = self.new_key_pair();
+        let withdraw_auth = rule!(require(NonFungibleGlobalId::from_public_key(&key_pair.0)));
+        let account = self.new_account_advanced(OwnerRole::Fixed(withdraw_auth));
+        (key_pair.0, key_pair.1, account)
+    }
+
+    pub fn new_account(
+        &mut self,
+        is_virtual: bool,
+    ) -> (Secp256k1PublicKey, Secp256k1PrivateKey, ComponentAddress) {
+        if is_virtual {
+            self.new_virtual_account()
+        } else {
+            self.new_allocated_account()
+        }
+    }
+
+    pub fn publish_package(
+        &mut self,
+        code: Vec<u8>,
+        definition: PackageDefinition,
+        metadata: BTreeMap<String, MetadataValue>,
+        owner_role: OwnerRole,
+    ) -> PackageAddress {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .publish_package_advanced(None, code, definition, metadata, owner_role)
+            .build();
+
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit(true).new_package_addresses()[0]
+    }
+
+    pub fn publish_package_with_owner(
+        &mut self,
+        code: Vec<u8>,
+        definition: PackageDefinition,
+        owner_badge: NonFungibleGlobalId,
+    ) -> PackageAddress {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .publish_package_with_owner(code, definition, owner_badge)
+            .build();
+
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit(true).new_package_addresses()[0]
+    }
+
+    pub fn compile<P: AsRef<Path>>(&mut self, package_dir: P) -> (Vec<u8>, PackageDefinition) {
+        Compile::compile(package_dir)
+    }
+
+    pub fn compile_and_publish<P: AsRef<Path>>(&mut self, package_dir: P) -> PackageAddress {
+        let (code, definition) = Compile::compile(package_dir);
+        self.publish_package(code, definition, BTreeMap::new(), OwnerRole::None)
+    }
+
+    pub fn compile_and_publish_with_owner<P: AsRef<Path>>(
+        &mut self,
+        package_dir: P,
+        owner_badge: NonFungibleGlobalId,
+    ) -> PackageAddress {
+        let (code, definition) = Compile::compile(package_dir);
+        self.publish_package_with_owner(code, definition, owner_badge)
+    }
+
+    pub fn execute_manifest<T>(
+        &mut self,
+        manifest: TransactionManifestV1,
+        initial_proofs: T,
+    ) -> TransactionReceipt
+    where
+        T: IntoIterator<Item = NonFungibleGlobalId>,
+    {
+        let nonce = self.next_transaction_nonce();
+        self.execute_transaction(
+            TestTransaction::new_from_nonce(manifest, nonce)
+                .prepare()
+                .expect("expected transaction to be preparable")
+                .get_executable(initial_proofs.into_iter().collect()),
+            FeeReserveConfig::default(),
+            ExecutionConfig::for_test_transaction(),
+        )
+    }
+
+    pub fn execute_transaction(
+        &mut self,
+        executable: Executable,
+        fee_reserve_config: FeeReserveConfig,
+        mut execution_config: ExecutionConfig,
+    ) -> TransactionReceipt {
+        // Override the kernel trace config
+        execution_config = execution_config.with_kernel_trace(self.trace);
+
+        let transaction_receipt = execute_transaction(
+            &mut self.substate_db,
+            Vm {
+                scrypto_vm: &self.scrypto_vm,
+                native_vm: self.native_vm.clone(),
+            },
+            &fee_reserve_config,
+            &execution_config,
+            &executable,
+        );
+        if let TransactionResult::Commit(commit) = &transaction_receipt.transaction_result {
+            self.substate_db
+                .commit(&commit.state_updates.database_updates);
+        }
+        transaction_receipt
+    }
+
+    pub fn create_fungible_resource(
+        &mut self,
+        amount: Decimal,
+        divisibility: u8,
+        account: ComponentAddress,
+    ) -> ResourceAddress {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .create_fungible_resource(
+                OwnerRole::None,
+                true,
+                divisibility,
+                FungibleResourceRoles::default(),
+                metadata!(),
+                Some(amount),
+            )
+            .try_deposit_batch_or_abort(account)
+            .build();
+        let receipt = self.execute_manifest(manifest, vec![]);
+        receipt.expect_commit(true).new_resource_addresses()[0]
+    }
+}

--- a/scrypto-unit/src/lib.rs
+++ b/scrypto-unit/src/lib.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "rocksdb")]
+mod basic_rocksdb_test_runner;
 mod test_runner;
 mod utils;
 
 pub use crate::utils::*;
+#[cfg(feature = "rocksdb")]
+pub use basic_rocksdb_test_runner::*;
 pub use test_runner::*;


### PR DESCRIPTION
## Summary

- Revert https://github.com/radixdlt/radixdlt-scrypto/pull/1255
- Pin rust version to `1.70`, which is causing `overflow evaluating the requirement` issue

Note that reverting rust version alone didn't solve the problem, see https://github.com/radixdlt/radixdlt-scrypto/pull/1261
