### PR TITLE
chore: Update version numbers to 0.12.0 in preparation for RCnet v3

### DIFF
--- a/native-sdk/Cargo.toml
+++ b/native-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native-sdk"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-common"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-derive/Cargo.toml
+++ b/radix-engine-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-derive"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [lib]

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-interface"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-queries"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-store-interface/Cargo.toml
+++ b/radix-engine-store-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-store-interface"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-stores/Cargo.toml
+++ b/radix-engine-stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-stores"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-tests/Cargo.toml
+++ b/radix-engine-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine-tests"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine-tests/tests/blueprints/reentrancy/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/reentrancy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reentrancy"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radix-engine"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/sbor-derive-common/Cargo.toml
+++ b/sbor-derive-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbor-derive-common"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/sbor-derive/Cargo.toml
+++ b/sbor-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbor-derive"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [lib]

--- a/sbor-tests/Cargo.toml
+++ b/sbor-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbor-tests"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbor"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/scrypto-derive/Cargo.toml
+++ b/scrypto-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-derive"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [lib]

--- a/scrypto-schema/Cargo.toml
+++ b/scrypto-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-schema"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/scrypto-tests/Cargo.toml
+++ b/scrypto-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-tests"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/scrypto-unit/Cargo.toml
+++ b/scrypto-unit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto-unit"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "native-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "radix-engine-common",
  "radix-engine-derive",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags",
  "colored",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bech32",
  "blake2",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags",
  "const-sha1",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-queries"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hex",
  "itertools",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-store-interface"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hex",
  "itertools",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-stores"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hex",
  "itertools",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "const-sha1",
  "itertools",
@@ -1221,7 +1221,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypto-schema"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags",
  "radix-engine-common",
@@ -1314,7 +1314,7 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "simulator"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cargo_toml",
  "clap",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "transaction"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bech32",
  "ed25519-dalek",
@@ -1543,7 +1543,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "utils"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "indexmap 2.0.0-pre",
 ]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "simulator"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/transaction-scenarios/Cargo.toml
+++ b/transaction-scenarios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction-scenarios"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
Update crate version numbers to 0.12.0 in preparation for RCnet v3