### PR TITLE
Features/SCRY-452 Blueprint and Wasm export names validation

### DIFF
--- a/radix-engine-tests/tests/package.rs
+++ b/radix-engine-tests/tests/package.rs
@@ -369,14 +369,14 @@ fn name_validation_blueprint() {
     let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
 
     definition.blueprints = BTreeMap::from([(
-            String::from("wrong_bluepint_name_*"),
-            definition
-                .blueprints
-                .first_entry()
-                .unwrap()
-                .get()
-                .to_owned(),
-        )]);
+        String::from("wrong_bluepint_name_*"),
+        definition
+            .blueprints
+            .first_entry()
+            .unwrap()
+            .get()
+            .to_owned(),
+    )]);
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/package.rs
+++ b/radix-engine-tests/tests/package.rs
@@ -363,75 +363,113 @@ fn should_not_be_able_to_publish_native_packages_in_scrypto() {
 }
 
 #[test]
-fn package_definition_names_validation() {
+fn name_validation_blueprint() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+
+    definition.blueprints = BTreeMap::from([(
+            String::from("wrong_bluepint_name_*"),
+            definition
+                .blueprints
+                .first_entry()
+                .unwrap()
+                .get()
+                .to_owned(),
+        )]);
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
+        .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
+        .build();
+
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_specific_failure(|e| {
+        matches!(
+            e,
+            RuntimeError::ApplicationError(ApplicationError::PackageError(
+                PackageError::InvalidName(..)
+            ))
+        )
+    });
+}
+
+#[test]
+fn name_validation_feature_set() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+
+    definition
+        .blueprints
+        .first_entry()
+        .unwrap()
+        .get_mut()
+        .feature_set
+        .insert(String::from("wrong-feature"));
+
+    // Act
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
+        .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
+        .build();
+
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+    // Assert
+    receipt.expect_specific_failure(|e| {
+        matches!(
+            e,
+            RuntimeError::ApplicationError(ApplicationError::PackageError(
+                PackageError::InvalidName(..)
+            ))
+        )
+    });
+}
+
+#[test]
+fn name_validation_function() {
+    // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
 
-    for i in 1..=3 {
-        // Arrange
-        let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
 
-        match i {
-            // Validate wrong blueprint name
-            1 => {
-                definition.blueprints = BTreeMap::from([(
-                    String::from("wrong_bluepint_name_*"),
-                    definition
-                        .blueprints
-                        .first_entry()
-                        .unwrap()
-                        .get()
-                        .to_owned(),
-                )]);
-            }
-            // Validate wrong feature name
-            2 => {
-                definition
-                    .blueprints
-                    .first_entry()
-                    .unwrap()
-                    .get_mut()
-                    .feature_set
-                    .insert(String::from("wrong-feature"));
-            }
-            // Validate wrong feature name
-            3 => {
-                definition
-                    .blueprints
-                    .first_entry()
-                    .unwrap()
-                    .get_mut()
-                    .schema
-                    .functions
-                    .functions
-                    .insert(
-                        String::from("self"),
-                        FunctionSchemaInit {
-                            receiver: None,
-                            input: TypeRef::Static(LocalTypeIndex::WellKnown(0)),
-                            output: TypeRef::Static(LocalTypeIndex::WellKnown(0)),
-                            export: String::from("self"),
-                        },
-                    );
-            }
-            _ => break,
-        }
+    definition
+        .blueprints
+        .first_entry()
+        .unwrap()
+        .get_mut()
+        .schema
+        .functions
+        .functions
+        .insert(
+            String::from("self"),
+            FunctionSchemaInit {
+                receiver: None,
+                input: TypeRef::Static(LocalTypeIndex::WellKnown(0)),
+                output: TypeRef::Static(LocalTypeIndex::WellKnown(0)),
+                export: String::from("self"),
+            },
+        );
 
-        // Act
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
-            .build();
+    // Act
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
+        .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
+        .build();
 
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
-        // Assert
-        receipt.expect_specific_failure(|e| {
-            matches!(
-                e,
-                RuntimeError::ApplicationError(ApplicationError::PackageError(
-                    PackageError::InvalidName(..)
-                ))
-            )
-        });
-    }
+    // Assert
+    receipt.expect_specific_failure(|e| {
+        matches!(
+            e,
+            RuntimeError::ApplicationError(ApplicationError::PackageError(
+                PackageError::InvalidName(..)
+            ))
+        )
+    });
 }

--- a/radix-engine-tests/tests/wasm_validation.rs
+++ b/radix-engine-tests/tests/wasm_validation.rs
@@ -1,4 +1,5 @@
 use radix_engine::vm::wasm::{InvalidMemory, PrepareError, WasmValidator};
+use radix_engine_queries::typed_substate_layout::PackageDefinition;
 use scrypto_unit::*;
 
 #[test]
@@ -25,4 +26,40 @@ fn test_large_memory() {
         )),
         result
     );
+}
+
+#[test]
+fn invalid_export_name_should_fail() {
+    // List of some invalid names (non conforming to Rust Ident).
+    let names = ["a b", "a$", "a!", "a-", "a\u{221A}", "\0", "a\'", "self", "crate", "super", "Self"];
+    // Veryfing various export names like function, global and memory section.
+    let replace_tokens = ["FUNCTION_NAME", "GLOBAL_NAME", "MEMORY_NAME"];
+
+    for token in replace_tokens {
+        for name in names {
+            // Arrange
+            let code_str = r##"
+                    (module
+                        (func (export "FUNCTION_NAME") (result i32)
+                            i32.const 1
+                        )
+                        (global (export "GLOBAL_NAME") i32 (i32.const 1))
+                        (memory $0 1)
+                        (export "MEMORY_NAME" (memory $0))
+                    )
+                    "##
+            .replace(token, name.clone());
+            let code = wat2wasm(code_str.as_str());
+
+            // Act
+            let result = WasmValidator::default()
+                .validate(&code, PackageDefinition::default().blueprints.values());
+
+            // Assert
+            assert_eq!(
+                result,
+                Err(PrepareError::InvalidExportName(name.to_string()))
+            );
+        }
+    }
 }

--- a/radix-engine-tests/tests/wasm_validation.rs
+++ b/radix-engine-tests/tests/wasm_validation.rs
@@ -31,7 +31,19 @@ fn test_large_memory() {
 #[test]
 fn invalid_export_name_should_fail() {
     // List of some invalid names (non conforming to Rust Ident).
-    let names = ["a b", "a$", "a!", "a-", "a\u{221A}", "\0", "a\'", "self", "crate", "super", "Self"];
+    let names = [
+        "a b",
+        "a$",
+        "a!",
+        "a-",
+        "a\u{221A}",
+        "\0",
+        "a\'",
+        "self",
+        "crate",
+        "super",
+        "Self",
+    ];
     // Veryfing various export names like function, global and memory section.
     let replace_tokens = ["FUNCTION_NAME", "GLOBAL_NAME", "MEMORY_NAME"];
 

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -25,6 +25,7 @@ paste = { version = "1.0.13" }
 
 # WASM validation
 wasmparser = { version = "0.107.0", default-features = false }
+syn = { version = "2.0.28", default-features = false, features = ["parsing"] }
 
 # WASM instrumentation
 wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument", branch = "radix-master", default-features = false,  features = ["ignore_custom_section"]}

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -435,6 +435,10 @@ fn validate_names(definition: &PackageDefinition) -> Result<(), PackageError> {
             condition(name)?;
         }
 
+        for name in bp_init.feature_set.iter() {
+            condition(name)?;
+        }
+
         if let PackageRoyaltyConfig::Enabled(list) = &bp_init.royalty_config {
             for (name, _) in list.iter() {
                 condition(name)?;
@@ -444,6 +448,22 @@ fn validate_names(definition: &PackageDefinition) -> Result<(), PackageError> {
         if let FunctionAuth::AccessRules(list) = &bp_init.auth_config.function_auth {
             for (name, _) in list.iter() {
                 condition(name)?;
+            }
+        }
+
+        if let MethodAuthTemplate::StaticRoles(static_roles) = &bp_init.auth_config.method_auth {
+            if let RoleSpecification::Normal(list) = &static_roles.roles {
+                for (role_key, _) in list.iter() {
+                    condition(&role_key.key)?;
+                }
+            }
+            for (key, accessibility) in static_roles.methods.iter() {
+                condition(&key.ident)?;
+                if let MethodAccessibility::RoleProtected(role_list) = accessibility {
+                    for role_key in &role_list.list {
+                        condition(&role_key.key)?;
+                    }
+                }
             }
         }
     }

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -42,7 +42,7 @@ pub use radix_engine_interface::blueprints::package::{
     PackageInstrumentedCodeSubstate, PackageOriginalCodeSubstate, PackageRoyaltyAccumulatorSubstate,
 };
 
-pub const PACKAGE_ROYALTY_FEATURE: &str = "package-royalty";
+pub const PACKAGE_ROYALTY_FEATURE: &str = "package_royalty";
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum PackageError {

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -22,6 +22,8 @@ pub enum PrepareError {
     InvalidMemory(InvalidMemory),
     /// Invalid table section
     InvalidTable(InvalidTable),
+    /// Invalid export symbol name
+    InvalidExportName(String),
     /// Too many targets in the `br_table` instruction
     TooManyTargetsInBrTable,
     /// Too many functions

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -1,13 +1,13 @@
 use crate::types::*;
 use crate::vm::wasm::{constants::*, errors::*, PrepareError};
 use radix_engine_interface::blueprints::package::BlueprintDefinitionInit;
+use syn::Ident;
 use wasm_instrument::{
     gas_metering::{self, Rules},
     inject_stack_limiter,
     utils::module_info::ModuleInfo,
 };
 use wasmparser::{ExternalKind, FuncType, Operator, Type, TypeRef, ValType, WasmFeatures};
-use syn::Ident;
 
 use super::WasmiModule;
 #[derive(Debug)]
@@ -852,7 +852,8 @@ impl WasmModule {
     pub fn enforce_export_names(self) -> Result<Self, PrepareError> {
         // Any exported name should follow Rust Identifier specification
         for name in &self.module.export_names {
-            syn::parse_str::<Ident>(name).map_err(|_| PrepareError::InvalidExportName(name.to_string()))?;
+            syn::parse_str::<Ident>(name)
+                .map_err(|_| PrepareError::InvalidExportName(name.to_string()))?;
         }
 
         Ok(self)

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -7,6 +7,7 @@ use wasm_instrument::{
     utils::module_info::ModuleInfo,
 };
 use wasmparser::{ExternalKind, FuncType, Operator, Type, TypeRef, ValType, WasmFeatures};
+use syn::Ident;
 
 use super::WasmiModule;
 #[derive(Debug)]
@@ -844,6 +845,15 @@ impl WasmModule {
         }
 
         // FIXME: do we need to enforce limit on the number of locals and parameters?
+
+        Ok(self)
+    }
+
+    pub fn enforce_export_names(self) -> Result<Self, PrepareError> {
+        // Any exported name should follow Rust Identifier specification
+        for name in &self.module.export_names {
+            syn::parse_str::<Ident>(name).map_err(|_| PrepareError::InvalidExportName(name.to_string()))?;
+        }
 
         Ok(self)
     }

--- a/radix-engine/src/vm/wasm/wasm_validator.rs
+++ b/radix-engine/src/vm/wasm/wasm_validator.rs
@@ -33,6 +33,7 @@ impl WasmValidator {
         WasmModule::init(code)?
             .enforce_no_start_function()?
             .enforce_import_limit()?
+            .enforce_export_names()?
             .enforce_memory_limit_and_inject_max(self.max_memory_size_in_pages)?
             .enforce_table_limit(self.max_initial_table_size)?
             .enforce_br_table_limit(self.max_number_of_br_table_targets)?


### PR DESCRIPTION
## Summary
All Wasm exported names and Blueprint name and its components should follow Rust Identifier specification

## Details
Added new functions: `enforce_export_names()` into `WasmModule` and `validate_names` into `package` module which uses `syn` crate `parse_str()` function to validate `Ident` conformance.

## Testing
Added new test which verifies if prohibited names are rejected with appropriate error.

## Update Recommendations
If anyone was using non 'Ident' conformant names, such Wasm/Blueprint will fail now.