### PR TITLE
Fix bnum_integer overflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,38 @@ jobs:
           -p radix-engine-tests
         ./check_stack_usage.sh
 
+  radix-engine-release:
+    # Run tests in release variant.
+    # We are particularly interested with the flags:
+    # - debug-assertions,
+    # - overflow-checks
+    # which are false for release variant
+    name: Run Radix Engine tests (release)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [k8s-linux-runner]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.70.0
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+    - name: Add wasm target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Run tests
+      run: |
+        cargo nextest run \
+          --release \
+          --features serde \
+          -p radix-engine-common \
+          -p radix-engine-derive \
+          -p radix-engine-interface \
+          -p radix-engine \
+          -p radix-engine-tests
+        ./check_stack_usage.sh
+
   radix-engine-no-std:
     name: Run Radix Engine tests (no_std)
     runs-on: ${{ matrix.os }}

--- a/radix-engine-common/src/math/bnum_integer.rs
+++ b/radix-engine-common/src/math/bnum_integer.rs
@@ -386,7 +386,7 @@ macro_rules! op_impl_unsigned {
                     }
 
                     pub fn next_power_of_two(self) -> Self {
-                        Self(self.0.next_power_of_two())
+                        Self(self.0.checked_next_power_of_two().expect("Overflow"))
                     }
                 }
             )*

--- a/radix-engine-common/src/math/bnum_integer/bits.rs
+++ b/radix-engine-common/src/math/bnum_integer/bits.rs
@@ -203,40 +203,36 @@ macro_rules! impl_bits {
                     }
                 }
 
-                impl Shl for $t {
+                impl Shl<u32> for $t {
                     type Output = Self;
 
                     #[inline]
-                    fn shl(self, other: Self) -> Self {
-                        let shift_by = u32::try_from(other).expect("Overflow");
-                        Self(self.0.checked_shl(shift_by).expect("Overflow"))
+                    fn shl(self, other: u32) -> Self {
+                        Self(self.0.checked_shl(other).expect("Overflow"))
                     }
                 }
 
 
-                impl ShlAssign for $t {
+                impl ShlAssign<u32> for $t {
                     #[inline]
-                    fn shl_assign(&mut self, other: Self) {
-                        let shift_by = u32::try_from(other).expect("Overflow");
-                        self.0 = self.0.checked_shl(shift_by).expect("Overflow");
+                    fn shl_assign(&mut self, other: u32) {
+                        self.0 = self.0.checked_shl(other).expect("Overflow");
                     }
                 }
 
-                impl Shr for $t {
+                impl Shr<u32> for $t {
                     type Output = Self;
 
                     #[inline]
-                    fn shr(self, other: Self) -> $t {
-                        let shift_by = u32::try_from(other).expect("Overflow");
-                        Self(self.0.checked_shr(shift_by).expect("Overflow"))
+                    fn shr(self, other: u32) -> $t {
+                        Self(self.0.checked_shr(other).expect("Overflow"))
                     }
                 }
 
-                impl ShrAssign for $t {
+                impl ShrAssign<u32> for $t {
                     #[inline]
-                    fn shr_assign(&mut self, other: Self) {
-                        let shift_by = u32::try_from(other).expect("Overflow");
-                        self.0 = self.0.checked_shr(shift_by).expect("Overflow");
+                    fn shr_assign(&mut self, other: u32) {
+                        self.0 = self.0.checked_shr(other).expect("Overflow");
                     }
                 }
             }

--- a/radix-engine-common/src/math/bnum_integer/bits.rs
+++ b/radix-engine-common/src/math/bnum_integer/bits.rs
@@ -208,7 +208,8 @@ macro_rules! impl_bits {
 
                     #[inline]
                     fn shl(self, other: Self) -> Self {
-                        Self(self.0 << other.0)
+                        let shift_by = u32::try_from(other).expect("Overflow");
+                        Self(self.0.checked_shl(shift_by).expect("Overflow"))
                     }
                 }
 
@@ -216,7 +217,8 @@ macro_rules! impl_bits {
                 impl ShlAssign for $t {
                     #[inline]
                     fn shl_assign(&mut self, other: Self) {
-                        self.0 <<= other.0;
+                        let shift_by = u32::try_from(other).expect("Overflow");
+                        self.0 = self.0.checked_shl(shift_by).expect("Overflow");
                     }
                 }
 
@@ -225,14 +227,16 @@ macro_rules! impl_bits {
 
                     #[inline]
                     fn shr(self, other: Self) -> $t {
-                        Self(self.0 >> other.0)
+                        let shift_by = u32::try_from(other).expect("Overflow");
+                        Self(self.0.checked_shr(shift_by).expect("Overflow"))
                     }
                 }
 
                 impl ShrAssign for $t {
                     #[inline]
                     fn shr_assign(&mut self, other: Self) {
-                        self.0 >>= other.0;
+                        let shift_by = u32::try_from(other).expect("Overflow");
+                        self.0 = self.0.checked_shr(shift_by).expect("Overflow");
                     }
                 }
             }

--- a/radix-engine-common/src/math/bnum_integer/test_macros.rs
+++ b/radix-engine-common/src/math/bnum_integer/test_macros.rs
@@ -89,25 +89,25 @@ macro_rules! test_impl {
                 #[test]
                 #[should_panic]
                 fn  [<test_shl_overflow_$i:lower>]() {
-                    let _ = <$i>::MAX << (<$i>::try_from(<$i>::BITS).unwrap() + <$i>::one());  // panics because of overflow
+                    let _ = <$i>::MAX << (<$i>::BITS + 1);  // panics because of overflow
                 }
 
                 #[test]
                 #[should_panic]
                 fn  [<test_shr_overflow_$i:lower>]() {
-                    let _ = <$i>::MAX >> (<$i>::try_from(<$i>::BITS).unwrap() + <$i>::one());  // panics because of overflow
+                    let _ = <$i>::MAX >> (<$i>::BITS + 1);  // panics because of overflow
                 }
 
                 #[test]
                 #[should_panic]
                 fn  [<test_shl_overflow_neg_$i:lower>]() {
-                    let _ = <$i>::MIN << (<$i>::try_from(<$i>::BITS).unwrap() + <$i>::one());  // panics because of overflow
+                    let _ = <$i>::MIN << (<$i>::BITS + 1);  // panics because of overflow
                 }
 
                 #[test]
                 #[should_panic]
                 fn  [<test_shr_overflow_neg_$i:lower>]() {
-                    let _ = <$i>::MIN >> (<$i>::try_from(<$i>::BITS).unwrap() + <$i>::one());  // panics because of overflow
+                    let _ = <$i>::MIN >> (<$i>::BITS + 1);  // panics because of overflow
                 }
 
                 #[test]


### PR DESCRIPTION
## Summary
Assure `bnum_integer` will panic on overflow for `release` variant

## Testing
Below tests were failing
```
cargo nextest run --release    -p radix-engine-common 
    -E '(test(bnum) & test(overflow) & test(test_sh)) | test(test_0b10000001_next_power_of_two)'
```


