### PR TITLE
Add owner role to initial bootstrapped package objects

### DIFF
--- a/radix-engine-tests/tests/system_genesis_packages.rs
+++ b/radix-engine-tests/tests/system_genesis_packages.rs
@@ -1,0 +1,80 @@
+use radix_engine::blueprints::resource::ResourceNativePackage;
+use radix_engine::errors::{RuntimeError, SystemError, SystemModuleError};
+use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
+use radix_engine::system::system_callback::SystemLockData;
+use radix_engine::system::system_modules::auth::AuthError;
+use radix_engine::types::*;
+use radix_engine::vm::{OverridePackageCode, VmInvoke};
+use radix_engine_interface::api::node_modules::auth::{
+    RoleAssignmentSetInput, ROLE_ASSIGNMENT_SET_IDENT,
+};
+use radix_engine_interface::api::{ClientApi, ObjectModuleId};
+use radix_engine_interface::blueprints::package::{
+    PackageClaimRoyaltiesInput, PackageDefinition, PACKAGE_CLAIM_ROYALTIES_IDENT, RESOURCE_CODE_ID,
+};
+use scrypto_unit::*;
+use transaction::builder::ManifestBuilder;
+
+#[test]
+fn claiming_royalties_on_native_packages_should_be_unauthorized() {
+    const BLUEPRINT_NAME: &str = "MyBlueprint";
+    const CUSTOM_PACKAGE_CODE_ID: u64 = 1024;
+
+    // Arrange
+    #[derive(Clone)]
+    struct TestInvoke;
+    impl VmInvoke for TestInvoke {
+        fn invoke<Y>(
+            &mut self,
+            export_name: &str,
+            _input: &IndexedScryptoValue,
+            api: &mut Y,
+        ) -> Result<IndexedScryptoValue, RuntimeError>
+        where
+            Y: ClientApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        {
+            match export_name {
+                "test" => {
+                    api.call_method_advanced(
+                        PACKAGE_PACKAGE.as_node_id(),
+                        ObjectModuleId::Main,
+                        false,
+                        PACKAGE_CLAIM_ROYALTIES_IDENT,
+                        scrypto_encode(&PackageClaimRoyaltiesInput {}).unwrap(),
+                    )?;
+                    Ok(IndexedScryptoValue::from_typed(&()))
+                }
+                _ => Ok(IndexedScryptoValue::from_typed(&())),
+            }
+        }
+    }
+    let mut test_runner = TestRunnerBuilder::new()
+        .with_custom_extension(OverridePackageCode::new(CUSTOM_PACKAGE_CODE_ID, TestInvoke))
+        .build();
+    let package_address = test_runner.publish_native_package(
+        CUSTOM_PACKAGE_CODE_ID,
+        PackageDefinition::new_functions_only_test_definition(
+            BLUEPRINT_NAME,
+            vec![("test", "test", false)],
+        ),
+    );
+
+    // Act
+    let receipt = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee(test_runner.faucet_component(), 500u32)
+            .call_function(package_address, BLUEPRINT_NAME, "test", manifest_args!())
+            .build(),
+        vec![],
+    );
+
+    // Assert
+    receipt.expect_specific_failure(|e| {
+        matches!(
+            e,
+            RuntimeError::SystemModuleError(SystemModuleError::AuthError(AuthError::Unauthorized(
+                ..
+            )))
+        )
+    });
+}

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -29,7 +29,9 @@ use syn::Ident;
 
 // Import and re-export substate types
 use crate::roles_template;
-use crate::system::node_modules::role_assignment::RoleAssignmentNativePackage;
+use crate::system::node_modules::role_assignment::{
+    OwnerRoleSubstate, RoleAssignmentNativePackage,
+};
 use crate::system::node_modules::royalty::RoyaltyUtil;
 use crate::system::system::{
     FieldSubstate, KeyValueEntrySubstate, SubstateMutability, SystemService,
@@ -644,6 +646,7 @@ pub fn create_bootstrap_package_partitions(
         );
     }
 
+    // Metadata
     {
         let mut metadata_partition = BTreeMap::new();
         for (key, value) in metadata.data {
@@ -663,6 +666,26 @@ pub fn create_bootstrap_package_partitions(
             );
         }
         partitions.insert(METADATA_BASE_PARTITION, metadata_partition);
+    }
+
+    // Role Assignment
+    {
+        let mut role_assignment_fields_partition = BTreeMap::new();
+
+        let owner_role_substate = FieldSubstate::new_field(OwnerRoleSubstate {
+            owner_role_entry: OwnerRoleEntry::new(AccessRule::DenyAll, OwnerRoleUpdater::None),
+        });
+        role_assignment_fields_partition.insert(
+            SubstateKey::Field(0u8),
+            IndexedScryptoValue::from_typed(&owner_role_substate),
+        );
+
+        partitions.insert(
+            ROLE_ASSIGNMENT_BASE_PARTITION
+                .at_offset(ROLE_ASSIGNMENT_FIELDS_PARTITION_OFFSET)
+                .unwrap(),
+            role_assignment_fields_partition,
+        );
     }
 
     {


### PR DESCRIPTION
## Summary
Add owner role to initial boostrapped package object so that we don't induce `SubstateFault` when calling `PackageRoyalty_claim_royalties`