### PR TITLE
tweak: ManifestBuilder and TestRunner improvements

### DIFF
--- a/radix-engine-interface/src/api/node_modules/metadata/models/mod.rs
+++ b/radix-engine-interface/src/api/node_modules/metadata/models/mod.rs
@@ -6,6 +6,7 @@ pub use self::url::*;
 pub use discriminators::*;
 pub use origin::*;
 
+use crate::internal_prelude::*;
 use crate::types::KeyValueStoreInit;
 use crate::*;
 #[cfg(feature = "radix_engine_fuzzing")]
@@ -18,8 +19,6 @@ use radix_engine_common::math::Decimal;
 use radix_engine_common::time::Instant;
 use radix_engine_common::types::GlobalAddress;
 use radix_engine_interface::blueprints::resource::NonFungibleGlobalId;
-use sbor::rust::fmt::Debug;
-use sbor::rust::prelude::*;
 use sbor::SborEnum;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
@@ -331,6 +330,9 @@ impl_metadata_val!(
 // Additional to metadata value implementations
 
 impl_metadata_val_alias!(String, |<'a>| &'a str);
+impl_metadata_val_alias!(GlobalAddress, ComponentAddress);
+impl_metadata_val_alias!(GlobalAddress, ResourceAddress);
+impl_metadata_val_alias!(GlobalAddress, PackageAddress);
 
 impl ToMetadataEntry for MetadataValue {
     fn to_metadata_entry(self) -> Option<MetadataValue> {

--- a/radix-engine-interface/src/blueprints/resource/non_fungible_global_id.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible_global_id.rs
@@ -39,6 +39,10 @@ impl NonFungibleGlobalId {
         NonFungibleGlobalId::new(GLOBAL_CALLER_VIRTUAL_BADGE, local_id)
     }
 
+    pub fn into_parts(self) -> (ResourceAddress, NonFungibleLocalId) {
+        (self.0, self.1)
+    }
+
     /// Returns the resource address.
     pub fn resource_address(&self) -> ResourceAddress {
         self.0

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -51,7 +51,7 @@ pub mod prelude {
     pub use crate::api::field_api::*;
     pub use crate::api::node_modules::metadata::*;
     pub use crate::api::*;
-    pub use crate::blueprints::resource::NonFungibleGlobalId;
+    pub use crate::blueprints::resource::*;
     pub use crate::macros::*;
     pub use crate::schema::*;
     pub use crate::traits::*;

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -82,13 +82,13 @@ fn bench_radiswap(c: &mut Criterion) {
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     btc_mint_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .mint_fungible(btc, btc_init_amount)
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     eth_mint_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .mint_fungible(eth, eth_init_amount)
                 .take_all_from_worktop(btc, "liquidity_part_1")
@@ -121,13 +121,13 @@ fn bench_radiswap(c: &mut Criterion) {
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         btc_mint_auth,
-                        &btreeset!(NonFungibleLocalId::integer(1)),
+                        [NonFungibleLocalId::integer(1)],
                     )
                     .mint_fungible(btc, dec!("100"))
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         eth_mint_auth,
-                        &btreeset!(NonFungibleLocalId::integer(1)),
+                        [NonFungibleLocalId::integer(1)],
                     )
                     .mint_fungible(eth, dec!("100"))
                     .try_deposit_batch_or_abort(account2, None)

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -65,7 +65,7 @@ fn bench_radiswap(c: &mut Criterion) {
                     "new",
                     manifest_args!(OwnerRole::None, btc, eth),
                 )
-                .try_deposit_batch_or_abort(account, None)
+                .try_deposit_entire_worktop_or_abort(account, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk)],
         )
@@ -102,7 +102,7 @@ fn bench_radiswap(c: &mut Criterion) {
                         manifest_args!(bucket1, bucket2),
                     )
                 })
-                .try_deposit_batch_or_abort(account, None)
+                .try_deposit_entire_worktop_or_abort(account, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk)],
         )
@@ -130,7 +130,7 @@ fn bench_radiswap(c: &mut Criterion) {
                         [NonFungibleLocalId::integer(1)],
                     )
                     .mint_fungible(eth, dec!("100"))
-                    .try_deposit_batch_or_abort(account2, None)
+                    .try_deposit_entire_worktop_or_abort(account2, None)
                     .build(),
                 vec![NonFungibleGlobalId::from_public_key(&pk)],
             )
@@ -182,7 +182,7 @@ fn do_swap(
             let to_trade_bucket = lookup.bucket("to_trade");
             builder.call_method(component_address, "swap", manifest_args!(to_trade_bucket))
         })
-        .try_deposit_batch_or_abort(account.1, None)
+        .try_deposit_entire_worktop_or_abort(account.1, None)
         .build();
 
     test_runner

--- a/radix-engine-tests/benches/resources_usage.rs
+++ b/radix-engine-tests/benches/resources_usage.rs
@@ -165,7 +165,7 @@ fn transfer_test(c: &mut Criterion) {
             let manifest = ManifestBuilder::new()
                 .lock_fee_from_faucet()
                 .get_free_xrd_from_faucet()
-                .try_deposit_batch_or_abort(account, None)
+                .try_deposit_entire_worktop_or_abort(account, None)
                 .build();
             execute_and_commit_transaction(
                 &mut substate_db,
@@ -190,7 +190,7 @@ fn transfer_test(c: &mut Criterion) {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .get_free_xrd_from_faucet()
-        .try_deposit_batch_or_abort(account1, None)
+        .try_deposit_entire_worktop_or_abort(account1, None)
         .build();
 
     for nonce in 0..1000 {
@@ -211,7 +211,7 @@ fn transfer_test(c: &mut Criterion) {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account1, XRD, dec!("0.000001"))
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .build();
 
     // Loop

--- a/radix-engine-tests/benches/transaction_processing.rs
+++ b/radix-engine-tests/benches/transaction_processing.rs
@@ -87,7 +87,7 @@ fn compiled_notarized_transaction() -> Vec<u8> {
                         .collect::<BTreeMap<NonFungibleLocalId, EmptyStruct>>(),
                 ),
             )
-            .try_deposit_batch_or_abort(component_address, None)
+            .try_deposit_entire_worktop_or_abort(component_address, None)
             .build()
     };
     let header = TransactionHeaderV1 {

--- a/radix-engine-tests/benches/transaction_validation.rs
+++ b/radix-engine-tests/benches/transaction_validation.rs
@@ -60,7 +60,7 @@ fn bench_transaction_validation(c: &mut Criterion) {
         .manifest(
             ManifestBuilder::new()
                 .withdraw_from_account(account1, XRD, 1)
-                .try_deposit_batch_or_abort(account2, None)
+                .try_deposit_entire_worktop_or_abort(account2, None)
                 .build(),
         )
         .notarize(&signer)

--- a/radix-engine-tests/benches/transfer.rs
+++ b/radix-engine-tests/benches/transfer.rs
@@ -69,7 +69,7 @@ fn bench_transfer(c: &mut Criterion) {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .get_free_xrd_from_faucet()
-        .try_deposit_batch_or_abort(account1, None)
+        .try_deposit_entire_worktop_or_abort(account1, None)
         .build();
     for nonce in 0..1000 {
         execute_and_commit_transaction(
@@ -89,7 +89,7 @@ fn bench_transfer(c: &mut Criterion) {
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account1)
         .withdraw_from_account(account1, XRD, dec!("0.000001"))
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .build();
 
     // Loop

--- a/radix-engine-tests/tests/access_controller.rs
+++ b/radix-engine-tests/tests/access_controller.rs
@@ -1973,7 +1973,7 @@ impl AccessControllerTestRunner {
                     non_fungible_local_ids,
                 },
             )
-            .try_deposit_batch_or_abort(self.account.0, None)
+            .try_deposit_entire_worktop_or_abort(self.account.0, None)
             .build();
         self.execute_manifest(manifest)
     }

--- a/radix-engine-tests/tests/account.rs
+++ b/radix-engine-tests/tests/account.rs
@@ -35,7 +35,7 @@ fn securify_account(is_virtual: bool, use_key: bool, expect_success: bool) {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_method(account, ACCOUNT_SECURIFY_IDENT, AccountSecurifyInput {})
-        .try_deposit_batch_or_refund(storing_account, None)
+        .try_deposit_entire_worktop_or_refund(storing_account, None)
         .build();
     let initial_proofs = if use_key {
         vec![NonFungibleGlobalId::from_public_key(&key)]
@@ -87,7 +87,7 @@ where
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_and_withdraw(account, 500, XRD, 1)
-        .try_deposit_batch_or_refund(other_account, None)
+        .try_deposit_entire_worktop_or_refund(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -116,7 +116,7 @@ fn can_withdraw_non_fungible_from_my_account_internal(use_virtual: bool) {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_and_withdraw(account, 500, resource_address, 1)
-        .try_deposit_batch_or_refund(other_account, None)
+        .try_deposit_entire_worktop_or_refund(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -145,7 +145,7 @@ fn cannot_withdraw_from_other_account_internal(is_virtual: bool) {
     let manifest = ManifestBuilder::new()
         .lock_fee(account, 500u32)
         .withdraw_from_account(other_account, XRD, 1)
-        .try_deposit_batch_or_refund(account, None)
+        .try_deposit_entire_worktop_or_refund(account, None)
         .build();
 
     // Act
@@ -269,7 +269,7 @@ fn securified_account_is_owned_by_correct_owner_badge() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_method(account, ACCOUNT_SECURIFY_IDENT, AccountSecurifyInput {})
-        .try_deposit_batch_or_refund(account, None)
+        .try_deposit_entire_worktop_or_refund(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);

--- a/radix-engine-tests/tests/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/account_deposit_modes.rs
@@ -82,7 +82,7 @@ fn account_try_deposit_method_is_callable_with_out_owner_signature() {
 }
 
 #[test]
-fn account_try_deposit_batch_or_refund_method_is_callable_with_out_owner_signature() {
+fn account_try_deposit_batch_or_refund_method_is_callable_without_owner_signature() {
     // Arrange
     for is_virtual in [true, false] {
         let mut test_runner = AccountDepositModesTestRunner::new(is_virtual);
@@ -97,7 +97,31 @@ fn account_try_deposit_batch_or_refund_method_is_callable_with_out_owner_signatu
 }
 
 #[test]
-fn account_try_deposit_or_abort_method_is_callable_with_out_owner_signature() {
+fn account_try_deposit_batch_or_refund_method_is_callable_with_array_of_resources() {
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let (_, _, account_address) = test_runner.new_account(true);
+
+    let receipt = test_runner.execute_manifest_ignoring_fee(
+        ManifestBuilder::new()
+            .get_free_xrd_from_faucet()
+            .take_all_from_worktop(XRD, "xrd_1a")
+            .take_all_from_worktop(XRD, "xrd_1b")
+            .try_deposit_batch_or_refund(account_address, ["xrd_1a", "xrd_1b"], None)
+            .try_deposit_batch_or_refund(account_address, Vec::<String>::new(), None)
+            .take_all_from_worktop(XRD, "xrd_2a")
+            .take_all_from_worktop(XRD, "xrd_2b")
+            .try_deposit_batch_or_abort(account_address, ["xrd_2a", "xrd_2b"], None)
+            .try_deposit_batch_or_abort(account_address, Vec::<String>::new(), None)
+            .build(),
+        [],
+    );
+
+    // Assert
+    receipt.expect_commit_success();
+}
+
+#[test]
+fn account_try_deposit_or_abort_method_is_callable_without_owner_signature() {
     // Arrange
     for is_virtual in [true, false] {
         let mut test_runner = AccountDepositModesTestRunner::new(is_virtual);
@@ -112,7 +136,7 @@ fn account_try_deposit_or_abort_method_is_callable_with_out_owner_signature() {
 }
 
 #[test]
-fn account_try_deposit_batch_or_abort_method_is_callable_with_out_owner_signature() {
+fn account_try_deposit_batch_or_abort_method_is_callable_without_owner_signature() {
     // Arrange
     for is_virtual in [true, false] {
         let mut test_runner = AccountDepositModesTestRunner::new(is_virtual);
@@ -573,7 +597,7 @@ impl AccountDepositModesTestRunner {
             .get_component_balance(self.component_address, resource_address);
         let manifest = ManifestBuilder::new()
             .withdraw_from_account(self.component_address, resource_address, balance)
-            .try_deposit_batch_or_refund(virtual_account, None)
+            .try_deposit_entire_worktop_or_refund(virtual_account, None)
             .build();
 
         self.execute_manifest(manifest, true)

--- a/radix-engine-tests/tests/auth_account.rs
+++ b/radix-engine-tests/tests/auth_account.rs
@@ -20,7 +20,7 @@ fn test_auth_rule(
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account, XRD, 1)
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, AuthAddresses::signer_set(signer_public_keys));
@@ -231,7 +231,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
         .pop_from_auth_zone("second_proof")
         .drop_proof("second_proof")
         .return_to_worktop("free_xrd")
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -258,7 +258,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
         .pop_from_auth_zone("proof2")
         .drop_proof("proof2")
         .return_to_worktop("free_xrd")
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -285,7 +285,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
         .pop_from_auth_zone("proof2")
         .drop_proof("proof2")
         .return_to_worktop("bucket")
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -311,7 +311,7 @@ fn can_update_updatable_owner_role_account() {
         .pop_from_auth_zone("proof2")
         .drop_proof("proof2")
         .return_to_worktop("bucket")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/radix-engine-tests/tests/auth_component.rs
+++ b/radix-engine-tests/tests/auth_component.rs
@@ -186,10 +186,7 @@ fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
-        .create_proof_from_account_of_non_fungible(
-            account,
-            auth_id,
-        )
+        .create_proof_from_account_of_non_fungible(account, auth_id)
         .call_method(
             my_component,
             "cross_component_call",

--- a/radix-engine-tests/tests/auth_component.rs
+++ b/radix-engine-tests/tests/auth_component.rs
@@ -144,7 +144,7 @@ fn can_make_cross_component_call_with_resource_authorization() {
         .withdraw_non_fungibles_from_account(
             account,
             auth_id.resource_address(),
-            &BTreeSet::from([auth_id.local_id().clone()]),
+            [auth_id.local_id().clone()],
         )
         .call_method(
             my_component,
@@ -186,10 +186,9 @@ fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
-        .create_proof_from_account_of_non_fungibles(
+        .create_proof_from_account_of_non_fungible(
             account,
-            auth_id.resource_address(),
-            &btreeset!(auth_id.local_id().clone()),
+            auth_id,
         )
         .call_method(
             my_component,

--- a/radix-engine-tests/tests/auth_mutability.rs
+++ b/radix-engine-tests/tests/auth_mutability.rs
@@ -78,13 +78,13 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                     admin_auth,
                     [NonFungibleLocalId::integer(1)],
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     updater_role_key,
@@ -106,13 +106,13 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                     admin_auth,
                     [NonFungibleLocalId::integer(1)],
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     updater_role_key,
@@ -134,7 +134,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                         admin_auth,
                         [NonFungibleLocalId::integer(1)],
                     )
-                    .update_role(
+                    .set_role(
                         token_address,
                         ObjectModuleId::Main,
                         role_key,
@@ -156,7 +156,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                     admin_auth,
                     [NonFungibleLocalId::integer(1)],
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     role_key,
@@ -176,7 +176,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                     admin_auth,
                     [NonFungibleLocalId::integer(1)],
                 )
-                .update_role(
+                .set_role(
                     token_address,
                     ObjectModuleId::Main,
                     role_key,

--- a/radix-engine-tests/tests/auth_mutability.rs
+++ b/radix-engine-tests/tests/auth_mutability.rs
@@ -76,7 +76,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .update_role(
                     token_address,
@@ -104,7 +104,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .update_role(
                     token_address,
@@ -132,7 +132,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         admin_auth,
-                        &btreeset!(NonFungibleLocalId::integer(1)),
+                        [NonFungibleLocalId::integer(1)],
                     )
                     .update_role(
                         token_address,
@@ -154,7 +154,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .update_role(
                     token_address,
@@ -174,7 +174,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .update_role(
                     token_address,

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -49,7 +49,7 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .create_proof_from_account_of_amount(account, admin_auth, dec!(1))
-            .update_role(
+            .set_role(
                 token_address,
                 module,
                 role_key,

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -85,28 +85,28 @@ fn test_resource_auth(action: Action, update_auth: bool, use_other_auth: bool, e
     builder = match action {
         Action::Mint => builder
             .mint_fungible(token_address, dec!("1.0"))
-            .try_deposit_batch_or_abort(account, None),
+            .try_deposit_entire_worktop_or_abort(account, None),
         Action::Burn => builder
             .create_proof_from_account_of_amount(account, withdraw_auth, dec!(1))
             .withdraw_from_account(account, token_address, dec!("1.0"))
             .burn_from_worktop(dec!("1.0"), token_address)
-            .try_deposit_batch_or_abort(account, None),
+            .try_deposit_entire_worktop_or_abort(account, None),
         Action::Withdraw => builder
             .withdraw_from_account(account, token_address, dec!("1.0"))
-            .try_deposit_batch_or_abort(account, None),
+            .try_deposit_entire_worktop_or_abort(account, None),
         Action::Deposit => builder
             .create_proof_from_account_of_amount(account, withdraw_auth, dec!(1))
             .withdraw_from_account(account, token_address, dec!("1.0"))
             .take_all_from_worktop(token_address, "withdrawn")
             .try_deposit_or_abort(account, None, "withdrawn")
-            .try_deposit_batch_or_abort(account, None),
+            .try_deposit_entire_worktop_or_abort(account, None),
         Action::Recall => {
             let vaults = test_runner.get_component_vaults(account, token_address);
             let vault_id = vaults[0];
 
             builder
                 .recall(InternalAddress::new_or_panic(vault_id.into()), Decimal::ONE)
-                .try_deposit_batch_or_abort(account, None)
+                .try_deposit_entire_worktop_or_abort(account, None)
         }
         Action::Freeze => {
             let vaults = test_runner.get_component_vaults(account, token_address);

--- a/radix-engine-tests/tests/auth_vault.rs
+++ b/radix-engine-tests/tests/auth_vault.rs
@@ -40,11 +40,11 @@ fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
             account,
             500,
             auth_resource_address,
-            &BTreeSet::from([NonFungibleLocalId::integer(1)]),
+            [NonFungibleLocalId::integer(1)],
         )
         .take_non_fungibles_from_worktop(
             auth_resource_address,
-            &BTreeSet::from([NonFungibleLocalId::integer(1)]),
+            [NonFungibleLocalId::integer(1)],
             "bucket",
         )
         .create_proof_from_bucket_of_all("bucket", "proof")

--- a/radix-engine-tests/tests/auth_vault.rs
+++ b/radix-engine-tests/tests/auth_vault.rs
@@ -14,7 +14,7 @@ fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_and_withdraw(account, 500, token_resource_address, 1)
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -53,7 +53,7 @@ fn can_withdraw_restricted_transfer_from_my_account_with_auth() {
         .pop_from_auth_zone("proof2")
         .drop_proof("proof2")
         .return_to_worktop("bucket")
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/auth_zone.rs
+++ b/radix-engine-tests/tests/auth_zone.rs
@@ -112,10 +112,10 @@ fn test_auth_zone_create_proof_of_all_for_non_fungible() {
         .create_proof_from_account_of_non_fungibles(
             account,
             resource_address,
-            &btreeset!(
+            [
                 NonFungibleLocalId::integer(1),
-                NonFungibleLocalId::integer(2)
-            ),
+                NonFungibleLocalId::integer(2),
+            ],
         )
         .create_proof_from_auth_zone_of_all(resource_address, "proof")
         .drop_proof("proof")

--- a/radix-engine-tests/tests/balance_changes.rs
+++ b/radix-engine-tests/tests/balance_changes.rs
@@ -173,7 +173,7 @@ fn test_balance_changes_when_recall() {
             InternalAddress::new_or_panic(vault_id.into()),
             Decimal::one(),
         )
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -220,7 +220,7 @@ fn test_balance_changes_when_transferring_non_fungibles() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account, resource_address, dec!("1.0"))
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);

--- a/radix-engine-tests/tests/bucket.rs
+++ b/radix-engine-tests/tests/bucket.rs
@@ -18,7 +18,7 @@ fn test_bucket_internal(method_name: &str, args: ManifestValue, expect_success: 
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account)
         .call_function_raw(package_address, "BucketTest", method_name, args)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -113,7 +113,7 @@ fn test_bucket_of_badges() {
         .call_function(package_address, "BadgeTest", "split", manifest_args!())
         .call_function(package_address, "BadgeTest", "borrow", manifest_args!())
         .call_function(package_address, "BadgeTest", "query", manifest_args!())
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -245,7 +245,7 @@ fn test_drop_locked_fungible_bucket() {
             "drop_locked_fungible_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -280,7 +280,7 @@ fn test_drop_locked_non_fungible_bucket() {
             "drop_locked_non_fungible_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/bucket.rs
+++ b/radix-engine-tests/tests/bucket.rs
@@ -213,7 +213,7 @@ fn create_empty_bucket() {
         .return_to_worktop("bucket1")
         .take_from_worktop(XRD, Decimal::zero(), "bucket2")
         .return_to_worktop("bucket2")
-        .take_non_fungibles_from_worktop(non_fungible_resource, &BTreeSet::new(), "bucket3")
+        .take_non_fungibles_from_worktop(non_fungible_resource, [], "bucket3")
         .return_to_worktop("bucket3")
         .build();
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/common_transformation_costs.rs
+++ b/radix-engine-tests/tests/common_transformation_costs.rs
@@ -280,7 +280,7 @@ fn estimate_adding_signature() {
             for _ in 0..10 {
                 builder = builder
                     .withdraw_from_account(account1, XRD, 1) // require auth
-                    .try_deposit_batch_or_abort(account2, None); // require no auth
+                    .try_deposit_entire_worktop_or_abort(account2, None); // require no auth
             }
             builder
         })
@@ -348,7 +348,7 @@ fn estimate_notarizing(notary_is_signatory: bool) {
             for _ in 0..10 {
                 builder = builder
                     .withdraw_from_account(account1, XRD, 1) // require auth
-                    .try_deposit_batch_or_abort(account2, None); // require no auth
+                    .try_deposit_entire_worktop_or_abort(account2, None); // require no auth
             }
             builder
         })

--- a/radix-engine-tests/tests/component.rs
+++ b/radix-engine-tests/tests/component.rs
@@ -37,7 +37,7 @@ fn test_component() {
         )
         .call_method(component, "get_component_state", manifest_args!())
         .call_method(component, "put_component_state", manifest_args!())
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt2 = test_runner.execute_manifest(
         manifest2,

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -526,7 +526,7 @@ fn register_validator_with_auth_succeeds() {
         .create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -597,7 +597,7 @@ fn unregister_validator_with_auth_succeeds() {
         .create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .unregister_validator(validator_address)
         .build();
@@ -665,7 +665,7 @@ fn test_disabled_delegated_stake(owner: bool, expect_success: bool) {
         .create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -686,7 +686,7 @@ fn test_disabled_delegated_stake(owner: bool, expect_success: bool) {
         builder = builder.create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         );
     }
 
@@ -759,7 +759,7 @@ fn registered_validator_with_no_stake_does_not_become_part_of_validator_set_on_e
         .create_proof_from_account_of_non_fungibles(
             account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -1144,7 +1144,7 @@ fn decreasing_validator_fee_takes_effect_during_next_epoch() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -1308,9 +1308,9 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
                     .create_proof_from_account_of_non_fungibles(
                         validator_account,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .call_method(
                         validator_address,
@@ -1341,9 +1341,9 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
                     .create_proof_from_account_of_non_fungibles(
                         validator_account,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .call_method(
                         validator_address,
@@ -1523,9 +1523,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .register_validator(validator_address)
@@ -1541,9 +1541,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -1559,9 +1559,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .register_validator(validator_address)
                     .build();
@@ -1571,9 +1571,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -1589,9 +1589,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .register_validator(validator_address)
                     .build();
@@ -1601,9 +1601,9 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -1854,7 +1854,7 @@ fn unregistered_validator_gets_removed_on_epoch_change() {
         .create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .unregister_validator(validator_address)
         .build();
@@ -1909,7 +1909,7 @@ fn updated_validator_keys_gets_updated_on_epoch_change() {
         .create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2065,7 +2065,7 @@ fn owner_can_lock_stake_units() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2134,7 +2134,7 @@ fn owner_can_start_unlocking_stake_units() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2163,7 +2163,7 @@ fn owner_can_start_unlocking_stake_units() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2235,7 +2235,7 @@ fn owner_can_start_unlock_of_max_should_not_panic() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2264,7 +2264,7 @@ fn owner_can_start_unlock_of_max_should_not_panic() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2319,7 +2319,7 @@ fn multiple_pending_owner_stake_unit_withdrawals_stack_up() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2356,7 +2356,7 @@ fn multiple_pending_owner_stake_unit_withdrawals_stack_up() {
             .create_proof_from_account_of_non_fungibles(
                 validator_account,
                 VALIDATOR_OWNER_BADGE,
-                &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+                [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
             )
             .call_method(
                 validator_address,
@@ -2435,7 +2435,7 @@ fn starting_unlock_of_owner_stake_units_moves_already_available_ones_to_separate
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2464,7 +2464,7 @@ fn starting_unlock_of_owner_stake_units_moves_already_available_ones_to_separate
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2486,7 +2486,7 @@ fn starting_unlock_of_owner_stake_units_moves_already_available_ones_to_separate
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2557,7 +2557,7 @@ fn owner_can_finish_unlocking_stake_units_after_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2586,7 +2586,7 @@ fn owner_can_finish_unlocking_stake_units_after_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2608,7 +2608,7 @@ fn owner_can_finish_unlocking_stake_units_after_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2680,7 +2680,7 @@ fn owner_can_not_finish_unlocking_stake_units_before_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(
             validator_account,
@@ -2709,7 +2709,7 @@ fn owner_can_not_finish_unlocking_stake_units_before_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2731,7 +2731,7 @@ fn owner_can_not_finish_unlocking_stake_units_before_delay() {
         .create_proof_from_account_of_non_fungibles(
             validator_account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -3120,27 +3120,35 @@ fn significant_protocol_updates_are_emitted_in_epoch_change_event() {
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[0],
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validators_addresses[0].as_node_id().0).unwrap()),
+            [
+                NonFungibleLocalId::bytes(validators_addresses[0].as_node_id().0).unwrap(),
+            ],
         )
         .signal_protocol_update_readiness(validators_addresses[0], "a".repeat(32).as_str())
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[1],
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validators_addresses[1].as_node_id().0).unwrap()),
+            [
+                NonFungibleLocalId::bytes(validators_addresses[1].as_node_id().0).unwrap(),
+            ],
         )
         .signal_protocol_update_readiness(validators_addresses[1], "a".repeat(32).as_str())
         // Validator 2 (10 units of stake) signals the readiness for protocol update "b..bb"
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[2],
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validators_addresses[2].as_node_id().0).unwrap()),
+            [
+                NonFungibleLocalId::bytes(validators_addresses[2].as_node_id().0).unwrap(),
+            ],
         )
         .signal_protocol_update_readiness(validators_addresses[2], "b".repeat(32).as_str())
         // Validator 3 (3 units of stake) signals the readiness for protocol update "c..cc"
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[3],
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validators_addresses[3].as_node_id().0).unwrap()),
+            [
+                NonFungibleLocalId::bytes(validators_addresses[3].as_node_id().0).unwrap(),
+            ],
         )
         .signal_protocol_update_readiness(validators_addresses[3], "c".repeat(32).as_str())
         .build();

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -436,7 +436,7 @@ fn create_validator_with_low_payment_amount_should_fail(amount: Decimal, expect_
             .withdraw_from_account(account, XRD, amount)
             .take_all_from_worktop(XRD, "creation_fee")
             .create_validator(public_key, Decimal::ONE, "creation_fee")
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -701,7 +701,7 @@ fn test_disabled_delegated_stake(owner: bool, expect_success: bool) {
                 builder.call_method(validator_address, "stake", manifest_args!(bucket))
             }
         })
-        .try_deposit_batch_or_abort(validator_account_address, None)
+        .try_deposit_entire_worktop_or_abort(validator_account_address, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -1523,7 +1523,7 @@ impl RegisterAndStakeTransactionType {
                     .register_validator(validator_address)
                     .take_all_from_worktop(XRD, "stake")
                     .stake_validator_as_owner(validator_address, "stake")
-                    .try_deposit_batch_or_abort(account_address, None)
+                    .try_deposit_entire_worktop_or_abort(account_address, None)
                     .build();
                 vec![manifest]
             }
@@ -1539,7 +1539,7 @@ impl RegisterAndStakeTransactionType {
                     .take_all_from_worktop(XRD, "stake")
                     .stake_validator_as_owner(validator_address, "stake")
                     .register_validator(validator_address)
-                    .try_deposit_batch_or_abort(account_address, None)
+                    .try_deposit_entire_worktop_or_abort(account_address, None)
                     .build();
                 vec![manifest]
             }
@@ -1564,7 +1564,7 @@ impl RegisterAndStakeTransactionType {
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
                     .stake_validator_as_owner(validator_address, "stake")
-                    .try_deposit_batch_or_abort(account_address, None)
+                    .try_deposit_entire_worktop_or_abort(account_address, None)
                     .build();
 
                 vec![register_manifest, stake_manifest]
@@ -1590,7 +1590,7 @@ impl RegisterAndStakeTransactionType {
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
                     .stake_validator_as_owner(validator_address, "stake")
-                    .try_deposit_batch_or_abort(account_address, None)
+                    .try_deposit_entire_worktop_or_abort(account_address, None)
                     .build();
 
                 vec![stake_manifest, register_manifest]
@@ -1951,7 +1951,7 @@ fn cannot_claim_unstake_immediately() {
         .unstake_validator(validator_address, "stake_units")
         .take_all_from_worktop(validator_substate.claim_nft, "unstake_nft")
         .claim_xrd(validator_address, "unstake_nft")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -1995,7 +1995,7 @@ fn can_claim_unstake_after_epochs() {
         .withdraw_from_account(account_with_su, validator_substate.stake_unit_resource, 1)
         .take_all_from_worktop(validator_substate.stake_unit_resource, "stake_units")
         .unstake_validator(validator_address, "stake_units")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -2010,7 +2010,7 @@ fn can_claim_unstake_after_epochs() {
         .withdraw_from_account(account_with_su, validator_substate.claim_nft, 1)
         .take_all_from_worktop(validator_substate.claim_nft, "unstake_receipt")
         .claim_xrd(validator_address, "unstake_receipt")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -2778,7 +2778,7 @@ fn unstaked_validator_gets_less_stake_on_epoch_change() {
         .withdraw_from_account(account_with_su, validator_substate.stake_unit_resource, 1)
         .take_all_from_worktop(validator_substate.stake_unit_resource, "stake_units")
         .unstake_validator(validator_address, "stake_units")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt1 = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -1300,28 +1300,25 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
     let mut total_rewards = Decimal::ZERO;
     let mut last_reward;
 
-    last_reward =
-        test_runner
-            .execute_manifest(
-                ManifestBuilder::new()
-                    .lock_fee_from_faucet()
-                    .create_proof_from_account_of_non_fungibles(
-                        validator_account,
-                        VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
-                    )
-                    .call_method(
-                        validator_address,
-                        VALIDATOR_UPDATE_FEE_IDENT,
-                        manifest_args!(Decimal::zero()),
-                    )
-                    .build(),
-                vec![NonFungibleGlobalId::from_public_key(&validator_key)],
-            )
-            .fee_summary
-            .expected_reward_if_single_validator();
+    last_reward = test_runner
+        .execute_manifest(
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
+                .create_proof_from_account_of_non_fungibles(
+                    validator_account,
+                    VALIDATOR_OWNER_BADGE,
+                    [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
+                )
+                .call_method(
+                    validator_address,
+                    VALIDATOR_UPDATE_FEE_IDENT,
+                    manifest_args!(Decimal::zero()),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&validator_key)],
+        )
+        .fee_summary
+        .expected_reward_if_single_validator();
     total_rewards = total_rewards.safe_add(last_reward).unwrap();
 
     // ... and wait 1 epoch to make it effective
@@ -1333,28 +1330,25 @@ fn increasing_validator_fee_takes_effect_after_configured_epochs_delay() {
     let current_epoch = initial_epoch.next();
 
     // Act: request the fee increase
-    last_reward =
-        test_runner
-            .execute_manifest(
-                ManifestBuilder::new()
-                    .lock_fee_from_faucet()
-                    .create_proof_from_account_of_non_fungibles(
-                        validator_account,
-                        VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
-                    )
-                    .call_method(
-                        validator_address,
-                        VALIDATOR_UPDATE_FEE_IDENT,
-                        manifest_args!(increased_fee_factor),
-                    )
-                    .build(),
-                vec![NonFungibleGlobalId::from_public_key(&validator_key)],
-            )
-            .fee_summary
-            .expected_reward_if_single_validator();
+    last_reward = test_runner
+        .execute_manifest(
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
+                .create_proof_from_account_of_non_fungibles(
+                    validator_account,
+                    VALIDATOR_OWNER_BADGE,
+                    [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
+                )
+                .call_method(
+                    validator_address,
+                    VALIDATOR_UPDATE_FEE_IDENT,
+                    manifest_args!(increased_fee_factor),
+                )
+                .build(),
+            vec![NonFungibleGlobalId::from_public_key(&validator_key)],
+        )
+        .fee_summary
+        .expected_reward_if_single_validator();
     total_rewards = total_rewards.safe_add(last_reward).unwrap();
     let increase_effective_at_epoch = current_epoch.after(fee_increase_delay_epochs);
 
@@ -1523,9 +1517,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .register_validator(validator_address)
@@ -1541,9 +1533,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -1559,9 +1549,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .register_validator(validator_address)
                     .build();
@@ -1571,9 +1559,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -1589,9 +1575,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .register_validator(validator_address)
                     .build();
@@ -1601,9 +1585,7 @@ impl RegisterAndStakeTransactionType {
                     .create_proof_from_account_of_non_fungibles(
                         account_address,
                         VALIDATOR_OWNER_BADGE,
-                        [
-                            NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ],
+                        [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
                     )
                     .withdraw_from_account(account_address, XRD, stake_amount)
                     .take_all_from_worktop(XRD, "stake")
@@ -3120,35 +3102,27 @@ fn significant_protocol_updates_are_emitted_in_epoch_change_event() {
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[0],
             VALIDATOR_OWNER_BADGE,
-            [
-                NonFungibleLocalId::bytes(validators_addresses[0].as_node_id().0).unwrap(),
-            ],
+            [NonFungibleLocalId::bytes(validators_addresses[0].as_node_id().0).unwrap()],
         )
         .signal_protocol_update_readiness(validators_addresses[0], "a".repeat(32).as_str())
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[1],
             VALIDATOR_OWNER_BADGE,
-            [
-                NonFungibleLocalId::bytes(validators_addresses[1].as_node_id().0).unwrap(),
-            ],
+            [NonFungibleLocalId::bytes(validators_addresses[1].as_node_id().0).unwrap()],
         )
         .signal_protocol_update_readiness(validators_addresses[1], "a".repeat(32).as_str())
         // Validator 2 (10 units of stake) signals the readiness for protocol update "b..bb"
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[2],
             VALIDATOR_OWNER_BADGE,
-            [
-                NonFungibleLocalId::bytes(validators_addresses[2].as_node_id().0).unwrap(),
-            ],
+            [NonFungibleLocalId::bytes(validators_addresses[2].as_node_id().0).unwrap()],
         )
         .signal_protocol_update_readiness(validators_addresses[2], "b".repeat(32).as_str())
         // Validator 3 (3 units of stake) signals the readiness for protocol update "c..cc"
         .create_proof_from_account_of_non_fungibles(
             validators_owner_badge_holders[3],
             VALIDATOR_OWNER_BADGE,
-            [
-                NonFungibleLocalId::bytes(validators_addresses[3].as_node_id().0).unwrap(),
-            ],
+            [NonFungibleLocalId::bytes(validators_addresses[3].as_node_id().0).unwrap()],
         )
         .signal_protocol_update_readiness(validators_addresses[3], "c".repeat(32).as_str())
         .build();

--- a/radix-engine-tests/tests/core.rs
+++ b/radix-engine-tests/tests/core.rs
@@ -16,7 +16,7 @@ fn test_call() {
         .lock_fee_from_faucet()
         .call_function(package_address, "MoveTest", "move_bucket", manifest_args![])
         .call_function(package_address, "MoveTest", "move_proof", manifest_args![])
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/data_validation.rs
+++ b/radix-engine-tests/tests/data_validation.rs
@@ -44,7 +44,7 @@ fn create_manifest_with_middle(
             )
         })
         .return_to_worktop("proof_bucket")
-        .try_deposit_batch_or_abort(sink_account(), None)
+        .try_deposit_entire_worktop_or_abort(sink_account(), None)
         .build()
 }
 

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -1154,7 +1154,7 @@ fn validator_registration_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -1216,7 +1216,7 @@ fn validator_unregistration_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -1232,7 +1232,7 @@ fn validator_unregistration_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .unregister_validator(validator_address)
         .build();
@@ -1294,7 +1294,7 @@ fn validator_staking_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -1310,7 +1310,7 @@ fn validator_staking_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .withdraw_from_account(account, XRD, 100)
         .take_all_from_worktop(XRD, "stake")
@@ -1750,7 +1750,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();
@@ -1766,7 +1766,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .call_method(
             validator_address,
@@ -2083,7 +2083,7 @@ fn mint_burn_events_should_match_total_supply_for_non_fungible_resource() {
         .withdraw_non_fungibles_from_account(
             account,
             resource_address,
-            &btreeset!(NonFungibleLocalId::integer(4)),
+            [NonFungibleLocalId::integer(4)],
         )
         .burn_all_from_worktop(resource_address)
         .build();

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -398,7 +398,7 @@ fn vault_fungible_recall_emits_correct_events() {
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET, 500)
         .recall(InternalAddress::new_or_panic(vault_id.into()), 1)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -474,7 +474,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
                 metadata!(),
                 Some([(id.clone(), EmptyStruct {})]),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = test_runner.execute_manifest(manifest, vec![]);
         (receipt.expect_commit(true).new_resource_addresses()[0], id)
@@ -484,7 +484,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET, 500)
         .recall(InternalAddress::new_or_panic(vault_id.into()), 1)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -564,7 +564,7 @@ fn resource_manager_new_vault_emits_correct_events() {
             metadata!(),
             Some(1.into()),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -653,7 +653,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
                 metadata!(),
                 None,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = test_runner.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -746,7 +746,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
                 metadata!(),
                 None::<BTreeMap<NonFungibleLocalId, EmptyStruct>>,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = test_runner.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -861,9 +861,9 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
             resource_address,
             [(id.clone(), EmptyStruct {}), (id2.clone(), EmptyStruct {})],
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .withdraw_from_account(account, resource_address, dec!("2"))
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -1315,7 +1315,7 @@ fn validator_staking_emits_correct_event() {
         .withdraw_from_account(account, XRD, 100)
         .take_all_from_worktop(XRD, "stake")
         .stake_validator_as_owner(validator_address, "stake")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -1457,7 +1457,7 @@ fn validator_unstake_emits_correct_events() {
         .withdraw_from_account(account_with_su, validator_substate.stake_unit_resource, 1)
         .take_all_from_worktop(validator_substate.stake_unit_resource, "stake_units")
         .unstake_validator(validator_address, "stake_units")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -1618,7 +1618,7 @@ fn validator_claim_xrd_emits_correct_events() {
         .withdraw_from_account(account_with_su, validator_substate.stake_unit_resource, 1)
         .take_all_from_worktop(validator_substate.stake_unit_resource, "stake_units")
         .unstake_validator(validator_address, "stake_units")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -1633,7 +1633,7 @@ fn validator_claim_xrd_emits_correct_events() {
         .withdraw_from_account(account_with_su, validator_substate.claim_nft, 1)
         .take_all_from_worktop(validator_substate.claim_nft, "unstake_nft")
         .claim_xrd(validator_address, "unstake_nft")
-        .try_deposit_batch_or_abort(account_with_su, None)
+        .try_deposit_entire_worktop_or_abort(account_with_su, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -2157,7 +2157,7 @@ fn account_withdraw_and_deposit_fungibles_should_emit_correct_event() {
     // Act
     let manifest = ManifestBuilder::new()
         .withdraw_from_account(account, XRD, 1)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.preview_manifest(
         manifest,
@@ -2240,7 +2240,7 @@ fn account_withdraw_and_deposit_non_fungibles_should_emit_correct_event() {
     // Act
     let manifest = ManifestBuilder::new()
         .withdraw_from_account(account, resource_address, 2)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.preview_manifest(
         manifest,
@@ -2692,7 +2692,7 @@ fn account_deposit_batch_methods_emits_expected_events_when_deposit_fails() {
         )
         .withdraw_from_account(account, XRD, 1)
         .withdraw_from_account(account, resource_address, 3)
-        .try_deposit_batch_or_refund(account, None)
+        .try_deposit_entire_worktop_or_refund(account, None)
         .deposit_batch(account)
         .build();
     let receipt = test_runner.preview_manifest(

--- a/radix-engine-tests/tests/execution_trace.rs
+++ b/radix-engine-tests/tests/execution_trace.rs
@@ -408,12 +408,11 @@ fn test_worktop_changes() {
         .withdraw_non_fungibles_from_account(
             account,
             non_fungible_resource,
-            &[
+            [
                 NonFungibleLocalId::integer(1),
                 NonFungibleLocalId::integer(2),
                 NonFungibleLocalId::integer(3),
-            ]
-            .into(),
+            ],
         )
         .take_all_from_worktop(fungible_resource, "bucket1")
         .return_to_worktop("bucket1")
@@ -425,11 +424,10 @@ fn test_worktop_changes() {
         .return_to_worktop("bucket4")
         .take_non_fungibles_from_worktop(
             non_fungible_resource,
-            &[
+            [
                 NonFungibleLocalId::integer(1),
                 NonFungibleLocalId::integer(3),
-            ]
-            .into(),
+            ],
             "bucket5",
         )
         .return_to_worktop("bucket5")

--- a/radix-engine-tests/tests/execution_trace.rs
+++ b/radix-engine-tests/tests/execution_trace.rs
@@ -431,7 +431,7 @@ fn test_worktop_changes() {
             "bucket5",
         )
         .return_to_worktop("bucket5")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.preview_manifest(
         manifest,

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -230,7 +230,7 @@ fn test_fee_accounting_success() {
     let manifest = ManifestBuilder::new()
         .lock_fee(account1, 500)
         .withdraw_from_account(account1, XRD, 66)
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -281,7 +281,7 @@ fn test_fee_accounting_failure() {
     let manifest = ManifestBuilder::new()
         .lock_fee(account1, 500)
         .withdraw_from_account(account1, XRD, 66)
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .assert_worktop_contains(XRD, 1)
         .build();
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/identity.rs
+++ b/radix-engine-tests/tests/identity.rs
@@ -25,7 +25,7 @@ fn cannot_securify_in_advanced_mode() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -56,7 +56,7 @@ fn can_securify_from_virtual_identity() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -78,7 +78,7 @@ fn cannot_securify_twice() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -92,7 +92,7 @@ fn cannot_securify_twice() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -121,7 +121,7 @@ fn can_set_metadata_after_securify() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -206,7 +206,7 @@ fn securified_identity_is_owned_by_correct_owner_badge() {
             IDENTITY_SECURIFY_IDENT,
             IdentitySecurifyToSingleBadgeInput {},
         )
-        .try_deposit_batch_or_refund(account, None)
+        .try_deposit_entire_worktop_or_refund(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);

--- a/radix-engine-tests/tests/identity.rs
+++ b/radix-engine-tests/tests/identity.rs
@@ -133,7 +133,7 @@ fn can_set_metadata_after_securify() {
         .create_proof_from_account_of_non_fungibles(
             account,
             IDENTITY_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(identity_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(identity_address.as_node_id().0).unwrap()],
         )
         .set_metadata(
             identity_address,
@@ -168,7 +168,7 @@ fn can_set_metadata_on_securified_identity() {
         .create_proof_from_account_of_non_fungibles(
             account,
             IDENTITY_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(identity_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(identity_address.as_node_id().0).unwrap()],
         )
         .set_metadata(
             identity_address,

--- a/radix-engine-tests/tests/local_component.rs
+++ b/radix-engine-tests/tests/local_component.rs
@@ -92,7 +92,7 @@ fn recursion_bomb() {
                 manifest_args!(lookup.bucket("xrd")),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -123,7 +123,7 @@ fn recursion_bomb_to_failure() {
                 manifest_args!(lookup.bucket("bucket")),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -162,7 +162,7 @@ fn recursion_bomb_2() {
                 manifest_args!(lookup.bucket("bucket")),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -193,7 +193,7 @@ fn recursion_bomb_2_to_failure() {
                 manifest_args!(lookup.bucket("bucket")),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/metadata_package.rs
+++ b/radix-engine-tests/tests/metadata_package.rs
@@ -56,7 +56,7 @@ fn can_set_package_metadata_with_owner() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .publish_package(code, single_function_package_definition("Test", "f"))
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     let package_address = receipt.expect_commit(true).new_package_addresses()[0];

--- a/radix-engine-tests/tests/metadata_package.rs
+++ b/radix-engine-tests/tests/metadata_package.rs
@@ -67,7 +67,7 @@ fn can_set_package_metadata_with_owner() {
         .create_proof_from_account_of_non_fungibles(
             account,
             PACKAGE_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(package_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(package_address.as_node_id().0).unwrap()],
         )
         .set_metadata(
             package_address,

--- a/radix-engine-tests/tests/metadata_validator.rs
+++ b/radix-engine-tests/tests/metadata_validator.rs
@@ -18,7 +18,7 @@ fn can_set_validator_metadata_with_owner() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator.as_node_id().0).unwrap()],
         )
         .set_metadata(
             validator,

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -356,7 +356,7 @@ fn run_basic_transfer(mode: Mode) {
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account1)
         .withdraw_from_account(account1, XRD, 100)
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .build();
 
     let (receipt, _) = execute_with_time_logging(
@@ -381,7 +381,7 @@ fn run_basic_transfer_to_virtual_account(mode: Mode) {
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account1)
         .withdraw_from_account(account1, XRD, 100)
-        .try_deposit_batch_or_abort(account2, None)
+        .try_deposit_entire_worktop_or_abort(account2, None)
         .build();
 
     let (receipt, _) = execute_with_time_logging(
@@ -425,7 +425,7 @@ fn run_radiswap(mode: Mode) {
                     "new",
                     manifest_args!(OwnerRole::None, btc, eth),
                 )
-                .try_deposit_batch_or_abort(account2, None)
+                .try_deposit_entire_worktop_or_abort(account2, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk2)],
         )
@@ -450,7 +450,7 @@ fn run_radiswap(mode: Mode) {
                         manifest_args!(lookup.bucket("btc"), lookup.bucket("eth")),
                     )
                 })
-                .try_deposit_batch_or_abort(account2, None)
+                .try_deposit_entire_worktop_or_abort(account2, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk2)],
         )
@@ -463,7 +463,7 @@ fn run_radiswap(mode: Mode) {
             ManifestBuilder::new()
                 .lock_fee(account2, 500)
                 .withdraw_from_account(account2, btc, btc_amount)
-                .try_deposit_batch_or_abort(account3, None)
+                .try_deposit_entire_worktop_or_abort(account3, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk2)],
         )
@@ -481,7 +481,7 @@ fn run_radiswap(mode: Mode) {
                 let bucket = lookup.bucket("to_trade");
                 builder.call_method(component_address, "swap", manifest_args!(bucket))
             })
-            .try_deposit_batch_or_abort(account3, None)
+            .try_deposit_entire_worktop_or_abort(account3, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&pk3)],
     );
@@ -528,7 +528,7 @@ fn run_flash_loan(mode: Mode) {
                         manifest_args!(lookup.bucket("bucket")),
                     )
                 })
-                .try_deposit_batch_or_abort(account2, None)
+                .try_deposit_entire_worktop_or_abort(account2, None)
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk2)],
         )
@@ -553,7 +553,7 @@ fn run_flash_loan(mode: Mode) {
                     manifest_args!(lookup.bucket("repayment"), lookup.bucket("promise")),
                 )
             })
-            .try_deposit_batch_or_abort(account3, None)
+            .try_deposit_entire_worktop_or_abort(account3, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&pk3)],
     );
@@ -663,7 +663,7 @@ fn run_mint_nfts_from_manifest(mode: Mode, nft_data: TestNonFungibleData) {
                 metadata! {},
                 Some(entries),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let transaction = create_notarized_transaction(
             TransactionParams {
@@ -723,7 +723,9 @@ fn can_run_large_manifest() {
             .take_from_worktop(XRD, 1, &bucket)
             .return_to_worktop(bucket);
     }
-    let manifest = builder.try_deposit_batch_or_abort(account, None).build();
+    let manifest = builder
+        .try_deposit_entire_worktop_or_abort(account, None)
+        .build();
 
     let (receipt, _) = execute_with_time_logging(
         &mut test_runner,

--- a/radix-engine-tests/tests/native_blueprint_call_validator.rs
+++ b/radix-engine-tests/tests/native_blueprint_call_validator.rs
@@ -18,7 +18,7 @@ fn validator_sees_valid_transfer_manifest_as_valid() {
     // Arrange
     let manifest = ManifestBuilder::new()
         .withdraw_from_account(account1(), XRD, dec!("10"))
-        .try_deposit_batch_or_abort(account2(), None)
+        .try_deposit_entire_worktop_or_abort(account2(), None)
         .build();
 
     // Act
@@ -35,7 +35,7 @@ fn validator_sees_invalid_transfer_manifest_as_invalid() {
     // Arrange
     let manifest = ManifestBuilder::new()
         .call_method(account1(), "withdraw", manifest_args!())
-        .try_deposit_batch_or_abort(account2(), None)
+        .try_deposit_entire_worktop_or_abort(account2(), None)
         .build();
 
     // Act
@@ -50,7 +50,7 @@ fn validator_invalidates_calls_to_unknown_methods_on_a_known_blueprint() {
     // Arrange
     let manifest = ManifestBuilder::new()
         .call_method(account1(), "my_made_up_method", manifest_args!())
-        .try_deposit_batch_or_abort(account2(), None)
+        .try_deposit_entire_worktop_or_abort(account2(), None)
         .build();
 
     // Act

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -545,7 +545,7 @@ fn test_mint_update_and_withdraw() {
         .create_proof_from_account_of_non_fungibles(
             account,
             nft_resource_address,
-            &btreeset!(NonFungibleLocalId::integer(0)),
+            [NonFungibleLocalId::integer(0)],
         )
         .take_all_from_worktop(badge_resource_address, "badge")
         .pop_from_auth_zone("proof")
@@ -563,16 +563,14 @@ fn test_mint_update_and_withdraw() {
     );
     receipt.expect_commit_success();
 
-    let mut nfid_list = BTreeSet::new();
-    nfid_list.insert(NonFungibleLocalId::integer(0)); // ID from NonFungibleTest::create_non_fungible_mutable
-
-    // transfer
+    // Transfer
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account, nft_resource_address, 1)
         .assert_worktop_contains_any(nft_resource_address)
         .assert_worktop_contains(nft_resource_address, 1)
-        .assert_worktop_contains_non_fungibles(nft_resource_address, &nfid_list)
+        // ID from NonFungibleTest::create_non_fungible_mutable
+        .assert_worktop_contains_non_fungibles(nft_resource_address, [NonFungibleLocalId::integer(0)])
         .try_deposit_batch_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -570,7 +570,10 @@ fn test_mint_update_and_withdraw() {
         .assert_worktop_contains_any(nft_resource_address)
         .assert_worktop_contains(nft_resource_address, 1)
         // ID from NonFungibleTest::create_non_fungible_mutable
-        .assert_worktop_contains_non_fungibles(nft_resource_address, [NonFungibleLocalId::integer(0)])
+        .assert_worktop_contains_non_fungibles(
+            nft_resource_address,
+            [NonFungibleLocalId::integer(0)],
+        )
         .try_deposit_batch_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -24,7 +24,7 @@ fn can_mint_non_fungible_with_global() {
             "create_non_fungible_with_global",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -51,7 +51,7 @@ fn create_non_fungible_mutable() {
             "create_non_fungible_mutable",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -76,7 +76,7 @@ fn can_burn_non_fungible() {
             "create_burnable_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     let resource_address = receipt.expect_commit(true).new_resource_addresses()[0];
@@ -100,7 +100,7 @@ fn can_burn_non_fungible() {
             "verify_does_not_exist",
             manifest_args!(non_fungible_global_id),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .assert_worktop_contains(resource_address, 0)
         .build();
     let receipt = test_runner.execute_manifest(
@@ -128,7 +128,7 @@ fn test_take_non_fungible() {
             "take_non_fungible_and_put_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -152,7 +152,7 @@ fn test_take_non_fungibles() {
             "take_non_fungibles_and_put_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -173,7 +173,7 @@ fn can_update_non_fungible_when_mutable() {
             "update_non_fungible",
             manifest_args!("available".to_string(), true),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -195,7 +195,7 @@ fn cannot_update_non_fungible_when_not_mutable() {
             "update_non_fungible",
             manifest_args!("tastes_great".to_string(), false),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -224,7 +224,7 @@ fn cannot_update_non_fungible_when_does_not_exist() {
             "update_non_fungible",
             manifest_args!("does_not_exist".to_string(), false),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -260,7 +260,7 @@ fn can_call_non_fungible_data_reference() {
             "create_non_fungible_reference",
             manifest_args!(account),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -299,7 +299,7 @@ fn cannot_have_non_fungible_data_ownership() {
             "update_non_fungible_with_ownership",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -328,7 +328,7 @@ fn can_update_and_get_non_fungible() {
             "update_and_get_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -350,7 +350,7 @@ fn can_update_and_get_non_fungible_reference() {
             "update_and_get_non_fungible_reference",
             manifest_args!(account),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -373,7 +373,7 @@ fn can_check_if_contains_non_fungible_in_vault() {
             "contains_non_fungible_vault",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -400,7 +400,7 @@ fn can_check_if_contains_non_fungible_in_bucket() {
             "contains_non_fungible_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
 
     // Act
@@ -445,7 +445,7 @@ fn test_non_fungible_part_1() {
             "take_and_put_bucket",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -480,7 +480,7 @@ fn test_non_fungible_part_2() {
             "get_non_fungible_local_ids_vault",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -503,7 +503,7 @@ fn test_singleton_non_fungible() {
             "singleton_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -529,7 +529,7 @@ fn test_mint_update_and_withdraw() {
             "create_non_fungible_mutable",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -555,7 +555,7 @@ fn test_mint_update_and_withdraw() {
             "update_nft",
             |lookup| (lookup.bucket("badge"), lookup.proof("proof")),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -574,7 +574,7 @@ fn test_mint_update_and_withdraw() {
             nft_resource_address,
             [NonFungibleLocalId::integer(0)],
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -599,7 +599,7 @@ fn create_non_fungible_with_id_type_different_than_in_initial_supply() {
             "create_wrong_non_fungible_local_id_type",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -626,7 +626,7 @@ fn create_bytes_non_fungible() {
             "create_bytes_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -650,7 +650,7 @@ fn create_string_non_fungible() {
             "create_string_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -674,7 +674,7 @@ fn create_ruid_non_fungible() {
             "create_ruid_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -724,7 +724,7 @@ fn can_mint_ruid_non_fungible_in_scrypto() {
             "create_ruid_non_fungible_and_mint",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -779,7 +779,7 @@ fn can_mint_ruid_non_fungible_with_reference_in_manifest() {
             }],
         )
         .assert_worktop_contains_any(resource_address)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -819,7 +819,7 @@ fn can_mint_ruid_non_fungible_in_manifest() {
             }],
         )
         .assert_worktop_contains_any(resource_address)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -841,7 +841,7 @@ fn cant_burn_non_fungible_with_wrong_non_fungible_local_id_type() {
             "create_burnable_non_fungible",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     let resource_address = receipt.expect_commit(true).new_resource_addresses()[0];

--- a/radix-engine-tests/tests/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/pool_multi_resource.rs
@@ -895,7 +895,7 @@ impl<const N: usize> TestEnvironment<N> {
                 MULTI_RESOURCE_POOL_CONTRIBUTE_IDENT,
                 manifest_args!(ManifestExpression::EntireWorktop),
             )
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -917,7 +917,7 @@ impl<const N: usize> TestEnvironment<N> {
                     },
                 )
             })
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -960,7 +960,7 @@ impl<const N: usize> TestEnvironment<N> {
                     withdraw_strategy,
                 },
             )
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }

--- a/radix-engine-tests/tests/pool_one_resource.rs
+++ b/radix-engine-tests/tests/pool_one_resource.rs
@@ -759,7 +759,7 @@ impl TestEnvironment {
                     },
                 )
             })
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -781,7 +781,7 @@ impl TestEnvironment {
                     },
                 )
             })
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -818,7 +818,7 @@ impl TestEnvironment {
                     withdraw_strategy,
                 },
             )
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }

--- a/radix-engine-tests/tests/pool_two_resource.rs
+++ b/radix-engine-tests/tests/pool_two_resource.rs
@@ -925,7 +925,7 @@ fn contribution_of_large_values_should_not_cause_panic() {
                 },
             )
         })
-        .try_deposit_batch_or_abort(test_runner.account_component_address, None)
+        .try_deposit_entire_worktop_or_abort(test_runner.account_component_address, None)
         .build();
 
     // Act
@@ -996,7 +996,7 @@ fn contributing_to_a_pool_with_very_large_difference_in_reserves_succeeds() {
                     },
                 )
             })
-            .try_deposit_batch_or_abort(test_runner.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(test_runner.account_component_address, None)
             .build()
     };
     test_runner
@@ -1124,7 +1124,7 @@ impl TestEnvironment {
                     },
                 )
             })
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -1145,7 +1145,7 @@ impl TestEnvironment {
                     TwoResourcePoolRedeemManifestInput { bucket },
                 )
             })
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }
@@ -1189,7 +1189,7 @@ impl TestEnvironment {
                     withdraw_strategy,
                 },
             )
-            .try_deposit_batch_or_abort(self.account_component_address, None)
+            .try_deposit_entire_worktop_or_abort(self.account_component_address, None)
             .build();
         self.execute_manifest(manifest, sign)
     }

--- a/radix-engine-tests/tests/preview.rs
+++ b/radix-engine-tests/tests/preview.rs
@@ -126,7 +126,7 @@ fn test_assume_all_signature_proofs_flag_method_authorization() {
     let manifest = ManifestBuilder::new()
         .lock_fee(account, 500)
         .withdraw_from_account(account, XRD, 1)
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
 
     let (_, preview_intent) = prepare_matching_test_tx_and_preview_intent(

--- a/radix-engine-tests/tests/proof.rs
+++ b/radix-engine-tests/tests/proof.rs
@@ -490,7 +490,7 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
                 .withdraw_non_fungibles_from_account(
                     account,
                     resource_address,
-                    &btreeset!(NonFungibleLocalId::integer(1)),
+                    [NonFungibleLocalId::integer(1)],
                 )
                 .take_all_from_worktop(resource_address, "bucket")
                 .with_name_lookup(|builder, lookup| {
@@ -510,17 +510,17 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
         .withdraw_non_fungibles_from_account(
             account,
             resource_address,
-            &BTreeSet::from([
+            [
                 NonFungibleLocalId::integer(2),
                 NonFungibleLocalId::integer(3),
-            ]),
+            ],
         )
         .take_non_fungibles_from_worktop(
             resource_address,
-            &BTreeSet::from([
+            [
                 NonFungibleLocalId::integer(2),
                 NonFungibleLocalId::integer(3),
-            ]),
+            ],
             "bucket",
         )
         .with_name_lookup(|builder, lookup| {
@@ -560,22 +560,22 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
         .create_proof_from_account_of_non_fungibles(
             account,
             resource_address,
-            &BTreeSet::from([
+            [
                 NonFungibleLocalId::integer(1),
                 NonFungibleLocalId::integer(2),
-            ]),
+            ],
         )
         .create_proof_from_account_of_non_fungibles(
             account,
             resource_address,
-            &BTreeSet::from([NonFungibleLocalId::integer(3)]),
+            [NonFungibleLocalId::integer(3)],
         )
         .create_proof_from_auth_zone_of_non_fungibles(
             resource_address,
-            &BTreeSet::from([
+            [
                 NonFungibleLocalId::integer(2),
                 NonFungibleLocalId::integer(3),
-            ]),
+            ],
             "proof",
         )
         .with_name_lookup(|builder, lookup| {
@@ -585,10 +585,10 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
                 "assert_ids",
                 manifest_args!(
                     lookup.proof("proof"),
-                    BTreeSet::from([
+                    [
                         NonFungibleLocalId::integer(2),
                         NonFungibleLocalId::integer(3)
-                    ]),
+                    ],
                     resource_address
                 ),
             )

--- a/radix-engine-tests/tests/proof.rs
+++ b/radix-engine-tests/tests/proof.rs
@@ -27,7 +27,7 @@ fn can_create_clone_and_drop_bucket_proof() {
                 manifest_args!(lookup.bucket("bucket"), dec!(1)),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -159,7 +159,7 @@ fn can_use_bucket_for_authorization() {
                 manifest_args!(auth_bucket, burnable_bucket),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -418,7 +418,7 @@ fn can_move_locked_bucket() {
                 manifest_args!(lookup.bucket("bucket")),
             )
         })
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/recallable.rs
+++ b/radix-engine-tests/tests/recallable.rs
@@ -20,7 +20,7 @@ fn non_existing_vault_should_cause_error() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .recall(non_existing_address, Decimal::one())
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -51,7 +51,7 @@ fn cannot_take_on_non_recallable_vault() {
             InternalAddress::new_or_panic(vault_id.into()),
             Decimal::one(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -84,7 +84,7 @@ fn can_take_on_recallable_vault() {
             InternalAddress::new_or_panic(vault_id.into()),
             Decimal::one(),
         )
-        .try_deposit_batch_or_abort(other_account, None)
+        .try_deposit_entire_worktop_or_abort(other_account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -137,7 +137,7 @@ fn test_recall_on_internal_vault() {
                 "recall_on_internal_vault",
                 manifest_args!(),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -172,7 +172,7 @@ fn test_recall_on_received_direct_access_reference() {
                 "recall_on_direct_access_ref",
                 manifest_args!(InternalAddress::new_or_panic(vault_id.into())),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -81,7 +81,7 @@ fn test_resource_manager() {
             "update_resource_metadata",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -108,7 +108,7 @@ fn mint_with_bad_granularity_should_fail() {
             "create_fungible_and_mint",
             manifest_args!(0u8, dec!("0.1")),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -185,7 +185,7 @@ fn mint_too_much_should_fail() {
                 dec!("1461501637330902918203684832717")
             ),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -226,7 +226,7 @@ fn can_mint_with_proof_in_root() {
             [NonFungibleLocalId::integer(1)],
         )
         .mint_fungible(resource, 1)
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -260,7 +260,7 @@ fn cannot_mint_in_component_with_proof_in_root() {
             [NonFungibleLocalId::integer(1)],
         )
         .call_method(component, "mint", manifest_args!(resource))
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -372,7 +372,7 @@ fn test_fungible_resource_amount_for_withdrawal() {
             "fungible_resource_amount_for_withdrawal",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -396,7 +396,7 @@ fn test_non_fungible_resource_amount_for_withdrawal() {
             "non_fungible_resource_amount_for_withdrawal",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -420,7 +420,7 @@ fn test_fungible_resource_take_advanced() {
             "fungible_resource_take_advanced",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -532,7 +532,7 @@ fn test_non_fungible_resource_take_advanced() {
             "non_fungible_resource_take_advanced",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -556,7 +556,7 @@ fn can_use_fungible_types_in_interface() {
             "test_fungible_types",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 
@@ -580,7 +580,7 @@ fn can_use_non_fungible_types_in_interface() {
             "test_non_fungible_types",
             manifest_args!(),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -223,7 +223,7 @@ fn can_mint_with_proof_in_root() {
         .create_proof_from_account_of_non_fungibles(
             account,
             admin_token,
-            &btreeset!(NonFungibleLocalId::integer(1)),
+            [NonFungibleLocalId::integer(1)],
         )
         .mint_fungible(resource, 1)
         .try_deposit_batch_or_abort(account, None)
@@ -257,7 +257,7 @@ fn cannot_mint_in_component_with_proof_in_root() {
         .create_proof_from_account_of_non_fungibles(
             account,
             admin_token,
-            &btreeset!(NonFungibleLocalId::integer(1)),
+            [NonFungibleLocalId::integer(1)],
         )
         .call_method(component, "mint", manifest_args!(resource))
         .try_deposit_batch_or_abort(account, None)
@@ -298,7 +298,7 @@ fn can_burn_with_proof_in_root() {
         .create_proof_from_account_of_non_fungibles(
             account,
             admin_token,
-            &btreeset!(NonFungibleLocalId::integer(1)),
+            [NonFungibleLocalId::integer(1)],
         )
         .mint_fungible(resource, 1)
         .burn_all_from_worktop(resource)
@@ -332,7 +332,7 @@ fn cannot_burn_in_component_with_proof_in_root() {
         .create_proof_from_account_of_non_fungibles(
             account,
             admin_token,
-            &btreeset!(NonFungibleLocalId::integer(1)),
+            [NonFungibleLocalId::integer(1)],
         )
         .mint_fungible(resource, 1)
         .take_all_from_worktop(resource, "to_burn")

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -151,11 +151,7 @@ fn component_role_assignment_can_be_mutated_through_manifest(to_rule: AccessRule
     // Act
     let receipt = test_runner.execute_manifest(
         MutableRolesTestRunner::manifest_builder()
-            .set_main_role(
-                test_runner.component_address,
-                "borrow_funds_auth",
-                to_rule,
-            )
+            .set_main_role(test_runner.component_address, "borrow_funds_auth", to_rule)
             .build(),
     );
 

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -151,10 +151,9 @@ fn component_role_assignment_can_be_mutated_through_manifest(to_rule: AccessRule
     // Act
     let receipt = test_runner.execute_manifest(
         MutableRolesTestRunner::manifest_builder()
-            .update_role(
+            .set_main_role(
                 test_runner.component_address,
-                ObjectModuleId::Main,
-                RoleKey::new("borrow_funds_auth"),
+                "borrow_funds_auth",
                 to_rule,
             )
             .build(),
@@ -415,7 +414,7 @@ impl MutableRolesTestRunner {
         access_rule: AccessRule,
     ) -> TransactionReceipt {
         let manifest = Self::manifest_builder()
-            .update_role(
+            .set_role(
                 self.component_address,
                 ObjectModuleId::Main,
                 role_key,

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -252,7 +252,7 @@ fn test_claim_royalty() {
                 [NonFungibleLocalId::integer(1)],
             )
             .claim_package_royalties(package_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -263,7 +263,7 @@ fn test_claim_royalty() {
         ManifestBuilder::new()
             .lock_standard_test_fee(account)
             .claim_component_royalties(component_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -249,7 +249,7 @@ fn test_claim_royalty() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .claim_package_royalties(package_address)
             .try_deposit_batch_or_abort(account, None)
@@ -390,7 +390,7 @@ fn cannot_set_component_royalty_if_greater_than_allowed() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .set_component_royalty(
                 component_address,
@@ -429,7 +429,7 @@ fn cannot_set_royalty_after_locking() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .lock_component_royalty(component_address, "paid_method")
             .build(),
@@ -444,7 +444,7 @@ fn cannot_set_royalty_after_locking() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .set_component_royalty(
                 component_address,
@@ -490,7 +490,7 @@ fn set_up_package_and_component() -> (
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],

--- a/radix-engine-tests/tests/royalty_auth.rs
+++ b/radix-engine-tests/tests/royalty_auth.rs
@@ -25,7 +25,7 @@ fn package_owner_can_claim_royalty() {
                 [NonFungibleLocalId::integer(1)],
             )
             .claim_package_royalties(package_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -51,7 +51,7 @@ fn non_package_owner_cannot_claim_royalty() {
         ManifestBuilder::new()
             .lock_fee(account, 5000)
             .claim_package_royalties(package_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -139,7 +139,7 @@ fn component_owner_can_claim_royalty() {
                 [NonFungibleLocalId::integer(1)],
             )
             .claim_component_royalties(component_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -159,7 +159,7 @@ fn non_component_owner_cannot_claim_royalty() {
         ManifestBuilder::new()
             .lock_fee(account, 5000)
             .claim_component_royalties(component_address)
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -209,7 +209,7 @@ fn set_up_package_and_component() -> (
                 "create_component_with_royalty_enabled",
                 manifest_args!(owner_badge_addr),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/radix-engine-tests/tests/royalty_auth.rs
+++ b/radix-engine-tests/tests/royalty_auth.rs
@@ -22,7 +22,7 @@ fn package_owner_can_claim_royalty() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .claim_package_royalties(package_address)
             .try_deposit_batch_or_abort(account, None)
@@ -79,7 +79,7 @@ fn component_owner_can_set_royalty() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .set_component_royalty(
                 component_address,
@@ -136,7 +136,7 @@ fn component_owner_can_claim_royalty() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .claim_component_royalties(component_address)
             .try_deposit_batch_or_abort(account, None)
@@ -201,7 +201,7 @@ fn set_up_package_and_component() -> (
             .create_proof_from_account_of_non_fungibles(
                 account,
                 owner_badge_resource,
-                &btreeset!(NonFungibleLocalId::integer(1)),
+                [NonFungibleLocalId::integer(1)],
             )
             .call_function(
                 package_address,

--- a/radix-engine-tests/tests/scrypto_validator.rs
+++ b/radix-engine-tests/tests/scrypto_validator.rs
@@ -43,7 +43,7 @@ fn can_call_total_stake_xrd_amount_in_scrypto() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 VALIDATOR_OWNER_BADGE,
-                &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+                [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
             )
             .withdraw_from_account(account, XRD, 10)
             .take_all_from_worktop(XRD, "xrd")
@@ -87,7 +87,7 @@ fn can_call_total_stake_unit_supply_in_scrypto() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 VALIDATOR_OWNER_BADGE,
-                &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+                [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
             )
             .withdraw_from_account(account, XRD, 10)
             .take_all_from_worktop(XRD, "xrd")
@@ -131,7 +131,7 @@ fn can_call_validator_get_redemption_value_in_scrypto() {
             .create_proof_from_account_of_non_fungibles(
                 account,
                 VALIDATOR_OWNER_BADGE,
-                &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+                [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
             )
             .withdraw_from_account(account, XRD, 10)
             .take_all_from_worktop(XRD, "xrd")

--- a/radix-engine-tests/tests/system_global_address.rs
+++ b/radix-engine-tests/tests/system_global_address.rs
@@ -140,7 +140,7 @@ fn global_address_access_from_direct_access_methods_should_fail_even_with_borrow
                 "recall_on_direct_access_ref_method",
                 manifest_args!(InternalAddress::new_or_panic(vault_id.into())),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build(),
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/radix-engine-tests/tests/transaction.rs
+++ b/radix-engine-tests/tests/transaction.rs
@@ -53,13 +53,13 @@ fn test_call_method_with_all_resources_doesnt_drop_auth_zone_proofs() {
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .create_proof_from_auth_zone_of_all(XRD, "proof1")
         .push_to_auth_zone("proof1")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .create_proof_from_auth_zone_of_all(XRD, "proof2")
         .push_to_auth_zone("proof2")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .create_proof_from_auth_zone_of_all(XRD, "proof3")
         .push_to_auth_zone("proof3")
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,
@@ -187,7 +187,7 @@ fn test_faucet_drain_attempt_should_fail() {
         .lock_standard_test_fee(account)
         .get_free_xrd_from_faucet()
         .get_free_xrd_from_faucet()
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/transaction_multi_threaded.rs
+++ b/radix-engine-tests/tests/transaction_multi_threaded.rs
@@ -81,7 +81,7 @@ mod multi_threaded_test {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .get_free_xrd_from_faucet()
-            .try_deposit_batch_or_abort(account1, None)
+            .try_deposit_entire_worktop_or_abort(account1, None)
             .build();
         for nonce in 0..10 {
             execute_and_commit_transaction(
@@ -101,7 +101,7 @@ mod multi_threaded_test {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .withdraw_from_account(account1, XRD, dec!("0.000001"))
-            .try_deposit_batch_or_abort(account2, None)
+            .try_deposit_entire_worktop_or_abort(account2, None)
             .build();
 
         // Spawning threads that will attempt to withdraw some XRD amount from account1 and deposit to

--- a/radix-engine-tests/tests/tx_processor_access.rs
+++ b/radix-engine-tests/tests/tx_processor_access.rs
@@ -85,7 +85,7 @@ fn should_not_be_able_to_steal_money_through_tx_processor_call() {
     let initial_balance = test_runner.get_component_balance(account0, XRD);
     let instructions = ManifestBuilder::new()
         .withdraw_from_account(account0, XRD, 10)
-        .try_deposit_batch_or_abort(account1, None)
+        .try_deposit_entire_worktop_or_abort(account1, None)
         .build()
         .instructions;
     let manifest_encoded_instructions = manifest_encode(&instructions).unwrap();

--- a/radix-engine-tests/tests/validator.rs
+++ b/radix-engine-tests/tests/validator.rs
@@ -37,7 +37,7 @@ where
         builder = builder.create_proof_from_account_of_non_fungibles(
             validator_account_address,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         );
     }
     let manifest = builder
@@ -98,7 +98,7 @@ fn check_if_validator_accepts_delegated_stake() {
         .create_proof_from_account_of_non_fungibles(
             account,
             VALIDATOR_OWNER_BADGE,
-            &btreeset!(NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()),
+            [NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()],
         )
         .register_validator(validator_address)
         .build();

--- a/radix-engine-tests/tests/vault.rs
+++ b/radix-engine-tests/tests/vault.rs
@@ -620,7 +620,7 @@ fn withdraw_with_over_specified_divisibility_should_result_in_error() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account, resource_address, dec!("5.55555"))
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt =
         test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk)]);
@@ -714,7 +714,7 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
             "take_ids",
             manifest_args!(btreeset![NonFungibleLocalId::integer(1)]),
         )
-        .try_deposit_batch_or_abort(account, None)
+        .try_deposit_entire_worktop_or_abort(account, None)
         .build();
     let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
 

--- a/radix-engine-tests/tests/vault_burn.rs
+++ b/radix-engine-tests/tests/vault_burn.rs
@@ -812,7 +812,7 @@ fn can_burn_by_amount_from_fungible_account_vault() {
                 metadata!(),
                 Some(100.into()),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
             .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
@@ -859,7 +859,7 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
                     NonFungibleLocalId::integer(2) => EmptyStruct {},
                 )),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
             .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
@@ -902,7 +902,7 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
                     NonFungibleLocalId::integer(2) => EmptyStruct {},
                 )),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
             .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])

--- a/radix-engine-tests/tests/vault_freeze.rs
+++ b/radix-engine-tests/tests/vault_freeze.rs
@@ -176,9 +176,6 @@ fn can_freezy_recall_unfreezy_non_fungible_vault() {
     let vaults = test_runner.get_component_vaults(account, resource_address);
     let vault_id = vaults[0];
     let internal_address = InternalAddress::new_or_panic(vault_id.into());
-    let mut ids = BTreeSet::new();
-    ids.insert(NonFungibleLocalId::integer(1));
-    ids.insert(NonFungibleLocalId::integer(2));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -193,9 +190,15 @@ fn can_freezy_recall_unfreezy_non_fungible_vault() {
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
-        .assert_worktop_contains_non_fungibles(resource_address, &BTreeSet::new())
-        .recall_non_fungibles(internal_address, &ids)
-        .assert_worktop_contains_non_fungibles(resource_address, &ids)
+        .assert_worktop_contains_non_fungibles(resource_address, [])
+        .recall_non_fungibles(internal_address, [
+            NonFungibleLocalId::integer(1),
+            NonFungibleLocalId::integer(2),
+        ])
+        .assert_worktop_contains_non_fungibles(resource_address, [
+            NonFungibleLocalId::integer(1),
+            NonFungibleLocalId::integer(2),
+        ])
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/radix-engine-tests/tests/vault_freeze.rs
+++ b/radix-engine-tests/tests/vault_freeze.rs
@@ -191,14 +191,20 @@ fn can_freezy_recall_unfreezy_non_fungible_vault() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .assert_worktop_contains_non_fungibles(resource_address, [])
-        .recall_non_fungibles(internal_address, [
-            NonFungibleLocalId::integer(1),
-            NonFungibleLocalId::integer(2),
-        ])
-        .assert_worktop_contains_non_fungibles(resource_address, [
-            NonFungibleLocalId::integer(1),
-            NonFungibleLocalId::integer(2),
-        ])
+        .recall_non_fungibles(
+            internal_address,
+            [
+                NonFungibleLocalId::integer(1),
+                NonFungibleLocalId::integer(2),
+            ],
+        )
+        .assert_worktop_contains_non_fungibles(
+            resource_address,
+            [
+                NonFungibleLocalId::integer(1),
+                NonFungibleLocalId::integer(2),
+            ],
+        )
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -1038,9 +1038,9 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         VALIDATOR_OWNER_BADGE,
-                        &btreeset!(
+                        [
                             NonFungibleLocalId::bytes(validator_address.as_node_id().0).unwrap()
-                        ),
+                        ],
                     )
                     .take_all_from_worktop(XRD, "bucket")
                     .with_bucket("bucket", |builder, bucket| {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -809,7 +809,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
 
         let manifest = ManifestBuilder::new()
             .get_free_xrd_from_faucet()
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest_ignoring_fee(manifest, vec![]);
         receipt.expect_commit_success();
@@ -989,7 +989,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .create_identity()
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
@@ -1008,7 +1008,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .get_free_xrd_from_faucet()
             .take_from_worktop(XRD, *DEFAULT_VALIDATOR_XRD_COST, "xrd_creation_fee")
             .create_validator(pub_key, Decimal::ONE, "xrd_creation_fee")
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         let address = receipt.expect_commit(true).new_component_addresses()[0];
@@ -1025,7 +1025,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .get_free_xrd_from_faucet()
             .take_from_worktop(XRD, *DEFAULT_VALIDATOR_XRD_COST, "xrd_creation_fee")
             .create_validator(pub_key, Decimal::ONE, "xrd_creation_fee")
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         let validator_address = receipt.expect_commit(true).new_component_addresses()[0];
@@ -1467,7 +1467,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 Some(5.into()),
             )
-            .try_deposit_batch_or_abort(to, None)
+            .try_deposit_entire_worktop_or_abort(to, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -1720,7 +1720,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 Some(entries),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -1742,7 +1742,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 Some(amount),
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -1774,7 +1774,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 None,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         let resource_address = receipt.expect_commit(true).new_resource_addresses()[0];
@@ -1804,7 +1804,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 amount,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -1837,7 +1837,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 amount,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]
@@ -1874,7 +1874,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 metadata!(),
                 initial_supply,
             )
-            .try_deposit_batch_or_abort(account, None)
+            .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit(true).new_resource_addresses()[0]

--- a/simulator/src/resim/cmd_call_function.rs
+++ b/simulator/src/resim/cmd_call_function.rs
@@ -69,7 +69,7 @@ impl CallFunction {
                 self.arguments.clone(),
                 Some(default_account),
             )?
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_call_method.rs
+++ b/simulator/src/resim/cmd_call_method.rs
@@ -66,7 +66,7 @@ impl CallMethod {
                 self.arguments.clone(),
                 Some(default_account),
             )?
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_mint.rs
+++ b/simulator/src/resim/cmd_mint.rs
@@ -53,7 +53,7 @@ impl Mint {
         }
         let manifest = builder
             .mint_fungible(self.resource_address.0, self.amount)
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -78,7 +78,7 @@ impl NewAccount {
                         NonFungibleLocalId::integer(1) => (),
                     )),
                 )
-                .try_deposit_batch_or_refund(account, None)
+                .try_deposit_entire_worktop_or_refund(account, None)
                 .build();
             let receipt = handle_manifest(
                 manifest,

--- a/simulator/src/resim/cmd_new_badge_fixed.rs
+++ b/simulator/src/resim/cmd_new_badge_fixed.rs
@@ -85,7 +85,7 @@ impl NewBadgeFixed {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .new_badge_fixed(OwnerRole::None, metadata, self.total_supply)
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_simple_badge.rs
+++ b/simulator/src/resim/cmd_new_simple_badge.rs
@@ -90,7 +90,7 @@ impl NewSimpleBadge {
                     NonFungibleLocalId::integer(1) => (),
                 )),
             )
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         let receipt = handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_new_token_fixed.rs
+++ b/simulator/src/resim/cmd_new_token_fixed.rs
@@ -85,7 +85,7 @@ impl NewTokenFixed {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .new_token_fixed(OwnerRole::None, metadata, self.total_supply)
-            .try_deposit_batch_or_refund(default_account, None)
+            .try_deposit_entire_worktop_or_refund(default_account, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -65,7 +65,7 @@ impl Transfer {
             }
         };
         let manifest = builder
-            .try_deposit_batch_or_refund(self.recipient.0, None)
+            .try_deposit_entire_worktop_or_refund(self.recipient.0, None)
             .build();
         handle_manifest(
             manifest,

--- a/simulator/src/resim/cmd_transfer.rs
+++ b/simulator/src/resim/cmd_transfer.rs
@@ -61,7 +61,7 @@ impl Transfer {
                 builder.withdraw_from_account(default_account, resource_address, amount)
             }
             ResourceSpecifier::Ids(ids, resource_address) => {
-                builder.withdraw_non_fungibles_from_account(default_account, resource_address, &ids)
+                builder.withdraw_non_fungibles_from_account(default_account, resource_address, ids)
             }
         };
         let manifest = builder

--- a/simulator/src/utils/common_instructions.rs
+++ b/simulator/src/utils/common_instructions.rs
@@ -87,7 +87,7 @@ pub fn create_proof_from_account<'a>(
             .create_proof_from_account_of_non_fungibles(
                 account,
                 resource_address,
-                &non_fungible_local_ids,
+                non_fungible_local_ids,
             ),
     };
     Ok(builder)
@@ -273,10 +273,10 @@ fn build_call_argument<'a>(
                         builder = builder.withdraw_non_fungibles_from_account(
                             account,
                             resource_address,
-                            &ids,
+                            ids.clone(),
                         );
                     }
-                    builder.take_non_fungibles_from_worktop(resource_address, &ids, &bucket_name)
+                    builder.take_non_fungibles_from_worktop(resource_address, ids, &bucket_name)
                 }
             };
             let bucket = builder.bucket(bucket_name);
@@ -312,7 +312,7 @@ fn build_call_argument<'a>(
                             .create_proof_from_account_of_non_fungibles(
                                 account,
                                 resource_address,
-                                &ids,
+                                ids,
                             )
                             .pop_from_auth_zone(&proof_name)
                     } else {

--- a/transaction-scenarios/src/scenarios/fungible_resource.rs
+++ b/transaction-scenarios/src/scenarios/fungible_resource.rs
@@ -57,7 +57,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                     metadata!(),
                                     Some(dec!("100000")),
                                 )
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(
+                                    config.user_account_1.address,
+                                    None,
+                                )
                         },
                         vec![],
                     )
@@ -78,7 +81,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                 state.max_divisibility_fungible_resource.unwrap(),
                                 dec!("100"),
                             )
-                            .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_1.address,
+                                None,
+                            )
                     },
                     vec![],
                 )
@@ -119,7 +125,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                 )
                                 .try_deposit_or_abort(config.user_account_2.address, None, bucket);
                         }
-                        builder.try_deposit_batch_or_abort(config.user_account_1.address, None)
+                        builder.try_deposit_entire_worktop_or_abort(
+                            config.user_account_1.address,
+                            None,
+                        )
                     },
                     vec![&config.user_account_1.key],
                 )
@@ -151,7 +160,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                     |builder| {
                         builder
                             .recall(state.vault1.unwrap(), dec!("1"))
-                            .try_deposit_batch_or_abort(config.user_account_2.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_2.address,
+                                None,
+                            )
                     },
                     vec![&config.user_account_1.key],
                 )
@@ -183,7 +195,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                     |builder| {
                         builder
                             .recall(state.vault1.unwrap(), dec!("2"))
-                            .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_1.address,
+                                None,
+                            )
                     },
                     vec![&config.user_account_1.key],
                 )
@@ -209,7 +224,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                     metadata!(),
                                     Some(dec!("100000")),
                                 )
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(
+                                    config.user_account_1.address,
+                                    None,
+                                )
                         },
                         vec![],
                     )
@@ -231,7 +249,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                 state.min_divisibility_fungible_resource.unwrap(),
                                 dec!("166"),
                             )
-                            .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_1.address,
+                                None,
+                            )
                     },
                     vec![],
                 )
@@ -246,7 +267,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                     state.min_divisibility_fungible_resource.unwrap(),
                                     dec!("1.1"),
                                 )
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(
+                                    config.user_account_1.address,
+                                    None,
+                                )
                         },
                         vec![],
                     )
@@ -263,7 +287,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                 state.min_divisibility_fungible_resource.unwrap(),
                                 dec!("234"),
                             )
-                            .try_deposit_batch_or_abort(config.user_account_2.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_2.address,
+                                None,
+                            )
                     },
                     vec![&config.user_account_1.key],
                 )
@@ -279,7 +306,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                                     state.min_divisibility_fungible_resource.unwrap(),
                                     dec!("0.0001"),
                                 )
-                                .try_deposit_batch_or_abort(config.user_account_2.address, None)
+                                .try_deposit_entire_worktop_or_abort(
+                                    config.user_account_2.address,
+                                    None,
+                                )
                         },
                         vec![&config.user_account_1.key],
                     )
@@ -321,7 +351,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                     |builder| {
                         builder
                             .recall(state.vault2.unwrap(), dec!("2"))
-                            .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(
+                                config.user_account_1.address,
+                                None,
+                            )
                     },
                     vec![&config.user_account_1.key],
                 )
@@ -333,7 +366,10 @@ impl ScenarioCreator for FungibleResourceScenarioCreator {
                         |builder| {
                             builder
                                 .recall(state.vault2.unwrap(), dec!("123.12321"))
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(
+                                    config.user_account_1.address,
+                                    None,
+                                )
                         },
                         vec![&config.user_account_1.key],
                     )

--- a/transaction-scenarios/src/scenarios/metadata.rs
+++ b/transaction-scenarios/src/scenarios/metadata.rs
@@ -113,7 +113,7 @@ impl ScenarioInstance for MetadataScenario {
                                     )
                                 ))),
                             )
-                            .try_deposit_batch_or_abort(user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(user_account_1.address, None)
                     },
                     vec![],
                 )
@@ -147,7 +147,7 @@ impl ScenarioInstance for MetadataScenario {
                         for (k, v) in create_metadata() {
                             builder = builder.set_metadata(address, k, v);
                         }
-                        builder.try_deposit_batch_or_abort(user_account_1.address, None)
+                        builder.try_deposit_entire_worktop_or_abort(user_account_1.address, None)
                     },
                     vec![],
                 )
@@ -182,7 +182,7 @@ impl ScenarioInstance for MetadataScenario {
                                 },
                                 Some(100_000_000_000u64.into()),
                             )
-                            .try_deposit_batch_or_abort(user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(user_account_1.address, None)
                     },
                     vec![],
                 )
@@ -223,7 +223,7 @@ impl ScenarioInstance for MetadataScenario {
                                 },
                                 Some(100_000_000_000u64.into()),
                             )
-                            .try_deposit_batch_or_abort(user_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(user_account_1.address, None)
                     },
                     vec![],
                 )

--- a/transaction-scenarios/src/scenarios/non_fungible_resource.rs
+++ b/transaction-scenarios/src/scenarios/non_fungible_resource.rs
@@ -72,7 +72,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     metadata! {},
                                     Some(entries),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![],
                     )
@@ -106,7 +106,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     metadata! {},
                                     Some(entries),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![],
                     )
@@ -139,7 +139,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     metadata! {},
                                     Some(entries),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![],
                     )
@@ -168,7 +168,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     NonFungibleResourceRoles::single_locked_rule(rule!(allow_all)),
                                     Some(entries),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![],
                     )
@@ -199,7 +199,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     state.integer_non_fungible_resource.unwrap(),
                                     entries,
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![],
                     )
@@ -250,7 +250,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     state.integer_non_fungible_resource.unwrap(),
                                     dec!(1),
                                 )
-                                .try_deposit_batch_or_abort(
+                                .try_deposit_entire_worktop_or_abort(
                                     config.occasional_recipient_account.address,
                                     None
                                 )
@@ -291,7 +291,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                     NonFungibleLocalId::integer(120)
                                 ],
                             )
-                            .try_deposit_batch_or_abort(config.occasional_recipient_account.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.occasional_recipient_account.address, None)
                     },
                     vec![&config.main_account.key],
                 )
@@ -338,7 +338,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                         NonFungibleLocalId::integer(130)
                                     ],
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![&config.main_account.key],
                     )
@@ -363,7 +363,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                         NonFungibleLocalId::integer(3) => (),
                                     )),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![&config.main_account.key],
                     )
@@ -434,7 +434,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                         },
                                     )),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![&config.main_account.key],
                     )
@@ -458,7 +458,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                         NonFungibleLocalId::integer(8),
                                     ]
                                 )
-                                .try_deposit_batch_or_abort(config.occasional_recipient_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.occasional_recipient_account.address, None)
                         },
                         vec![&config.main_account.key],
                     )
@@ -499,7 +499,7 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                         },
                                     )),
                                 )
-                                .try_deposit_batch_or_abort(config.main_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.main_account.address, None)
                         },
                         vec![&config.main_account.key],
                     )

--- a/transaction-scenarios/src/scenarios/non_fungible_resource.rs
+++ b/transaction-scenarios/src/scenarios/non_fungible_resource.rs
@@ -221,11 +221,15 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                 .withdraw_non_fungibles_from_account(
                                     config.main_account.address,
                                     state.integer_non_fungible_resource.unwrap(),
-                                    &btreeset!(NonFungibleLocalId::integer(110)),
+                                    [
+                                        NonFungibleLocalId::integer(110),
+                                    ],
                                 )
                                 .take_non_fungibles_from_worktop(
                                     state.integer_non_fungible_resource.unwrap(),
-                                    &btreeset!(NonFungibleLocalId::integer(110)),
+                                    [
+                                        NonFungibleLocalId::integer(110),
+                                    ],
                                     "non_fungibles_to_burn",
                                 )
                                 .burn_resource("non_fungibles_to_burn")
@@ -283,7 +287,9 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                         builder
                             .recall_non_fungibles(
                                 state.vault1.unwrap(),
-                                &btreeset!(NonFungibleLocalId::integer(120)),
+                                [
+                                    NonFungibleLocalId::integer(120)
+                                ],
                             )
                             .try_deposit_batch_or_abort(config.occasional_recipient_account.address, None)
                     },
@@ -328,7 +334,9 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                             builder
                                 .recall_non_fungibles(
                                     state.vault1.unwrap(),
-                                    &btreeset!(NonFungibleLocalId::integer(130)),
+                                    [
+                                        NonFungibleLocalId::integer(130)
+                                    ],
                                 )
                                 .try_deposit_batch_or_abort(config.main_account.address, None)
                         },
@@ -445,10 +453,10 @@ impl ScenarioCreator for NonFungibleResourceScenarioCreator {
                                 .withdraw_non_fungibles_from_account(
                                     config.main_account.address,
                                     state.integer_non_fungible_resource_with_metadata_standard_data.unwrap(),
-                                    &btreeset!(
+                                    [
                                         NonFungibleLocalId::integer(4),
                                         NonFungibleLocalId::integer(8),
-                                    )
+                                    ]
                                 )
                                 .try_deposit_batch_or_abort(config.occasional_recipient_account.address, None)
                         },

--- a/transaction-scenarios/src/scenarios/radiswap.rs
+++ b/transaction-scenarios/src/scenarios/radiswap.rs
@@ -450,12 +450,9 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                         "radiswap-set-two-way-linking",
                         |builder| {
                             builder
-                                .create_proof_from_account_of_non_fungibles(
+                                .create_proof_from_account_of_non_fungible(
                                     config.radiswap_dapp_definition_account.address,
-                                    state.owner_badge.get()?.resource_address(),
-                                    &btreeset!(
-                                        state.owner_badge.get()?.local_id().clone()
-                                    ),
+                                    state.owner_badge.get()?
                                 )
                                 // Set up two-way-linking
                                 .set_metadata(

--- a/transaction-scenarios/src/scenarios/radiswap.rs
+++ b/transaction-scenarios/src/scenarios/radiswap.rs
@@ -135,7 +135,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                 },
                                 Some(100_000_000_000u64.into()),
                             )
-                            .try_deposit_batch_or_abort(config.storing_account.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.storing_account.address, None)
                             .done()
                         },
                         vec![],
@@ -176,7 +176,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                         (NonFungibleLocalId::integer(1), ())
                                     ]),
                                 )
-                                .try_deposit_batch_or_abort(definition_account, None)
+                                .try_deposit_entire_worktop_or_abort(definition_account, None)
                                 .set_metadata(definition_account, "account_type", "dapp definition")
                                 .set_metadata(definition_account, "name", "Radiswap dApp Definition")
                                 .set_metadata(definition_account, "description", "[EXAMPLE] The Radiswap dApp definition account")
@@ -252,7 +252,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                     state.pool_2.resource_2.get()?,
                                 )
                             )
-                            .try_deposit_batch_or_abort(config.radiswap_dapp_definition_account.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.radiswap_dapp_definition_account.address, None)
                             .done()
                         },
                         vec![],
@@ -329,7 +329,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                         lookup.bucket("pool_2_resource_2"),
                                     ),
                                 )
-                                .try_deposit_batch_or_abort(config.storing_account.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.storing_account.address, None)
                                 .done()
                         },
                         vec![&config.storing_account.key],
@@ -342,7 +342,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                         "radiswap-distribute-tokens",
                         |mut builder| {
                             builder = builder.get_free_xrd_from_faucet()
-                                .try_deposit_batch_or_abort(config.storing_account.address, None);
+                                .try_deposit_entire_worktop_or_abort(config.storing_account.address, None);
                             for destination_account in [&config.user_account_1, &config.user_account_2, &config.user_account_3]
                             {
                                 for resource_address in [
@@ -359,7 +359,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                         333,
                                     );
                                 }
-                                builder = builder.try_deposit_batch_or_abort(destination_account.address, None);
+                                builder = builder.try_deposit_entire_worktop_or_abort(destination_account.address, None);
                             }
                             builder.done()
                         },
@@ -388,7 +388,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                         lookup.bucket("input"),
                                     )
                                 )
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.user_account_1.address, None)
                                 .done()
                         },
                         vec![&config.user_account_1.key],
@@ -418,7 +418,7 @@ impl ScenarioCreator for RadiswapScenarioCreator {
                                         manifest_args!(bucket),
                                     )
                                 })
-                                .try_deposit_batch_or_abort(config.user_account_1.address, None)
+                                .try_deposit_entire_worktop_or_abort(config.user_account_1.address, None)
                                 .done()
                         },
                         vec![&config.user_account_1.key],

--- a/transaction-scenarios/src/scenarios/transfer_xrd.rs
+++ b/transaction-scenarios/src/scenarios/transfer_xrd.rs
@@ -68,7 +68,7 @@ impl ScenarioCreator for TransferXrdScenarioCreator {
                     |builder| {
                         builder
                             .withdraw_from_account(config.from_account.address, XRD, dec!(1))
-                            .try_deposit_batch_or_abort(config.to_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.to_account_1.address, None)
                             .done()
                     },
                     vec![&config.from_account.key],
@@ -80,7 +80,7 @@ impl ScenarioCreator for TransferXrdScenarioCreator {
                     |builder| {
                         builder
                             .withdraw_from_account(config.from_account.address, XRD, dec!(1))
-                            .try_deposit_batch_or_refund(config.to_account_1.address, None)
+                            .try_deposit_entire_worktop_or_refund(config.to_account_1.address, None)
                             .done()
                     },
                     vec![&config.from_account.key],
@@ -104,9 +104,9 @@ impl ScenarioCreator for TransferXrdScenarioCreator {
                     |builder| {
                         builder
                             .withdraw_from_account(config.from_account.address, XRD, dec!(1))
-                            .try_deposit_batch_or_abort(config.to_account_1.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.to_account_1.address, None)
                             .withdraw_from_account(config.from_account.address, XRD, dec!(1))
-                            .try_deposit_batch_or_abort(config.to_account_2.address, None)
+                            .try_deposit_entire_worktop_or_abort(config.to_account_2.address, None)
                             .done()
                     },
                     vec![&config.from_account.key],

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -914,6 +914,105 @@ impl ManifestBuilder {
         self.call_module_method(address, ObjectModuleId::Main, method_name, arguments)
     }
 
+    pub fn call_metadata_method(
+        self,
+        address: impl ResolvableGlobalAddress,
+        method_name: impl Into<String>,
+        arguments: impl ResolvableArguments,
+    ) -> Self {
+        self.call_module_method(address, ObjectModuleId::Metadata, method_name, arguments)
+    }
+
+    pub fn call_royalty_method(
+        self,
+        address: impl ResolvableGlobalAddress,
+        method_name: impl Into<String>,
+        arguments: impl ResolvableArguments,
+    ) -> Self {
+        self.call_module_method(address, ObjectModuleId::Royalty, method_name, arguments)
+    }
+
+    pub fn set_owner_role(
+        self,
+        address: impl ResolvableGlobalAddress,
+        rule: impl Into<AccessRule>,
+    ) -> Self {
+        self.call_module_method(
+            address,
+            ObjectModuleId::RoleAssignment,
+            ROLE_ASSIGNMENT_SET_OWNER_IDENT,
+            RoleAssignmentSetOwnerInput { rule: rule.into() },
+        )
+    }
+
+    pub fn lock_owner_role(self, address: impl ResolvableGlobalAddress) -> Self {
+        self.call_module_method(
+            address,
+            ObjectModuleId::RoleAssignment,
+            ROLE_ASSIGNMENT_LOCK_OWNER_IDENT,
+            RoleAssignmentLockOwnerInput {},
+        )
+    }
+
+    pub fn set_main_role(
+        self,
+        address: impl ResolvableGlobalAddress,
+        role_key: impl Into<RoleKey>,
+        rule: impl Into<AccessRule>,
+    ) -> Self {
+        self.set_role(address, ObjectModuleId::Main, role_key, rule)
+    }
+
+    pub fn set_role(
+        self,
+        address: impl ResolvableGlobalAddress,
+        role_module: ObjectModuleId,
+        role_key: impl Into<RoleKey>,
+        rule: impl Into<AccessRule>,
+    ) -> Self {
+        self.call_module_method(
+            address,
+            ObjectModuleId::RoleAssignment,
+            ROLE_ASSIGNMENT_SET_IDENT,
+            RoleAssignmentSetInput {
+                module: role_module,
+                role_key: role_key.into(),
+                rule: rule.into(),
+            },
+        )
+    }
+
+    pub fn get_role(
+        self,
+        address: impl ResolvableGlobalAddress,
+        role_module: ObjectModuleId,
+        role_key: RoleKey,
+    ) -> Self {
+        self.call_module_method(
+            address,
+            ObjectModuleId::RoleAssignment,
+            ROLE_ASSIGNMENT_GET_IDENT,
+            RoleAssignmentGetInput {
+                module: role_module,
+                role_key: role_key.into(),
+            },
+        )
+    }
+
+    pub fn call_role_assignment_method(
+        self,
+        address: impl ResolvableGlobalAddress,
+        method_name: impl Into<String>,
+        arguments: impl ResolvableArguments,
+    ) -> Self {
+        self.call_module_method(
+            address,
+            ObjectModuleId::RoleAssignment,
+            method_name,
+            arguments,
+        )
+    }
+
     pub fn call_module_method(
         self,
         address: impl ResolvableGlobalAddress,
@@ -1066,57 +1165,6 @@ impl ManifestBuilder {
             address: address.into(),
             method_name: COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT.to_string(),
             args: to_manifest_value_and_unwrap!(&ComponentClaimRoyaltiesInput {}),
-        })
-    }
-
-    pub fn set_owner_role(self, address: impl ResolvableGlobalAddress, rule: AccessRule) -> Self {
-        let address = address.resolve(&self.registrar);
-        self.add_instruction(InstructionV1::CallRoleAssignmentMethod {
-            address: address.into(),
-            method_name: ROLE_ASSIGNMENT_SET_OWNER_IDENT.to_string(),
-            args: to_manifest_value_and_unwrap!(&RoleAssignmentSetOwnerInput { rule }),
-        })
-    }
-
-    pub fn update_role(
-        self,
-        address: impl ResolvableGlobalAddress,
-        module: ObjectModuleId,
-        role_key: RoleKey,
-        rule: AccessRule,
-    ) -> Self {
-        let address = address.resolve(&self.registrar);
-        self.add_instruction(InstructionV1::CallRoleAssignmentMethod {
-            address: address.into(),
-            method_name: ROLE_ASSIGNMENT_SET_IDENT.to_string(),
-            args: to_manifest_value_and_unwrap!(&RoleAssignmentSetInput {
-                module,
-                role_key,
-                rule,
-            }),
-        })
-    }
-
-    pub fn lock_owner_role(self, address: impl ResolvableGlobalAddress) -> Self {
-        let address = address.resolve(&self.registrar);
-        self.add_instruction(InstructionV1::CallRoleAssignmentMethod {
-            address: address.into(),
-            method_name: ROLE_ASSIGNMENT_LOCK_OWNER_IDENT.to_string(),
-            args: to_manifest_value_and_unwrap!(&RoleAssignmentLockOwnerInput {}),
-        })
-    }
-
-    pub fn get_role(
-        self,
-        address: impl ResolvableGlobalAddress,
-        module: ObjectModuleId,
-        role_key: RoleKey,
-    ) -> Self {
-        let address = address.resolve(&self.registrar);
-        self.add_instruction(InstructionV1::CallRoleAssignmentMethod {
-            address: address.into(),
-            method_name: ROLE_ASSIGNMENT_GET_IDENT.to_string(),
-            args: to_manifest_value_and_unwrap!(&RoleAssignmentGetInput { module, role_key }),
         })
     }
 

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -1806,22 +1806,37 @@ impl ManifestBuilder {
         )
     }
 
+    /// Note - the batch should either be:
+    /// * `ManifestExpression::EntireWorktop`,
+    /// * An array, vec, or btreeset of bucket names or ManifestBuckets, eg `["my_bucket_1", "my_bucket_2"]`
+    /// * An empty, explicitly typed array of strings, eg `Vec::<String>::new()`
     pub fn try_deposit_batch_or_abort(
         self,
         account_address: impl ResolvableComponentAddress,
+        batch: impl ResolvableBucketBatch,
         authorized_depositor_badge: Option<ResourceOrNonFungible>,
     ) -> Self {
         let address = account_address.resolve(&self.registrar);
+        let batch = batch.resolve(&self.registrar);
 
         self.registrar.consume_all_buckets();
 
         self.call_method(
             address,
             ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT,
-            manifest_args!(
-                ManifestExpression::EntireWorktop,
-                authorized_depositor_badge
-            ),
+            manifest_args!(batch, authorized_depositor_badge),
+        )
+    }
+
+    pub fn try_deposit_entire_worktop_or_abort(
+        self,
+        account_address: impl ResolvableComponentAddress,
+        authorized_depositor_badge: Option<ResourceOrNonFungible>,
+    ) -> Self {
+        self.try_deposit_batch_or_abort(
+            account_address,
+            ManifestExpression::EntireWorktop,
+            authorized_depositor_badge,
         )
     }
 
@@ -1842,22 +1857,37 @@ impl ManifestBuilder {
         )
     }
 
+    /// Note - the batch should either be:
+    /// * `ManifestExpression::EntireWorktop`,
+    /// * An array, vec, or btreeset of bucket names or ManifestBuckets, eg `["my_bucket_1", "my_bucket_2"]`
+    /// * An empty, explicitly typed array of strings, eg `Vec::<String>::new()`
     pub fn try_deposit_batch_or_refund(
         self,
         account_address: impl ResolvableComponentAddress,
+        batch: impl ResolvableBucketBatch,
         authorized_depositor_badge: Option<ResourceOrNonFungible>,
     ) -> Self {
         let address = account_address.resolve(&self.registrar);
+        let batch = batch.resolve(&self.registrar);
 
         self.registrar.consume_all_buckets();
 
         self.call_method(
             address,
             ACCOUNT_TRY_DEPOSIT_BATCH_OR_REFUND_IDENT,
-            manifest_args!(
-                ManifestExpression::EntireWorktop,
-                authorized_depositor_badge
-            ),
+            manifest_args!(batch, authorized_depositor_badge),
+        )
+    }
+
+    pub fn try_deposit_entire_worktop_or_refund(
+        self,
+        account_address: impl ResolvableComponentAddress,
+        authorized_depositor_badge: Option<ResourceOrNonFungible>,
+    ) -> Self {
+        self.try_deposit_batch_or_refund(
+            account_address,
+            ManifestExpression::EntireWorktop,
+            authorized_depositor_badge,
         )
     }
 

--- a/transaction/src/builder/manifest_namer.rs
+++ b/transaction/src/builder/manifest_namer.rs
@@ -684,6 +684,88 @@ impl ResolvableBucketBatch for ManifestExpression {
     }
 }
 
+/// This is created so that you can put TransactionSignatures::None in your TestRunner
+/// Because [] can't resolve the correct generic when used as a trait impl
+pub enum TransactionSignatures {
+    None,
+    Some(Vec<NonFungibleGlobalId>),
+}
+
+pub trait ResolvableTransactionSignatures {
+    fn resolve(self) -> Vec<NonFungibleGlobalId>;
+}
+
+impl ResolvableTransactionSignatures for TransactionSignatures {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        match self {
+            TransactionSignatures::None => vec![],
+            TransactionSignatures::Some(signatures) => signatures,
+        }
+    }
+}
+
+impl ResolvableTransactionSignatures for Vec<NonFungibleGlobalId> {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self
+    }
+}
+
+impl<const N: usize> ResolvableTransactionSignatures for [NonFungibleGlobalId; N] {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self.into()
+    }
+}
+
+impl ResolvableTransactionSignatures for NonFungibleGlobalId {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        vec![self]
+    }
+}
+
+impl ResolvableTransactionSignatures for Vec<PublicKey> {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self.into_iter()
+            .map(|key| NonFungibleGlobalId::from_public_key(&key))
+            .collect()
+    }
+}
+
+impl<const N: usize> ResolvableTransactionSignatures for [PublicKey; N] {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self.into_iter()
+            .map(|key| NonFungibleGlobalId::from_public_key(&key))
+            .collect()
+    }
+}
+
+impl ResolvableTransactionSignatures for PublicKey {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        vec![NonFungibleGlobalId::from_public_key(&self)]
+    }
+}
+
+impl ResolvableTransactionSignatures for Vec<PublicKeyHash> {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self.into_iter()
+            .map(|key_hash| NonFungibleGlobalId::from_public_key_hash(key_hash))
+            .collect()
+    }
+}
+
+impl<const N: usize> ResolvableTransactionSignatures for [PublicKeyHash; N] {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        self.into_iter()
+            .map(|key_hash| NonFungibleGlobalId::from_public_key_hash(key_hash))
+            .collect()
+    }
+}
+
+impl ResolvableTransactionSignatures for PublicKeyHash {
+    fn resolve(self) -> Vec<NonFungibleGlobalId> {
+        vec![NonFungibleGlobalId::from_public_key_hash(self)]
+    }
+}
+
 pub trait ResolvableComponentAddress {
     fn resolve(self, registrar: &ManifestNameRegistrar) -> DynamicComponentAddress;
 }

--- a/transaction/src/builder/manifest_namer.rs
+++ b/transaction/src/builder/manifest_namer.rs
@@ -646,6 +646,44 @@ pub struct NamedManifestAddress {
 // OTHER RESOLVABLE TRAITS FOR THE MANIFEST BUILDER
 //=================================================
 
+pub trait ResolvableBucketBatch {
+    fn resolve(self, registrar: &ManifestNameRegistrar) -> ManifestValue;
+}
+
+impl<B: ExistingManifestBucket> ResolvableBucketBatch for BTreeSet<B> {
+    fn resolve(self, registrar: &ManifestNameRegistrar) -> ManifestValue {
+        let buckets: Vec<_> = self.into_iter().map(|b| b.resolve(registrar)).collect();
+        manifest_decode(&manifest_encode(&buckets).unwrap()).unwrap()
+    }
+}
+
+impl<B: ExistingManifestBucket, const N: usize> ResolvableBucketBatch for [B; N] {
+    fn resolve(self, registrar: &ManifestNameRegistrar) -> ManifestValue {
+        let buckets: Vec<_> = self.into_iter().map(|b| b.resolve(registrar)).collect();
+        manifest_decode(&manifest_encode(&buckets).unwrap()).unwrap()
+    }
+}
+
+impl<B: ExistingManifestBucket> ResolvableBucketBatch for Vec<B> {
+    fn resolve(self, registrar: &ManifestNameRegistrar) -> ManifestValue {
+        let buckets: Vec<_> = self.into_iter().map(|b| b.resolve(registrar)).collect();
+        manifest_decode(&manifest_encode(&buckets).unwrap()).unwrap()
+    }
+}
+
+impl ResolvableBucketBatch for ManifestExpression {
+    fn resolve(self, _: &ManifestNameRegistrar) -> ManifestValue {
+        match &self {
+            ManifestExpression::EntireWorktop => {
+                manifest_decode(&manifest_encode(&self).unwrap()).unwrap()
+            }
+            ManifestExpression::EntireAuthZone => {
+                panic!("Not an allowed expression for a batch of buckets")
+            }
+        }
+    }
+}
+
 pub trait ResolvableComponentAddress {
     fn resolve(self, registrar: &ManifestNameRegistrar) -> DynamicComponentAddress;
 }


### PR DESCRIPTION
## Summary
A number of finishing tweaks/refactors that I promised to get into improving developer UX for RCnet v3 - based on a list of minor tweaks I have in my notes - either things requested by the community, or things I wanted to finish off.

_All of these are quality of life changes, none of these have any functional impact on the node or engine_

### ManifestBuilder
* All ManifestBuilder methods taking NonFungibleLocalIds now take an `IntoIterator<Item = NonFungibleLocalId>` - so that you can pass it in with an array `[..]` or `btreeset!(..)` - this is for consistency with the other methods.
* New ManifestBuilder method: `create_proof_from_account_of_non_fungible` - which takes a single `NonFungibleGlobalId`
* Both `try_deposit_batch_or_abort` and `try_deposit_batch_or_refund` now accept a batch. The old methods, hard-coding `batch = ManifestExpression::EntireWorktop` are now `try_deposit_entire_worktop_or_abort` / `try_deposit_entire_worktop_or_refund`
* Added `burn_non_fungibles_in_account` /  `burn_non_fungible_in_account` helper methods on manifest builder
* Add `call_metatadata_method` etc
* Renamed `update_role` to `set_role` for consistency, and changed it to accept `Into<X>` 
* Metadata: Add conversions from ResourceAddress, ComponentAddress and PackageAddress to GlobalAddress

### TestRunner
* Added `execute_unsigned_built_manifest_with_faucet_lock_fee`, `execute_unsigned_built_manifest`, `execute_built_manifest_with_faucet_lock_fee` and `execute_built_manifest` which all take a `|builder| => { .. }`. For signatures, the latter take anything which can be turned into signatures, including `TransactionSignatures::None`, as well as single/vecs/arrays of NonFungibleGlobalId, PublicKey and PublicKeyHash.

### NonFungibleData derive
* Make `NonFungibleData` derive work with generics

## Update Instructions
### For dApp Developers

* If you have an error with a manifest builder method which used to take a `&BTreeSet<NonFungibleLocalId>`, just remove the reference `&`, or replace the BTreeSet with an array `[..]`.
* If you have an error with a manifest builder `try_deposit_batch_or_X` method, rename the method to `try_deposit_entire_worktop_or_abort` or `try_deposit_entire_worktop_or_refund`
* If you have an error with a manifest builder `update_role` method, change the method name to `set_role` or `set_main_role`.