### PR TITLE
Update moka version

### DIFF
--- a/assets/blueprints/Cargo.lock
+++ b/assets/blueprints/Cargo.lock
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ca9b167ed904bc89a2f64c4be5014615c26fd9c4ddd2042c6094744c7df11a"
+checksum = "b28455ac4363046076054a7e9cfbd7f168019c29dba32a625f59fc0aeffaaea4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -16,7 +16,7 @@ hex = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 bitflags = { version = "1.3" }
 lru = { version = "0.8.1", default-features = false, optional = true}
-moka = { version = "0.9.4", features = ["sync"], default-features = false, optional = true }
+moka = { version = "0.9.9", features = ["sync"], default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 perfcnt = { version = "0.8.0", optional = true }
 radix-engine-profiling = { path = "../radix-engine-profiling", optional = true, features = ["resource_tracker"] }


### PR DESCRIPTION
## Summary
The current version of moka (`0.9.4`) has a bug (https://github.com/moka-rs/moka/pull/272). Updated to version `0.9.9` which fixed bug.