### PR TITLE
Adjust call_per_local_cost

### DIFF
--- a/radix-engine-tests/assets/cost_flash_loan.csv
+++ b/radix-engine-tests/assets/cost_flash_loan.csv
@@ -1,9 +1,9 @@
-Total Cost (XRD)                                                           ,     0.13748343,    100.0%
-+ Execution Cost (XRD)                                                     ,     0.13712343,     99.7%
+Total Cost (XRD)                                                           ,     0.13752672,    100.0%
++ Execution Cost (XRD)                                                     ,     0.13716672,     99.7%
 + Tipping Cost (XRD)                                                       ,              0,      0.0%
 + State Expansion Cost (XRD)                                               ,        0.00036,      0.3%
 + Royalty Cost (XRD)                                                       ,              0,      0.0%
-Total Cost Units Consumed                                                  ,       13712343,    100.0%
+Total Cost Units Consumed                                                  ,       13716672,    100.0%
 AfterInvoke                                                                ,           1880,      0.0%
 AllocateNodeId                                                             ,          30500,      0.2%
 BeforeInvoke                                                               ,          34224,      0.2%
@@ -56,8 +56,8 @@ RunNativeCode::take_FungibleVault                                          ,    
 RunNativeCode::try_deposit_batch_or_abort                                  ,          63706,      0.5%
 RunNativeCode::unlock_amount_FungibleVault                                 ,          47112,      0.3%
 RunNativeCode::withdraw                                                    ,          47564,      0.3%
-RunWasmCode::BasicFlashLoan_repay_loan                                     ,          68603,      0.5%
-RunWasmCode::BasicFlashLoan_take_loan                                      ,         117221,      0.9%
+RunWasmCode::BasicFlashLoan_repay_loan                                     ,          70268,      0.5%
+RunWasmCode::BasicFlashLoan_take_loan                                      ,         119885,      0.9%
 TxBaseCost                                                                 ,          50000,      0.4%
 TxPayloadCost                                                              ,          20560,      0.1%
 TxSignatureVerification                                                    ,           7000,      0.1%

--- a/radix-engine-tests/assets/cost_mint_large_size_nfts_from_manifest.csv
+++ b/radix-engine-tests/assets/cost_mint_large_size_nfts_from_manifest.csv
@@ -1,9 +1,9 @@
-Total Cost (XRD)                                                           ,    10.22800201,    100.0%
-+ Execution Cost (XRD)                                                     ,     0.92287201,      9.0%
+Total Cost (XRD)                                                           ,    10.22800534,    100.0%
++ Execution Cost (XRD)                                                     ,     0.92287534,      9.0%
 + Tipping Cost (XRD)                                                       ,              0,      0.0%
 + State Expansion Cost (XRD)                                               ,        9.30513,     91.0%
 + Royalty Cost (XRD)                                                       ,              0,      0.0%
-Total Cost Units Consumed                                                  ,       92287201,    100.0%
+Total Cost Units Consumed                                                  ,       92287534,    100.0%
 AfterInvoke                                                                ,            494,      0.0%
 AllocateNodeId                                                             ,          10500,      0.0%
 BeforeInvoke                                                               ,        1867440,      2.0%
@@ -42,7 +42,7 @@ RunNativeCode::get_amount_NonFungibleBucket                                ,    
 RunNativeCode::lock_fee                                                    ,          61733,      0.1%
 RunNativeCode::put_NonFungibleVault                                        ,          17297,      0.0%
 RunNativeCode::try_deposit_batch_or_abort                                  ,          63706,      0.1%
-RunWasmCode::Faucet_lock_fee                                               ,          17987,      0.0%
+RunWasmCode::Faucet_lock_fee                                               ,          18320,      0.0%
 SetSubstate                                                                ,         105248,      0.1%
 TxBaseCost                                                                 ,          50000,      0.1%
 TxPayloadCost                                                              ,       37194400,     40.3%

--- a/radix-engine-tests/assets/cost_mint_small_size_nfts_from_manifest.csv
+++ b/radix-engine-tests/assets/cost_mint_small_size_nfts_from_manifest.csv
@@ -1,9 +1,9 @@
-Total Cost (XRD)                                                           ,     0.55807993,    100.0%
-+ Execution Cost (XRD)                                                     ,     0.51310993,     91.9%
+Total Cost (XRD)                                                           ,     0.55808326,    100.0%
++ Execution Cost (XRD)                                                     ,     0.51311326,     91.9%
 + Tipping Cost (XRD)                                                       ,              0,      0.0%
 + State Expansion Cost (XRD)                                               ,        0.04497,      8.1%
 + Royalty Cost (XRD)                                                       ,              0,      0.0%
-Total Cost Units Consumed                                                  ,       51310993,    100.0%
+Total Cost Units Consumed                                                  ,       51311326,    100.0%
 AfterInvoke                                                                ,            494,      0.0%
 AllocateNodeId                                                             ,          10500,      0.0%
 BeforeInvoke                                                               ,          15408,      0.0%
@@ -42,7 +42,7 @@ RunNativeCode::get_amount_NonFungibleBucket                                ,    
 RunNativeCode::lock_fee                                                    ,          61733,      0.1%
 RunNativeCode::put_NonFungibleVault                                        ,          17297,      0.0%
 RunNativeCode::try_deposit_batch_or_abort                                  ,          63706,      0.1%
-RunWasmCode::Faucet_lock_fee                                               ,          17987,      0.0%
+RunWasmCode::Faucet_lock_fee                                               ,          18320,      0.0%
 SetSubstate                                                                ,         105248,      0.2%
 TxBaseCost                                                                 ,          50000,      0.1%
 TxPayloadCost                                                              ,         153760,      0.3%

--- a/radix-engine-tests/assets/cost_publish_large_package.csv
+++ b/radix-engine-tests/assets/cost_publish_large_package.csv
@@ -1,9 +1,9 @@
-Total Cost (XRD)                                                           ,    21.83308234,    100.0%
-+ Execution Cost (XRD)                                                     ,     0.87679234,      4.0%
+Total Cost (XRD)                                                           ,    21.83308567,    100.0%
++ Execution Cost (XRD)                                                     ,     0.87679567,      4.0%
 + Tipping Cost (XRD)                                                       ,              0,      0.0%
 + State Expansion Cost (XRD)                                               ,       20.95629,     96.0%
 + Royalty Cost (XRD)                                                       ,              0,      0.0%
-Total Cost Units Consumed                                                  ,       87679234,    100.0%
+Total Cost Units Consumed                                                  ,       87679567,    100.0%
 AfterInvoke                                                                ,            274,      0.0%
 AllocateNodeId                                                             ,           7500,      0.0%
 BeforeInvoke                                                               ,        2099672,      2.4%
@@ -32,7 +32,7 @@ RunNativeCode::create_empty_vault_FungibleResourceManager                  ,    
 RunNativeCode::create_with_data                                            ,          26638,      0.0%
 RunNativeCode::lock_fee                                                    ,          61733,      0.1%
 RunNativeCode::publish_wasm_advanced                                       ,       32927576,     37.6%
-RunWasmCode::Faucet_lock_fee                                               ,          17987,      0.0%
+RunWasmCode::Faucet_lock_fee                                               ,          18320,      0.0%
 TxBaseCost                                                                 ,          50000,      0.1%
 TxPayloadCost                                                              ,       41911800,     47.8%
 TxSignatureVerification                                                    ,              0,      0.0%

--- a/radix-engine-tests/assets/cost_radiswap.csv
+++ b/radix-engine-tests/assets/cost_radiswap.csv
@@ -1,9 +1,9 @@
-Total Cost (XRD)                                                           ,     0.08877459,    100.0%
-+ Execution Cost (XRD)                                                     ,     0.08644459,     97.4%
+Total Cost (XRD)                                                           ,     0.08879457,    100.0%
++ Execution Cost (XRD)                                                     ,     0.08646457,     97.4%
 + Tipping Cost (XRD)                                                       ,              0,      0.0%
 + State Expansion Cost (XRD)                                               ,        0.00233,      2.6%
 + Royalty Cost (XRD)                                                       ,              0,      0.0%
-Total Cost Units Consumed                                                  ,        8644459,    100.0%
+Total Cost Units Consumed                                                  ,        8646457,    100.0%
 AfterInvoke                                                                ,           1368,      0.0%
 AllocateNodeId                                                             ,          15500,      0.2%
 BeforeInvoke                                                               ,          16440,      0.2%
@@ -15,7 +15,7 @@ CreateNode                                                                 ,    
 DropNode                                                                   ,          29192,      0.3%
 EmitEvent                                                                  ,           5416,      0.1%
 LockFee                                                                    ,            500,      0.0%
-OpenSubstate                                                               ,        3713113,     43.0%
+OpenSubstate                                                               ,        3713113,     42.9%
 OpenSubstate::GlobalAccount                                                ,          16682,      0.2%
 OpenSubstate::GlobalFungibleResourceManager                                ,          27558,      0.3%
 OpenSubstate::GlobalGenericComponent                                       ,           2802,      0.0%
@@ -43,7 +43,7 @@ RunNativeCode::take_FungibleVault                                          ,    
 RunNativeCode::take_advanced_FungibleVault                                 ,          53491,      0.6%
 RunNativeCode::try_deposit_batch_or_abort                                  ,          63706,      0.7%
 RunNativeCode::withdraw                                                    ,          47564,      0.6%
-RunWasmCode::Radiswap_swap                                                 ,          97907,      1.1%
+RunWasmCode::Radiswap_swap                                                 ,          99905,      1.2%
 TxBaseCost                                                                 ,          50000,      0.6%
 TxPayloadCost                                                              ,          14120,      0.2%
 TxSignatureVerification                                                    ,           7000,      0.1%

--- a/radix-engine/src/vm/wasm/wasm_validator_config.rs
+++ b/radix-engine/src/vm/wasm/wasm_validator_config.rs
@@ -9,7 +9,6 @@ use super::InstructionWeights;
 pub struct WasmValidatorConfigV1 {
     weights: InstructionWeights,
     max_stack_size: u32,
-    call_per_local_cost: u32,
 }
 
 impl WasmValidatorConfigV1 {
@@ -17,8 +16,6 @@ impl WasmValidatorConfigV1 {
         Self {
             weights: InstructionWeights::default(),
             max_stack_size: 1024,
-            // TODO adjust the proper value
-            call_per_local_cost: 1,
         }
     }
 
@@ -612,7 +609,7 @@ impl Rules for WasmValidatorConfigV1 {
     }
 
     fn call_per_local_cost(&self) -> u32 {
-        self.call_per_local_cost
+        self.weights.call_per_local
     }
 }
 
@@ -622,6 +619,6 @@ mod tests {
 
     #[test]
     fn print_params() {
-        assert_eq!(format!("{:?}", WasmValidatorConfigV1::new()), "WasmValidatorConfigV1 { weights: InstructionWeights { version: 4, fallback: 0, i64const: 1372, i64load: 3597, i64store: 3905, select: 3434, if: 8054, br: 3529, br_if: 4706, br_table: 8198, br_table_per_entry: 29, call: 14340, call_indirect: 19936, call_per_local: 1651, local_get: 2816, local_set: 2822, local_tee: 2087, global_get: 7002, global_set: 7806, memory_size: 2555, memory_grow: 14764221, i64clz: 1509, i64ctz: 2035, i64popcnt: 1499, i64eqz: 1889, i64extendsi32: 1478, i64extendui32: 1939, i32wrapi64: 1505, i64eq: 2149, i64ne: 1628, i64lts: 1654, i64ltu: 2088, i64gts: 2205, i64gtu: 1661, i64les: 1648, i64leu: 2135, i64ges: 2226, i64geu: 1661, i64add: 1623, i64sub: 2212, i64mul: 1640, i64divs: 2678, i64divu: 1751, i64rems: 2659, i64remu: 1681, i64and: 2045, i64or: 1641, i64xor: 2196, i64shl: 1662, i64shrs: 2124, i64shru: 1646, i64rotl: 1658, i64rotr: 2062 }, max_stack_size: 1024, call_per_local_cost: 1 }")
+        assert_eq!(format!("{:?}", WasmValidatorConfigV1::new()), "WasmValidatorConfigV1 { weights: InstructionWeights { version: 4, fallback: 0, i64const: 1372, i64load: 3597, i64store: 3905, select: 3434, if: 8054, br: 3529, br_if: 4706, br_table: 8198, br_table_per_entry: 29, call: 14340, call_indirect: 19936, call_per_local: 1651, local_get: 2816, local_set: 2822, local_tee: 2087, global_get: 7002, global_set: 7806, memory_size: 2555, memory_grow: 14764221, i64clz: 1509, i64ctz: 2035, i64popcnt: 1499, i64eqz: 1889, i64extendsi32: 1478, i64extendui32: 1939, i32wrapi64: 1505, i64eq: 2149, i64ne: 1628, i64lts: 1654, i64ltu: 2088, i64gts: 2205, i64gtu: 1661, i64les: 1648, i64leu: 2135, i64ges: 2226, i64geu: 1661, i64add: 1623, i64sub: 2212, i64mul: 1640, i64divs: 2678, i64divu: 1751, i64rems: 2659, i64remu: 1681, i64and: 2045, i64or: 1641, i64xor: 2196, i64shl: 1662, i64shrs: 2124, i64shru: 1646, i64rotl: 1658, i64rotr: 2062 }, max_stack_size: 1024 }")
     }
 }


### PR DESCRIPTION
## Summary

Adjust `call_per_local_cost` calculation 

## Details

Reuse already existing `InstructionWeights.call_per_local` (the way [Substrate does](https://github.com/paritytech/substrate/blob/monthly-2023-06/frame/contracts/src/schedule.rs#L747))

## Testing
Cost metering tests were updated

