### PR TITLE
Limit the number of buffers in WasmRuntime

### DIFF
--- a/radix-engine-common/src/constants/transaction_execution.rs
+++ b/radix-engine-common/src/constants/transaction_execution.rs
@@ -102,3 +102,6 @@ pub const USD_PRICE_IN_XRD: &str = "16.666666666666666666";
 
 /// The maximum that a package or component owner is allowed to set their method royalty to. 10 USD
 pub const MAX_PER_FUNCTION_ROYALTY_IN_XRD: &str = "166.666666666666666666";
+
+/// The maximum number of "live" buffers maintained by Scrypto runtime.
+pub const MAX_NUMBER_OF_BUFFERS: usize = 32;

--- a/radix-engine-tests/tests/blueprints/transaction_limits/src/transaction_limits.rs
+++ b/radix-engine-tests/tests/blueprints/transaction_limits/src/transaction_limits.rs
@@ -160,3 +160,31 @@ mod invoke_limits {
         pub fn callee(_: Vec<u8>) {}
     }
 }
+
+#[blueprint]
+mod buffer_limit {
+    struct BufferLimit {
+        state: Vec<u8>,
+    }
+
+    impl BufferLimit {
+        pub fn new() -> Global<BufferLimit> {
+            BufferLimit {
+                state: [0u8; 200 * 1024].to_vec(),
+            }
+            .instantiate()
+            .prepare_to_globalize(OwnerRole::None)
+            .globalize()
+        }
+
+        pub fn allocate_buffers(&self, n: u32) {
+            let handle =
+                ScryptoVmV1Api::actor_open_field(ACTOR_STATE_SELF, 0u8, LockFlags::empty());
+            for _ in 0..n {
+                unsafe {
+                    scrypto::engine::wasm_api::field_entry::field_entry_read(handle);
+                }
+            }
+        }
+    }
+}

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -149,6 +149,8 @@ pub enum WasmRuntimeError {
     FeeReserveError(FeeReserveError),
 
     InvalidEventFlags(u32),
+
+    TooManyBuffers,
 }
 
 impl SelfError for WasmRuntimeError {

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -21,6 +21,7 @@ where
     package_address: PackageAddress,
     export_name: String,
     wasm_execution_units_buffer: u32,
+    max_number_of_buffers: usize,
 }
 
 impl<'y, Y> ScryptoRuntime<'y, Y>
@@ -35,6 +36,7 @@ where
             package_address,
             export_name,
             wasm_execution_units_buffer: 0,
+            max_number_of_buffers: MAX_NUMBER_OF_BUFFERS,
         }
     }
 }
@@ -48,6 +50,10 @@ where
         buffer: Vec<u8>,
     ) -> Result<Buffer, InvokeError<WasmRuntimeError>> {
         assert!(buffer.len() <= 0xffffffff);
+
+        if self.buffers.len() >= self.max_number_of_buffers {
+            return Err(InvokeError::SelfError(WasmRuntimeError::TooManyBuffers));
+        }
 
         let id = self.next_buffer_id;
         let len = buffer.len();


### PR DESCRIPTION
## Summary

Limit the number of buffers in WasmRuntime

## Testing

New tests added
