### PR TITLE
Adjust mint limit to 2^152

### DIFF
--- a/radix-engine-tests/tests/common_transactions.rs
+++ b/radix-engine-tests/tests/common_transactions.rs
@@ -4,6 +4,7 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::{RoleDefinition, ToRoleEntry};
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::{metadata, metadata_init, mint_roles};
+use scrypto::prelude::Pow;
 use scrypto::NonFungibleData;
 use scrypto_unit::TestRunnerBuilder;
 use transaction::manifest::{compile, BlobProvider};
@@ -110,6 +111,42 @@ fn creating_a_fungible_resource_with_initial_supply_succeeds() {
     .expect_commit_success();
 }
 
+/// An example manifest for creating a new fungible resource with an maximum initial supply
+#[test]
+fn creating_a_fungible_resource_with_max_initial_supply_succeeds() {
+    run_manifest(|account_address, address_bech32_encoder| {
+        let initial_supply = Decimal(I192::from(2).pow(152));
+
+        let manifest = replace_variables!(
+            include_str!(
+                "../../transaction/examples/resources/creation/fungible/with_initial_supply.rtm"
+            ),
+            initial_supply = initial_supply,
+            account_address = account_address.display(address_bech32_encoder)
+        );
+        (manifest, Vec::new())
+    })
+    .expect_commit_success();
+}
+
+/// An example manifest for creating a new fungible resource with an exceeded maximum initial supply
+#[test]
+fn creating_a_fungible_resource_with_exceeded_initial_supply_fails() {
+    run_manifest(|account_address, address_bech32_encoder| {
+        let initial_supply = Decimal(I192::from(2).pow(152) + I192::ONE);
+
+        let manifest = replace_variables!(
+            include_str!(
+                "../../transaction/examples/resources/creation/fungible/with_initial_supply.rtm"
+            ),
+            initial_supply = initial_supply,
+            account_address = account_address.display(address_bech32_encoder)
+        );
+        (manifest, Vec::new())
+    })
+    .expect_commit_failure();
+}
+
 /// An example manifest for creating a new non-fungible resource with no supply
 #[test]
 fn creating_a_non_fungible_resource_with_no_initial_supply_succeeds() {
@@ -180,6 +217,59 @@ fn minting_of_fungible_resource_succeeds() {
             );
             (manifest, Vec::new())
         },
+        true,
+    );
+}
+
+/// A sample manifest for minting of a fungible resource with maximum mint amount
+#[test]
+fn minting_of_fungible_resource_max_mint_amount_succeeds() {
+    test_manifest_with_restricted_minting_resource(
+        ResourceType::Fungible { divisibility: 18 },
+        |account_address,
+         minter_badge_resource_address,
+         mintable_fungible_resource_address,
+         address_bech32_encoder| {
+            let mint_amount = Decimal(I192::from(2).pow(152));
+
+            let manifest = replace_variables!(
+                include_str!("../../transaction/examples/resources/mint/fungible/mint.rtm"),
+                account_address = account_address.display(address_bech32_encoder),
+                mintable_fungible_resource_address =
+                    mintable_fungible_resource_address.display(address_bech32_encoder),
+                minter_badge_resource_address =
+                    minter_badge_resource_address.display(address_bech32_encoder),
+                mint_amount = mint_amount
+            );
+            (manifest, Vec::new())
+        },
+        true,
+    );
+}
+
+/// A sample manifest for minting of a fungible resource with maximum mint amount
+#[test]
+fn minting_of_fungible_resource_exceed_max_mint_amount_fails() {
+    test_manifest_with_restricted_minting_resource(
+        ResourceType::Fungible { divisibility: 18 },
+        |account_address,
+         minter_badge_resource_address,
+         mintable_fungible_resource_address,
+         address_bech32_encoder| {
+            let mint_amount = Decimal(I192::from(2).pow(152) + I192::ONE);
+
+            let manifest = replace_variables!(
+                include_str!("../../transaction/examples/resources/mint/fungible/mint.rtm"),
+                account_address = account_address.display(address_bech32_encoder),
+                mintable_fungible_resource_address =
+                    mintable_fungible_resource_address.display(address_bech32_encoder),
+                minter_badge_resource_address =
+                    minter_badge_resource_address.display(address_bech32_encoder),
+                mint_amount = mint_amount
+            );
+            (manifest, Vec::new())
+        },
+        false,
     );
 }
 
@@ -205,6 +295,7 @@ fn minting_of_non_fungible_resource_succeeds() {
             );
             (manifest, Vec::new())
         },
+        true,
     );
 }
 
@@ -225,6 +316,7 @@ fn changing_default_deposit_rule_succeeds() {
             );
             (manifest, Vec::new())
         },
+        true,
     );
 }
 
@@ -259,6 +351,7 @@ where
 fn test_manifest_with_restricted_minting_resource<F>(
     resource_type: ResourceType,
     string_manifest_builder: F,
+    expect_success: bool,
 ) where
     F: Fn(
         &ComponentAddress,
@@ -336,7 +429,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
 
     test_runner
         .execute_manifest(manifest, vec![virtual_badge_non_fungible_global_id])
-        .expect_commit_success();
+        .expect_commit(expect_success);
 }
 
 fn test_manifest_with_additional_accounts<F>(accounts_required: u16, string_manifest_builder: F)

--- a/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -18,7 +18,7 @@ use radix_engine_interface::*;
 const DIVISIBILITY_MAXIMUM: u8 = 18;
 
 lazy_static! {
-    static ref MAX_MINT_AMOUNT: Decimal = Decimal(I192::from(2).pow(160)); // 2^160 subunits
+    static ref MAX_MINT_AMOUNT: Decimal = Decimal(I192::from(2).pow(152)); // 2^152 subunits
 }
 
 /// Represents an error when accessing a bucket.


### PR DESCRIPTION
## Summary
Adjust mint limit to 2^152

## Testing
Tests added to verify the limits.

## Update Recommendations

### For dApp Developers
Make sure to not mint or create resources with inital supply greater than 2^152.


