### PR TITLE
Rename Bnum integer types

### DIFF
--- a/radix-engine-common/src/macros.rs
+++ b/radix-engine-common/src/macros.rs
@@ -13,13 +13,13 @@ macro_rules! dec {
             let base = $crate::math::Decimal::try_from($base).unwrap();
             if $shift >= 0 {
                 base * $crate::math::Decimal::try_from(
-                    $crate::math::BnumI192::from(10u8)
+                    $crate::math::I192::from(10u8)
                         .pow(u32::try_from($shift).expect("Shift overflow")),
                 )
                 .expect("Shift overflow")
             } else {
                 base / $crate::math::Decimal::try_from(
-                    $crate::math::BnumI192::from(10u8)
+                    $crate::math::I192::from(10u8)
                         .pow(u32::try_from(-$shift).expect("Shift overflow")),
                 )
                 .expect("Shift overflow")
@@ -54,13 +54,13 @@ macro_rules! pdec {
             let base = $crate::math::PreciseDecimal::try_from($base).unwrap();
             if $shift >= 0 {
                 base * $crate::math::PreciseDecimal::try_from(
-                    $crate::math::BnumI256::from(10u8)
+                    $crate::math::I256::from(10u8)
                         .pow(u32::try_from($shift).expect("Shift overflow")),
                 )
                 .expect("Shift overflow")
             } else {
                 base / $crate::math::PreciseDecimal::try_from(
-                    $crate::math::BnumI256::from(10u8)
+                    $crate::math::I256::from(10u8)
                         .pow(u32::try_from(-$shift).expect("Shift overflow")),
                 )
                 .expect("Shift overflow")

--- a/radix-engine-common/src/math/bnum_integer.rs
+++ b/radix-engine-common/src/math/bnum_integer.rs
@@ -120,20 +120,20 @@ macro_rules! types {
     };
 }
 types! {
-    BnumI192, BInt::<3>,
-    BnumI256, BInt::<4>,
-    BnumI320, BInt::<5>,
-    BnumI384, BInt::<6>,
-    BnumI448, BInt::<7>,
-    BnumI512, BInt::<8>,
-    BnumI768, BInt::<12>,
-    BnumU192, BUint::<3>,
-    BnumU256, BUint::<4>,
-    BnumU320, BUint::<5>,
-    BnumU384, BUint::<6>,
-    BnumU448, BUint::<7>,
-    BnumU512, BUint::<8>,
-    BnumU768, BUint::<12>
+    I192, BInt::<3>,
+    I256, BInt::<4>,
+    I320, BInt::<5>,
+    I384, BInt::<6>,
+    I448, BInt::<7>,
+    I512, BInt::<8>,
+    I768, BInt::<12>,
+    U192, BUint::<3>,
+    U256, BUint::<4>,
+    U320, BUint::<5>,
+    U384, BUint::<6>,
+    U448, BUint::<7>,
+    U512, BUint::<8>,
+    U768, BUint::<12>
 }
 
 pub trait Sqrt {
@@ -373,20 +373,20 @@ macro_rules! op_impl {
         }
     };
 }
-op_impl! { BnumI192 }
-op_impl! { BnumI256 }
-op_impl! { BnumI320 }
-op_impl! { BnumI384 }
-op_impl! { BnumI448 }
-op_impl! { BnumI512 }
-op_impl! { BnumI768 }
-op_impl! { BnumU192 }
-op_impl! { BnumU256 }
-op_impl! { BnumU320 }
-op_impl! { BnumU384 }
-op_impl! { BnumU448 }
-op_impl! { BnumU512 }
-op_impl! { BnumU768 }
+op_impl! { I192 }
+op_impl! { I256 }
+op_impl! { I320 }
+op_impl! { I384 }
+op_impl! { I448 }
+op_impl! { I512 }
+op_impl! { I768 }
+op_impl! { U192 }
+op_impl! { U256 }
+op_impl! { U320 }
+op_impl! { U384 }
+op_impl! { U448 }
+op_impl! { U512 }
+op_impl! { U768 }
 
 macro_rules! op_impl_unsigned {
     ($($t:ty),*) => {
@@ -405,13 +405,13 @@ macro_rules! op_impl_unsigned {
         }
     };
 }
-op_impl_unsigned! { BnumU192 }
-op_impl_unsigned! { BnumU256 }
-op_impl_unsigned! { BnumU320 }
-op_impl_unsigned! { BnumU384 }
-op_impl_unsigned! { BnumU448 }
-op_impl_unsigned! { BnumU512 }
-op_impl_unsigned! { BnumU768 }
+op_impl_unsigned! { U192 }
+op_impl_unsigned! { U256 }
+op_impl_unsigned! { U320 }
+op_impl_unsigned! { U384 }
+op_impl_unsigned! { U448 }
+op_impl_unsigned! { U512 }
+op_impl_unsigned! { U768 }
 
 macro_rules! op_impl_signed {
     ($($t:ty),*) => {
@@ -478,13 +478,13 @@ macro_rules! op_impl_signed {
     }
 }
 
-op_impl_signed! { BnumI192 }
-op_impl_signed! { BnumI256 }
-op_impl_signed! { BnumI320 }
-op_impl_signed! { BnumI384 }
-op_impl_signed! { BnumI448 }
-op_impl_signed! { BnumI512 }
-op_impl_signed! { BnumI768 }
+op_impl_signed! { I192 }
+op_impl_signed! { I256 }
+op_impl_signed! { I320 }
+op_impl_signed! { I384 }
+op_impl_signed! { I448 }
+op_impl_signed! { I512 }
+op_impl_signed! { I768 }
 
 macro_rules! error {
     ($($t:ident),*) => {
@@ -512,18 +512,18 @@ macro_rules! error {
     };
 }
 error! {
-    BnumI192,
-    BnumI256,
-    BnumI320,
-    BnumI384,
-    BnumI448,
-    BnumI512,
-    BnumI768,
-    BnumU192,
-    BnumU256,
-    BnumU320,
-    BnumU384,
-    BnumU448,
-    BnumU512,
-    BnumU768
+    I192,
+    I256,
+    I320,
+    I384,
+    I448,
+    I512,
+    I768,
+    U192,
+    U256,
+    U320,
+    U384,
+    U448,
+    U512,
+    U768
 }

--- a/radix-engine-common/src/math/bnum_integer/bits.rs
+++ b/radix-engine-common/src/math/bnum_integer/bits.rs
@@ -239,17 +239,17 @@ macro_rules! impl_bits {
         )*
     }
 }
-impl_bits! { BnumI192, BInt::<3> }
-impl_bits! { BnumI256, BInt::<4> }
-impl_bits! { BnumI320, BInt::<5> }
-impl_bits! { BnumI384, BInt::<6> }
-impl_bits! { BnumI448, BInt::<7> }
-impl_bits! { BnumI512, BInt::<8> }
-impl_bits! { BnumI768, BInt::<12> }
-impl_bits! { BnumU192, BUint::<3> }
-impl_bits! { BnumU256, BUint::<4> }
-impl_bits! { BnumU320, BUint::<5> }
-impl_bits! { BnumU384, BUint::<6> }
-impl_bits! { BnumU448, BUint::<7> }
-impl_bits! { BnumU512, BUint::<8> }
-impl_bits! { BnumU768, BUint::<12> }
+impl_bits! { I192, BInt::<3> }
+impl_bits! { I256, BInt::<4> }
+impl_bits! { I320, BInt::<5> }
+impl_bits! { I384, BInt::<6> }
+impl_bits! { I448, BInt::<7> }
+impl_bits! { I512, BInt::<8> }
+impl_bits! { I768, BInt::<12> }
+impl_bits! { U192, BUint::<3> }
+impl_bits! { U256, BUint::<4> }
+impl_bits! { U320, BUint::<5> }
+impl_bits! { U384, BUint::<6> }
+impl_bits! { U448, BUint::<7> }
+impl_bits! { U512, BUint::<8> }
+impl_bits! { U768, BUint::<12> }

--- a/radix-engine-common/src/math/bnum_integer/convert.rs
+++ b/radix-engine-common/src/math/bnum_integer/convert.rs
@@ -36,34 +36,34 @@ macro_rules! impl_to_primitive {
         }
     }
 }
-impl_from_primitive! { BnumI192, BInt::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI256, BInt::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI320, BInt::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI384, BInt::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI448, BInt::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI512, BInt::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumI768, BInt::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU192, BUint::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU256, BUint::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU320, BUint::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU384, BUint::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU448, BUint::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU512, BUint::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_from_primitive! { BnumU768, BUint::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI192, BInt::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI256, BInt::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI320, BInt::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI384, BInt::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI448, BInt::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI512, BInt::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumI768, BInt::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU192, BUint::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU256, BUint::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU320, BUint::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU384, BUint::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU448, BUint::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU512, BUint::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
-impl_to_primitive! { BnumU768, BUint::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I192, BInt::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I256, BInt::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I320, BInt::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I384, BInt::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I448, BInt::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I512, BInt::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { I768, BInt::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U192, BUint::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U256, BUint::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U320, BUint::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U384, BUint::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U448, BUint::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U512, BUint::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_from_primitive! { U768, BUint::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I192, BInt::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I256, BInt::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I320, BInt::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I384, BInt::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I448, BInt::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I512, BInt::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { I768, BInt::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U192, BUint::<3>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U256, BUint::<4>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U320, BUint::<5>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U384, BUint::<6>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U448, BUint::<7>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U512, BUint::<8>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
+impl_to_primitive! { U768, BUint::<12>, (u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize) }
 
 macro_rules! impl_from_builtin{
     ($t:ident, $wrapped:ty, ($($o:ident),*)) => {
@@ -122,43 +122,43 @@ macro_rules! impl_to_builtin{
     };
 }
 
-impl_from_builtin! { BnumI192, BInt::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI320, BInt::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI448, BInt::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumI768, BInt::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU192, BUint::<3>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU256, BUint::<4>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU320, BUint::<5>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU384, BUint::<6>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU448, BUint::<7>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU512, BUint::<8>, (u8, u16, u32, u64, u128, usize)}
-impl_from_builtin! { BnumU768, BUint::<12>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I192, BInt::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I320, BInt::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I448, BInt::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { I768, BInt::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U192, BUint::<3>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U256, BUint::<4>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U320, BUint::<5>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U384, BUint::<6>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U448, BUint::<7>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U512, BUint::<8>, (u8, u16, u32, u64, u128, usize)}
+impl_from_builtin! { U768, BUint::<12>, (u8, u16, u32, u64, u128, usize)}
 
-impl_try_from_builtin! { BnumU192, BUint::<3>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU256, BUint::<4>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU320, BUint::<5>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU384, BUint::<6>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU448, BUint::<7>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU512, BUint::<8>, (i8, i16, i32, i64, i128, isize)}
-impl_try_from_builtin! { BnumU768, BUint::<12>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U192, BUint::<3>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U256, BUint::<4>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U320, BUint::<5>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U384, BUint::<6>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U448, BUint::<7>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U512, BUint::<8>, (i8, i16, i32, i64, i128, isize)}
+impl_try_from_builtin! { U768, BUint::<12>, (i8, i16, i32, i64, i128, isize)}
 
-impl_to_builtin! { BnumI192, BInt::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI320, BInt::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI448, BInt::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumI768, BInt::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU192, BUint::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU256, BUint::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU320, BUint::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU384, BUint::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU448, BUint::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU512, BUint::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
-impl_to_builtin! { BnumU768, BUint::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I192, BInt::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I256, BInt::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I320, BInt::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I384, BInt::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I448, BInt::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I512, BInt::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { I768, BInt::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U192, BUint::<3>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U256, BUint::<4>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U320, BUint::<5>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U384, BUint::<6>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U448, BUint::<7>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U512, BUint::<8>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
+impl_to_builtin! { U768, BUint::<12>, (i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize)}
 
 macro_rules! impl_try_from_bigint {
     ($($t:ident, $wrapped:ty),*) => {
@@ -194,34 +194,34 @@ macro_rules! impl_to_bigint {
         }
     };
 }
-impl_try_from_bigint! { BnumI192, BInt::<3>  }
-impl_try_from_bigint! { BnumI256, BInt::<4>  }
-impl_try_from_bigint! { BnumI320, BInt::<5>  }
-impl_try_from_bigint! { BnumI384, BInt::<6>  }
-impl_try_from_bigint! { BnumI448, BInt::<7>  }
-impl_try_from_bigint! { BnumI512, BInt::<8>  }
-impl_try_from_bigint! { BnumI768, BInt::<12> }
-impl_try_from_bigint! { BnumU192, BUint::<3> }
-impl_try_from_bigint! { BnumU256, BUint::<4> }
-impl_try_from_bigint! { BnumU320, BUint::<5> }
-impl_try_from_bigint! { BnumU384, BUint::<6> }
-impl_try_from_bigint! { BnumU448, BUint::<7> }
-impl_try_from_bigint! { BnumU512, BUint::<8> }
-impl_try_from_bigint! { BnumU768, BUint::<12> }
-impl_to_bigint! { BnumI192, BInt::<3> }
-impl_to_bigint! { BnumI256, BInt::<4> }
-impl_to_bigint! { BnumI320, BInt::<5> }
-impl_to_bigint! { BnumI384, BInt::<6> }
-impl_to_bigint! { BnumI448, BInt::<7> }
-impl_to_bigint! { BnumI512, BInt::<8> }
-impl_to_bigint! { BnumI768, BInt::<12> }
-impl_to_bigint! { BnumU192, BUint::<3> }
-impl_to_bigint! { BnumU256, BUint::<4> }
-impl_to_bigint! { BnumU320, BUint::<5> }
-impl_to_bigint! { BnumU384, BUint::<6> }
-impl_to_bigint! { BnumU448, BUint::<7> }
-impl_to_bigint! { BnumU512, BUint::<8> }
-impl_to_bigint! { BnumU768, BUint::<12> }
+impl_try_from_bigint! { I192, BInt::<3>  }
+impl_try_from_bigint! { I256, BInt::<4>  }
+impl_try_from_bigint! { I320, BInt::<5>  }
+impl_try_from_bigint! { I384, BInt::<6>  }
+impl_try_from_bigint! { I448, BInt::<7>  }
+impl_try_from_bigint! { I512, BInt::<8>  }
+impl_try_from_bigint! { I768, BInt::<12> }
+impl_try_from_bigint! { U192, BUint::<3> }
+impl_try_from_bigint! { U256, BUint::<4> }
+impl_try_from_bigint! { U320, BUint::<5> }
+impl_try_from_bigint! { U384, BUint::<6> }
+impl_try_from_bigint! { U448, BUint::<7> }
+impl_try_from_bigint! { U512, BUint::<8> }
+impl_try_from_bigint! { U768, BUint::<12> }
+impl_to_bigint! { I192, BInt::<3> }
+impl_to_bigint! { I256, BInt::<4> }
+impl_to_bigint! { I320, BInt::<5> }
+impl_to_bigint! { I384, BInt::<6> }
+impl_to_bigint! { I448, BInt::<7> }
+impl_to_bigint! { I512, BInt::<8> }
+impl_to_bigint! { I768, BInt::<12> }
+impl_to_bigint! { U192, BUint::<3> }
+impl_to_bigint! { U256, BUint::<4> }
+impl_to_bigint! { U320, BUint::<5> }
+impl_to_bigint! { U384, BUint::<6> }
+impl_to_bigint! { U448, BUint::<7> }
+impl_to_bigint! { U512, BUint::<8> }
+impl_to_bigint! { U768, BUint::<12> }
 
 macro_rules! impl_from_string {
     ($($t:ident, $wrapped:ty),*) => {
@@ -241,20 +241,20 @@ macro_rules! impl_from_string {
     };
 }
 
-impl_from_string! { BnumI192, BInt::<3> }
-impl_from_string! { BnumI256, BInt::<4> }
-impl_from_string! { BnumI320, BInt::<5> }
-impl_from_string! { BnumI384, BInt::<6> }
-impl_from_string! { BnumI448, BInt::<7> }
-impl_from_string! { BnumI512, BInt::<8> }
-impl_from_string! { BnumI768, BInt::<12> }
-impl_from_string! { BnumU192, BUint::<3> }
-impl_from_string! { BnumU256, BUint::<4> }
-impl_from_string! { BnumU320, BUint::<5> }
-impl_from_string! { BnumU384, BUint::<6> }
-impl_from_string! { BnumU448, BUint::<7> }
-impl_from_string! { BnumU512, BUint::<8> }
-impl_from_string! { BnumU768, BUint::<12> }
+impl_from_string! { I192, BInt::<3> }
+impl_from_string! { I256, BInt::<4> }
+impl_from_string! { I320, BInt::<5> }
+impl_from_string! { I384, BInt::<6> }
+impl_from_string! { I448, BInt::<7> }
+impl_from_string! { I512, BInt::<8> }
+impl_from_string! { I768, BInt::<12> }
+impl_from_string! { U192, BUint::<3> }
+impl_from_string! { U256, BUint::<4> }
+impl_from_string! { U320, BUint::<5> }
+impl_from_string! { U384, BUint::<6> }
+impl_from_string! { U448, BUint::<7> }
+impl_from_string! { U512, BUint::<8> }
+impl_from_string! { U768, BUint::<12> }
 
 macro_rules! impl_try_from_bnum {
     ($t:ident, $wrapped:ty, ($($into:ident, $into_wrap:ty),*)) => {
@@ -327,303 +327,303 @@ macro_rules! impl_from_bnum {
 }
 
 impl_try_from_bnum! {
-    BnumI192, BInt::<3>, (
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I192, BInt::<3>, (
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI192, BInt::<3>, (
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>
+    I192, BInt::<3>, (
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI256, BInt::<4>, (
-        BnumI192, BInt::<3>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I256, BInt::<4>, (
+        I192, BInt::<3>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI256, BInt::<4>, (
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>
+    I256, BInt::<4>, (
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI320, BInt::<5>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I320, BInt::<5>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI320, BInt::<5>, (
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>
+    I320, BInt::<5>, (
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI384, BInt::<6>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I384, BInt::<6>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI384, BInt::<6>, (
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>
+    I384, BInt::<6>, (
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI448, BInt::<7>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I448, BInt::<7>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI448, BInt::<7>, (
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>
+    I448, BInt::<7>, (
+        I512, BInt::<8>,
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI512, BInt::<8>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I512, BInt::<8>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 impl_from_bnum! {
-    BnumI512, BInt::<8>, (
-        BnumI768, BInt::<12>
+    I512, BInt::<8>, (
+        I768, BInt::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumI768, BInt::<12>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    I768, BInt::<12>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 // must fit 0 - MAX
 impl_try_from_bnum! {
-    BnumU192, BUint::<3>, (
-        BnumI192, BInt::<3>
+    U192, BUint::<3>, (
+        I192, BInt::<3>
     )
 }
 impl_from_bnum! {
-    BnumU192, BUint::<3>, (
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    U192, BUint::<3>, (
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU256, BUint::<4>, (
-        BnumI192, BInt::<3>,
-        BnumU192, BUint::<3>,
-        BnumI256, BInt::<4>
+    U256, BUint::<4>, (
+        I192, BInt::<3>,
+        U192, BUint::<3>,
+        I256, BInt::<4>
     )
 }
 impl_from_bnum! {
-    BnumU256, BUint::<4>, (
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    U256, BUint::<4>, (
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU320, BUint::<5>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>
+    U320, BUint::<5>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        U192, BUint::<3>,
+        U256, BUint::<4>
     )
 }
 impl_from_bnum! {
-    BnumU320, BUint::<5>, (
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    U320, BUint::<5>, (
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU384, BUint::<6>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>
+    U384, BUint::<6>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>
     )
 }
 impl_from_bnum! {
-    BnumU384, BUint::<6>, (
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    U384, BUint::<6>, (
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U448, BUint::<7>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU448, BUint::<7>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>
+    U448, BUint::<7>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>
     )
 }
 impl_from_bnum! {
-    BnumU448, BUint::<7>, (
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU512, BUint::<8>,
-        BnumU768, BUint::<12>
+    U448, BUint::<7>, (
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U512, BUint::<8>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU512, BUint::<8>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>
+    U512, BUint::<8>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>
     )
 }
 impl_from_bnum! {
-    BnumU512, BUint::<8>, (
-        BnumI768, BInt::<12>,
-        BnumU768, BUint::<12>
+    U512, BUint::<8>, (
+        I768, BInt::<12>,
+        U768, BUint::<12>
     )
 }
 
 impl_try_from_bnum! {
-    BnumU768, BUint::<12>, (
-        BnumI192, BInt::<3>,
-        BnumI256, BInt::<4>,
-        BnumI320, BInt::<5>,
-        BnumI384, BInt::<6>,
-        BnumI448, BInt::<7>,
-        BnumI512, BInt::<8>,
-        BnumI768, BInt::<12>,
-        BnumU192, BUint::<3>,
-        BnumU256, BUint::<4>,
-        BnumU320, BUint::<5>,
-        BnumU384, BUint::<6>,
-        BnumU448, BUint::<7>,
-        BnumU512, BUint::<8>
+    U768, BUint::<12>, (
+        I192, BInt::<3>,
+        I256, BInt::<4>,
+        I320, BInt::<5>,
+        I384, BInt::<6>,
+        I448, BInt::<7>,
+        I512, BInt::<8>,
+        I768, BInt::<12>,
+        U192, BUint::<3>,
+        U256, BUint::<4>,
+        U320, BUint::<5>,
+        U384, BUint::<6>,
+        U448, BUint::<7>,
+        U512, BUint::<8>
     )
 }
 
@@ -693,34 +693,34 @@ macro_rules! impl_to_bytes {
     };
 }
 
-impl_from_bytes! { BnumI192, BInt::<3> }
-impl_from_bytes! { BnumI256, BInt::<4> }
-impl_from_bytes! { BnumI320, BInt::<5> }
-impl_from_bytes! { BnumI384, BInt::<6> }
-impl_from_bytes! { BnumI448, BInt::<7> }
-impl_from_bytes! { BnumI512, BInt::<8> }
-impl_from_bytes! { BnumI768, BInt::<12> }
-impl_from_bytes! { BnumU192, BUint::<3> }
-impl_from_bytes! { BnumU256, BUint::<4> }
-impl_from_bytes! { BnumU320, BUint::<5> }
-impl_from_bytes! { BnumU384, BUint::<6> }
-impl_from_bytes! { BnumU448, BUint::<7> }
-impl_from_bytes! { BnumU512, BUint::<8> }
-impl_from_bytes! { BnumU768, BUint::<12> }
-impl_to_bytes! { BnumI192, BInt::<3> }
-impl_to_bytes! { BnumI256, BInt::<4> }
-impl_to_bytes! { BnumI320, BInt::<5> }
-impl_to_bytes! { BnumI384, BInt::<6> }
-impl_to_bytes! { BnumI448, BInt::<7> }
-impl_to_bytes! { BnumI512, BInt::<8> }
-impl_to_bytes! { BnumI768, BInt::<12> }
-impl_to_bytes! { BnumU192, BUint::<3> }
-impl_to_bytes! { BnumU256, BUint::<4> }
-impl_to_bytes! { BnumU320, BUint::<5> }
-impl_to_bytes! { BnumU384, BUint::<6> }
-impl_to_bytes! { BnumU448, BUint::<7> }
-impl_to_bytes! { BnumU512, BUint::<8> }
-impl_to_bytes! { BnumU768, BUint::<12> }
+impl_from_bytes! { I192, BInt::<3> }
+impl_from_bytes! { I256, BInt::<4> }
+impl_from_bytes! { I320, BInt::<5> }
+impl_from_bytes! { I384, BInt::<6> }
+impl_from_bytes! { I448, BInt::<7> }
+impl_from_bytes! { I512, BInt::<8> }
+impl_from_bytes! { I768, BInt::<12> }
+impl_from_bytes! { U192, BUint::<3> }
+impl_from_bytes! { U256, BUint::<4> }
+impl_from_bytes! { U320, BUint::<5> }
+impl_from_bytes! { U384, BUint::<6> }
+impl_from_bytes! { U448, BUint::<7> }
+impl_from_bytes! { U512, BUint::<8> }
+impl_from_bytes! { U768, BUint::<12> }
+impl_to_bytes! { I192, BInt::<3> }
+impl_to_bytes! { I256, BInt::<4> }
+impl_to_bytes! { I320, BInt::<5> }
+impl_to_bytes! { I384, BInt::<6> }
+impl_to_bytes! { I448, BInt::<7> }
+impl_to_bytes! { I512, BInt::<8> }
+impl_to_bytes! { I768, BInt::<12> }
+impl_to_bytes! { U192, BUint::<3> }
+impl_to_bytes! { U256, BUint::<4> }
+impl_to_bytes! { U320, BUint::<5> }
+impl_to_bytes! { U384, BUint::<6> }
+impl_to_bytes! { U448, BUint::<7> }
+impl_to_bytes! { U512, BUint::<8> }
+impl_to_bytes! { U768, BUint::<12> }
 
 macro_rules! impl_from_u64_arr_signed {
     ($($t:ident, $wrapped:ty),*) => {
@@ -753,18 +753,18 @@ macro_rules! from_u64_arr_unsigned {
     };
 }
 
-impl_from_u64_arr_signed! { BnumI192, BInt::<3> }
-impl_from_u64_arr_signed! { BnumI256, BInt::<4> }
-impl_from_u64_arr_signed! { BnumI320, BInt::<5> }
-impl_from_u64_arr_signed! { BnumI384, BInt::<6> }
-impl_from_u64_arr_signed! { BnumI448, BInt::<7> }
-impl_from_u64_arr_signed! { BnumI512, BInt::<8> }
-impl_from_u64_arr_signed! { BnumI768, BInt::<12> }
+impl_from_u64_arr_signed! { I192, BInt::<3> }
+impl_from_u64_arr_signed! { I256, BInt::<4> }
+impl_from_u64_arr_signed! { I320, BInt::<5> }
+impl_from_u64_arr_signed! { I384, BInt::<6> }
+impl_from_u64_arr_signed! { I448, BInt::<7> }
+impl_from_u64_arr_signed! { I512, BInt::<8> }
+impl_from_u64_arr_signed! { I768, BInt::<12> }
 
-from_u64_arr_unsigned! { BnumU192, BUint::<3> }
-from_u64_arr_unsigned! { BnumU256, BUint::<4> }
-from_u64_arr_unsigned! { BnumU320, BUint::<5> }
-from_u64_arr_unsigned! { BnumU384, BUint::<6> }
-from_u64_arr_unsigned! { BnumU448, BUint::<7> }
-from_u64_arr_unsigned! { BnumU512, BUint::<8> }
-from_u64_arr_unsigned! { BnumU768, BUint::<12> }
+from_u64_arr_unsigned! { U192, BUint::<3> }
+from_u64_arr_unsigned! { U256, BUint::<4> }
+from_u64_arr_unsigned! { U320, BUint::<5> }
+from_u64_arr_unsigned! { U384, BUint::<6> }
+from_u64_arr_unsigned! { U448, BUint::<7> }
+from_u64_arr_unsigned! { U512, BUint::<8> }
+from_u64_arr_unsigned! { U768, BUint::<12> }

--- a/radix-engine-common/src/math/bnum_integer/test.rs
+++ b/radix-engine-common/src/math/bnum_integer/test.rs
@@ -7,63 +7,63 @@ use num_bigint::{BigInt, Sign};
 
 use radix_engine_common::*;
 
-test_impl! {BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768}
-test_impl! {BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768}
+test_impl! {I192, I256, I320, I384, I448, I512, I768}
+test_impl! {U192, U256, U320, U384, U448, U512, U768}
 
 test_add_all! {
-    (BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768,
-     BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768),
-    (BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768,
-     BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768)
+    (I192, I256, I320, I384, I448, I512, I768,
+     U192, U256, U320, U384, U448, U512, U768),
+    (I192, I256, I320, I384, I448, I512, I768,
+     U192, U256, U320, U384, U448, U512, U768)
 }
 
-test_signed! { BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768 }
-test_unsigned! { BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768 }
+test_signed! { I192, I256, I320, I384, I448, I512, I768 }
+test_unsigned! { U192, U256, U320, U384, U448, U512, U768 }
 
-test_from_all_types_safe_builtin! {BnumI192, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI192, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I192, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I192, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI256, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI256, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I256, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I256, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI320, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI320, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I320, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I320, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI384, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI384, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I384, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I384, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI448, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI448, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I448, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I448, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI512, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI512, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I512, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I512, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumI768, (i8, i16, i32, i64, i128)}
-test_from_all_types_safe_builtin! {BnumI768, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {I768, (i8, i16, i32, i64, i128)}
+test_from_all_types_safe_builtin! {I768, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_builtin! {BnumU192, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU256, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU320, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU384, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU448, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU512, (u8, u16, u32, u64, u128)}
-test_from_all_types_safe_builtin! {BnumU768, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U192, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U256, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U320, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U384, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U448, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U512, (u8, u16, u32, u64, u128)}
+test_from_all_types_safe_builtin! {U768, (u8, u16, u32, u64, u128)}
 
-test_from_all_types_safe_safe! {BnumI192, (BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768)}
-test_from_all_types_safe_safe! {BnumI256, (BnumI192, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768)}
-test_from_all_types_safe_safe! {BnumI320, (BnumI192, BnumI256, BnumI384, BnumI448, BnumI512, BnumI768)}
-test_from_all_types_safe_safe! {BnumI384, (BnumI192, BnumI256, BnumI320, BnumI448, BnumI512, BnumI768)}
-test_from_all_types_safe_safe! {BnumI448, (BnumI192, BnumI256, BnumI320, BnumI384, BnumI512, BnumI768)}
-test_from_all_types_safe_safe! {BnumI512, (BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI768)}
-test_from_all_types_safe_safe! {BnumI768, (BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512)}
+test_from_all_types_safe_safe! {I192, (I256, I320, I384, I448, I512, I768)}
+test_from_all_types_safe_safe! {I256, (I192, I320, I384, I448, I512, I768)}
+test_from_all_types_safe_safe! {I320, (I192, I256, I384, I448, I512, I768)}
+test_from_all_types_safe_safe! {I384, (I192, I256, I320, I448, I512, I768)}
+test_from_all_types_safe_safe! {I448, (I192, I256, I320, I384, I512, I768)}
+test_from_all_types_safe_safe! {I512, (I192, I256, I320, I384, I448, I768)}
+test_from_all_types_safe_safe! {I768, (I192, I256, I320, I384, I448, I512)}
 
-test_from_all_types_safe_safe! {BnumU192, (BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768)}
-test_from_all_types_safe_safe! {BnumU256, (BnumU192, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768)}
-test_from_all_types_safe_safe! {BnumU320, (BnumU192, BnumU256, BnumU384, BnumU448, BnumU512, BnumU768)}
-test_from_all_types_safe_safe! {BnumU384, (BnumU192, BnumU256, BnumU320, BnumU448, BnumU512, BnumU768)}
-test_from_all_types_safe_safe! {BnumU448, (BnumU192, BnumU256, BnumU320, BnumU384, BnumU512, BnumU768)}
-test_from_all_types_safe_safe! {BnumU512, (BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU768)}
-test_from_all_types_safe_safe! {BnumU768, (BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512)}
+test_from_all_types_safe_safe! {U192, (U256, U320, U384, U448, U512, U768)}
+test_from_all_types_safe_safe! {U256, (U192, U320, U384, U448, U512, U768)}
+test_from_all_types_safe_safe! {U320, (U192, U256, U384, U448, U512, U768)}
+test_from_all_types_safe_safe! {U384, (U192, U256, U320, U448, U512, U768)}
+test_from_all_types_safe_safe! {U448, (U192, U256, U320, U384, U512, U768)}
+test_from_all_types_safe_safe! {U512, (U192, U256, U320, U384, U448, U768)}
+test_from_all_types_safe_safe! {U768, (U192, U256, U320, U384, U448, U512)}
 
 #[cfg(test)]
 macro_rules! assert_int_size {
@@ -77,20 +77,20 @@ macro_rules! assert_int_size {
 #[test]
 fn test_int_size() {
     assert_int_size! {
-        192 BnumI192,
-        256 BnumI256,
-        320 BnumI320,
-        384 BnumI384,
-        448 BnumI448,
-        512 BnumI512,
-        768 BnumI768,
-        192 BnumU192,
-        256 BnumU256,
-        320 BnumU320,
-        384 BnumU384,
-        448 BnumU448,
-        512 BnumU512,
-        768 BnumU768
+        192 I192,
+        256 I256,
+        320 I320,
+        384 I384,
+        448 I448,
+        512 I512,
+        768 I768,
+        192 U192,
+        256 U256,
+        320 U320,
+        384 U384,
+        448 U448,
+        512 U512,
+        768 U768
     }
 }
 
@@ -290,9 +290,9 @@ macro_rules! test_bnums {
 }
 
 #[cfg(test)]
-test_bnums! { BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768 }
+test_bnums! { I192, I256, I320, I384, I448, I512, I768 }
 #[cfg(test)]
-test_bnums! { BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768 }
+test_bnums! { U192, U256, U320, U384, U448, U512, U768 }
 
 #[cfg(test)]
 macro_rules! test_bnums_signed {
@@ -311,14 +311,14 @@ macro_rules! test_bnums_signed {
     }
 }
 #[cfg(test)]
-test_bnums_signed! { BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768 }
+test_bnums_signed! { I192, I256, I320, I384, I448, I512, I768 }
 
 #[test]
 #[should_panic(expected = "Err")]
 fn test_string_to_bnum_panic_2() {
     assert_eq!(
-        BnumI256::MAX,
-        BnumI256::from_str(
+        I256::MAX,
+        I256::from_str(
             "578960446186580977117854925043439539266349923328202820197287920039565648199670"
         )
         .unwrap()
@@ -377,88 +377,88 @@ macro_rules! test_to_from_bigint {
         }
     }
 }
-test_to_from_bigint! { BnumI192, BnumI256, BnumI320, BnumI384, BnumI448, BnumI512, BnumI768 }
-test_to_from_bigint! { BnumU192, BnumU256, BnumU320, BnumU384, BnumU448, BnumU512, BnumU768 }
+test_to_from_bigint! { I192, I256, I320, I384, I448, I512, I768 }
+test_to_from_bigint! { U192, U256, U320, U384, U448, U512, U768 }
 
 #[test]
 fn test_bnum_to_bnum() {
-    let a = BnumI192::from(1);
-    let b = BnumU192::try_from(a).unwrap();
-    assert_eq!(b, BnumU192::ONE);
+    let a = I192::from(1);
+    let b = U192::try_from(a).unwrap();
+    assert_eq!(b, U192::ONE);
 
-    let a = BnumI256::from(1);
-    let b = BnumU256::try_from(a).unwrap();
-    assert_eq!(b, BnumU256::ONE);
+    let a = I256::from(1);
+    let b = U256::try_from(a).unwrap();
+    assert_eq!(b, U256::ONE);
 
-    let a = BnumI256::from(-123);
-    let b = BnumI512::from(a);
+    let a = I256::from(-123);
+    let b = I512::from(a);
     assert_eq!(a.to_string(), b.to_string());
 
-    let a = BnumI256::MAX;
-    let b = BnumU256::try_from(a).unwrap();
+    let a = I256::MAX;
+    let b = U256::try_from(a).unwrap();
     assert_eq!(a.to_string(), b.to_string());
 
-    let a = BnumI256::MIN;
-    let b = BnumI512::from(a);
+    let a = I256::MIN;
+    let b = I512::from(a);
     assert_eq!(a.to_string(), b.to_string());
 
-    let a = BnumU256::MAX;
-    let b = BnumI512::from(a);
+    let a = U256::MAX;
+    let b = I512::from(a);
     assert_eq!(a.to_string(), b.to_string());
 
-    let a = BnumU256::MAX;
-    let b = BnumI384::from(a);
+    let a = U256::MAX;
+    let b = I384::from(a);
     assert_eq!(a.to_string(), b.to_string());
 }
 
 #[test]
 fn test_bnum_to_bnum_errors() {
-    let i512 = BnumI512::MIN;
-    let err = BnumI192::try_from(i512).unwrap_err();
-    assert_eq!(err, ParseBnumI192Error::Overflow);
+    let i512 = I512::MIN;
+    let err = I192::try_from(i512).unwrap_err();
+    assert_eq!(err, ParseI192Error::Overflow);
 
-    let i512 = BnumI512::MIN;
-    let err = BnumI256::try_from(i512).unwrap_err();
-    assert_eq!(err, ParseBnumI256Error::Overflow);
+    let i512 = I512::MIN;
+    let err = I256::try_from(i512).unwrap_err();
+    assert_eq!(err, ParseI256Error::Overflow);
 
     // I256::MAX + 1
-    let i256_str = BnumI256::MAX.to_string();
-    let i512 = BnumI512::from_str(&i256_str).unwrap() + BnumI512::ONE;
-    let err = BnumI256::try_from(i512).unwrap_err();
-    assert_eq!(err, ParseBnumI256Error::Overflow);
+    let i256_str = I256::MAX.to_string();
+    let i512 = I512::from_str(&i256_str).unwrap() + I512::ONE;
+    let err = I256::try_from(i512).unwrap_err();
+    assert_eq!(err, ParseI256Error::Overflow);
 
     // I256::MIN - 1
-    let i256_str = BnumI256::MIN.to_string();
-    let i512 = BnumI512::from_str(&i256_str).unwrap() - BnumI512::ONE;
-    let err = BnumI256::try_from(i512).unwrap_err();
-    assert_eq!(err, ParseBnumI256Error::Overflow);
+    let i256_str = I256::MIN.to_string();
+    let i512 = I512::from_str(&i256_str).unwrap() - I512::ONE;
+    let err = I256::try_from(i512).unwrap_err();
+    assert_eq!(err, ParseI256Error::Overflow);
 
-    let u256 = BnumU256::MAX;
-    let err = BnumI256::try_from(u256).unwrap_err();
-    assert_eq!(err, ParseBnumI256Error::Overflow);
+    let u256 = U256::MAX;
+    let err = I256::try_from(u256).unwrap_err();
+    assert_eq!(err, ParseI256Error::Overflow);
 
-    let i512_str = BnumI512::MAX.to_string();
-    let u512 = BnumU512::from_str(&i512_str).unwrap() + BnumU512::ONE;
-    let err = BnumU256::try_from(u512).unwrap_err();
-    assert_eq!(err, ParseBnumU256Error::Overflow);
+    let i512_str = I512::MAX.to_string();
+    let u512 = U512::from_str(&i512_str).unwrap() + U512::ONE;
+    let err = U256::try_from(u512).unwrap_err();
+    assert_eq!(err, ParseU256Error::Overflow);
 
-    let u512 = BnumU512::MAX;
-    let err = BnumI256::try_from(u512).unwrap_err();
-    assert_eq!(err, ParseBnumI256Error::Overflow);
+    let u512 = U512::MAX;
+    let err = I256::try_from(u512).unwrap_err();
+    assert_eq!(err, ParseI256Error::Overflow);
 
-    let a = BnumU256::MAX;
-    let b = BnumI256::try_from(a).unwrap_err();
-    assert_eq!(b, ParseBnumI256Error::Overflow);
+    let a = U256::MAX;
+    let b = I256::try_from(a).unwrap_err();
+    assert_eq!(b, ParseI256Error::Overflow);
 
-    let i512 = -BnumI512::ONE;
-    let err = BnumU256::try_from(i512).unwrap_err();
-    assert_eq!(err, ParseBnumU256Error::NegativeToUnsigned);
+    let i512 = -I512::ONE;
+    let err = U256::try_from(i512).unwrap_err();
+    assert_eq!(err, ParseU256Error::NegativeToUnsigned);
 
-    let i256 = BnumI256::from(-123);
-    let err = BnumU512::try_from(i256).unwrap_err();
-    assert_eq!(err, ParseBnumU512Error::NegativeToUnsigned);
+    let i256 = I256::from(-123);
+    let err = U512::try_from(i256).unwrap_err();
+    assert_eq!(err, ParseU512Error::NegativeToUnsigned);
 
-    let i384 = BnumI384::MAX;
-    let err = BnumU256::try_from(i384).unwrap_err();
-    assert_eq!(err, ParseBnumU256Error::Overflow);
+    let i384 = I384::MAX;
+    let err = U256::try_from(i384).unwrap_err();
+    assert_eq!(err, ParseU256Error::Overflow);
 }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -32,7 +32,7 @@ use crate::*;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Decimal(pub BnumI192);
+pub struct Decimal(pub I192);
 
 impl Default for Decimal {
     fn default() -> Self {
@@ -57,20 +57,20 @@ macro_rules! fmt_remainder {
 
 impl Decimal {
     /// The min value of `Decimal`.
-    pub const MIN: Self = Self(BnumI192::MIN);
+    pub const MIN: Self = Self(I192::MIN);
 
     /// The max value of `Decimal`.
-    pub const MAX: Self = Self(BnumI192::MAX);
+    pub const MAX: Self = Self(I192::MAX);
 
     /// The bit length of number storing `Decimal`.
-    pub const BITS: usize = BnumI192::BITS as usize;
+    pub const BITS: usize = I192::BITS as usize;
 
     /// The fixed scale used by `Decimal`.
     pub const SCALE: u32 = 18;
 
-    pub const ZERO: Self = Self(BnumI192::ZERO);
+    pub const ZERO: Self = Self(I192::ZERO);
 
-    pub const ONE: Self = Self(BnumI192::from_digits([10_u64.pow(Decimal::SCALE), 0, 0]));
+    pub const ONE: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE), 0, 0]));
 
     /// Returns `Decimal` of 0.
     pub fn zero() -> Self {
@@ -84,17 +84,17 @@ impl Decimal {
 
     /// Whether this decimal is zero.
     pub fn is_zero(&self) -> bool {
-        self.0 == BnumI192::ZERO
+        self.0 == I192::ZERO
     }
 
     /// Whether this decimal is positive.
     pub fn is_positive(&self) -> bool {
-        self.0 > BnumI192::ZERO
+        self.0 > I192::ZERO
     }
 
     /// Whether this decimal is negative.
     pub fn is_negative(&self) -> bool {
-        self.0 < BnumI192::ZERO
+        self.0 < I192::ZERO
     }
 
     /// Returns the absolute value.
@@ -122,53 +122,53 @@ impl Decimal {
         assert!(decimal_places >= 0);
 
         let n = Self::SCALE - decimal_places as u32;
-        let divisor: BnumI192 = BnumI192::TEN.pow(n);
+        let divisor: I192 = I192::TEN.pow(n);
         match mode {
             RoundingMode::ToPositiveInfinity => {
-                if self.0 % divisor == BnumI192::ZERO {
+                if self.0 % divisor == I192::ZERO {
                     *self
                 } else if self.is_negative() {
                     Self(self.0 / divisor * divisor)
                 } else {
-                    Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                    Self((self.0 / divisor + I192::ONE) * divisor)
                 }
             }
             RoundingMode::ToNegativeInfinity => {
-                if self.0 % divisor == BnumI192::ZERO {
+                if self.0 % divisor == I192::ZERO {
                     *self
                 } else if self.is_negative() {
-                    Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                    Self((self.0 / divisor - I192::ONE) * divisor)
                 } else {
                     Self(self.0 / divisor * divisor)
                 }
             }
             RoundingMode::ToZero => {
-                if self.0 % divisor == BnumI192::ZERO {
+                if self.0 % divisor == I192::ZERO {
                     *self
                 } else {
                     Self(self.0 / divisor * divisor)
                 }
             }
             RoundingMode::AwayFromZero => {
-                if self.0 % divisor == BnumI192::ZERO {
+                if self.0 % divisor == I192::ZERO {
                     *self
                 } else if self.is_negative() {
-                    Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                    Self((self.0 / divisor - I192::ONE) * divisor)
                 } else {
-                    Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                    Self((self.0 / divisor + I192::ONE) * divisor)
                 }
             }
             RoundingMode::ToNearestMidpointTowardZero => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI192::ZERO {
+                if remainder == I192::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI192::from(2);
+                    let mid_point = divisor / I192::from(2);
                     if remainder > mid_point {
                         if self.is_negative() {
-                            Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                            Self((self.0 / divisor - I192::ONE) * divisor)
                         } else {
-                            Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                            Self((self.0 / divisor + I192::ONE) * divisor)
                         }
                     } else {
                         Self(self.0 / divisor * divisor)
@@ -177,15 +177,15 @@ impl Decimal {
             }
             RoundingMode::ToNearestMidpointAwayFromZero => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI192::ZERO {
+                if remainder == I192::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI192::from(2);
+                    let mid_point = divisor / I192::from(2);
                     if remainder >= mid_point {
                         if self.is_negative() {
-                            Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                            Self((self.0 / divisor - I192::ONE) * divisor)
                         } else {
-                            Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                            Self((self.0 / divisor + I192::ONE) * divisor)
                         }
                     } else {
                         Self(self.0 / divisor * divisor)
@@ -194,25 +194,25 @@ impl Decimal {
             }
             RoundingMode::ToNearestMidpointToEven => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI192::ZERO {
+                if remainder == I192::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI192::from(2);
+                    let mid_point = divisor / I192::from(2);
                     match remainder.cmp(&mid_point) {
                         Ordering::Greater => {
                             if self.is_negative() {
-                                Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                                Self((self.0 / divisor - I192::ONE) * divisor)
                             } else {
-                                Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                                Self((self.0 / divisor + I192::ONE) * divisor)
                             }
                         }
                         Ordering::Equal => {
-                            if self.0 / divisor % BnumI192::from(2) == BnumI192::ZERO {
+                            if self.0 / divisor % I192::from(2) == I192::ZERO {
                                 Self(self.0 / divisor * divisor)
                             } else if self.is_negative() {
-                                Self((self.0 / divisor - BnumI192::ONE) * divisor)
+                                Self((self.0 / divisor - I192::ONE) * divisor)
                             } else {
-                                Self((self.0 / divisor + BnumI192::ONE) * divisor)
+                                Self((self.0 / divisor + I192::ONE) * divisor)
                             }
                         }
                         Ordering::Less => Self(self.0 / divisor * divisor),
@@ -224,14 +224,14 @@ impl Decimal {
 
     /// Calculates power using exponentiation by squaring".
     pub fn powi(&self, exp: i64) -> Self {
-        let one_256 = BnumI256::from(Self::ONE.0);
-        let base_256 = BnumI256::from(self.0);
+        let one_256 = I256::from(Self::ONE.0);
+        let base_256 = I256::from(self.0);
         let div = |x: i64, y: i64| x.checked_div(y).expect("Overflow");
         let sub = |x: i64, y: i64| x.checked_sub(y).expect("Overflow");
         let mul = |x: i64, y: i64| x.checked_mul(y).expect("Overflow");
 
         if exp < 0 {
-            let dec_192 = BnumI192::try_from(one_256 * one_256 / base_256).expect("Overflow");
+            let dec_192 = I192::try_from(one_256 * one_256 / base_256).expect("Overflow");
             return Self(dec_192).powi(mul(exp, -1));
         }
         if exp == 0 {
@@ -241,10 +241,10 @@ impl Decimal {
             return *self;
         }
         if exp % 2 == 0 {
-            let dec_192 = BnumI192::try_from(base_256 * base_256 / one_256).expect("Overflow");
+            let dec_192 = I192::try_from(base_256 * base_256 / one_256).expect("Overflow");
             Self(dec_192).powi(div(exp, 2))
         } else {
-            let dec_192 = BnumI192::try_from(base_256 * base_256 / one_256).expect("Overflow");
+            let dec_192 = I192::try_from(base_256 * base_256 / one_256).expect("Overflow");
             let sub_dec = Self(dec_192);
             *self * sub_dec.powi(div(sub(exp, 1), 2))
         }
@@ -259,12 +259,12 @@ impl Decimal {
             return Some(Self::ZERO);
         }
 
-        // The BnumI192 i associated to a Decimal d is : i = d*10^18.
+        // The I192 i associated to a Decimal d is : i = d*10^18.
         // Therefore, taking sqrt yields sqrt(i) = sqrt(d)*10^9 => We lost precision
         // To get the right precision, we compute : sqrt(i*10^18) = sqrt(d)*10^18
-        let self_256 = BnumI256::from(self.0);
-        let correct_nb = self_256 * BnumI256::from(Self::ONE.0);
-        let sqrt = BnumI192::try_from(correct_nb.sqrt()).expect("Overflow");
+        let self_256 = I256::from(self.0);
+        let correct_nb = self_256 * I256::from(Self::ONE.0);
+        let sqrt = I192::try_from(correct_nb.sqrt()).expect("Overflow");
         Some(Self(sqrt))
     }
 
@@ -275,9 +275,9 @@ impl Decimal {
         }
 
         // By reasoning in the same way as before, we realise that we need to multiply by 10^36
-        let self_320 = BnumI320::from(self.0);
-        let correct_nb = self_320 * BnumI320::from(Self::ONE.0).pow(2);
-        let cbrt = BnumI192::try_from(correct_nb.cbrt()).expect("Overflow");
+        let self_320 = I320::from(self.0);
+        let correct_nb = self_320 * I320::from(Self::ONE.0).pow(2);
+        let cbrt = I192::try_from(correct_nb.cbrt()).expect("Overflow");
         Self(cbrt)
     }
 
@@ -296,7 +296,7 @@ impl Decimal {
             // To not overflow, we use BigInts
             let self_bigint = BigInt::from(self.0);
             let correct_nb = self_bigint * BigInt::from(Self::ONE.0).pow(n - 1);
-            let nth_root = BnumI192::try_from(correct_nb.nth_root(n)).unwrap();
+            let nth_root = I192::try_from(correct_nb.nth_root(n)).unwrap();
             Some(Decimal(nth_root))
         }
     }
@@ -306,7 +306,7 @@ macro_rules! from_int {
     ($type:ident) => {
         impl From<$type> for Decimal {
             fn from(val: $type) -> Self {
-                Self(BnumI192::from(val) * Self::ONE.0)
+                Self(I192::from(val) * Self::ONE.0)
             }
         }
     };
@@ -378,11 +378,11 @@ impl Mul<Decimal> for Decimal {
 
     #[inline]
     fn mul(self, other: Decimal) -> Self::Output {
-        // Use BnumI256 (BInt<4>) to not overflow.
-        let a = BnumI256::from(self.0);
-        let b = BnumI256::from(other.0);
-        let c = a * b / BnumI256::from(Self::ONE.0);
-        let c_192 = BnumI192::try_from(c).expect("Overflow");
+        // Use I256 (BInt<4>) to not overflow.
+        let a = I256::from(self.0);
+        let b = I256::from(other.0);
+        let c = a * b / I256::from(Self::ONE.0);
+        let c_192 = I192::try_from(c).expect("Overflow");
         Decimal(c_192)
     }
 }
@@ -392,11 +392,11 @@ impl Div<Decimal> for Decimal {
 
     #[inline]
     fn div(self, other: Decimal) -> Self::Output {
-        // Use BnumI256 (BInt<4>) to not overflow.
-        let a = BnumI256::from(self.0);
-        let b = BnumI256::from(other.0);
-        let c = a * BnumI256::from(Self::ONE.0) / b;
-        let c_192 = BnumI192::try_from(c).expect("Overflow");
+        // Use I256 (BInt<4>) to not overflow.
+        let a = I256::from(self.0);
+        let b = I256::from(other.0);
+        let c = a * I256::from(Self::ONE.0) / b;
+        let c_192 = I192::try_from(c).expect("Overflow");
         Decimal(c_192)
     }
 }
@@ -573,7 +573,7 @@ impl TryFrom<&[u8]> for Decimal {
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         if slice.len() == Self::BITS / 8 {
-            match BnumI192::try_from(slice) {
+            match I192::try_from(slice) {
                 Ok(val) => Ok(Self(val)),
                 Err(_) => Err(ParseDecimalError::Overflow),
             }
@@ -608,10 +608,10 @@ impl FromStr for Decimal {
     type Err = ParseDecimalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tens = BnumI192::from(10);
+        let tens = I192::from(10);
         let v: Vec<&str> = s.split('.').collect();
 
-        let mut int = match BnumI192::from_str(v[0]) {
+        let mut int = match I192::from_str(v[0]) {
             Ok(val) => val,
             Err(_) => return Err(ParseDecimalError::InvalidDigit),
         };
@@ -625,7 +625,7 @@ impl FromStr for Decimal {
                 Err(Self::Err::UnsupportedDecimalPlace)
             }?;
 
-            let frac = match BnumI192::from_str(v[1]) {
+            let frac = match I192::from_str(v[1]) {
                 Ok(val) => val,
                 Err(_) => return Err(ParseDecimalError::InvalidDigit),
             };
@@ -643,7 +643,7 @@ impl FromStr for Decimal {
 
 impl fmt::Display for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        const MULTIPLIER: BnumI192 = Decimal::ONE.0;
+        const MULTIPLIER: I192 = Decimal::ONE.0;
         let quotient = self.0 / MULTIPLIER;
         let remainder = self.0 % MULTIPLIER;
 
@@ -654,7 +654,7 @@ impl fmt::Display for Decimal {
             // take care of sign in case quotient == zere and remainder < 0,
             // eg.
             //  self.0=-100000000000000000 -> -0.1
-            if remainder < BnumI192::ZERO && quotient == BnumI192::ZERO {
+            if remainder < I192::ZERO && quotient == I192::ZERO {
                 sign.push('-');
             }
             let rem_str = format!(fmt_remainder!(), remainder.abs());
@@ -700,8 +700,8 @@ impl TryFrom<PreciseDecimal> for Decimal {
     type Error = ParseDecimalError;
 
     fn try_from(val: PreciseDecimal) -> Result<Self, Self::Error> {
-        let val_i256 = val.0 / BnumI256::from(10i8).pow(PreciseDecimal::SCALE - Decimal::SCALE);
-        let result = BnumI192::try_from(val_i256);
+        let val_i256 = val.0 / I256::from(10i8).pow(PreciseDecimal::SCALE - Decimal::SCALE);
+        let result = I192::try_from(val_i256);
         match result {
             Ok(val_i192) => Ok(Self(val_i192)),
             Err(_) => Err(ParseDecimalError::Overflow),
@@ -716,7 +716,7 @@ macro_rules! try_from_integer {
                 type Error = ParseDecimalError;
 
                 fn try_from(val: $t) -> Result<Self, Self::Error> {
-                    match BnumI192::try_from(val) {
+                    match I192::try_from(val) {
                         Ok(val) => {
                             match val.checked_mul(Self::ONE.0) {
                                 Some(mul) => Ok(Self(mul)),
@@ -730,7 +730,7 @@ macro_rules! try_from_integer {
         )*
     };
 }
-try_from_integer!(BnumI192, BnumI256, BnumI512, BnumU192, BnumU256, BnumU512);
+try_from_integer!(I192, I256, I512, U192, U256, U512);
 
 #[cfg(test)]
 mod tests {
@@ -1372,16 +1372,16 @@ mod tests {
     }
 
     test_try_from_integer_overflow! {
-        (BnumI192::MAX, 1),
-        (BnumI192::MIN, 2),
+        (I192::MAX, 1),
+        (I192::MIN, 2),
         // maximal Decimal integer part + 1
-        (BnumI192::MAX/(BnumI192::from(10).pow(Decimal::SCALE)) + BnumI192::ONE, 3),
+        (I192::MAX/(I192::from(10).pow(Decimal::SCALE)) + I192::ONE, 3),
         // minimal Decimal integer part - 1
-        (BnumI192::MIN/(BnumI192::from(10).pow(Decimal::SCALE)) - BnumI192::ONE, 4),
-        (BnumU256::MAX, 5),
-        (BnumI512::MAX, 6),
-        (BnumI512::MIN, 7),
-        (BnumU512::MAX, 8)
+        (I192::MIN/(I192::from(10).pow(Decimal::SCALE)) - I192::ONE, 4),
+        (U256::MAX, 5),
+        (I512::MAX, 6),
+        (I512::MIN, 7),
+        (U512::MAX, 8)
     }
 
     macro_rules! test_try_from_integer {
@@ -1399,16 +1399,16 @@ mod tests {
     }
 
     test_try_from_integer! {
-        (BnumI192::ONE, "1", 1),
-        (-BnumI192::ONE, "-1", 2),
+        (I192::ONE, "1", 1),
+        (-I192::ONE, "-1", 2),
         // maximal Decimal integer part
-        (BnumI192::MAX/(BnumI192::from(10_u64.pow(Decimal::SCALE))), "3138550867693340381917894711603833208051", 3),
+        (I192::MAX/(I192::from(10_u64.pow(Decimal::SCALE))), "3138550867693340381917894711603833208051", 3),
         // minimal Decimal integer part
-        (BnumI192::MIN/(BnumI192::from(10_u64.pow(Decimal::SCALE))), "-3138550867693340381917894711603833208051", 4),
-        (BnumU256::MIN, "0", 5),
-        (BnumU512::MIN, "0", 6),
-        (BnumI512::ONE, "1", 7),
-        (-BnumI512::ONE, "-1", 8)
+        (I192::MIN/(I192::from(10_u64.pow(Decimal::SCALE))), "-3138550867693340381917894711603833208051", 4),
+        (U256::MIN, "0", 5),
+        (U512::MIN, "0", 6),
+        (I512::ONE, "1", 7),
+        (-I512::ONE, "-1", 8)
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -35,7 +35,7 @@ use crate::*;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PreciseDecimal(pub BnumI256);
+pub struct PreciseDecimal(pub I256);
 
 impl Default for PreciseDecimal {
     fn default() -> Self {
@@ -60,20 +60,20 @@ macro_rules! fmt_remainder {
 
 impl PreciseDecimal {
     /// The min value of `PreciseDecimal`.
-    pub const MIN: Self = Self(BnumI256::MIN);
+    pub const MIN: Self = Self(I256::MIN);
 
     /// The max value of `PreciseDecimal`.
-    pub const MAX: Self = Self(BnumI256::MAX);
+    pub const MAX: Self = Self(I256::MAX);
 
     /// The bit length of number storing `PreciseDecimal`.
-    pub const BITS: usize = BnumI256::BITS as usize;
+    pub const BITS: usize = I256::BITS as usize;
 
     /// The fixed scale used by `PreciseDecimal`.
     pub const SCALE: u32 = 36;
 
-    pub const ZERO: Self = Self(BnumI256::ZERO);
+    pub const ZERO: Self = Self(I256::ZERO);
 
-    pub const ONE: Self = Self(BnumI256::from_digits([
+    pub const ONE: Self = Self(I256::from_digits([
         12919594847110692864,
         54210108624275221,
         0,
@@ -92,17 +92,17 @@ impl PreciseDecimal {
 
     /// Whether this decimal is zero.
     pub fn is_zero(&self) -> bool {
-        self.0 == BnumI256::zero()
+        self.0 == I256::zero()
     }
 
     /// Whether this decimal is positive.
     pub fn is_positive(&self) -> bool {
-        self.0 > BnumI256::zero()
+        self.0 > I256::zero()
     }
 
     /// Whether this decimal is negative.
     pub fn is_negative(&self) -> bool {
-        self.0 < BnumI256::zero()
+        self.0 < I256::zero()
     }
 
     /// Returns the absolute value.
@@ -130,53 +130,53 @@ impl PreciseDecimal {
         assert!(decimal_places >= 0);
 
         let n = Self::SCALE - decimal_places as u32;
-        let divisor: BnumI256 = BnumI256::TEN.pow(n);
+        let divisor: I256 = I256::TEN.pow(n);
         match mode {
             RoundingMode::ToPositiveInfinity => {
-                if self.0 % divisor == BnumI256::ZERO {
+                if self.0 % divisor == I256::ZERO {
                     *self
                 } else if self.is_negative() {
                     Self(self.0 / divisor * divisor)
                 } else {
-                    Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                    Self((self.0 / divisor + I256::ONE) * divisor)
                 }
             }
             RoundingMode::ToNegativeInfinity => {
-                if self.0 % divisor == BnumI256::ZERO {
+                if self.0 % divisor == I256::ZERO {
                     *self
                 } else if self.is_negative() {
-                    Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                    Self((self.0 / divisor - I256::ONE) * divisor)
                 } else {
                     Self(self.0 / divisor * divisor)
                 }
             }
             RoundingMode::ToZero => {
-                if self.0 % divisor == BnumI256::ZERO {
+                if self.0 % divisor == I256::ZERO {
                     *self
                 } else {
                     Self(self.0 / divisor * divisor)
                 }
             }
             RoundingMode::AwayFromZero => {
-                if self.0 % divisor == BnumI256::ZERO {
+                if self.0 % divisor == I256::ZERO {
                     *self
                 } else if self.is_negative() {
-                    Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                    Self((self.0 / divisor - I256::ONE) * divisor)
                 } else {
-                    Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                    Self((self.0 / divisor + I256::ONE) * divisor)
                 }
             }
             RoundingMode::ToNearestMidpointTowardZero => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI256::ZERO {
+                if remainder == I256::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI256::from(2);
+                    let mid_point = divisor / I256::from(2);
                     if remainder > mid_point {
                         if self.is_negative() {
-                            Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                            Self((self.0 / divisor - I256::ONE) * divisor)
                         } else {
-                            Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                            Self((self.0 / divisor + I256::ONE) * divisor)
                         }
                     } else {
                         Self(self.0 / divisor * divisor)
@@ -185,15 +185,15 @@ impl PreciseDecimal {
             }
             RoundingMode::ToNearestMidpointAwayFromZero => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI256::ZERO {
+                if remainder == I256::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI256::from(2);
+                    let mid_point = divisor / I256::from(2);
                     if remainder >= mid_point {
                         if self.is_negative() {
-                            Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                            Self((self.0 / divisor - I256::ONE) * divisor)
                         } else {
-                            Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                            Self((self.0 / divisor + I256::ONE) * divisor)
                         }
                     } else {
                         Self(self.0 / divisor * divisor)
@@ -202,25 +202,25 @@ impl PreciseDecimal {
             }
             RoundingMode::ToNearestMidpointToEven => {
                 let remainder = (self.0 % divisor).abs();
-                if remainder == BnumI256::ZERO {
+                if remainder == I256::ZERO {
                     *self
                 } else {
-                    let mid_point = divisor / BnumI256::from(2);
+                    let mid_point = divisor / I256::from(2);
                     match remainder.cmp(&mid_point) {
                         Ordering::Greater => {
                             if self.is_negative() {
-                                Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                                Self((self.0 / divisor - I256::ONE) * divisor)
                             } else {
-                                Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                                Self((self.0 / divisor + I256::ONE) * divisor)
                             }
                         }
                         Ordering::Equal => {
-                            if self.0 / divisor % BnumI256::from(2) == BnumI256::ZERO {
+                            if self.0 / divisor % I256::from(2) == I256::ZERO {
                                 Self(self.0 / divisor * divisor)
                             } else if self.is_negative() {
-                                Self((self.0 / divisor - BnumI256::ONE) * divisor)
+                                Self((self.0 / divisor - I256::ONE) * divisor)
                             } else {
-                                Self((self.0 / divisor + BnumI256::ONE) * divisor)
+                                Self((self.0 / divisor + I256::ONE) * divisor)
                             }
                         }
                         Ordering::Less => Self(self.0 / divisor * divisor),
@@ -232,15 +232,15 @@ impl PreciseDecimal {
 
     /// Calculates power using exponentiation by squaring.
     pub fn powi(&self, exp: i64) -> Self {
-        let one_384 = BnumI384::from(Self::ONE.0);
-        let base_384 = BnumI384::from(self.0);
+        let one_384 = I384::from(Self::ONE.0);
+        let base_384 = I384::from(self.0);
         let div = |x: i64, y: i64| x.checked_div(y).expect("Overflow");
         let sub = |x: i64, y: i64| x.checked_sub(y).expect("Overflow");
         let mul = |x: i64, y: i64| x.checked_mul(y).expect("Overflow");
 
         if exp < 0 {
             let sub_384 = one_384 * one_384 / base_384;
-            let sub_256 = BnumI256::try_from(sub_384).expect("Overflow");
+            let sub_256 = I256::try_from(sub_384).expect("Overflow");
             return Self(sub_256).powi(mul(exp, -1));
         }
         if exp == 0 {
@@ -251,11 +251,11 @@ impl PreciseDecimal {
         }
         if exp % 2 == 0 {
             let sub_384 = base_384 * base_384 / one_384;
-            let sub_256 = BnumI256::try_from(sub_384).expect("Overflow");
+            let sub_256 = I256::try_from(sub_384).expect("Overflow");
             Self(sub_256).powi(div(exp, 2))
         } else {
             let sub_384 = base_384 * base_384 / one_384;
-            let sub_256 = BnumI256::try_from(sub_384).expect("Overflow");
+            let sub_256 = I256::try_from(sub_384).expect("Overflow");
             let sub_pdec = Self(sub_256);
             *self * sub_pdec.powi(div(sub(exp, 1), 2))
         }
@@ -270,12 +270,12 @@ impl PreciseDecimal {
             return Some(Self::ZERO);
         }
 
-        // The BnumI256 i associated to a Decimal d is : i = d*10^36.
+        // The I256 i associated to a Decimal d is : i = d*10^36.
         // Therefore, taking sqrt yields sqrt(i) = sqrt(d)*10^32 => We lost precision
         // To get the right precision, we compute : sqrt(i*10^36) = sqrt(d)*10^36
-        let self_384 = BnumI384::from(self.0);
-        let correct_nb = self_384 * BnumI384::from(Self::ONE.0);
-        let sqrt = BnumI256::try_from(correct_nb.sqrt()).expect("Overflow");
+        let self_384 = I384::from(self.0);
+        let correct_nb = self_384 * I384::from(Self::ONE.0);
+        let sqrt = I256::try_from(correct_nb.sqrt()).expect("Overflow");
         Some(Self(sqrt))
     }
 
@@ -288,7 +288,7 @@ impl PreciseDecimal {
         // By reasoning in the same way as before, we realise that we need to multiply by 10^36
         let self_bigint = BigInt::from(self.0);
         let correct_nb: BigInt = self_bigint * BigInt::from(Self::ONE.0).pow(2_u32);
-        let cbrt = BnumI256::try_from(correct_nb.cbrt()).unwrap();
+        let cbrt = I256::try_from(correct_nb.cbrt()).unwrap();
         Self(cbrt)
     }
 
@@ -307,7 +307,7 @@ impl PreciseDecimal {
             // To not overflow, we use BigInt
             let self_integer = BigInt::from(self.0);
             let correct_nb = self_integer * BigInt::from(Self::ONE.0).pow(n - 1);
-            let nth_root = BnumI256::try_from(correct_nb.nth_root(n)).unwrap();
+            let nth_root = I256::try_from(correct_nb.nth_root(n)).unwrap();
             Some(Self(nth_root))
         }
     }
@@ -317,7 +317,7 @@ macro_rules! from_int {
     ($type:ident) => {
         impl From<$type> for PreciseDecimal {
             fn from(val: $type) -> Self {
-                Self(BnumI256::from(val) * Self::ONE.0)
+                Self(I256::from(val) * Self::ONE.0)
             }
         }
     };
@@ -389,11 +389,11 @@ impl Mul<PreciseDecimal> for PreciseDecimal {
 
     #[inline]
     fn mul(self, other: PreciseDecimal) -> Self::Output {
-        // Use BnumI384 to not overflow.
-        let a = BnumI384::from(self.0);
-        let b = BnumI384::from(other.0);
-        let c = a * b / BnumI384::from(Self::ONE.0);
-        let c_256 = BnumI256::try_from(c).expect("Overflow");
+        // Use I384 to not overflow.
+        let a = I384::from(self.0);
+        let b = I384::from(other.0);
+        let c = a * b / I384::from(Self::ONE.0);
+        let c_256 = I256::try_from(c).expect("Overflow");
         PreciseDecimal(c_256)
     }
 }
@@ -403,11 +403,11 @@ impl Div<PreciseDecimal> for PreciseDecimal {
 
     #[inline]
     fn div(self, other: PreciseDecimal) -> Self::Output {
-        // Use BnumI384 to not overflow.
-        let a = BnumI384::from(self.0);
-        let b = BnumI384::from(other.0);
-        let c = a * BnumI384::from(Self::ONE.0) / b;
-        let c_256 = BnumI256::try_from(c).expect("Overflow");
+        // Use I384 to not overflow.
+        let a = I384::from(self.0);
+        let b = I384::from(other.0);
+        let c = a * I384::from(Self::ONE.0) / b;
+        let c_256 = I256::try_from(c).expect("Overflow");
         PreciseDecimal(c_256)
     }
 }
@@ -584,7 +584,7 @@ impl TryFrom<&[u8]> for PreciseDecimal {
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         if slice.len() == Self::BITS / 8 {
-            match BnumI256::try_from(slice) {
+            match I256::try_from(slice) {
                 Ok(val) => Ok(Self(val)),
                 Err(_) => Err(ParsePreciseDecimalError::Overflow),
             }
@@ -623,10 +623,10 @@ impl FromStr for PreciseDecimal {
     type Err = ParsePreciseDecimalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tens = BnumI256::from(10);
+        let tens = I256::from(10);
         let v: Vec<&str> = s.split('.').collect();
 
-        let mut int = match BnumI256::from_str(v[0]) {
+        let mut int = match I256::from_str(v[0]) {
             Ok(val) => val,
             Err(_) => return Err(ParsePreciseDecimalError::InvalidDigit),
         };
@@ -640,7 +640,7 @@ impl FromStr for PreciseDecimal {
                 Err(Self::Err::UnsupportedDecimalPlace)
             }?;
 
-            let frac = match BnumI256::from_str(v[1]) {
+            let frac = match I256::from_str(v[1]) {
                 Ok(val) => val,
                 Err(_) => return Err(ParsePreciseDecimalError::InvalidDigit),
             };
@@ -659,7 +659,7 @@ impl FromStr for PreciseDecimal {
 
 impl fmt::Display for PreciseDecimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        const MULTIPLIER: BnumI256 = PreciseDecimal::ONE.0;
+        const MULTIPLIER: I256 = PreciseDecimal::ONE.0;
         let quotient = self.0 / MULTIPLIER;
         let remainder = self.0 % MULTIPLIER;
 
@@ -670,7 +670,7 @@ impl fmt::Display for PreciseDecimal {
             // take care of sign in case quotient == zere and remainder < 0,
             // eg.
             //  self.0=-100000000000000000 -> -0.1
-            if remainder < BnumI256::ZERO && quotient == BnumI256::ZERO {
+            if remainder < I256::ZERO && quotient == I256::ZERO {
                 sign.push('-');
             }
             let rem_str = format!(fmt_remainder!(), remainder.abs());
@@ -714,10 +714,7 @@ impl fmt::Display for ParsePreciseDecimalError {
 
 impl From<Decimal> for PreciseDecimal {
     fn from(val: Decimal) -> Self {
-        Self(
-            BnumI256::try_from(val.0).unwrap()
-                * BnumI256::from(10i8).pow(Self::SCALE - Decimal::SCALE),
-        )
+        Self(I256::try_from(val.0).unwrap() * I256::from(10i8).pow(Self::SCALE - Decimal::SCALE))
     }
 }
 
@@ -731,7 +728,7 @@ impl Truncate<Decimal> for PreciseDecimal {
 
     fn truncate(self) -> Self::Output {
         Decimal(
-            (self.0 / BnumI256::from(10i8).pow(PreciseDecimal::SCALE - Decimal::SCALE))
+            (self.0 / I256::from(10i8).pow(PreciseDecimal::SCALE - Decimal::SCALE))
                 .try_into()
                 .expect("Overflow"),
         )
@@ -743,7 +740,7 @@ macro_rules! from_integer {
         $(
             impl From<$t> for PreciseDecimal {
                 fn from(val: $t) -> Self {
-                    Self(BnumI256::from(val) * Self::ONE.0)
+                    Self(I256::from(val) * Self::ONE.0)
                 }
             }
         )*
@@ -756,7 +753,7 @@ macro_rules! try_from_integer {
                 type Error = ParsePreciseDecimalError;
 
                 fn try_from(val: $t) -> Result<Self, Self::Error> {
-                    match BnumI256::try_from(val) {
+                    match I256::try_from(val) {
                         Ok(val) => {
                             match val.checked_mul(Self::ONE.0) {
                                 Some(mul) => Ok(Self(mul)),
@@ -771,9 +768,9 @@ macro_rules! try_from_integer {
     };
 }
 
-from_integer!(BnumI192, BnumU192);
-try_from_integer!(BnumI256, BnumI320, BnumI384, BnumI448, BnumI512);
-try_from_integer!(BnumU256, BnumU320, BnumU384, BnumU448, BnumU512);
+from_integer!(I192, U192);
+try_from_integer!(I256, I320, I384, I448, I512);
+try_from_integer!(U256, U320, U384, U448, U512);
 
 #[cfg(test)]
 mod tests {
@@ -795,21 +792,21 @@ mod tests {
             "0.000000000000000000123456789123456789"
         );
         assert_eq!(
-            PreciseDecimal(BnumI256::from(10).pow(PreciseDecimal::SCALE)).to_string(),
+            PreciseDecimal(I256::from(10).pow(PreciseDecimal::SCALE)).to_string(),
             "1"
         );
         assert_eq!(
             PreciseDecimal(
-                BnumI256::from(10)
+                I256::from(10)
                     .pow(PreciseDecimal::SCALE)
-                    .mul(BnumI256::from(123))
+                    .mul(I256::from(123))
             )
             .to_string(),
             "123"
         );
         assert_eq!(
             PreciseDecimal(
-                BnumI256::from_str("123456789000000000000000000000000000000000000").unwrap()
+                I256::from_str("123456789000000000000000000000000000000000000").unwrap()
             )
             .to_string(),
             "123456789"
@@ -829,23 +826,20 @@ mod tests {
     fn test_parse_precise_decimal() {
         assert_eq!(
             PreciseDecimal::from_str("0.000000000000000001").unwrap(),
-            PreciseDecimal(BnumI256::from(10).pow(18)),
+            PreciseDecimal(I256::from(10).pow(18)),
         );
         assert_eq!(
             PreciseDecimal::from_str("0.123456789123456789").unwrap(),
-            PreciseDecimal(
-                BnumI256::from(123456789123456789i128).mul(BnumI256::from(10i8).pow(18))
-            ),
+            PreciseDecimal(I256::from(123456789123456789i128).mul(I256::from(10i8).pow(18))),
         );
         assert_eq!(
             PreciseDecimal::from_str("1").unwrap(),
-            PreciseDecimal(BnumI256::from(10).pow(PreciseDecimal::SCALE)),
+            PreciseDecimal(I256::from(10).pow(PreciseDecimal::SCALE)),
         );
         assert_eq!(
             PreciseDecimal::from_str("123456789123456789").unwrap(),
             PreciseDecimal(
-                BnumI256::from(123456789123456789i128)
-                    .mul(BnumI256::from(10).pow(PreciseDecimal::SCALE))
+                I256::from(123456789123456789i128).mul(I256::from(10).pow(PreciseDecimal::SCALE))
             ),
         );
         assert_eq!(
@@ -1437,14 +1431,14 @@ mod tests {
     }
 
     test_try_from_integer_overflow! {
-        (BnumI256::MAX, 1),
-        (BnumI256::MIN, 2),
+        (I256::MAX, 1),
+        (I256::MIN, 2),
         // maximal PreciseDecimal integer part + 1
-        (BnumI256::MAX/(BnumI256::from(10).pow(PreciseDecimal::SCALE)) + BnumI256::ONE, 3),
+        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)) + I256::ONE, 3),
         // minimal PreciseDecimal integer part - 1
-        (BnumI256::MIN/(BnumI256::from(10).pow(PreciseDecimal::SCALE)) - BnumI256::ONE, 4),
-        (BnumI256::MIN, 5),
-        (BnumI256::MAX, 6)
+        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)) - I256::ONE, 4),
+        (I256::MIN, 5),
+        (I256::MAX, 6)
     }
 
     macro_rules! test_try_from_integer {
@@ -1462,13 +1456,13 @@ mod tests {
     }
 
     test_try_from_integer! {
-        (BnumI256::ONE, "1", 1),
-        (-BnumI256::ONE, "-1", 2),
+        (I256::ONE, "1", 1),
+        (-I256::ONE, "-1", 2),
         // maximal PreciseDecimal integer part
-        (BnumI256::MAX/(BnumI256::from(10).pow(PreciseDecimal::SCALE)), "57896044618658097711785492504343953926634", 3),
+        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)), "57896044618658097711785492504343953926634", 3),
         // minimal PreciseDecimal integer part
-        (BnumI256::MIN/(BnumI256::from(10).pow(PreciseDecimal::SCALE)), "-57896044618658097711785492504343953926634", 4),
-        (BnumU256::MIN, "0", 5)
+        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)), "-57896044618658097711785492504343953926634", 4),
+        (U256::MIN, "0", 5)
     }
 
     macro_rules! test_from_integer {
@@ -1486,10 +1480,10 @@ mod tests {
     }
 
     test_from_integer! {
-        (BnumI192::ONE, "1", 1),
-        (-BnumI192::ONE, "-1", 2),
-        (BnumU192::MIN, "0", 3),
-        (BnumU192::ONE, "1", 4)
+        (I192::ONE, "1", 1),
+        (-I192::ONE, "-1", 2),
+        (U192::MIN, "0", 3),
+        (U192::ONE, "1", 4)
     }
 
     #[test]

--- a/radix-engine-interface/src/blueprints/resource/mod.rs
+++ b/radix-engine-interface/src/blueprints/resource/mod.rs
@@ -38,14 +38,14 @@ use sbor::rust::vec::Vec;
 
 pub fn check_fungible_amount(amount: &Decimal, divisibility: u8) -> bool {
     !amount.is_negative()
-        && amount.0 % BnumI192::from(10i128.pow((18 - divisibility).into())) == BnumI192::from(0)
+        && amount.0 % I192::from(10i128.pow((18 - divisibility).into())) == I192::from(0)
 }
 
 pub fn check_non_fungible_amount(amount: &Decimal) -> Result<u32, ()> {
     // Integers between [0..u32::MAX]
     if amount >= &Decimal::from(u32::MIN)
         && amount <= &Decimal::from(u32::MAX)
-        && amount.0 % BnumI192::from(10i128.pow(18)) == BnumI192::from(0)
+        && amount.0 % I192::from(10i128.pow(18)) == I192::from(0)
     {
         Ok(u32::from_str(&amount.to_string()).unwrap())
     } else {

--- a/radix-engine-tests/tests/auth_account.rs
+++ b/radix-engine-tests/tests/auth_account.rs
@@ -243,7 +243,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
 fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let xrd_auth = rule!(require_amount(Decimal(BnumI192::from(1)), XRD));
+    let xrd_auth = rule!(require_amount(Decimal(I192::from(1)), XRD));
     let account = test_runner.new_account_advanced(OwnerRole::Fixed(xrd_auth));
     let (_, _, other_account) = test_runner.new_allocated_account();
 
@@ -297,7 +297,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
 fn can_update_updatable_owner_role_account() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let xrd_auth = rule!(require_amount(Decimal(BnumI192::from(1)), XRD));
+    let xrd_auth = rule!(require_amount(Decimal(I192::from(1)), XRD));
     let account = test_runner.new_account_advanced(OwnerRole::Updatable(xrd_auth));
 
     // Act

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -1143,7 +1143,7 @@ fn create_sort_prefix_from_stake(stake: Decimal) -> u16 {
     // In reality, validators will have far less than u16::MAX * 100k stake, but let's handle that case just in case
     let stake_100k = stake / Decimal::from(100000);
     let stake_100k_whole_units = (stake_100k / Decimal::from(10).powi(Decimal::SCALE.into())).0;
-    let stake_u16 = if stake_100k_whole_units > BnumI192::from(u16::MAX) {
+    let stake_u16 = if stake_100k_whole_units > I192::from(u16::MAX) {
         u16::MAX
     } else {
         stake_100k_whole_units.try_into().unwrap()

--- a/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -18,7 +18,7 @@ use radix_engine_interface::*;
 const DIVISIBILITY_MAXIMUM: u8 = 18;
 
 lazy_static! {
-    static ref MAX_MINT_AMOUNT: Decimal = Decimal(BnumI192::from(2).pow(160)); // 2^160 subunits
+    static ref MAX_MINT_AMOUNT: Decimal = Decimal(I192::from(2).pow(160)); // 2^160 subunits
 }
 
 /// Represents an error when accessing a bucket.


### PR DESCRIPTION
## Summary

Examples:
BnumI256 -> I256
BnumU256 -> U256

### For dApp Developers
Revise scrypto code and rename Bnum types accordingly
