### PR TITLE
Revert "Remove unused visit_node_id from state traverser"

### DIFF
--- a/radix-engine-common/src/types/node_and_substate.rs
+++ b/radix-engine-common/src/types/node_and_substate.rs
@@ -255,3 +255,9 @@ impl SubstateKey {
 pub type FieldKey = u8;
 pub type MapKey = Vec<u8>;
 pub type SortedKey = ([u8; 2], Vec<u8>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollectionKeyType {
+    Map,
+    Sorted,
+}

--- a/radix-engine-queries/src/query/accounter.rs
+++ b/radix-engine-queries/src/query/accounter.rs
@@ -24,7 +24,7 @@ impl<'s, S: SubstateDatabase> ResourceAccounter<'s, S> {
     pub fn traverse(&mut self, node_id: NodeId) {
         let mut state_tree_visitor =
             StateTreeTraverser::new(self.substate_db, &mut self.accounting, 100);
-        state_tree_visitor.traverse_subtree(node_id)
+        state_tree_visitor.traverse_subtree(None, node_id)
     }
 
     pub fn close(self) -> Accounting {

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -164,6 +164,16 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         module_id: ObjectModuleId,
         field_index: u8,
     ) -> Result<IndexedScryptoValue, SystemReaderError> {
+        self.read_object_field_advanced(node_id, module_id, field_index)
+            .map(|x| x.0)
+    }
+
+    pub fn read_object_field_advanced(
+        &self,
+        node_id: &NodeId,
+        module_id: ObjectModuleId,
+        field_index: u8,
+    ) -> Result<(IndexedScryptoValue, PartitionNumber), SystemReaderError> {
         let blueprint_id = self.get_blueprint_id(node_id, module_id)?;
         let definition = self.get_blueprint_definition(&blueprint_id)?;
         let partition_description = &definition
@@ -194,8 +204,9 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
             )
             .ok_or_else(|| SystemReaderError::FieldDoesNotExist)?;
 
-        Ok(IndexedScryptoValue::from_scrypto_value(
-            substate.into_payload(),
+        Ok((
+            IndexedScryptoValue::from_scrypto_value(substate.into_payload()),
+            partition_number,
         ))
     }
 
@@ -350,7 +361,23 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         node_id: &NodeId,
         module_id: ObjectModuleId,
         collection_index: CollectionIndex,
-    ) -> Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + '_>, SystemReaderError> {
+    ) -> Result<Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>, SystemReaderError> {
+        self.collection_iter_advanced(node_id, module_id, collection_index)
+            .map(|x| x.0)
+    }
+
+    pub fn collection_iter_advanced(
+        &self,
+        node_id: &NodeId,
+        module_id: ObjectModuleId,
+        collection_index: CollectionIndex,
+    ) -> Result<
+        (
+            Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>,
+            PartitionNumber,
+        ),
+        SystemReaderError,
+    > {
         if self.tracked.is_some() {
             panic!("substates_iter with overlay not supported.");
         }
@@ -381,20 +408,10 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
                 let key = match schema {
                     BlueprintCollectionSchema::KeyValueStore(..)
                     | BlueprintCollectionSchema::Index(..) => {
-                        let substate_key =
-                            SpreadPrefixKeyMapper::from_db_sort_key::<MapKey>(&entry.0);
-                        match substate_key {
-                            SubstateKey::Map(map_key) => map_key,
-                            _ => panic!("Unexpected SubstateKey"),
-                        }
+                        SpreadPrefixKeyMapper::from_db_sort_key::<MapKey>(&entry.0)
                     }
                     BlueprintCollectionSchema::SortedIndex(..) => {
-                        let substate_key =
-                            SpreadPrefixKeyMapper::from_db_sort_key::<SortedKey>(&entry.0);
-                        match substate_key {
-                            SubstateKey::Sorted((_sort, map_key)) => map_key,
-                            _ => panic!("Unexpected SubstateKey"),
-                        }
+                        SpreadPrefixKeyMapper::from_db_sort_key::<SortedKey>(&entry.0)
                     }
                 };
 
@@ -412,7 +429,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
                 Some((key, value))
             });
 
-        Ok(Box::new(iter))
+        Ok((Box::new(iter), partition_number))
     }
 
     pub fn get_object_info<A: Into<GlobalAddress>>(

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -611,6 +611,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             )
             .unwrap()
             .map(|(key, value)| {
+                let key = key.into_map();
                 let hash: SchemaHash = scrypto_decode(&key).unwrap();
                 let schema: PackageSchemaEntryPayload = scrypto_decode(&value).unwrap();
                 (hash, schema.content)
@@ -631,7 +632,8 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             )
             .unwrap()
             .map(|(key, value)| {
-                let key: BlueprintVersionKey = scrypto_decode(&key).unwrap();
+                let map_key = key.into_map();
+                let key: BlueprintVersionKey = scrypto_decode(&map_key).unwrap();
                 let definition: PackageBlueprintVersionDefinitionEntryPayload =
                     scrypto_decode(&value).unwrap();
                 (key, definition.into_latest())
@@ -721,7 +723,8 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             )
             .unwrap()
             .map(|(key, _)| {
-                let id: NonFungibleLocalId = scrypto_decode(&key).unwrap();
+                let map_key = key.into_map();
+                let id: NonFungibleLocalId = scrypto_decode(&map_key).unwrap();
                 id
             })
             .collect();
@@ -2131,7 +2134,7 @@ impl<'d, D: SubstateDatabase> SubtreeVaults<'d, D> {
     pub fn get_all(&self, node_id: &NodeId) -> IndexMap<ResourceAddress, Vec<NodeId>> {
         let mut vault_finder = VaultFinder::new();
         let mut traverser = StateTreeTraverser::new(self.database, &mut vault_finder, 100);
-        traverser.traverse_subtree(*node_id);
+        traverser.traverse_subtree(None, *node_id);
         vault_finder.to_vaults()
     }
 

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -284,7 +284,8 @@ fn get_entity_metadata<T: SubstateDatabase>(
         )
         .unwrap()
         .map(|(key, value)| {
-            let key = scrypto_decode::<String>(&key).unwrap();
+            let map_key = key.into_map();
+            let key = scrypto_decode::<String>(&map_key).unwrap();
             let value = scrypto_decode::<MetadataEntryEntryPayload>(&value).unwrap();
             (key, value.into_latest())
         })


### PR DESCRIPTION
This reverts commit 0282a78c8008376c1ebc3f87ce6976afa81aeb3e.

## Summary
```
INSTRUCTIONS:
Add summary - one or two sentences explaining the purpose of this PR.
```

## Details
```
INSTRUCTIONS:
Provide further details about the changes, or how they fit into the roadmap.
You can delete this section if it's not useful.
```

## Testing
```
INSTRUCTIONS:
Further details about the tests you've added or manually performed.
You can delete this section if it's not useful.
```

## Update Recommendations
```
INSTRUCTIONS:
This section is to provide recommendations to consumers of this repo about how they
should handle breaking changes, or integrate new features. The two key stakeholder
groups are dApp Developers and Internal Integrators, and there are separate sections
for each.

In order to allow us to compile aggregated update instructions across PRs, please tag the PR
with 0+ of the relevant labels:
* scrypto-lib - Any change to the scrypto library
* sbor - Any breaking change to SBOR encoding/decoding
* manifest - Any change to manifest display, compilation/decompilation
* transaction - Any change which affects the compiled manifest, or transaction semantics
* substate - Any change to substates, the state model, or what's stored in the DB
* native-blueprint-interface - Any change to the interface of native blueprints
* files-moved - Any change to where engine types have moved, which will require
  internal integrators to update their imports

If you have a breaking change which doesn't fix into a category above, then tag it with
the closest label, and discuss in slack/discord.

If your PR contains no breaking changes or new features or hasn't been tagged, this whole
section can be deleted.
```

### For dApp Developers
```
INSTRUCTIONS:
Migration recommendations for a dApp developer to update their dApp/integrations
due to to the change/s in this PR.

These will be aggregated by the Developer Ecosystem team and included in the next Scrypto migration guide
(eg https://docs-babylon.radixdlt.com/main/scrypto/release_notes/migrating_from_0.7_to_0.8.html )
```

### For Internal Integrators
```
INSTRUCTIONS:
Instructions to any internal integrations (eg Node, Toolkit, Gateway, Ledger App) for how the changes may affect
them and recommendations for how they should update to support this change.
```
