### PR TITLE
Decimal arithmetic operation inspection

### DIFF
--- a/assets/blueprints/genesis_helper/src/lib.rs
+++ b/assets/blueprints/genesis_helper/src/lib.rs
@@ -152,7 +152,9 @@ mod genesis_helper {
                 for v in allocations.iter().flat_map(|(_, allocations)| {
                     allocations.iter().map(|alloc| alloc.xrd_amount.clone())
                 }) {
-                    sum = sum.safe_add(v).unwrap();
+                    sum = sum
+                        .safe_add(v)
+                        .expect("Overflow because resource limit exceeded");
                 }
                 sum
             };
@@ -254,7 +256,9 @@ mod genesis_helper {
                 let amount_needed = {
                     let mut sum = Decimal::ZERO;
                     for v in allocations.iter().map(|alloc| alloc.amount.clone()) {
-                        sum = sum.safe_add(v).unwrap();
+                        sum = sum
+                            .safe_add(v)
+                            .expect("Overflow because resource limit exceeded");
                     }
                     sum
                 };
@@ -277,7 +281,9 @@ mod genesis_helper {
             let xrd_needed = {
                 let mut sum = Decimal::ZERO;
                 for v in allocations.iter().map(|(_, amount)| amount.clone()) {
-                    sum = sum.safe_add(v).unwrap();
+                    sum = sum
+                        .safe_add(v)
+                        .expect("Overflow because resource limit exceeded");
                 }
                 sum
             };

--- a/radix-engine-common/src/macros.rs
+++ b/radix-engine-common/src/macros.rs
@@ -2,10 +2,12 @@
 ///
 #[macro_export]
 macro_rules! dec {
+    // NOTE: Decimal arithmetic operation safe unwrap.
+    // In general, it is assumed that reasonable literals are provided.
+    // If not then something is definitely wrong and panic is fine.
     ($x:literal) => {
         $crate::math::Decimal::try_from($x).unwrap()
     };
-
     ($base:literal, $shift:literal) => {
         // Base can be any type that converts into a Decimal, and shift must support
         // comparison and `-` unary operation, enforced by rustc.
@@ -49,6 +51,9 @@ macro_rules! i {
 ///
 #[macro_export]
 macro_rules! pdec {
+    // NOTE: PreciseDecimal arithmetic operation safe unwrap.
+    // In general, it is assumed that reasonable literals are provided.
+    // If not then something is definitely wrong and panic is fine.
     ($x:literal) => {
         $crate::math::PreciseDecimal::try_from($x).unwrap()
     };

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -160,6 +160,9 @@ impl EpochChangeCondition {
             // Need to avoid issues with divide by zero etc
             return false;
         }
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        // No realistic chance to overflow.
+        // 100 years in ms is less than 2^35
         let proportion_difference = (Decimal::from(actual_duration_millis)
             .safe_sub(self.target_duration_millis)
             .expect("Overflow"))

--- a/radix-engine-queries/src/query/accounter.rs
+++ b/radix-engine-queries/src/query/accounter.rs
@@ -51,7 +51,11 @@ impl Accounting {
         resource: &LiquidFungibleResource,
     ) {
         let entry = self.balances.entry(*address).or_default();
-        *entry = entry.safe_add(resource.amount()).unwrap()
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        //       Resources have a mint limit below the Decimal max
+        *entry = entry
+            .safe_add(resource.amount())
+            .expect("Resource overflow despite mint limit")
     }
 
     pub fn add_non_fungible_vault(

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -108,16 +108,20 @@ impl ActiveValidatorSet {
     }
 
     /// Note for performance - this is calculated by iterating over the whole validator set.
-    pub fn total_active_stake_xrd(&self) -> Decimal {
+    pub fn total_active_stake_xrd(&self) -> Result<Decimal, RuntimeError> {
         let mut sum = Decimal::ZERO;
         for v in self
             .validators_by_stake_desc
             .iter()
             .map(|(_, validator)| validator.stake)
         {
-            sum = sum.safe_add(v).unwrap();
+            sum = sum.safe_add(v).ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?;
         }
-        sum
+        Ok(sum)
     }
 
     pub fn validator_count(&self) -> usize {
@@ -182,12 +186,18 @@ impl ProposalStatistic {
     /// A ratio of successful to total proposals.
     /// There is a special case of a validator which did not have a chance of leading even a single
     /// round of consensus - currently we assume they should not be punished (i.e. we return `1.0`).
-    pub fn success_ratio(&self) -> Decimal {
+    pub fn success_ratio(&self) -> Result<Decimal, RuntimeError> {
         let total = self.made + self.missed;
         if total == 0 {
-            return Decimal::one();
+            return Ok(Decimal::one());
         }
-        Decimal::from(self.made).safe_div(total).unwrap()
+        Ok(Decimal::from(self.made)
+            .safe_div(total)
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?)
     }
 }
 
@@ -211,6 +221,7 @@ pub enum ConsensusManagerError {
     },
     AlreadyStarted,
     NotXrd,
+    UnexpectedDecimalComputationError,
 }
 
 declare_native_blueprint_state! {
@@ -852,7 +863,11 @@ impl ConsensusManagerBlueprint {
                 .config
                 .validator_creation_usd_cost
                 .safe_mul(api.usd_price()?)
-                .unwrap();
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
             Some(validator_creation_xrd_cost)
         } else {
             None
@@ -1094,7 +1109,11 @@ impl ConsensusManagerBlueprint {
         {
             next_validator_set_total_stake = next_validator_set_total_stake
                 .safe_add(validator.stake)
-                .unwrap();
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
             let rtn = api.call_method(
                 validator_address.as_node_id(),
                 VALIDATOR_GET_PROTOCOL_UPDATE_READINESS_IDENT,
@@ -1105,15 +1124,24 @@ impl ConsensusManagerBlueprint {
                 let entry = significant_protocol_update_readiness
                     .entry(protocol_update_readiness)
                     .or_insert(Decimal::zero());
-                *entry = entry.safe_add(validator.stake).unwrap()
+                *entry = entry
+                    .safe_add(validator.stake)
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
             }
         }
 
         // Only store protocol updates that have been signalled by at
         // least 10% of the new epoch's validator set total stake.
-        let significant_protocol_update_readiness_stake_threshold = next_validator_set_total_stake
-            .safe_mul(dec!("0.1"))
-            .unwrap();
+        let significant_protocol_update_readiness_stake_threshold =
+            next_validator_set_total_stake.safe_mul(dec!("0.1")).ok_or(
+                RuntimeError::ApplicationError(ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                )),
+            )?;
         significant_protocol_update_readiness.retain(|_, stake_signalled| {
             *stake_signalled >= significant_protocol_update_readiness_stake_threshold
         });
@@ -1184,7 +1212,7 @@ impl ConsensusManagerBlueprint {
                 validator.stake,
                 validator_statistics[index].clone(),
                 config.min_validator_reliability,
-            ) {
+            )? {
                 validator_infos.insert(
                     TryInto::<u8>::try_into(index)
                         .expect("Validator index exceeds the range of u8"),
@@ -1205,7 +1233,11 @@ impl ConsensusManagerBlueprint {
                 .values()
                 .map(|validator_info| validator_info.stake_xrd)
             {
-                sum = sum.safe_add(v).unwrap();
+                sum = sum.safe_add(v).ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
             }
             sum
         };
@@ -1219,17 +1251,30 @@ impl ConsensusManagerBlueprint {
         let emission_per_staked_xrd = config
             .total_emission_xrd_per_epoch
             .safe_div(stake_sum_xrd)
-            .unwrap();
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?;
         let effective_total_emission_xrd = {
             let mut sum = Decimal::ZERO;
 
-            for v in validator_infos.values().map(|validator_info| {
-                validator_info
+            for v in validator_infos.values() {
+                let emission = v
                     .effective_stake_xrd
                     .safe_mul(emission_per_staked_xrd)
-                    .unwrap()
-            }) {
-                sum = sum.safe_add(v).unwrap();
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
+                sum = sum
+                    .safe_add(emission)
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
             }
             sum
         };
@@ -1242,7 +1287,11 @@ impl ConsensusManagerBlueprint {
                 validator_info
                     .effective_stake_xrd
                     .safe_mul(emission_per_staked_xrd)
-                    .unwrap(),
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?,
                 api,
             )?;
             api.call_method(
@@ -1266,7 +1315,11 @@ impl ConsensusManagerBlueprint {
             let mut sum = Decimal::ZERO;
 
             for v in validator_rewards.proposer_rewards.values() {
-                sum = sum.safe_add(*v).unwrap();
+                sum = sum.safe_add(*v).ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
             }
             sum
         };
@@ -1277,7 +1330,11 @@ impl ConsensusManagerBlueprint {
             .safe_sub(total_individual_amount)
             .unwrap())
         .safe_div(stake_sum_xrd)
-        .unwrap();
+        .ok_or(RuntimeError::ApplicationError(
+            ApplicationError::ConsensusManagerError(
+                ConsensusManagerError::UnexpectedDecimalComputationError,
+            ),
+        ))?;
         for (index, validator_info) in validator_infos {
             let from_self = validator_rewards
                 .proposer_rewards
@@ -1286,8 +1343,19 @@ impl ConsensusManagerBlueprint {
             let from_pool = validator_info
                 .effective_stake_xrd
                 .safe_mul(reward_per_staked_xrd)
-                .unwrap();
-            let reward_amount = from_self.safe_add(from_pool).unwrap();
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
+            let reward_amount =
+                from_self
+                    .safe_add(from_pool)
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
             if reward_amount.is_zero() {
                 continue;
             }
@@ -1321,43 +1389,65 @@ impl ValidatorInfo {
         stake_xrd: Decimal,
         proposal_statistic: ProposalStatistic,
         min_required_reliability: Decimal,
-    ) -> Option<Self> {
+    ) -> Result<Option<Self>, RuntimeError> {
         if stake_xrd.is_positive() {
             let reliability_factor = Self::to_reliability_factor(
-                proposal_statistic.success_ratio(),
+                proposal_statistic.success_ratio()?,
                 min_required_reliability,
-            );
-            let effective_stake_xrd = stake_xrd.safe_mul(reliability_factor).unwrap();
-            Some(Self {
+            )?;
+            let effective_stake_xrd =
+                stake_xrd
+                    .safe_mul(reliability_factor)
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::ConsensusManagerError(
+                            ConsensusManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
+            Ok(Some(Self {
                 address,
                 stake_xrd,
                 proposal_statistic,
                 effective_stake_xrd,
-            })
+            }))
         } else {
-            None
+            Ok(None)
         }
     }
 
     /// Converts the absolute reliability measure (e.g. "0.97 uptime") into a reliability factor
     /// which directly drives the fraction of received emission (e.g. "0.25 of base emission"), by
     /// rescaling it into the allowed reliability range (e.g. "required >0.96 uptime").
-    fn to_reliability_factor(reliability: Decimal, min_required_reliability: Decimal) -> Decimal {
-        let reliability_reserve = reliability.safe_sub(min_required_reliability).unwrap();
+    fn to_reliability_factor(
+        reliability: Decimal,
+        min_required_reliability: Decimal,
+    ) -> Result<Decimal, RuntimeError> {
+        let reliability_reserve = reliability.safe_sub(min_required_reliability).ok_or(
+            RuntimeError::ApplicationError(ApplicationError::ConsensusManagerError(
+                ConsensusManagerError::UnexpectedDecimalComputationError,
+            )),
+        )?;
         if reliability_reserve.is_negative() {
-            return Decimal::zero();
+            return Ok(Decimal::zero());
         }
-        let max_allowed_unreliability = Decimal::one().safe_sub(min_required_reliability).unwrap();
+        let max_allowed_unreliability = Decimal::one().safe_sub(min_required_reliability).ok_or(
+            RuntimeError::ApplicationError(ApplicationError::ConsensusManagerError(
+                ConsensusManagerError::UnexpectedDecimalComputationError,
+            )),
+        )?;
         if max_allowed_unreliability.is_zero() {
             // special-casing the dirac delta behavior
             if reliability == Decimal::one() {
-                return Decimal::one();
+                return Ok(Decimal::one());
             } else {
-                return Decimal::zero();
+                return Ok(Decimal::zero());
             }
         }
-        reliability_reserve
+        Ok(reliability_reserve
             .safe_div(max_allowed_unreliability)
-            .unwrap()
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?)
     }
 }

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -1613,12 +1613,7 @@ impl ValidatorBlueprint {
         } else {
             amount_of_stake_units
                 .safe_mul(active_stake_amount)
-                .ok_or(RuntimeError::ApplicationError(
-                    ApplicationError::ValidatorError(
-                        ValidatorError::UnexpectedDecimalComputationError,
-                    ),
-                ))?
-                .safe_div(total_stake_unit_supply)
+                .and_then(|amount| amount.safe_div(total_stake_unit_supply))
                 .ok_or(RuntimeError::ApplicationError(
                     ApplicationError::ValidatorError(
                         ValidatorError::UnexpectedDecimalComputationError,
@@ -1640,12 +1635,7 @@ impl ValidatorBlueprint {
         } else {
             xrd_amount
                 .safe_mul(total_stake_unit_supply)
-                .ok_or(RuntimeError::ApplicationError(
-                    ApplicationError::ValidatorError(
-                        ValidatorError::UnexpectedDecimalComputationError,
-                    ),
-                ))?
-                .safe_div(total_stake_xrd_amount)
+                .and_then(|amount| amount.safe_div(total_stake_xrd_amount))
                 .ok_or(RuntimeError::ApplicationError(
                     ApplicationError::ValidatorError(
                         ValidatorError::UnexpectedDecimalComputationError,
@@ -1675,16 +1665,15 @@ fn create_sort_prefix_from_stake(stake: Decimal) -> Result<[u8; 2], RuntimeError
         .ok_or(RuntimeError::ApplicationError(
             ApplicationError::ValidatorError(ValidatorError::UnexpectedDecimalComputationError),
         ))?;
-    let stake_100k_whole_units = stake_100k
-        .safe_div(Decimal::from(10).safe_powi(Decimal::SCALE.into()).ok_or(
-            RuntimeError::ApplicationError(ApplicationError::ValidatorError(
-                ValidatorError::UnexpectedDecimalComputationError,
-            )),
-        )?)
+
+    let stake_100k_whole_units = Decimal::from(10)
+        .safe_powi(Decimal::SCALE.into())
+        .and_then(|power| stake_100k.safe_div(power))
         .ok_or(RuntimeError::ApplicationError(
             ApplicationError::ValidatorError(ValidatorError::UnexpectedDecimalComputationError),
         ))?
         .0;
+
     let stake_u16 = if stake_100k_whole_units > I192::from(u16::MAX) {
         u16::MAX
     } else {

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -1611,9 +1611,9 @@ impl ValidatorBlueprint {
         let xrd_amount = if total_stake_unit_supply.is_zero() {
             Decimal::zero()
         } else {
-            amount_of_stake_units
-                .safe_mul(active_stake_amount)
-                .and_then(|amount| amount.safe_div(total_stake_unit_supply))
+            active_stake_amount
+                .safe_div(total_stake_unit_supply)
+                .and_then(|amount| amount_of_stake_units.safe_mul(amount))
                 .ok_or(RuntimeError::ApplicationError(
                     ApplicationError::ValidatorError(
                         ValidatorError::UnexpectedDecimalComputationError,
@@ -1633,9 +1633,9 @@ impl ValidatorBlueprint {
         if total_stake_xrd_amount.is_zero() {
             Ok(xrd_amount)
         } else {
-            xrd_amount
-                .safe_mul(total_stake_unit_supply)
-                .and_then(|amount| amount.safe_div(total_stake_xrd_amount))
+            total_stake_unit_supply
+                .safe_div(total_stake_xrd_amount)
+                .and_then(|amount| xrd_amount.safe_mul(amount))
                 .ok_or(RuntimeError::ApplicationError(
                     ApplicationError::ValidatorError(
                         ValidatorError::UnexpectedDecimalComputationError,

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_bucket.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_bucket.rs
@@ -140,11 +140,11 @@ impl NonFungibleBucketBlueprint {
     where
         Y: KernelNodeApi + ClientApi<RuntimeError>,
     {
-        let amount = Self::liquid_amount(api)?
+        Self::liquid_amount(api)?
             .safe_add(Self::locked_amount(api)?)
-            .unwrap();
-
-        Ok(amount)
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::BucketError(BucketError::DecimalOverflow),
+            ))
     }
 
     pub fn get_resource_address<Y>(api: &mut Y) -> Result<ResourceAddress, RuntimeError>

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -104,6 +104,7 @@ pub enum NonFungibleResourceManagerError {
     DropNonEmptyBucket,
     NotMintable,
     NotBurnable,
+    UnexpectedDecimalComputationError,
 }
 
 /// Represents an error when accessing a bucket.
@@ -935,7 +936,14 @@ impl NonFungibleResourceManagerBlueprint {
                     total_supply_handle,
                 )?
                 .into_latest();
-            total_supply = total_supply.safe_add(entries.len()).unwrap();
+            total_supply =
+                total_supply
+                    .safe_add(entries.len())
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::NonFungibleResourceManagerError(
+                            NonFungibleResourceManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
             api.field_write_typed(
                 total_supply_handle,
                 &NonFungibleResourceManagerTotalSupplyFieldPayload::from_content_source(
@@ -1009,7 +1017,13 @@ impl NonFungibleResourceManagerBlueprint {
                     total_supply_handle,
                 )?
                 .into_latest();
-            total_supply = total_supply.safe_add(1).unwrap();
+            total_supply = total_supply
+                .safe_add(1)
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::NonFungibleResourceManagerError(
+                        NonFungibleResourceManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
             api.field_write_typed(
                 total_supply_handle,
                 &NonFungibleResourceManagerTotalSupplyFieldPayload::from_content_source(
@@ -1084,7 +1098,14 @@ impl NonFungibleResourceManagerBlueprint {
                     total_supply_handle,
                 )?
                 .into_latest();
-            total_supply = total_supply.safe_add(entries.len()).unwrap();
+            total_supply =
+                total_supply
+                    .safe_add(entries.len())
+                    .ok_or(RuntimeError::ApplicationError(
+                        ApplicationError::NonFungibleResourceManagerError(
+                            NonFungibleResourceManagerError::UnexpectedDecimalComputationError,
+                        ),
+                    ))?;
             api.field_write_typed(
                 total_supply_handle,
                 &NonFungibleResourceManagerTotalSupplyFieldPayload::from_content_source(
@@ -1308,7 +1329,11 @@ impl NonFungibleResourceManagerBlueprint {
                     total_supply_handle,
                 )?
                 .into_latest();
-            total_supply = total_supply.safe_sub(other_bucket.liquid.amount()).unwrap();
+            total_supply = total_supply.safe_sub(other_bucket.liquid.amount()).ok_or(
+                RuntimeError::ApplicationError(ApplicationError::NonFungibleResourceManagerError(
+                    NonFungibleResourceManagerError::UnexpectedDecimalComputationError,
+                )),
+            )?;
             api.field_write_typed(
                 total_supply_handle,
                 &NonFungibleResourceManagerTotalSupplyFieldPayload::from_content_source(

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
@@ -487,11 +487,11 @@ impl NonFungibleVaultBlueprint {
     where
         Y: KernelNodeApi + ClientApi<RuntimeError>,
     {
-        let amount = Self::liquid_amount(api)?
+        Self::liquid_amount(api)?
             .safe_add(Self::locked_amount(api)?)
-            .unwrap();
-
-        Ok(amount)
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::VaultError(VaultError::DecimalOverflow),
+            ))
     }
 
     pub fn contains_non_fungible<Y>(
@@ -921,7 +921,12 @@ impl NonFungibleVaultBlueprint {
                 ApplicationError::NonFungibleVaultError(NonFungibleVaultError::NotEnoughAmount),
             ));
         }
-        balance.amount = balance.amount.safe_sub(n).unwrap();
+        balance.amount = balance
+            .amount
+            .safe_sub(n)
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::VaultError(VaultError::DecimalOverflow),
+            ))?;
 
         let taken = {
             let ids: Vec<(NonFungibleLocalId, NonFungibleVaultNonFungibleEntryPayload)> = api
@@ -960,7 +965,13 @@ impl NonFungibleVaultBlueprint {
             .field_read_typed::<NonFungibleVaultBalanceFieldPayload>(handle)?
             .into_latest();
 
-        substate_ref.amount = substate_ref.amount.safe_sub(ids.len()).unwrap();
+        substate_ref.amount =
+            substate_ref
+                .amount
+                .safe_sub(ids.len())
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::VaultError(VaultError::DecimalOverflow),
+                ))?;
 
         // TODO: Batch remove
         for id in ids {
@@ -1008,7 +1019,13 @@ impl NonFungibleVaultBlueprint {
             .field_read_typed::<NonFungibleVaultBalanceFieldPayload>(handle)?
             .into_latest();
 
-        vault.amount = vault.amount.safe_add(resource.ids.len()).unwrap();
+        vault.amount =
+            vault
+                .amount
+                .safe_add(resource.ids.len())
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::VaultError(VaultError::DecimalOverflow),
+                ))?;
 
         // update liquidity
         // TODO: Batch update

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
@@ -416,7 +416,10 @@ impl NonFungibleVaultBlueprint {
         })?;
 
         // Take
-        balance.amount = balance.amount.safe_sub(n).unwrap();
+        balance.amount = balance
+            .amount
+            .safe_sub(n)
+            .ok_or_else(|| VaultError::DecimalOverflow)?;
         let taken = {
             let ids: Vec<(NonFungibleLocalId, NonFungibleVaultNonFungibleEntryPayload)> = api
                 .actor_index_drain_typed(

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -62,7 +62,9 @@ lazy_static! {
     pub static ref DEFAULT_VALIDATOR_USD_COST: Decimal = dec!("100");
     pub static ref DEFAULT_VALIDATOR_XRD_COST: Decimal = DEFAULT_VALIDATOR_USD_COST
         .safe_mul(Decimal::try_from(USD_PRICE_IN_XRD).unwrap())
-        .unwrap();
+        .unwrap();  // NOTE: Decimal arithmetic operation safe unwrap.
+                    // No chance to overflow.
+                    // The chance to overflow will be decreasing over time since USD price in XRD will only get lower ;)
 }
 
 //==========================================================================================

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -217,6 +217,7 @@ pub enum ComponentRoyaltyError {
         max: RoyaltyAmount,
         actual: RoyaltyAmount,
     },
+    UnexpectedDecimalComputationError,
 }
 
 pub struct RoyaltyUtil;
@@ -231,7 +232,14 @@ impl RoyaltyUtil {
         Y: ClientApi<RuntimeError>,
     {
         let max_royalty_in_xrd = api.max_per_function_royalty_in_xrd()?;
-        let max_royalty_in_usd = max_royalty_in_xrd.safe_div(api.usd_price()?).unwrap();
+        let max_royalty_in_usd =
+            max_royalty_in_xrd
+                .safe_div(api.usd_price()?)
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ComponentRoyaltyError(
+                        ComponentRoyaltyError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
 
         for royalty_amount in royalty_amounts {
             match royalty_amount {

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -177,6 +177,9 @@ impl SystemLoanFeeReserve {
         transaction_costing_parameters: &TransactionCostingParameters,
         abort_when_loan_repaid: bool,
     ) -> Self {
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        // No chance to overflow considering current costing parameters
+
         let tip_percentage = Decimal::ONE
             .safe_add(
                 transaction_costing_parameters

--- a/radix-engine/src/system/system_modules/costing/fee_summary.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_summary.rs
@@ -34,6 +34,9 @@ impl FeeReserveFinalizationSummary {
         self.total_bad_debt_in_xrd == 0.into()
     }
 
+    // NOTE: Decimal arithmetic operation safe unwrap.
+    // No chance to overflow considering current costing parameters
+
     pub fn total_cost(&self) -> Decimal {
         self.total_execution_cost_in_xrd
             .safe_add(self.total_finalization_cost_in_xrd)

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -18,6 +18,10 @@ use sbor::rust::fmt::Debug;
 // Note: ExecutionTrace must not produce any error or transactional side effect!
 //===================================================================================
 
+// TODO: Handle potential Decimal arithmetic operation (saf_add, safe_sub) errors instead of panicking.
+// ATM, ExecutionTrace cannot return any errors (as stated above), so it shall be thoroughly
+// designed.
+
 #[derive(Debug, Clone)]
 pub struct ExecutionTraceModule {
     /// Maximum depth up to which kernel calls are being traced.

--- a/radix-engine/src/transaction/state_update_summary.rs
+++ b/radix-engine/src/transaction/state_update_summary.rs
@@ -197,6 +197,7 @@ impl<'a, S: SubstateDatabase> BalanceAccounter<'a, S> {
                     .map(|old_balance| old_balance.into_payload().into_latest().amount())
                     .unwrap_or(Decimal::ZERO);
 
+                // TODO: Handle potential Decimal arithmetic operation (safe_sub) errors instead of panicking.
                 new_balance.safe_sub(old_balance).unwrap()
             })
             .filter(|change| change != &Decimal::ZERO) // prune

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -769,6 +769,9 @@ where
                 Decimal::min(locked.amount(), required)
             };
 
+            // NOTE: Decimal arithmetic operation safe unwrap.
+            // No chance to overflow considering current costing parameters
+
             // Take fees
             collected_fees.put(locked.take_by_amount(amount).unwrap());
             required = required.safe_sub(amount).unwrap();

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -441,6 +441,7 @@ impl TransactionReceipt {
     pub fn effective_execution_cost_unit_price(&self) -> Decimal {
         let dec_100 = dec!(100);
 
+        // Below unwraps are safe, no chance to overflow considering current costing parameters
         self.costing_parameters
             .execution_cost_unit_price
             .safe_mul(
@@ -459,6 +460,7 @@ impl TransactionReceipt {
     pub fn effective_finalization_cost_unit_price(&self) -> Decimal {
         let dec_100 = dec!(100);
 
+        // Below unwraps are safe, no chance to overflow considering current costing parameters
         self.costing_parameters
             .finalization_cost_unit_price
             .safe_mul(


### PR DESCRIPTION
## Summary
Inspect Decimal operations unwraps.
- replace (if necessary) them with proper error handling
- annotate those safe ones
- annotate those to be done later

NOTE: Unwraps in tests were left as is.

