### PR TITLE
Fix error naming

### DIFF
--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -200,7 +200,7 @@ pub enum CallFrameError {
     WriteSubstateError(WriteSubstateError),
 
     ScanSubstatesError(CallFrameScanSubstatesError),
-    TakeSubstatesError(CallFrameDrainSubstatesError),
+    DrainSubstatesError(CallFrameDrainSubstatesError),
     ScanSortedSubstatesError(CallFrameScanSortedSubstatesError),
     SetSubstatesError(CallFrameSetSubstateError),
     RemoveSubstatesError(CallFrameRemoveSubstateError),

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -824,7 +824,7 @@ where
         let (substates, store_access) = self
             .current_frame
             .drain_substates::<K, _>(node_id, partition_num, count, &mut self.heap, self.store)
-            .map_err(CallFrameError::TakeSubstatesError)
+            .map_err(CallFrameError::DrainSubstatesError)
             .map_err(KernelError::CallFrameError)
             .map_err(RuntimeError::KernelError)?;
 


### PR DESCRIPTION
## Summary
Simple naming fix to `DrainSubstatesError`