### PR TITLE
Cleanup authorized depositor badge behavior

### DIFF
--- a/radix-engine-tests/tests/account_authorized_depositors.rs
+++ b/radix-engine-tests/tests/account_authorized_depositors.rs
@@ -3,9 +3,6 @@ use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::account::*;
-use radix_engine_queries::typed_substate_layout::{
-    FungibleResourceManagerError, NonFungibleResourceManagerError,
-};
 use scrypto_unit::TestRunnerBuilder;
 use transaction::prelude::*;
 
@@ -70,6 +67,13 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -101,7 +105,7 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
         .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
-    receipt.expect_specific_failure(is_drop_non_empty_bucket_error);
+    receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
 }
 
 #[test]
@@ -116,6 +120,13 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -164,6 +175,13 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -208,6 +226,13 @@ fn authorized_depositor_can_be_removed_later() {
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -275,7 +300,7 @@ fn authorized_depositor_can_be_removed_later() {
         .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert 2
-    receipt.expect_specific_failure(is_drop_non_empty_bucket_error);
+    receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
 }
 
 #[test]
@@ -289,6 +314,13 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -322,7 +354,7 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
         .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
-    receipt.expect_specific_failure(is_drop_non_empty_bucket_error);
+    receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
 }
 
 #[test]
@@ -337,6 +369,13 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -385,6 +424,13 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -429,6 +475,13 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -479,6 +532,13 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -525,6 +585,13 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -569,6 +636,13 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
     test_runner
         .execute_manifest_ignoring_fee(
             ManifestBuilder::new()
+                .call_method(
+                    account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
@@ -619,6 +693,13 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -665,6 +746,13 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
             ManifestBuilder::new()
                 .call_method(
                     account1,
+                    ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                    AccountSetDefaultDepositRuleInput {
+                        default: DefaultDepositRule::Reject,
+                    },
+                )
+                .call_method(
+                    account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
                     AccountAddAuthorizedDepositorInput {
                         badge: badge.clone(),
@@ -698,25 +786,167 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
     receipt.expect_commit_success();
 }
 
+#[test]
+fn authorized_depositor_badge_is_ignored_when_deposit_batch_is_permitted_without_it() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (pk, _, account) = test_runner.new_account(false);
+
+    // Act
+    for method_name in [
+        ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT,
+        ACCOUNT_TRY_DEPOSIT_BATCH_OR_REFUND_IDENT,
+    ] {
+        let manifest = ManifestBuilder::new()
+            .lock_fee(FAUCET, 10)
+            .call_method(FAUCET, "free", ())
+            .call_method(
+                account,
+                method_name,
+                manifest_args!(
+                    ManifestExpression::EntireWorktop,
+                    Option::<ResourceOrNonFungible>::Some(ResourceOrNonFungible::Resource(XRD))
+                ),
+            )
+            .build();
+        let receipt =
+            test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
+
+        // Assert
+        receipt.expect_commit_success();
+    }
+}
+
+#[test]
+fn authorized_depositor_badge_is_ignored_when_deposit_is_permitted_without_it() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (pk, _, account) = test_runner.new_account(false);
+
+    // Act
+    for method_name in [
+        ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
+        ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
+    ] {
+        let manifest = ManifestBuilder::new()
+            .lock_fee(FAUCET, 10)
+            .call_method(FAUCET, "free", ())
+            .take_all_from_worktop(XRD, "bucket")
+            .with_bucket("bucket", |builder, bucket| {
+                builder.call_method(
+                    account,
+                    method_name,
+                    manifest_args!(
+                        bucket,
+                        Option::<ResourceOrNonFungible>::Some(ResourceOrNonFungible::Resource(XRD))
+                    ),
+                )
+            })
+            .build();
+        let receipt =
+            test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
+
+        // Assert
+        receipt.expect_commit_success();
+    }
+}
+
+#[test]
+fn authorized_depositor_badge_is_checked_when_deposit_cant_go_without_it() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (pk, _, account) = test_runner.new_account(false);
+
+    // Act
+    for method_name in [
+        ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
+        ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
+    ] {
+        let manifest = ManifestBuilder::new()
+            .lock_fee(FAUCET, 10)
+            .call_method(
+                account,
+                ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                AccountSetDefaultDepositRuleInput {
+                    default: DefaultDepositRule::Reject,
+                },
+            )
+            .call_method(FAUCET, "free", ())
+            .take_all_from_worktop(XRD, "bucket")
+            .with_bucket("bucket", |builder, bucket| {
+                builder.call_method(
+                    account,
+                    method_name,
+                    manifest_args!(
+                        bucket,
+                        Option::<ResourceOrNonFungible>::Some(ResourceOrNonFungible::Resource(XRD))
+                    ),
+                )
+            })
+            .build();
+        let receipt =
+            test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
+
+        // Assert
+        receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
+    }
+}
+
+#[test]
+fn authorized_depositor_badge_permits_caller_to_deposit() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (pk, _, account) = test_runner.new_account(false);
+
+    // Act
+    for method_name in [
+        ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
+        ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
+    ] {
+        let manifest = ManifestBuilder::new()
+            .lock_fee(FAUCET, 10)
+            .call_method(
+                account,
+                ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
+                AccountSetDefaultDepositRuleInput {
+                    default: DefaultDepositRule::Reject,
+                },
+            )
+            .call_method(
+                account,
+                ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
+                AccountAddAuthorizedDepositorInput {
+                    badge: ResourceOrNonFungible::Resource(XRD),
+                },
+            )
+            .create_proof_from_account_of_amount(account, XRD, 1)
+            .call_method(FAUCET, "free", ())
+            .take_all_from_worktop(XRD, "bucket")
+            .with_bucket("bucket", |builder, bucket| {
+                builder.call_method(
+                    account,
+                    method_name,
+                    manifest_args!(
+                        bucket,
+                        Option::<ResourceOrNonFungible>::Some(ResourceOrNonFungible::Resource(XRD))
+                    ),
+                )
+            })
+            .build();
+        let receipt =
+            test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
+
+        // Assert
+        receipt.expect_commit_success();
+    }
+}
+
 fn is_account_not_an_authorized_depositor_error(error: &RuntimeError) -> bool {
     matches!(
         error,
         RuntimeError::ApplicationError(ApplicationError::AccountError(
             AccountError::NotAnAuthorizedDepositor { .. }
         ))
-    )
-}
-
-fn is_drop_non_empty_bucket_error(error: &RuntimeError) -> bool {
-    matches!(
-        error,
-        RuntimeError::ApplicationError(
-            ApplicationError::FungibleResourceManagerError(
-                FungibleResourceManagerError::DropNonEmptyBucket
-            ) | ApplicationError::NonFungibleResourceManagerError(
-                NonFungibleResourceManagerError::DropNonEmptyBucket
-            )
-        )
     )
 }
 

--- a/radix-engine/src/blueprints/account/package.rs
+++ b/radix-engine/src/blueprints/account/package.rs
@@ -578,12 +578,11 @@ impl AccountNativePackage {
                     RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e))
                 })?;
 
-                let rtn = match authorized_depositor_badge {
-                    Some(badge) => {
-                        AccountBlueprint::try_authorized_deposit_or_refund(bucket, badge, api)?
-                    }
-                    None => AccountBlueprint::try_deposit_or_refund(bucket, api)?,
-                };
+                let rtn = AccountBlueprint::try_deposit_or_refund(
+                    bucket,
+                    authorized_depositor_badge,
+                    api,
+                )?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             ACCOUNT_TRY_DEPOSIT_BATCH_OR_REFUND_IDENT => {
@@ -594,12 +593,11 @@ impl AccountNativePackage {
                     RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e))
                 })?;
 
-                let rtn = match authorized_depositor_badge {
-                    Some(badge) => AccountBlueprint::try_authorized_deposit_batch_or_refund(
-                        buckets, badge, api,
-                    )?,
-                    None => AccountBlueprint::try_deposit_batch_or_refund(buckets, api)?,
-                };
+                let rtn = AccountBlueprint::try_deposit_batch_or_refund(
+                    buckets,
+                    authorized_depositor_badge,
+                    api,
+                )?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT => {
@@ -610,12 +608,11 @@ impl AccountNativePackage {
                     RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e))
                 })?;
 
-                let rtn = match authorized_depositor_badge {
-                    Some(badge) => {
-                        AccountBlueprint::try_authorized_deposit_or_abort(bucket, badge, api)?
-                    }
-                    None => AccountBlueprint::try_deposit_or_abort(bucket, api)?,
-                };
+                let rtn = AccountBlueprint::try_deposit_or_abort(
+                    bucket,
+                    authorized_depositor_badge,
+                    api,
+                )?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT => {
@@ -626,12 +623,11 @@ impl AccountNativePackage {
                     RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e))
                 })?;
 
-                let rtn = match authorized_depositor_badge {
-                    Some(badge) => AccountBlueprint::try_authorized_deposit_batch_or_abort(
-                        buckets, badge, api,
-                    )?,
-                    None => AccountBlueprint::try_deposit_batch_or_abort(buckets, api)?,
-                };
+                let rtn = AccountBlueprint::try_deposit_batch_or_abort(
+                    buckets,
+                    authorized_depositor_badge,
+                    api,
+                )?;
                 Ok(IndexedScryptoValue::from_typed(&rtn))
             }
             ACCOUNT_WITHDRAW_IDENT => {

--- a/transaction-scenarios/generated-examples/fungible_resource/005--fungible-max-div-freeze-withdraw.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/005--fungible-max-div-freeze-withdraw.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         1u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/006--fungible-max-div-freeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/006--fungible-max-div-freeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/007--fungible-max-div-freeze-burn.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/007--fungible-max-div-freeze-burn.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/008--fungible-max-div-recall-frozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/008--fungible-max-div-recall-frozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_FROM_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Decimal("1")
 ;
 CALL_METHOD

--- a/transaction-scenarios/generated-examples/fungible_resource/009--fungible-max-div-unfreeze-withdraw.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/009--fungible-max-div-unfreeze-withdraw.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         1u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/010--fungible-max-div-unfreeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/010--fungible-max-div-unfreeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/011--fungible-max-div-unfreeze-burn.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/011--fungible-max-div-unfreeze-burn.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/012--fungible-max-div-recall-unfrozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/012--fungible-max-div-recall-unfrozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_FROM_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Decimal("2")
 ;
 CALL_METHOD

--- a/transaction-scenarios/generated-examples/fungible_resource/013--fungible-max-div-freeze-withdraw-again.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/013--fungible-max-div-freeze-withdraw-again.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1trunxfphz7lhc7zjk0c5fdl3hx66zqd4ljg4nw0ywlcm70f6knx947")
+    Address("internal_vault_sim1tp2matlqjl40jwc2eaj3s28tnqn62llj3u7l38q807s4d9c4huf3ew")
     Tuple(
         1u32
     )

--- a/transaction-scenarios/generated-examples/fungible_resource/021--fungible-min-div-recall-correct-granularity.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/021--fungible-min-div-recall-correct-granularity.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_FROM_VAULT
-    Address("internal_vault_sim1tz7e7327jv8dd2ft3efhl4hp8s2uxld38295yj23dsnvzq9jdde2wn")
+    Address("internal_vault_sim1tr6st2z06l37q5kzzdd0zup2mry2k5dqa8hxggvac848y3a69clhwh")
     Decimal("2")
 ;
 CALL_METHOD

--- a/transaction-scenarios/generated-examples/fungible_resource/022--fungible-min-div-recall-wrong-granularity.rtm
+++ b/transaction-scenarios/generated-examples/fungible_resource/022--fungible-min-div-recall-wrong-granularity.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_FROM_VAULT
-    Address("internal_vault_sim1tz7e7327jv8dd2ft3efhl4hp8s2uxld38295yj23dsnvzq9jdde2wn")
+    Address("internal_vault_sim1tr6st2z06l37q5kzzdd0zup2mry2k5dqa8hxggvac848y3a69clhwh")
     Decimal("123.12321")
 ;
 CALL_METHOD

--- a/transaction-scenarios/generated-examples/non_fungible_resource/008--non-fungible-resource-freeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/008--non-fungible-resource-freeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/009--non-fungible-resource-freeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/009--non-fungible-resource-freeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 FREEZE_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/010--non-fungible-resource-recall-frozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/010--non-fungible-resource-recall-frozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_NON_FUNGIBLES_FROM_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#120#")
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/011--non-fungible-resource-unfreeze-withdraw.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/011--non-fungible-resource-unfreeze-withdraw.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Tuple(
         1u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/012--non-fungible-resource-unfreeze-deposit.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/012--non-fungible-resource-unfreeze-deposit.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Tuple(
         2u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/013--non-fungible-resource-unfreeze-burn.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/013--non-fungible-resource-unfreeze-burn.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 UNFREEZE_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Tuple(
         4u32
     )

--- a/transaction-scenarios/generated-examples/non_fungible_resource/014--non-fungible-resource-recall-unfrozen-vault.rtm
+++ b/transaction-scenarios/generated-examples/non_fungible_resource/014--non-fungible-resource-recall-unfrozen-vault.rtm
@@ -4,7 +4,7 @@ CALL_METHOD
     Decimal("5000")
 ;
 RECALL_NON_FUNGIBLES_FROM_VAULT
-    Address("internal_vault_sim1nz9ufjvfdpxd42s5adcj6ajsxmkvx0sskaxx7e4y6cp3endwadqm76")
+    Address("internal_vault_sim1nrvs5mvj7g3hph50ufuumajvd05jnw3l9ezl08jdfwccsywq7492y9")
     Array<NonFungibleLocalId>(
         NonFungibleLocalId("#130#")
     )


### PR DESCRIPTION
## Summary

This PR changes the behavior of the authorized depositor badge such that it's only checked if it's needed. If the resource deposit is permitted without the authorized depositor badge, then it happens, otherwise, we check the badge.
