### PR TITLE
tests: Add scenarios with example schemas, and metadata-standard nf data

### DIFF
--- a/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -211,6 +211,14 @@ pub struct NonFungibleResourceManagerUpdateDataInput {
     pub data: ScryptoValue,
 }
 
+#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+pub struct NonFungibleResourceManagerUpdateDataManifestInput {
+    pub id: NonFungibleLocalId,
+    pub field_name: String,
+    pub data: ManifestValue,
+}
+
 pub type NonFungibleResourceManagerUpdateDataOutput = ();
 
 pub const NON_FUNGIBLE_RESOURCE_MANAGER_EXISTS_IDENT: &str = "non_fungible_exists";

--- a/transaction-scenarios/Cargo.toml
+++ b/transaction-scenarios/Cargo.toml
@@ -10,6 +10,7 @@ radix-engine-stores = { path = "../radix-engine-stores", default-features = fals
 radix-engine-store-interface = { path = "../radix-engine-store-interface", default-features = false }
 radix-engine-constants = { path = "../radix-engine-constants", default-features = false }
 radix-engine-interface = { path = "../radix-engine-interface", default-features = false }
+scrypto = { path = "../scrypto", default-features = false }
 transaction = { path = "../transaction", default-features = false }
 utils = { path = "../utils", default-features = false }
 itertools = { version = "0.10.3", default-features = false }
@@ -19,8 +20,8 @@ walkdir = "2.3.3"
 [features]
 # You should enable either `std` or `alloc`
 default = ["std"]
-std = ["hex/std", "sbor/std", "transaction/std", "radix-engine/std", "radix-engine/moka", "radix-engine-stores/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std"]
-alloc = ["hex/alloc", "sbor/alloc", "transaction/alloc", "radix-engine/alloc", "radix-engine/lru", "radix-engine-stores/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc"]
+std = ["hex/std", "sbor/std", "scrypto/std", "transaction/std", "radix-engine/std", "radix-engine/moka", "radix-engine-stores/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std"]
+alloc = ["hex/alloc", "sbor/alloc", "scrypto/alloc", "transaction/alloc", "radix-engine/alloc", "radix-engine/lru", "radix-engine-stores/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]

--- a/transaction-scenarios/generated-examples/non_fungible_resource/001--non-fungible-resource-create.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/001--non-fungible-resource-create.rtm
@@ -72,7 +72,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
             Array<Tuple>(
                 Tuple(
                     Enum<1u8>(
-                        "ComplexFungibleData"
+                        "NestedFungibleData"
                     ),
                     Enum<1u8>(
                         Enum<0u8>(

--- a/transaction-scenarios/generated-examples/non_fungible_resource/002--non-fungible-resource-create-string.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/002--non-fungible-resource-create-string.rtm
@@ -72,7 +72,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
             Array<Tuple>(
                 Tuple(
                     Enum<1u8>(
-                        "ComplexFungibleData"
+                        "NestedFungibleData"
                     ),
                     Enum<1u8>(
                         Enum<0u8>(

--- a/transaction-scenarios/generated-examples/non_fungible_resource/003--non-fungible-resource-create-bytes.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/003--non-fungible-resource-create-bytes.rtm
@@ -72,7 +72,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
             Array<Tuple>(
                 Tuple(
                     Enum<1u8>(
-                        "ComplexFungibleData"
+                        "NestedFungibleData"
                     ),
                     Enum<1u8>(
                         Enum<0u8>(

--- a/transaction-scenarios/generated-examples/non_fungible_resource/004--non-fungible-resource-create-ruid.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/004--non-fungible-resource-create-ruid.rtm
@@ -74,7 +74,7 @@ CALL_FUNCTION
             Array<Tuple>(
                 Tuple(
                     Enum<1u8>(
-                        "ComplexFungibleData"
+                        "NestedFungibleData"
                     ),
                     Enum<1u8>(
                         Enum<0u8>(

--- a/transaction-scenarios/generated-examples/non_fungible_resource/005--non-fungible-resource-mint-32-nfts.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/005--non-fungible-resource-mint-32-nfts.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 MINT_NON_FUNGIBLE
-    Address("resource_sim1nfxa03qkvrs3798j38c2dwc89jyntte7452fwyqqm34fslhazr5ugq")
+    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
     Map<NonFungibleLocalId, Tuple>(
         NonFungibleLocalId("#100#") => Tuple(
             Tuple(

--- a/transaction-scenarios/generated-examples/non_fungible_resource/006--non-fungible-resource-burn.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/006--non-fungible-resource-burn.rtm
@@ -6,11 +6,11 @@ CALL_METHOD
 CALL_METHOD
     Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
     "withdraw"
-    Address("resource_sim1nfxa03qkvrs3798j38c2dwc89jyntte7452fwyqqm34fslhazr5ugq")
+    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
     Decimal("2")
 ;
 TAKE_ALL_FROM_WORKTOP
-    Address("resource_sim1nfxa03qkvrs3798j38c2dwc89jyntte7452fwyqqm34fslhazr5ugq")
+    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
     Bucket("to_burn")
 ;
 BURN_RESOURCE
@@ -19,13 +19,13 @@ BURN_RESOURCE
 CALL_METHOD
     Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
     "withdraw_non_fungibles"
-    Address("resource_sim1nfxa03qkvrs3798j38c2dwc89jyntte7452fwyqqm34fslhazr5ugq")
+    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#110#")
     )
 ;
 TAKE_NON_FUNGIBLES_FROM_WORKTOP
-    Address("resource_sim1nfxa03qkvrs3798j38c2dwc89jyntte7452fwyqqm34fslhazr5ugq")
+    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#110#")
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/008--non-fungible-resource-freeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/008--non-fungible-resource-freeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/009--non-fungible-resource-freeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/009--non-fungible-resource-freeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/010--non-fungible-resource-recall-frozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/010--non-fungible-resource-recall-frozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_NON_FUNGIBLES_FROM_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#120#")
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/011--non-fungible-resource-unfreeze-withdraw.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/011--non-fungible-resource-unfreeze-withdraw.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Tuple(
         1u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/012--non-fungible-resource-unfreeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/012--non-fungible-resource-unfreeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/013--non-fungible-resource-unfreeze-burn.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/013--non-fungible-resource-unfreeze-burn.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/014--non-fungible-resource-recall-unfrozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/014--non-fungible-resource-recall-unfrozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_NON_FUNGIBLES_FROM_VAULT
-    Address("internal_vault_sim1nr0y8rmqh83a74zpzzk5ssqxxswme7g3a7hsd7pezm7h9h7n8ae6w7")
+    Address("internal_vault_sim1npmumknljertzs00tkuvjsaht7sfa7clg3hgteclxf0qqp97anqj88")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#130#")
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/015--non-fungible-create-resource-with-supply-with-empty-data.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/015--non-fungible-create-resource-with-supply-with-empty-data.rtm
@@ -1,0 +1,51 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "lock_fee"
+    Decimal("5000")
+;
+CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
+    Enum<0u8>()
+    Enum<1u8>()
+    true
+    Tuple(
+        Tuple(
+            Array<Enum>(),
+            Array<Tuple>(),
+            Array<Enum>()
+        ),
+        Enum<0u8>(
+            66u8
+        ),
+        Array<String>()
+    )
+    Map<NonFungibleLocalId, Tuple>(
+        NonFungibleLocalId("#1#") => Tuple(
+            Tuple()
+        ),
+        NonFungibleLocalId("#2#") => Tuple(
+            Tuple()
+        ),
+        NonFungibleLocalId("#3#") => Tuple(
+            Tuple()
+        )
+    )
+    Tuple(
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>()
+    )
+    Tuple(
+        Map<String, Tuple>(),
+        Map<String, Enum>()
+    )
+    Enum<0u8>()
+;
+CALL_METHOD
+    Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
+    "try_deposit_batch_or_abort"
+    Expression("ENTIRE_WORKTOP")
+;

--- a/transaction-scenarios/generated-examples/non_fungible_resource/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.rtm
@@ -1,0 +1,177 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "lock_fee"
+    Decimal("5000")
+;
+CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
+    Enum<0u8>()
+    Enum<1u8>()
+    true
+    Tuple(
+        Tuple(
+            Array<Enum>(
+                Enum<14u8>(
+                    Array<Enum>(
+                        Enum<0u8>(
+                            12u8
+                        ),
+                        Enum<0u8>(
+                            12u8
+                        ),
+                        Enum<1u8>(
+                            1u64
+                        ),
+                        Enum<0u8>(
+                            10u8
+                        )
+                    )
+                ),
+                Enum<12u8>()
+            ),
+            Array<Tuple>(
+                Tuple(
+                    Enum<1u8>(
+                        "MetadataStandardNonFungibleData"
+                    ),
+                    Enum<1u8>(
+                        Enum<0u8>(
+                            Array<String>(
+                                "name",
+                                "description",
+                                "key_image_url",
+                                "arbitrary_coolness_rating"
+                            )
+                        )
+                    )
+                ),
+                Tuple(
+                    Enum<1u8>(
+                        "Url"
+                    ),
+                    Enum<0u8>()
+                )
+            ),
+            Array<Enum>(
+                Enum<0u8>(),
+                Enum<0u8>()
+            )
+        ),
+        Enum<1u8>(
+            0u64
+        ),
+        Array<String>()
+    )
+    Map<NonFungibleLocalId, Tuple>(
+        NonFungibleLocalId("#1#") => Tuple(
+            Tuple(
+                "Decentralized Exchanges",
+                "Decentralized Exchanges, also known as DEXes, allow users to exchange two or more tokens in a single transaction, at a certain price, without the need for another party to facilitate the transaction.\n\nDEXes allow users to trade assets without the need for a trusted third party. They are the first ever examples of a censorship resistant, non-custodial, and permissionless way of exchanging assets electronically.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414d213fd7349b654b9_icon-DEX.svg",
+                45u64
+            )
+        ),
+        NonFungibleLocalId("#2#") => Tuple(
+            Tuple(
+                "Stablecoins",
+                "A stablecoin is a class of cryptocurrencies that attempt to offer price stability and are backed by a reserve asset. Stablecoins have become popular as they provide the instant processing and security or privacy of cryptocurrencies' payments along with the volatility-free stable valuations of fiat currencies.\n\nStablecoins base their market value on an external reference. This could be a currency like the U.S. dollar or a commodity's price such as gold. Stablecoins achieve price stability via collateralization or algorithmic buying and selling of the reference asset or its derivatives.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f419f77f05b9086565e6_icon-stablecoin.svg",
+                5u64
+            )
+        ),
+        NonFungibleLocalId("#3#") => Tuple(
+            Tuple(
+                "Lending",
+                "In lending, borrowers pledge their crypto assets as collateral and avail loans in stablecoins or other crypto assets as a means of financing.\n\nHowever, unlike TradFi, DeFi lending uses algorithmic systems where lending and borrowing rates are determined automatically based on each asset's real-time supply and demand.\n\nThis automated approach means more flexibility and access for anyone looking for financing.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414979a8b045995bf75_ICON-LENDING.svg",
+                30u64
+            )
+        ),
+        NonFungibleLocalId("#4#") => Tuple(
+            Tuple(
+                "Insurance",
+                "Insurance protocols provide cover against smart contract failure & exchange hacks using a decentralized protocol, so people can share risk without needing an insurance company.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f4146c4528458c93da96_ICON-NFTS-1.svg",
+                0u64
+            )
+        ),
+        NonFungibleLocalId("#5#") => Tuple(
+            Tuple(
+                "Futures, Options, & Derivatives",
+                "A futures contract is an arrangement between two users on an exchange to buy and sell an underlying crypto asset at an agreed-upon price on a certain date in the future.\n\nOptions give the holder the right to buy (call) or sell (put) an underlying crypto asset at a set date without being obligated.\n\nSynthetic assets, also known as synths, are an asset class formed by combining cryptocurrencies and traditional derivative assets, making them tokenized derivatives.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414e8f31b971debfabe_ICON-FUTURES.svg",
+                10u64
+            )
+        ),
+        NonFungibleLocalId("#8#") => Tuple(
+            Tuple(
+                "Gaming",
+                "Since we have so many gamers who spend endless hours and money on gaming platforms, DeFi gaming platforms will enable them to monetize their time and progress. The play-to-earn games offer the best of both worlds - they provide an entertaining experience and make playing games lucrative.",
+                "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f416931770a50ed4a702_ICON-GAMING.svg",
+                71u64
+            )
+        )
+    )
+    Tuple(
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>()
+    )
+    Tuple(
+        Map<String, Tuple>(
+            "description" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "[EXAMPLE] An example NF using the metadata standard"
+                    )
+                ),
+                true
+            ),
+            "icon_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61aded05f3208c78b028bf99_Scrypto-Icon-Round%20(1).png"
+                    )
+                ),
+                true
+            ),
+            "info_url" => Tuple(
+                Enum<1u8>(
+                    Enum<13u8>(
+                        "https://developers.radixdlt.com/ecosystem"
+                    )
+                ),
+                true
+            ),
+            "name" => Tuple(
+                Enum<1u8>(
+                    Enum<0u8>(
+                        "Radix - Defi Use-cases"
+                    )
+                ),
+                true
+            ),
+            "tags" => Tuple(
+                Enum<1u8>(
+                    Enum<128u8>(
+                        Array<String>(
+                            "collection",
+                            "example-tag"
+                        )
+                    )
+                ),
+                true
+            )
+        ),
+        Map<String, Enum>()
+    )
+    Enum<0u8>()
+;
+CALL_METHOD
+    Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
+    "try_deposit_batch_or_abort"
+    Expression("ENTIRE_WORKTOP")
+;

--- a/transaction-scenarios/generated-examples/non_fungible_resource/017--non-fungible-transfer-metadata-standard-nfs.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/017--non-fungible-transfer-metadata-standard-nfs.rtm
@@ -5,9 +5,12 @@ CALL_METHOD
 ;
 CALL_METHOD
     Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
-    "withdraw"
-    Address("resource_sim1nftpvfauql53qkzxjzxtw9e28lxymhvfq8sg673dz9p562ldk60rg2")
-    Decimal("1")
+    "withdraw_non_fungibles"
+    Address("resource_sim1n2xsys57yk6kuw6xpjv7ecxhsl82vwzw4k2hx4ss5uh207uptm3lmk")
+    Array<NonFungibleLocalId>(
+        NonFungibleLocalId("#4#"),
+        NonFungibleLocalId("#8#")
+    )
 ;
 CALL_METHOD
     Address("account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0")

--- a/transaction-scenarios/generated-examples/non_fungible_resource/018--non-fungible-create-resource-with-supply-with-complex-data.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/018--non-fungible-create-resource-with-supply-with-complex-data.rtm
@@ -1,0 +1,235 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "lock_fee"
+    Decimal("5000")
+;
+CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
+    Enum<1u8>(
+        Enum<2u8>(
+            Enum<0u8>(
+                Enum<0u8>(
+                    Enum<0u8>(
+                        NonFungibleGlobalId("resource_sim1nfxxxxxxxxxxsecpsgxxxxxxxxx004638826440xxxxxxxxxwj8qq5:[4bacc54ffcf223a81aac5f9e4fa22fe33a266eb6b372f583daf7252b3e]")
+                    )
+                )
+            )
+        )
+    )
+    Enum<1u8>()
+    true
+    Tuple(
+        Tuple(
+            Array<Enum>(
+                Enum<14u8>(
+                    Array<Enum>(
+                        Enum<0u8>(
+                            10u8
+                        ),
+                        Enum<1u8>(
+                            1u64
+                        ),
+                        Enum<0u8>(
+                            12u8
+                        ),
+                        Enum<1u8>(
+                            2u64
+                        ),
+                        Enum<1u8>(
+                            4u64
+                        )
+                    )
+                ),
+                Enum<14u8>(
+                    Array<Enum>(
+                        Enum<0u8>(
+                            133u8
+                        ),
+                        Enum<0u8>(
+                            192u8
+                        )
+                    )
+                ),
+                Enum<14u8>(
+                    Array<Enum>(
+                        Enum<0u8>(
+                            7u8
+                        ),
+                        Enum<1u8>(
+                            3u64
+                        )
+                    )
+                ),
+                Enum<15u8>(
+                    Map<U8, Array>(
+                        0u8 => Array<Enum>(),
+                        1u8 => Array<Enum>(
+                            Enum<0u8>(
+                                12u8
+                            )
+                        )
+                    )
+                ),
+                Enum<15u8>(
+                    Map<U8, Array>(
+                        0u8 => Array<Enum>(),
+                        1u8 => Array<Enum>(
+                            Enum<1u8>(
+                                4u64
+                            )
+                        ),
+                        2u8 => Array<Enum>(
+                            Enum<1u8>(
+                                2u64
+                            )
+                        )
+                    )
+                )
+            ),
+            Array<Tuple>(
+                Tuple(
+                    Enum<1u8>(
+                        "ComplexNonFungibleData"
+                    ),
+                    Enum<1u8>(
+                        Enum<0u8>(
+                            Array<String>(
+                                "fixed_number",
+                                "fixed_non_fungible_global_id",
+                                "mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces",
+                                "inner_struct",
+                                "mutable_inner_enum"
+                            )
+                        )
+                    )
+                ),
+                Tuple(
+                    Enum<1u8>(
+                        "NonFungibleGlobalId"
+                    ),
+                    Enum<0u8>()
+                ),
+                Tuple(
+                    Enum<1u8>(
+                        "InnerStruct"
+                    ),
+                    Enum<1u8>(
+                        Enum<0u8>(
+                            Array<String>(
+                                "byte",
+                                "string"
+                            )
+                        )
+                    )
+                ),
+                Tuple(
+                    Enum<1u8>(
+                        "Option"
+                    ),
+                    Enum<1u8>(
+                        Enum<1u8>(
+                            Map<U8, Tuple>(
+                                0u8 => Tuple(
+                                    Enum<1u8>(
+                                        "None"
+                                    ),
+                                    Enum<0u8>()
+                                ),
+                                1u8 => Tuple(
+                                    Enum<1u8>(
+                                        "Some"
+                                    ),
+                                    Enum<0u8>()
+                                )
+                            )
+                        )
+                    )
+                ),
+                Tuple(
+                    Enum<1u8>(
+                        "InnerEnum"
+                    ),
+                    Enum<1u8>(
+                        Enum<1u8>(
+                            Map<U8, Tuple>(
+                                0u8 => Tuple(
+                                    Enum<1u8>(
+                                        "None"
+                                    ),
+                                    Enum<0u8>()
+                                ),
+                                1u8 => Tuple(
+                                    Enum<1u8>(
+                                        "InnerEnum"
+                                    ),
+                                    Enum<0u8>()
+                                ),
+                                2u8 => Tuple(
+                                    Enum<1u8>(
+                                        "InnerStruct"
+                                    ),
+                                    Enum<0u8>()
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            Array<Enum>(
+                Enum<0u8>(),
+                Enum<0u8>(),
+                Enum<0u8>(),
+                Enum<0u8>(),
+                Enum<0u8>()
+            )
+        ),
+        Enum<1u8>(
+            0u64
+        ),
+        Array<String>(
+            "mutable_inner_enum",
+            "mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces"
+        )
+    )
+    Map<NonFungibleLocalId, Tuple>(
+        NonFungibleLocalId("#1#") => Tuple(
+            Tuple(
+                100u64,
+                NonFungibleGlobalId("resource_sim1n2xsys57yk6kuw6xpjv7ecxhsl82vwzw4k2hx4ss5uh207uptm3lmk:#8#"),
+                "Some string which could be made long for test cases",
+                Tuple(
+                    42u8,
+                    Enum<1u8>(
+                        "Hello world!"
+                    )
+                ),
+                Enum<1u8>(
+                    Enum<0u8>()
+                )
+            )
+        )
+    )
+    Tuple(
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<0u8>(),
+        Enum<1u8>(
+            Tuple(
+                Enum<0u8>(),
+                Enum<0u8>()
+            )
+        )
+    )
+    Tuple(
+        Map<String, Tuple>(),
+        Map<String, Enum>()
+    )
+    Enum<0u8>()
+;
+CALL_METHOD
+    Address("account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw")
+    "try_deposit_batch_or_abort"
+    Expression("ENTIRE_WORKTOP")
+;

--- a/transaction-scenarios/generated-examples/non_fungible_resource/019--non-fungible-mutate-data.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/019--non-fungible-mutate-data.rtm
@@ -1,0 +1,26 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "lock_fee"
+    Decimal("5000")
+;
+CALL_METHOD
+    Address("resource_sim1ngnxhjv75v8vsnu8cy93znymku0ygxdtrkmgec5rwhjwjvtglyaeup")
+    "update_non_fungible_data"
+    NonFungibleLocalId("#1#")
+    "mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces"
+    "This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! This is a long string with repeats of length 50!! "
+;
+CALL_METHOD
+    Address("resource_sim1ngnxhjv75v8vsnu8cy93znymku0ygxdtrkmgec5rwhjwjvtglyaeup")
+    "update_non_fungible_data"
+    NonFungibleLocalId("#1#")
+    "mutable_inner_enum"
+    Enum<1u8>(
+        Enum<2u8>(
+            Tuple(
+                101u8,
+                Enum<0u8>()
+            )
+        )
+    )
+;

--- a/transaction-scenarios/src/scenarios/non_fungible_resource.rs
+++ b/transaction-scenarios/src/scenarios/non_fungible_resource.rs
@@ -606,7 +606,8 @@ pub struct ComplexNonFungibleData {
     pub fixed_number: u64,
     pub fixed_non_fungible_global_id: NonFungibleGlobalId,
     #[mutable]
-    pub mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces: String,
+    pub mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces:
+        String,
     pub inner_struct: InnerStruct,
     #[mutable]
     pub mutable_inner_enum: InnerEnum,

--- a/transaction-scenarios/src/scenarios/non_fungible_resource.rs
+++ b/transaction-scenarios/src/scenarios/non_fungible_resource.rs
@@ -2,6 +2,7 @@ use crate::internal_prelude::*;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::*;
+use scrypto::NonFungibleData;
 
 pub struct NonFungibleResourceScenarioConfig {
     pub main_account: VirtualAccount,
@@ -14,6 +15,9 @@ pub struct NonFungibleResourceScenarioState {
     pub string_non_fungible_resource: Option<ResourceAddress>,
     pub bytes_non_fungible_resource: Option<ResourceAddress>,
     pub ruid_non_fungible_resource: Option<ResourceAddress>,
+    pub integer_non_fungible_resource_with_empty_data: Option<ResourceAddress>,
+    pub integer_non_fungible_resource_with_metadata_standard_data: Option<ResourceAddress>,
+    pub integer_non_fungible_resource_with_complex_data: Option<ResourceAddress>,
     pub vault1: Option<InternalAddress>,
 }
 
@@ -50,7 +54,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                         "non-fungible-resource-create",
                         |builder| {
                             let mut entries = BTreeMap::new();
-                            entries.insert(NonFungibleLocalId::integer(1), ComplexFungibleData {
+                            entries.insert(NonFungibleLocalId::integer(1), NestedFungibleData {
                                 a: 859,
                                 b: vec!["hi".repeat(50)],
                                 c: AnotherObject {
@@ -87,7 +91,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                             let mut entries = BTreeMap::new();
                             entries.insert(
                                 NonFungibleLocalId::string("my_nft").unwrap(),
-                                ComplexFungibleData {
+                                NestedFungibleData {
                                     a: 859,
                                     b: vec!["hi".repeat(50)],
                                     c: AnotherObject { f1: btreemap!() },
@@ -120,7 +124,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                             let mut entries = BTreeMap::new();
                             entries.insert(
                                 NonFungibleLocalId::bytes(vec![0u8; 16]).unwrap(),
-                                ComplexFungibleData {
+                                NestedFungibleData {
                                     a: 859,
                                     b: vec!["hi".repeat(50)],
                                     c: AnotherObject { f1: btreemap!() },
@@ -151,7 +155,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                         "non-fungible-resource-create-ruid",
                         |builder| {
                             let mut entries = Vec::new();
-                            entries.push(ComplexFungibleData {
+                            entries.push(NestedFungibleData {
                                 a: 859,
                                 b: vec!["hi".repeat(50)],
                                 c: AnotherObject { f1: btreemap!() },
@@ -183,7 +187,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                             for i in 100..132 {
                                 entries.insert(
                                     NonFungibleLocalId::integer(i),
-                                    ComplexFungibleData {
+                                    NestedFungibleData {
                                         a: 859,
                                         b: vec!["hi".repeat(50)],
                                         c: AnotherObject { f1: btreemap!() },
@@ -332,6 +336,204 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                 },
                 |core, config, state, result| Ok(()),
             )
+            .successful_transaction_with_result_handler(
+                |core, config, state| {
+                    core.next_transaction_with_faucet_lock_fee(
+                        "non-fungible-create-resource-with-supply-with-empty-data",
+                        |builder| {
+                            builder
+                                .create_non_fungible_resource(
+                                    OwnerRole::None,
+                                    NonFungibleIdType::Integer,
+                                    true,
+                                    NonFungibleResourceRoles::default(),
+                                    metadata!(),
+                                    Some(btreemap!(
+                                        NonFungibleLocalId::integer(1) => (),
+                                        NonFungibleLocalId::integer(2) => (),
+                                        NonFungibleLocalId::integer(3) => (),
+                                    )),
+                                )
+                                .try_deposit_batch_or_abort(config.main_account.address)
+                        },
+                        vec![&config.main_account.key],
+                    )
+                },
+                |core, config, state, result| {
+                    state.integer_non_fungible_resource_with_empty_data = Some(result.new_resource_addresses()[0]);
+                    Ok(())
+                },
+            )
+            .successful_transaction_with_result_handler(
+                |core, config, state| {
+                    core.next_transaction_with_faucet_lock_fee(
+                        "non-fungible-create-resource-with-supply-with-metadata-standard-data",
+                        |builder| {
+                            builder
+                                .create_non_fungible_resource(
+                                    OwnerRole::None,
+                                    NonFungibleIdType::Integer,
+                                    true,
+                                    NonFungibleResourceRoles::default(),
+                                    // Images sourced from https://developers.radixdlt.com/ecosystem
+                                    metadata!(
+                                        init {
+                                            "name" => "Radix - Defi Use-cases", locked;
+                                            "description" => "[EXAMPLE] An example NF using the metadata standard", locked;
+                                            "tags" => ["collection", "example-tag"], locked;
+                                            "icon_url" => Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61aded05f3208c78b028bf99_Scrypto-Icon-Round%20(1).png"), locked;
+                                            "info_url" => Url::of("https://developers.radixdlt.com/ecosystem"), locked;
+                                        }
+                                    ),
+                                    Some(btreemap!(
+                                        NonFungibleLocalId::integer(1) => MetadataStandardNonFungibleData {
+                                            name: "Decentralized Exchanges".into(),
+                                            description: "Decentralized Exchanges, also known as DEXes, allow users to exchange two or more tokens in a single transaction, at a certain price, without the need for another party to facilitate the transaction.\n\nDEXes allow users to trade assets without the need for a trusted third party. They are the first ever examples of a censorship resistant, non-custodial, and permissionless way of exchanging assets electronically.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414d213fd7349b654b9_icon-DEX.svg"),
+                                            arbitrary_coolness_rating: 45,
+                                        },
+                                        NonFungibleLocalId::integer(2) => MetadataStandardNonFungibleData {
+                                            name: "Stablecoins".into(),
+                                            description: "A stablecoin is a class of cryptocurrencies that attempt to offer price stability and are backed by a reserve asset. Stablecoins have become popular as they provide the instant processing and security or privacy of cryptocurrencies' payments along with the volatility-free stable valuations of fiat currencies.\n\nStablecoins base their market value on an external reference. This could be a currency like the U.S. dollar or a commodity's price such as gold. Stablecoins achieve price stability via collateralization or algorithmic buying and selling of the reference asset or its derivatives.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f419f77f05b9086565e6_icon-stablecoin.svg"),
+                                            arbitrary_coolness_rating: 5,
+                                        },
+                                        NonFungibleLocalId::integer(3) => MetadataStandardNonFungibleData {
+                                            name: "Lending".into(),
+                                            description: "In lending, borrowers pledge their crypto assets as collateral and avail loans in stablecoins or other crypto assets as a means of financing.\n\nHowever, unlike TradFi, DeFi lending uses algorithmic systems where lending and borrowing rates are determined automatically based on each asset's real-time supply and demand.\n\nThis automated approach means more flexibility and access for anyone looking for financing.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414979a8b045995bf75_ICON-LENDING.svg"),
+                                            arbitrary_coolness_rating: 30,
+                                        },
+                                        NonFungibleLocalId::integer(4) => MetadataStandardNonFungibleData {
+                                            name: "Insurance".into(),
+                                            description: "Insurance protocols provide cover against smart contract failure & exchange hacks using a decentralized protocol, so people can share risk without needing an insurance company.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f4146c4528458c93da96_ICON-NFTS-1.svg"),
+                                            arbitrary_coolness_rating: 0,
+                                        },
+                                        NonFungibleLocalId::integer(5) => MetadataStandardNonFungibleData {
+                                            name: "Futures, Options, & Derivatives".into(),
+                                            description: "A futures contract is an arrangement between two users on an exchange to buy and sell an underlying crypto asset at an agreed-upon price on a certain date in the future.\n\nOptions give the holder the right to buy (call) or sell (put) an underlying crypto asset at a set date without being obligated.\n\nSynthetic assets, also known as synths, are an asset class formed by combining cryptocurrencies and traditional derivative assets, making them tokenized derivatives.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f414e8f31b971debfabe_ICON-FUTURES.svg"),
+                                            arbitrary_coolness_rating: 10,
+                                        },
+                                        // Skipping 6 and 7 because they don't need to be complete
+                                        NonFungibleLocalId::integer(8) => MetadataStandardNonFungibleData {
+                                            name: "Gaming".into(),
+                                            description: "Since we have so many gamers who spend endless hours and money on gaming platforms, DeFi gaming platforms will enable them to monetize their time and progress. The play-to-earn games offer the best of both worlds - they provide an entertaining experience and make playing games lucrative.".into(),
+                                            key_image_url: Url::of("https://assets-global.website-files.com/618962e5f285fb3c879d82ca/61b8f416931770a50ed4a702_ICON-GAMING.svg"),
+                                            arbitrary_coolness_rating: 71,
+                                        },
+                                    )),
+                                )
+                                .try_deposit_batch_or_abort(config.main_account.address)
+                        },
+                        vec![&config.main_account.key],
+                    )
+                },
+                |core, config, state, result| {
+                    state.integer_non_fungible_resource_with_metadata_standard_data = Some(result.new_resource_addresses()[0]);
+                    Ok(())
+                },
+            )
+            .successful_transaction(
+                |core, config, state| {
+                    core.next_transaction_with_faucet_lock_fee(
+                        "non-fungible-transfer-metadata-standard-nfs",
+                        |builder| {
+                            builder
+                                .withdraw_non_fungibles_from_account(
+                                    config.main_account.address,
+                                    state.integer_non_fungible_resource_with_metadata_standard_data.unwrap(),
+                                    &btreeset!(
+                                        NonFungibleLocalId::integer(4),
+                                        NonFungibleLocalId::integer(8),
+                                    )
+                                )
+                                .try_deposit_batch_or_abort(config.occasional_recipient_account.address)
+                        },
+                        vec![&config.main_account.key],
+                    )
+                },
+            )
+            .successful_transaction_with_result_handler(
+                |core, config, state| {
+                    core.next_transaction_with_faucet_lock_fee(
+                        "non-fungible-create-resource-with-supply-with-complex-data",
+                        |builder| {
+                            builder
+                                .create_non_fungible_resource(
+                                    // Make the Owner the same as the public key for the main account
+                                    // In reality, this should probably be a concrete badge, not a virtual badge, but for tests
+                                    // this is okay
+                                    OwnerRole::Fixed(rule!(require(NonFungibleGlobalId::from_public_key(&config.main_account.public_key)))),
+                                    NonFungibleIdType::Integer,
+                                    true,
+                                    NonFungibleResourceRoles {
+                                        non_fungible_data_update_roles: Some(NonFungibleDataUpdateRoles {
+                                            // Using "None" here makes it the owner role
+                                            non_fungible_data_updater: None,
+                                            non_fungible_data_updater_updater: None,
+                                        }),
+                                        ..NonFungibleResourceRoles::default()
+                                    },
+                                    metadata!(),
+                                    Some(btreemap!(
+                                        NonFungibleLocalId::integer(1) => ComplexNonFungibleData {
+                                            fixed_number: 100,
+                                            fixed_non_fungible_global_id: NonFungibleGlobalId::new(
+                                                state.integer_non_fungible_resource_with_metadata_standard_data.unwrap(),
+                                                NonFungibleLocalId::integer(8)
+                                            ),
+                                            mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces: "Some string which could be made long for test cases".to_string(),
+                                            inner_struct: InnerStruct { byte: 42u8, string: Some("Hello world!".into()) },
+                                            mutable_inner_enum: InnerEnum::InnerEnum(Box::new(InnerEnum::None))
+                                        },
+                                    )),
+                                )
+                                .try_deposit_batch_or_abort(config.main_account.address)
+                        },
+                        vec![&config.main_account.key],
+                    )
+                },
+                |core, config, state, result| {
+                    state.integer_non_fungible_resource_with_complex_data = Some(result.new_resource_addresses()[0]);
+                    Ok(())
+                },
+            )
+            .successful_transaction(
+                |core, config, state| {
+                    core.next_transaction_with_faucet_lock_fee(
+                        "non-fungible-mutate-data",
+                        |builder| {
+                            let mut really_long_string = String::new();
+                            for _ in 0..80 {
+                                really_long_string.push_str("This is a long string with repeats of length 50!! ");
+                            }
+                            assert_eq!(really_long_string.len(), 4000);
+                            builder
+                                .update_non_fungible_data(
+                                    state.integer_non_fungible_resource_with_complex_data.unwrap(),
+                                    NonFungibleLocalId::integer(1),
+                                    "mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces",
+                                    really_long_string,
+                                )
+                                .update_non_fungible_data(
+                                    state.integer_non_fungible_resource_with_complex_data.unwrap(),
+                                    NonFungibleLocalId::integer(1),
+                                    "mutable_inner_enum",
+                                    InnerEnum::InnerEnum(Box::new(InnerEnum::InnerStruct(Box::new(
+                                        InnerStruct {
+                                            byte: 101u8,
+                                            string: None,
+                                        }
+                                    )))),
+                                )
+                        },
+                        // The owner of the resource is this key
+                        vec![&config.main_account.key],
+                    )
+                },
+            )
             .finalize(|core, config, state| {
                 Ok(ScenarioOutput {
                     interesting_addresses: DescribedAddresses::new()
@@ -356,14 +558,26 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                             "ruid_non_fungible_resource",
                             state.ruid_non_fungible_resource.unwrap(),
                         )
-                        .add("non_fungible_vault", state.vault1.unwrap()),
+                        .add("non_fungible_vault", state.vault1.unwrap())
+                        .add(
+                            "integer_non_fungible_resource_with_empty_data",
+                            state.integer_non_fungible_resource_with_empty_data.unwrap(),
+                        )
+                        .add(
+                            "integer_non_fungible_resource_with_metadata_standard_data",
+                            state.integer_non_fungible_resource_with_metadata_standard_data.unwrap(),
+                        )
+                        .add(
+                            "integer_non_fungible_resource_with_complex_data",
+                            state.integer_non_fungible_resource_with_complex_data.unwrap(),
+                        ),
                 })
             })
     }
 }
 
 #[derive(ScryptoSbor, ManifestSbor)]
-struct ComplexFungibleData {
+struct NestedFungibleData {
     a: u32,
     b: Vec<String>,
     c: AnotherObject,
@@ -374,6 +588,41 @@ struct AnotherObject {
     f1: BTreeMap<String, (u8, (u16, Vec<Vec<u8>>))>,
 }
 
-impl NonFungibleData for ComplexFungibleData {
+impl NonFungibleData for NestedFungibleData {
     const MUTABLE_FIELDS: &'static [&'static str] = &["a", "c"];
 }
+
+#[derive(ScryptoSbor, ManifestSbor, NonFungibleData)]
+pub struct MetadataStandardNonFungibleData {
+    pub name: String,
+    pub description: String,
+    pub key_image_url: Url,
+    // Additional fields
+    pub arbitrary_coolness_rating: u64,
+}
+
+#[derive(ScryptoSbor, ManifestSbor, NonFungibleData)]
+pub struct ComplexNonFungibleData {
+    pub fixed_number: u64,
+    pub fixed_non_fungible_global_id: NonFungibleGlobalId,
+    #[mutable]
+    pub mutable_long_name_for_data_to_try_and_stretch_the_bounds_of_what_is_possible_in_user_interfaces: String,
+    pub inner_struct: InnerStruct,
+    #[mutable]
+    pub mutable_inner_enum: InnerEnum,
+}
+
+#[derive(ScryptoSbor, ManifestSbor)]
+pub struct InnerStruct {
+    pub byte: u8,
+    pub string: Option<String>,
+}
+
+#[derive(ScryptoSbor, ManifestSbor)]
+pub enum InnerEnum {
+    None,
+    InnerEnum(Box<InnerEnum>),
+    InnerStruct(Box<InnerStruct>),
+}
+
+pub type NoNonFungibleData = ();

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -669,6 +669,26 @@ impl ManifestBuilder {
         self.add_instruction(instruction)
     }
 
+    pub fn update_non_fungible_data(
+        self,
+        resource_address: impl ResolvableResourceAddress,
+        id: NonFungibleLocalId,
+        field_name: impl Into<String>,
+        data: impl ManifestEncode,
+    ) -> Self {
+        let address = resource_address.resolve(&self.registrar);
+        let data = manifest_decode(&manifest_encode(&data).unwrap()).unwrap();
+        self.call_method(
+            address,
+            NON_FUNGIBLE_RESOURCE_MANAGER_UPDATE_DATA_IDENT,
+            NonFungibleResourceManagerUpdateDataManifestInput {
+                id,
+                field_name: field_name.into(),
+                data,
+            },
+        )
+    }
+
     pub fn create_identity_advanced(self, owner_role: OwnerRole) -> Self {
         self.add_instruction(InstructionV1::CallFunction {
             package_address: IDENTITY_PACKAGE.into(),


### PR DESCRIPTION
## Summary
Theo needed to generate some example schemas, for their tests, and I suggested the easiest mechanism was to create some scenarios for them.

So we've created some scenarios/tests for a few of these cases.

I've merged into `rcnet-v2-phase-2` because I want it to be clear as examples for that release, although I'm not intending we include this in the scenarios / wipe genesis again as I don't want to disrupt upstream teams. I'll need to merge `release/rcnet-v2-phase-2` into `develop` after this branch is merged.

## For downstream teams

From the next release, the non-fungible resource scenario will have a `"integer_non_fungible_resource_with_metadata_standard_data"` resource address which has non-fungible data which aligns with the Metadata Standard.