### PR TITLE
Architecture: Explicit network definition

### DIFF
--- a/radix-engine-tests/benches/resources_usage.rs
+++ b/radix-engine-tests/benches/resources_usage.rs
@@ -153,7 +153,7 @@ fn transfer_test(c: &mut Criterion) {
                 &mut substate_db,
                 &mut scrypto_interpreter,
                 &CostingParameters::default(),
-                &ExecutionConfig::for_notarized_transaction(),
+                &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
                 &TestTransaction::new_from_nonce(manifest.clone(), 1)
                     .prepare()
                     .unwrap()
@@ -171,7 +171,7 @@ fn transfer_test(c: &mut Criterion) {
                 &mut substate_db,
                 &mut scrypto_interpreter,
                 &CostingParameters::default(),
-                &ExecutionConfig::for_notarized_transaction(),
+                &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
                 &TestTransaction::new_from_nonce(manifest.clone(), 1)
                     .prepare()
                     .unwrap()
@@ -198,7 +198,7 @@ fn transfer_test(c: &mut Criterion) {
             &mut substate_db,
             &mut scrypto_interpreter,
             &CostingParameters::default(),
-            &ExecutionConfig::for_notarized_transaction(),
+            &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
             &TestTransaction::new_from_nonce(manifest.clone(), nonce)
                 .prepare()
                 .unwrap()
@@ -222,7 +222,7 @@ fn transfer_test(c: &mut Criterion) {
                 &mut substate_db,
                 &mut scrypto_interpreter,
                 &CostingParameters::default(),
-                &ExecutionConfig::for_notarized_transaction(),
+                &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
                 &TestTransaction::new_from_nonce(manifest.clone(), nonce)
                     .prepare()
                     .unwrap()

--- a/radix-engine-tests/benches/transfer.rs
+++ b/radix-engine-tests/benches/transfer.rs
@@ -22,7 +22,7 @@ fn bench_transfer(c: &mut Criterion) {
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = InMemorySubstateDatabase::standard();
-    Bootstrapper::new(&mut substate_db, vm.clone(), false)
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false)
         .bootstrap_test_default()
         .unwrap();
 
@@ -44,7 +44,7 @@ fn bench_transfer(c: &mut Criterion) {
                 &mut substate_db,
                 vm.clone(),
                 &CostingParameters::default(),
-                &ExecutionConfig::for_notarized_transaction(),
+                &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
                 &TestTransaction::new_from_nonce(manifest.clone(), 1)
                     .prepare()
                     .unwrap()
@@ -71,7 +71,7 @@ fn bench_transfer(c: &mut Criterion) {
             &mut substate_db,
             vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_notarized_transaction(),
+            &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
             &TestTransaction::new_from_nonce(manifest.clone(), nonce)
                 .prepare()
                 .unwrap()
@@ -95,7 +95,7 @@ fn bench_transfer(c: &mut Criterion) {
                 &mut substate_db,
                 vm.clone(),
                 &CostingParameters::default(),
-                &ExecutionConfig::for_notarized_transaction(),
+                &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
                 &TestTransaction::new_from_nonce(manifest.clone(), nonce)
                     .prepare()
                     .unwrap()

--- a/radix-engine-tests/benches/transfer.rs
+++ b/radix-engine-tests/benches/transfer.rs
@@ -22,9 +22,14 @@ fn bench_transfer(c: &mut Criterion) {
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = InMemorySubstateDatabase::standard();
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false)
-        .bootstrap_test_default()
-        .unwrap();
+    Bootstrapper::new(
+        NetworkDefinition::simulator(),
+        &mut substate_db,
+        vm.clone(),
+        false,
+    )
+    .bootstrap_test_default()
+    .unwrap();
 
     // Create a key pair
     let private_key = Secp256k1PrivateKey::from_u64(1).unwrap();

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -38,7 +38,8 @@ fn test_bootstrap_receipt_should_match_constants() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,
@@ -117,7 +118,8 @@ fn test_bootstrap_receipts_should_have_complete_system_structure() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,
@@ -217,7 +219,8 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
 
     let GenesisReceipts {
         mut data_ingestion_receipts,
@@ -353,7 +356,8 @@ fn test_genesis_stake_allocation() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         mut data_ingestion_receipts,
@@ -435,7 +439,8 @@ fn test_genesis_time() {
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = InMemorySubstateDatabase::standard();
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
 
     let _ = bootstrapper
         .bootstrap_with_genesis_data(

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -38,7 +38,7 @@ fn test_bootstrap_receipt_should_match_constants() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, true);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,
@@ -117,7 +117,7 @@ fn test_bootstrap_receipts_should_have_complete_system_structure() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, true);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,
@@ -217,7 +217,7 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, false);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
 
     let GenesisReceipts {
         mut data_ingestion_receipts,
@@ -353,7 +353,7 @@ fn test_genesis_stake_allocation() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, true);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         mut data_ingestion_receipts,
@@ -435,7 +435,7 @@ fn test_genesis_time() {
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = InMemorySubstateDatabase::standard();
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, false);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false);
 
     let _ = bootstrapper
         .bootstrap_with_genesis_data(

--- a/radix-engine-tests/tests/common_transformation_costs.rs
+++ b/radix-engine-tests/tests/common_transformation_costs.rs
@@ -32,7 +32,8 @@ fn estimate_locking_fee_from_an_account_protected_by_signature() {
     let receipt1 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(100)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt1.expect_commit_success();
     println!("\n{:?}", receipt1);
@@ -49,7 +50,8 @@ fn estimate_locking_fee_from_an_account_protected_by_signature() {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);
@@ -84,7 +86,8 @@ fn estimate_locking_fee_from_an_account_protected_by_access_controller() {
     let receipt1 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(100)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt1.expect_commit_success();
     println!("\n{:?}", receipt1);
@@ -108,7 +111,8 @@ fn estimate_locking_fee_from_an_account_protected_by_access_controller() {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);
@@ -149,7 +153,8 @@ fn estimate_asserting_worktop_contains_fungible_resource() {
     let receipt1 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt1.expect_commit_success();
     println!("\n{:?}", receipt1);
@@ -171,7 +176,8 @@ fn estimate_asserting_worktop_contains_fungible_resource() {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);
@@ -216,7 +222,8 @@ fn estimate_asserting_worktop_contains_non_fungible_resource() {
     let receipt1 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt1.expect_commit_success();
     println!("\n{:?}", receipt1);
@@ -238,7 +245,8 @@ fn estimate_asserting_worktop_contains_non_fungible_resource() {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);
@@ -288,7 +296,8 @@ fn estimate_adding_signature() {
     let receipt1 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt1.expect_commit_success();
     println!("\n{:?}", receipt1);
@@ -304,7 +313,8 @@ fn estimate_adding_signature() {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);
@@ -364,7 +374,8 @@ fn estimate_notarizing(notary_is_signatory: bool) {
     let receipt2 = test_runner.execute_transaction(
         validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction().with_cost_breakdown(true),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
     );
     receipt2.expect_commit_success();
     println!("\n{:?}", receipt2);

--- a/radix-engine-tests/tests/fuzz_transactions.rs
+++ b/radix-engine-tests/tests/fuzz_transactions.rs
@@ -37,7 +37,7 @@ impl TransactionFuzzer {
         let vm = Vm::new(&scrypto_vm, native_vm.clone());
 
         let mut substate_db = InMemorySubstateDatabase::standard();
-        Bootstrapper::new(&mut substate_db, vm, false)
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
             .bootstrap_test_default()
             .unwrap();
 

--- a/radix-engine-tests/tests/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel_open_substate.rs
@@ -38,7 +38,7 @@ pub fn test_open_substate_of_invisible_package_address() {
         scrypto_vm: &scrypto_vm,
         native_vm: native_vm.clone(),
     };
-    Bootstrapper::new(&mut database, vm, false);
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut database, vm, false);
 
     // Create kernel
     let mut id_allocator = IdAllocator::new(executable.intent_hash().to_hash());

--- a/radix-engine-tests/tests/preview.rs
+++ b/radix-engine-tests/tests/preview.rs
@@ -38,7 +38,7 @@ fn test_transaction_preview_cost_estimate() {
     let actual_receipt = test_runner.execute_transaction(
         validate(&network, &notarized_transaction).get_executable(),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction()
+        ExecutionConfig::for_notarized_transaction(network.clone())
             .with_kernel_trace(true)
             .with_cost_breakdown(true),
     );

--- a/radix-engine-tests/tests/system_db_checker.rs
+++ b/radix-engine-tests/tests/system_db_checker.rs
@@ -18,7 +18,8 @@ fn system_database_checker_should_report_missing_owner_error_on_broken_db() {
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = InMemorySubstateDatabase::standard();
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, true);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
     bootstrapper.bootstrap_test_default().unwrap();
     let remove_owner_update = {
         let mut remove_owner_update = DatabaseUpdates::default();

--- a/radix-engine-tests/tests/transaction_executor.rs
+++ b/radix-engine-tests/tests/transaction_executor.rs
@@ -77,7 +77,7 @@ fn transaction_executed_after_valid_returns_that_rejection_reason() {
     let receipt = test_runner.execute_transaction(
         get_validated(&transaction).unwrap().get_executable(),
         CostingParameters::default(),
-        ExecutionConfig::for_test_transaction(),
+        ExecutionConfig::for_test_transaction()
     );
 
     // Assert
@@ -102,7 +102,7 @@ fn test_normal_transaction_flow() {
     let vm = Vm::new(&scrypto_vm, native_vm);
 
     let mut substate_db = InMemorySubstateDatabase::standard();
-    Bootstrapper::new(&mut substate_db, vm.clone(), true)
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), true)
         .bootstrap_test_default()
         .unwrap();
 

--- a/radix-engine-tests/tests/transaction_executor.rs
+++ b/radix-engine-tests/tests/transaction_executor.rs
@@ -77,7 +77,7 @@ fn transaction_executed_after_valid_returns_that_rejection_reason() {
     let receipt = test_runner.execute_transaction(
         get_validated(&transaction).unwrap().get_executable(),
         CostingParameters::default(),
-        ExecutionConfig::for_test_transaction()
+        ExecutionConfig::for_test_transaction(),
     );
 
     // Assert
@@ -102,9 +102,14 @@ fn test_normal_transaction_flow() {
     let vm = Vm::new(&scrypto_vm, native_vm);
 
     let mut substate_db = InMemorySubstateDatabase::standard();
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), true)
-        .bootstrap_test_default()
-        .unwrap();
+    Bootstrapper::new(
+        NetworkDefinition::simulator(),
+        &mut substate_db,
+        vm.clone(),
+        true,
+    )
+    .bootstrap_test_default()
+    .unwrap();
 
     let costing_parameters = CostingParameters::default();
     let execution_config = ExecutionConfig::for_test_transaction().with_kernel_trace(true);

--- a/radix-engine-tests/tests/transaction_multi_threaded.rs
+++ b/radix-engine-tests/tests/transaction_multi_threaded.rs
@@ -31,9 +31,14 @@ mod multi_threaded_test {
             native_vm,
         };
         let mut substate_db = InMemorySubstateDatabase::standard();
-        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false)
-            .bootstrap_test_default()
-            .unwrap();
+        Bootstrapper::new(
+            NetworkDefinition::simulator(),
+            &mut substate_db,
+            vm.clone(),
+            false,
+        )
+        .bootstrap_test_default()
+        .unwrap();
 
         // Create a key pair
         let private_key = Secp256k1PrivateKey::from_u64(1).unwrap();

--- a/radix-engine-tests/tests/transaction_multi_threaded.rs
+++ b/radix-engine-tests/tests/transaction_multi_threaded.rs
@@ -31,7 +31,7 @@ mod multi_threaded_test {
             native_vm,
         };
         let mut substate_db = InMemorySubstateDatabase::standard();
-        Bootstrapper::new(&mut substate_db, vm.clone(), false)
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false)
             .bootstrap_test_default()
             .unwrap();
 

--- a/radix-engine-tests/tests/transaction_tracker.rs
+++ b/radix-engine-tests/tests/transaction_tracker.rs
@@ -34,7 +34,7 @@ fn test_transaction_replay_protection() {
     let receipt = test_runner.execute_transaction(
         validated.get_executable(),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction(),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
     );
     receipt.expect_commit_success();
 
@@ -46,7 +46,7 @@ fn test_transaction_replay_protection() {
     let receipt = test_runner.execute_transaction(
         validated.get_executable(),
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction(),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
     );
     receipt.expect_specific_rejection(|e| match e {
         RejectionReason::IntentHashPreviouslyCommitted => true,
@@ -71,7 +71,7 @@ fn test_transaction_replay_protection() {
     let receipt = test_runner.execute_transaction(
         executable,
         CostingParameters::default(),
-        ExecutionConfig::for_notarized_transaction(),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
     );
     receipt.expect_commit_success();
 }

--- a/radix-engine-tests/tests/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/typed_substate_layout.rs
@@ -37,7 +37,8 @@ fn test_bootstrap_receipt_should_have_substate_changes_which_can_be_typed() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
+    let mut bootstrapper =
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,

--- a/radix-engine-tests/tests/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/typed_substate_layout.rs
@@ -37,7 +37,7 @@ fn test_bootstrap_receipt_should_have_substate_changes_which_can_be_typed() {
         },
     ];
 
-    let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, true);
+    let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
 
     let GenesisReceipts {
         system_bootstrap_receipt,
@@ -123,6 +123,7 @@ fn test_bootstrap_receipt_should_have_events_that_can_be_typed() {
     ];
 
     let mut bootstrapper = Bootstrapper::new(
+        NetworkDefinition::simulator(),
         &mut substate_db,
         Vm {
             scrypto_vm: &scrypto_vm,

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -270,7 +270,12 @@ where
     S: SubstateDatabase + CommittableSubstateDatabase,
     V: SystemCallbackObject + Clone,
 {
-    pub fn new(network_definition: NetworkDefinition, substate_db: &'s mut S, vm: V, trace: bool) -> Bootstrapper<'s, S, V> {
+    pub fn new(
+        network_definition: NetworkDefinition,
+        substate_db: &'s mut S,
+        vm: V,
+        trace: bool,
+    ) -> Bootstrapper<'s, S, V> {
         Bootstrapper {
             network_definition,
             substate_db,
@@ -374,7 +379,8 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
+                .with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected system bootstrap transaction to be preparable")
@@ -400,7 +406,8 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
+                .with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected genesis data chunk transaction to be preparable")
@@ -421,7 +428,8 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
+                .with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected genesis wrap up transaction to be preparable")

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -259,6 +259,7 @@ where
     S: SubstateDatabase + CommittableSubstateDatabase,
     V: SystemCallbackObject + Clone,
 {
+    network_definition: NetworkDefinition,
     substate_db: &'s mut S,
     vm: V,
     trace: bool,
@@ -269,8 +270,9 @@ where
     S: SubstateDatabase + CommittableSubstateDatabase,
     V: SystemCallbackObject + Clone,
 {
-    pub fn new(substate_db: &'s mut S, vm: V, trace: bool) -> Bootstrapper<'s, S, V> {
+    pub fn new(network_definition: NetworkDefinition, substate_db: &'s mut S, vm: V, trace: bool) -> Bootstrapper<'s, S, V> {
         Bootstrapper {
+            network_definition,
             substate_db,
             vm,
             trace,
@@ -372,7 +374,7 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction().with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected system bootstrap transaction to be preparable")
@@ -398,7 +400,7 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction().with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected genesis data chunk transaction to be preparable")
@@ -419,7 +421,7 @@ where
             self.substate_db,
             self.vm.clone(),
             &CostingParameters::default(),
-            &ExecutionConfig::for_genesis_transaction().with_kernel_trace(self.trace),
+            &ExecutionConfig::for_genesis_transaction(self.network_definition.clone()).with_kernel_trace(self.trace),
             &transaction
                 .prepare()
                 .expect("Expected genesis wrap up transaction to be preparable")

--- a/radix-engine/src/transaction/preview_executor.rs
+++ b/radix-engine/src/transaction/preview_executor.rs
@@ -32,7 +32,7 @@ pub fn execute_preview<S: SubstateDatabase, V: SystemCallbackObject + Clone>(
         substate_db,
         vm,
         &CostingParameters::default(),
-        &ExecutionConfig::for_preview().with_kernel_trace(with_kernel_trace),
+        &ExecutionConfig::for_preview(network.clone()).with_kernel_trace(with_kernel_trace),
         &validated.get_executable(),
     ))
 }

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -103,9 +103,9 @@ pub struct ExecutionConfig {
 impl ExecutionConfig {
     /// Creates an `ExecutionConfig` using default configurations.
     /// This is internal. Clients should use `for_xxx` constructors instead.
-    fn default() -> Self {
+    fn default(network_definition: NetworkDefinition) -> Self {
         Self {
-            network_definition: NetworkDefinition::simulator(),
+            network_definition,
             enabled_modules: EnabledModules::for_notarized_transaction(),
             abort_when_loan_repaid: false,
             enable_cost_breakdown: false,
@@ -126,27 +126,27 @@ impl ExecutionConfig {
         }
     }
 
-    pub fn for_genesis_transaction() -> Self {
+    pub fn for_genesis_transaction(network_definition: NetworkDefinition) -> Self {
         Self {
             enabled_modules: EnabledModules::for_genesis_transaction(),
             max_heap_substate_total_bytes: 512 * 1024 * 1024,
             max_track_substate_total_bytes: 512 * 1024 * 1024,
             max_number_of_events: 1024 * 1024,
-            ..Self::default()
+            ..Self::default(network_definition)
         }
     }
 
-    pub fn for_system_transaction() -> Self {
+    pub fn for_system_transaction(network_definition: NetworkDefinition) -> Self {
         Self {
             enabled_modules: EnabledModules::for_system_transaction(),
-            ..Self::default()
+            ..Self::default(network_definition)
         }
     }
 
-    pub fn for_notarized_transaction() -> Self {
+    pub fn for_notarized_transaction(network_definition: NetworkDefinition) -> Self {
         Self {
             enabled_modules: EnabledModules::for_notarized_transaction(),
-            ..Self::default()
+            ..Self::default(network_definition)
         }
     }
 
@@ -154,15 +154,15 @@ impl ExecutionConfig {
         Self {
             enabled_modules: EnabledModules::for_test_transaction(),
             enable_cost_breakdown: true,
-            ..Self::default()
+            ..Self::default(NetworkDefinition::simulator())
         }
     }
 
-    pub fn for_preview() -> Self {
+    pub fn for_preview(network_definition: NetworkDefinition) -> Self {
         Self {
             enabled_modules: EnabledModules::for_preview(),
             enable_cost_breakdown: true,
-            ..Self::default()
+            ..Self::default(network_definition)
         }
     }
 

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -312,7 +312,12 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         let native_vm = NativeVm::new_with_extension(self.custom_extension);
         let vm = Vm::new(&scrypto_vm, native_vm.clone());
         let mut substate_db = self.custom_database;
-        let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, bootstrap_trace);
+        let mut bootstrapper = Bootstrapper::new(
+            NetworkDefinition::simulator(),
+            &mut substate_db,
+            vm,
+            bootstrap_trace,
+        );
         let GenesisReceipts {
             system_bootstrap_receipt,
             data_ingestion_receipts,

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -312,7 +312,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         let native_vm = NativeVm::new_with_extension(self.custom_extension);
         let vm = Vm::new(&scrypto_vm, native_vm.clone());
         let mut substate_db = self.custom_database;
-        let mut bootstrapper = Bootstrapper::new(&mut substate_db, vm, bootstrap_trace);
+        let mut bootstrapper = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, bootstrap_trace);
         let GenesisReceipts {
             system_bootstrap_receipt,
             data_ingestion_receipts,
@@ -1068,7 +1068,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .expect("expected transaction to be preparable")
             .get_executable(btreeset!(AuthAddresses::system_role())),
             CostingParameters::default(),
-            ExecutionConfig::for_system_transaction(),
+            ExecutionConfig::for_system_transaction(NetworkDefinition::simulator()),
         );
 
         receipt.expect_commit_success();
@@ -1176,7 +1176,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         self.execute_transaction(
             validated.get_executable(),
             CostingParameters::default(),
-            ExecutionConfig::for_notarized_transaction(),
+            ExecutionConfig::for_notarized_transaction(network.clone()),
         )
     }
 
@@ -1912,7 +1912,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .expect("expected transaction to be preparable")
             .get_executable(proofs),
             CostingParameters::default(),
-            ExecutionConfig::for_system_transaction(),
+            ExecutionConfig::for_system_transaction(NetworkDefinition::simulator()),
         )
     }
 
@@ -1942,7 +1942,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .expect("expected transaction to be preparable")
             .get_executable(proofs),
             CostingParameters::default(),
-            ExecutionConfig::for_system_transaction(),
+            ExecutionConfig::for_system_transaction(NetworkDefinition::simulator()),
         )
     }
 
@@ -1964,7 +1964,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .expect("expected transaction to be preparable")
             .get_executable(proofs),
             CostingParameters::default(),
-            ExecutionConfig::for_system_transaction(),
+            ExecutionConfig::for_system_transaction(NetworkDefinition::simulator()),
         )
     }
 

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -69,7 +69,8 @@ impl Publish {
             let native_vm = DefaultNativeVm::new();
             let vm = Vm::new(&scrypto_vm, native_vm);
             let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-            Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+            Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+                .bootstrap_test_default();
 
             let node_id: NodeId = package_address.0.into();
 

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -69,7 +69,7 @@ impl Publish {
             let native_vm = DefaultNativeVm::new();
             let vm = Vm::new(&scrypto_vm, native_vm);
             let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-            Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+            Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
             let node_id: NodeId = package_address.0.into();
 

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -16,7 +16,8 @@ impl Show {
         let native_vm = DefaultNativeVm::new();
         let vm = Vm::new(&scrypto_vm, native_vm);
         let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+            .bootstrap_test_default();
 
         if let Ok(a) = SimulatorPackageAddress::from_str(&self.address) {
             dump_package(a.0, &substate_db, out).map_err(Error::LedgerDumpError)

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -16,7 +16,7 @@ impl Show {
         let native_vm = DefaultNativeVm::new();
         let vm = Vm::new(&scrypto_vm, native_vm);
         let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-        Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
         if let Ok(a) = SimulatorPackageAddress::from_str(&self.address) {
             dump_package(a.0, &substate_db, out).map_err(Error::LedgerDumpError)

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -23,7 +23,8 @@ impl ShowLedger {
         let native_vm = DefaultNativeVm::new();
         let vm = Vm::new(&scrypto_vm, native_vm);
         let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+            .bootstrap_test_default();
 
         Self::list_entries(out, &substate_db)?;
 

--- a/simulator/src/resim/cmd_show_ledger.rs
+++ b/simulator/src/resim/cmd_show_ledger.rs
@@ -23,7 +23,7 @@ impl ShowLedger {
         let native_vm = DefaultNativeVm::new();
         let vm = Vm::new(&scrypto_vm, native_vm);
         let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-        Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+        Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
         Self::list_entries(out, &substate_db)?;
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -172,7 +172,13 @@ pub fn handle_system_transaction<O: std::io::Write>(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false).bootstrap_test_default();
+    Bootstrapper::new(
+        NetworkDefinition::simulator(),
+        &mut substate_db,
+        vm.clone(),
+        false,
+    )
+    .bootstrap_test_default();
 
     let nonce = get_nonce()?;
     let transaction = SystemTransactionV1 {
@@ -246,7 +252,13 @@ pub fn handle_manifest<O: std::io::Write>(
             let native_vm = DefaultNativeVm::new();
             let vm = Vm::new(&scrypto_vm, native_vm);
             let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-            Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false).bootstrap_test_default();
+            Bootstrapper::new(
+                NetworkDefinition::simulator(),
+                &mut substate_db,
+                vm.clone(),
+                false,
+            )
+            .bootstrap_test_default();
 
             let sks = get_signing_keys(signing_keys)?;
             let initial_proofs = sks
@@ -331,7 +343,8 @@ pub fn export_package_schema(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let package_definition = system_reader.get_package_definition(package_address);
@@ -343,7 +356,8 @@ pub fn export_object_info(component_address: ComponentAddress) -> Result<ObjectI
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     system_reader
@@ -359,7 +373,8 @@ pub fn export_schema(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let schema = system_reader
@@ -389,7 +404,8 @@ pub fn get_blueprint_id(component_address: ComponentAddress) -> Result<Blueprint
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let object_info = system_reader
@@ -460,7 +476,8 @@ pub fn db_upsert_timestamps(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let mut writer = SystemDatabaseWriter::new(&mut substate_db);
 
@@ -494,7 +511,8 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
+        .bootstrap_test_default();
 
     let reader = SystemDatabaseReader::new(&substate_db);
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -172,7 +172,7 @@ pub fn handle_system_transaction<O: std::io::Write>(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm.clone(), false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false).bootstrap_test_default();
 
     let nonce = get_nonce()?;
     let transaction = SystemTransactionV1 {
@@ -246,7 +246,7 @@ pub fn handle_manifest<O: std::io::Write>(
             let native_vm = DefaultNativeVm::new();
             let vm = Vm::new(&scrypto_vm, native_vm);
             let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-            Bootstrapper::new(&mut substate_db, vm.clone(), false).bootstrap_test_default();
+            Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm.clone(), false).bootstrap_test_default();
 
             let sks = get_signing_keys(signing_keys)?;
             let initial_proofs = sks
@@ -331,7 +331,7 @@ pub fn export_package_schema(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let package_definition = system_reader.get_package_definition(package_address);
@@ -343,7 +343,7 @@ pub fn export_object_info(component_address: ComponentAddress) -> Result<ObjectI
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     system_reader
@@ -359,7 +359,7 @@ pub fn export_schema(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let schema = system_reader
@@ -389,7 +389,7 @@ pub fn get_blueprint_id(component_address: ComponentAddress) -> Result<Blueprint
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let system_reader = SystemDatabaseReader::new(&substate_db);
     let object_info = system_reader
@@ -460,7 +460,7 @@ pub fn db_upsert_timestamps(
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let mut writer = SystemDatabaseWriter::new(&mut substate_db);
 
@@ -494,7 +494,7 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
     let native_vm = DefaultNativeVm::new();
     let vm = Vm::new(&scrypto_vm, native_vm);
     let mut substate_db = RocksdbSubstateStore::standard(get_data_dir()?);
-    Bootstrapper::new(&mut substate_db, vm, false).bootstrap_test_default();
+    Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false).bootstrap_test_default();
 
     let reader = SystemDatabaseReader::new(&substate_db);
 

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -194,7 +194,8 @@ pub fn handle_system_transaction<O: std::io::Write>(
         &mut substate_db,
         vm,
         &CostingParameters::default(),
-        &ExecutionConfig::for_system_transaction().with_kernel_trace(trace),
+        &ExecutionConfig::for_system_transaction(NetworkDefinition::simulator())
+            .with_kernel_trace(trace),
         &transaction
             .prepare()
             .map_err(Error::TransactionPrepareError)?

--- a/transaction-scenarios/src/runners/dumper.rs
+++ b/transaction-scenarios/src/runners/dumper.rs
@@ -32,7 +32,7 @@ pub fn run_all_in_memory_and_dump_examples(
         native_vm,
     };
 
-    let receipts = Bootstrapper::new(&mut substate_db, vm, false)
+    let receipts = Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
         .bootstrap_test_default()
         .unwrap();
     let epoch = receipts


### PR DESCRIPTION
Require explicit network definition when setting up `ExecutionConfig` to prevent wrong definitions from being used