### PR TITLE
change ordering of dump_manifest_to_file_system

### DIFF
--- a/transaction-scenarios/src/scenario.rs
+++ b/transaction-scenarios/src/scenario.rs
@@ -56,8 +56,8 @@ impl NextTransaction {
         };
         let file_name = format!("{:03}--{}", self.stage_counter, self.logical_name);
         dump_manifest_to_file_system(
-            &self.manifest,
             self.naming.clone(),
+            &self.manifest,
             directory_path,
             Some(&file_name),
             &network,

--- a/transaction/src/manifest/dumper.rs
+++ b/transaction/src/manifest/dumper.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use super::decompiler::{decompile_with_known_naming, ManifestObjectNames};
 
 pub fn dump_manifest_to_file_system<P>(
-    manifest: &TransactionManifestV1,
     naming: ManifestObjectNames,
+    manifest: &TransactionManifestV1,
     directory_path: P,
     name: Option<&str>,
     network_definition: &NetworkDefinition,


### PR DESCRIPTION
## Summary

INSTRUCTIONS:

Currently using the `dump_manifest_to_file_system` create an awkward value moved error in Rust.

```rust
let manifest = ManifestBuilder::new()
    .lock_fee_from_faucet()
    .call_function(package_address, "Hello", "instantiate_hello", manifest_args!())
    .deposit_batch(account_component);

dump_manifest_to_file_system(
    &manifest.build(), // `.build` takes ownership of `Self`.
    manifest.object_names(), // Value moved error from `manifest` here.
    "./transaction_manifest", 
    Some("instantiate_hello"), 
    &NetworkDefinition::simulator()
).err();
```

This PR changes argument ordering of `dump_manifest_to_file_system` as a simple fix.  

```rust
let manifest = ManifestBuilder::new()
    .lock_fee_from_faucet()
    .call_function(package_address, "Hello", "instantiate_hello", manifest_args!())
    .deposit_batch(account_component);

dump_manifest_to_file_system(
    manifest.object_names(), // `ManifestObjectName` comes first 
    &manifest.build(), // Then use `.build` to return a `TransactionManifestV1`.
    "./transaction_manifest", 
    Some("instantiate_hello"), 
    &NetworkDefinition::simulator()
).err();
```

However, ideally `TransactionManifestV1` should also be able to retrieve `ManifestObjectNames`.

