### PR TITLE
Fix decimal and precise decimal arithmetics

### DIFF
--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -432,8 +432,9 @@ macro_rules! impl_arith_ops {
         impl Add<Decimal> for $type {
             type Output = Decimal;
 
+            #[inline]
             fn add(self, other: Decimal) -> Self::Output {
-                Decimal::from(self) + other
+                other + self
             }
         }
 
@@ -448,8 +449,9 @@ macro_rules! impl_arith_ops {
         impl Mul<Decimal> for $type {
             type Output = Decimal;
 
+            #[inline]
             fn mul(self, other: Decimal) -> Self::Output {
-                Decimal::from(self) * other
+                other * self
             }
         }
 

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -348,6 +348,7 @@ impl From<bool> for Decimal {
 impl Add<Decimal> for Decimal {
     type Output = Decimal;
 
+    #[inline]
     fn add(self, other: Decimal) -> Self::Output {
         let a = self.0;
         let b = other.0;
@@ -358,6 +359,7 @@ impl Add<Decimal> for Decimal {
 impl Sub<Decimal> for Decimal {
     type Output = Decimal;
 
+    #[inline]
     fn sub(self, other: Decimal) -> Self::Output {
         let a = self.0;
         let b = other.0;
@@ -368,6 +370,7 @@ impl Sub<Decimal> for Decimal {
 impl Mul<Decimal> for Decimal {
     type Output = Decimal;
 
+    #[inline]
     fn mul(self, other: Decimal) -> Self::Output {
         // Use BnumI384 (BInt<6>) to not overflow.
         let a = BnumI384::from(self.0);
@@ -381,6 +384,7 @@ impl Mul<Decimal> for Decimal {
 impl Div<Decimal> for Decimal {
     type Output = Decimal;
 
+    #[inline]
     fn div(self, other: Decimal) -> Self::Output {
         // Use BnumI384 (BInt<6>) to not overflow.
         let a = BnumI384::from(self.0);

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -1471,4 +1471,59 @@ mod tests {
             Err(ParsePreciseDecimalError::UnsupportedDecimalPlace)
         ))
     }
+
+    // These tests make sure that any basic arithmetic operation
+    // between Decimal and PreciseDecimal produces a PreciseDecimal, no matter the order.
+    // Additionally result of such operation shall be equal, if operands are derived from the same
+    // value
+    // Example:
+    //   Decimal(10) * PreciseDecimal(10) -> PreciseDecimal(100)
+    //   PreciseDecimal(10) * Decimal(10) -> PreciseDecimal(100)
+    #[test]
+    fn test_arith_precise_decimal_decimal() {
+        let p1 = PreciseDecimal::from(Decimal::MAX);
+        let d1 = Decimal::from(2);
+        let d2 = Decimal::MAX;
+        let p2 = PreciseDecimal::from(2);
+        assert_eq!(p1 * d1, d2 * p2);
+        assert_eq!(p1 / d1, d2 / p2);
+        assert_eq!(p1 + d1, d2 + p2);
+        assert_eq!(p1 - d1, d2 - p2);
+
+        let p1 = PreciseDecimal::from(Decimal::MIN);
+        let d1 = Decimal::from(2);
+        let d2 = Decimal::MIN;
+        let p2 = PreciseDecimal::from(2);
+        assert_eq!(p1 * d1, d2 * p2);
+        assert_eq!(p1 / d1, d2 / p2);
+        assert_eq!(p1 + d1, d2 + p2);
+        assert_eq!(p1 - d1, d2 - p2);
+
+        let p1 = pdec!("0.000001");
+        let d1 = dec!("0.001");
+        let d2 = dec!("0.000001");
+        let p2 = pdec!("0.001");
+        assert_eq!(p1 * d1, d2 * p2);
+        assert_eq!(p1 / d1, d2 / p2);
+        assert_eq!(p1 + d1, d2 + p2);
+        assert_eq!(p1 - d1, d2 - p2);
+
+        let p1 = pdec!("0.000000000000000001");
+        let d1 = Decimal::MIN;
+        let d2 = dec!("0.000000000000000001");
+        let p2 = PreciseDecimal::from(Decimal::MIN);
+        assert_eq!(p1 * d1, d2 * p2);
+        assert_eq!(p1 / d1, d2 / p2);
+        assert_eq!(p1 + d1, d2 + p2);
+        assert_eq!(p1 - d1, d2 - p2);
+
+        let p1 = PreciseDecimal::ZERO;
+        let d1 = Decimal::ONE;
+        let d2 = Decimal::ZERO;
+        let p2 = PreciseDecimal::ONE;
+        assert_eq!(p1 * d1, d2 * p2);
+        assert_eq!(p1 / d1, d2 / p2);
+        assert_eq!(p1 + d1, d2 + p2);
+        assert_eq!(p1 - d1, d2 - p2);
+    }
 }

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -363,6 +363,7 @@ impl From<bool> for PreciseDecimal {
 impl Add<PreciseDecimal> for PreciseDecimal {
     type Output = PreciseDecimal;
 
+    #[inline]
     fn add(self, other: PreciseDecimal) -> Self::Output {
         let a = self.0;
         let b = other.0;
@@ -373,6 +374,7 @@ impl Add<PreciseDecimal> for PreciseDecimal {
 impl Sub<PreciseDecimal> for PreciseDecimal {
     type Output = PreciseDecimal;
 
+    #[inline]
     fn sub(self, other: PreciseDecimal) -> Self::Output {
         let a = self.0;
         let b = other.0;
@@ -383,6 +385,7 @@ impl Sub<PreciseDecimal> for PreciseDecimal {
 impl Mul<PreciseDecimal> for PreciseDecimal {
     type Output = PreciseDecimal;
 
+    #[inline]
     fn mul(self, other: PreciseDecimal) -> Self::Output {
         // Use BnumI768 to not overflow.
         let a = BnumI768::from(self.0);
@@ -396,6 +399,7 @@ impl Mul<PreciseDecimal> for PreciseDecimal {
 impl Div<PreciseDecimal> for PreciseDecimal {
     type Output = PreciseDecimal;
 
+    #[inline]
     fn div(self, other: PreciseDecimal) -> Self::Output {
         // Use BnumI768 to not overflow.
         let a = BnumI768::from(self.0);

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -447,8 +447,9 @@ macro_rules! impl_arith_ops {
         impl Add<PreciseDecimal> for $type {
             type Output = PreciseDecimal;
 
+            #[inline]
             fn add(self, other: PreciseDecimal) -> Self::Output {
-                PreciseDecimal::from(self) + other
+                other + self
             }
         }
 
@@ -463,8 +464,9 @@ macro_rules! impl_arith_ops {
         impl Mul<PreciseDecimal> for $type {
             type Output = PreciseDecimal;
 
+            #[inline]
             fn mul(self, other: PreciseDecimal) -> Self::Output {
-                PreciseDecimal::from(self) * other
+                other * self
             }
         }
 

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -1083,7 +1083,7 @@ fn validator_receives_no_emission_when_too_many_proposals_missed() {
 
 macro_rules! assert_close_to {
     ($a:expr, $b:expr) => {
-        if ($a - $b).abs() > dec!("0.0001") {
+        if Decimal::from($a - $b).abs() > dec!("0.0001") {
             panic!("{} is not close to {}", $a, $b);
         }
     };


### PR DESCRIPTION
## Summary
Fix basic arithmetics for `Decimal` and `PreciseDecimal` types.

## Details

- Assure that basic arithmetic operations between: `Decimal` and `PreciseDecimal`, `Decimal` and primitive types, `PreciseDecimal` and primitive types are transitive. Which means they produce  expected type no matter the order of the operand types.
- Additionally results of such operations shall be equal, if operands are derived from the same value
Example 1:
    `Decimal(10)` * `PreciseDecimal(10)` = `PreciseDecimal(100)`
    `PreciseDecimal(10)` * `Decimal(10)` = `PreciseDecimal(100)`
Example 2:
    `Decimal(10)` * `10_u32` = `Decimal(100)`
    `10_u32` * `Decimal(10)` = `Decimal(100)`

This PR addresses the [issue reported by the community](https://discord.com/channels/417762285172555786/765994894749597697/1129167191057645709) 


## Testing
Respective tests were implemented

## Update Recommendations

All should work as before. Backward compatibility has been assured.

