### PR TITLE
add dApps related accounts in metadata scenario

### DIFF
--- a/transaction-scenarios/src/accounts.rs
+++ b/transaction-scenarios/src/accounts.rs
@@ -56,6 +56,22 @@ pub fn secp256k1_account_3() -> VirtualAccount {
     )
 }
 
+pub fn secp256k1_account_dashboard() -> VirtualAccount {
+    VirtualAccount::for_private_key(
+        Secp256k1PrivateKey::from_u64(53214)
+            .expect("Should be valid")
+            .into(),
+    )
+}
+
+pub fn secp256k1_account_sandbox() -> VirtualAccount {
+    VirtualAccount::for_private_key(
+        Secp256k1PrivateKey::from_u64(53215)
+            .expect("Should be valid")
+            .into(),
+    )
+}
+
 pub fn ed25519_account_1() -> VirtualAccount {
     VirtualAccount::for_private_key(
         Ed25519PrivateKey::from_u64(12451)


### PR DESCRIPTION
## Summary
Add predefined accounts which will be used as dApp definition addresses for project's team whenever new network is created
