### PR TITLE
Fix FIXME: Add OwnedNodeNotSupported error to scan_sorted_substates

### DIFF
--- a/radix-engine/src/kernel/call_frame.rs
+++ b/radix-engine/src/kernel/call_frame.rs
@@ -260,6 +260,7 @@ pub enum CallFrameDrainSubstatesError {
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum CallFrameScanSortedSubstatesError {
     NodeNotVisible(NodeId),
+    OwnedNodeNotSupported(NodeId),
 }
 
 impl<L: Clone> CallFrame<L> {
@@ -1058,7 +1059,9 @@ impl<L: Clone> CallFrame<L> {
                     self.stable_references
                         .insert(reference.clone(), StableReferenceType::Global);
                 } else {
-                    // FIXME: check if non-global reference is needed
+                    return Err(CallFrameScanSortedSubstatesError::OwnedNodeNotSupported(
+                        reference.clone(),
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Summary
Add error for owned nodes being scanned in scan_sorted_substates