### PR TITLE
Move wasm-opt from feature flag to cli arg

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -25,11 +25,7 @@ cargo_toml = { version = "0.11.5" }
 rand = { version = "0.8.5" }
 regex = { version = "1.5.5" }
 temp-env = { version = "0.2.0" }
-wasm-opt = { version = "0.114.1", optional = true }
-
-[features]
-default = ["wasm-opt"]
-wasm-opt = ["dep:wasm-opt"]
+wasm-opt = { version = "0.114.1" }
 
 [[bin]]
 name = "resim"

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -44,13 +44,18 @@ pub struct Publish {
     /// Turn on tracing
     #[clap(short, long)]
     pub trace: bool,
+
+    /// When passed, this argument disables wasm-opt from running on the built wasm.
+    #[clap(long)]
+    disable_wasm_opt: bool,
 }
 
 impl Publish {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         // Load wasm code
         let (code_path, definition_path) = if self.path.extension() != Some(OsStr::new("wasm")) {
-            build_package(&self.path, false, false).map_err(Error::BuildError)?
+            build_package(&self.path, false, false, self.disable_wasm_opt)
+                .map_err(Error::BuildError)?
         } else {
             let code_path = self.path.clone();
             let schema_path = code_path.with_extension("schema");

--- a/simulator/src/scrypto/cmd_build.rs
+++ b/simulator/src/scrypto/cmd_build.rs
@@ -15,6 +15,10 @@ pub struct Build {
     /// Turn on tracing
     #[clap(short, long)]
     trace: bool,
+
+    /// When passed, this argument disables wasm-opt from running on the built wasm.
+    #[clap(long)]
+    disable_wasm_opt: bool,
 }
 
 impl Build {
@@ -23,6 +27,7 @@ impl Build {
             self.path.clone().unwrap_or(current_dir().unwrap()),
             self.trace,
             false,
+            self.disable_wasm_opt,
         )
         .map(|_| ())
         .map_err(Error::BuildError)


### PR DESCRIPTION
## Summary

This PR moves wasm-opt from being a feature flag to being an arg to the scrypto cli tool. By default, wasm-opt is enabled. The wasm-opt arg must be passed in to disable it. 