### PR TITLE
Feature / Add Default trait implementation for ManifestBuilder

### DIFF
--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -1823,3 +1823,9 @@ impl ManifestBuilder {
         decompile_with_known_naming(&self.instructions, network_definition, self.object_names())
     }
 }
+
+impl Default for ManifestBuilder {
+    fn default() -> Self {
+        ManifestBuilder::new()
+    }
+}


### PR DESCRIPTION
## Summary
ManifestBuilder currently doesn't have a `Default` trait implementation which is useful for the use with e.g. `men::take`

## Testing
Since the whole ManifestBuilder is not covered by tests yet (?), I tested it manually by using a fork of the Scrypto repo as target in our blueprint tests.