### PR TITLE
Returning resultant balance together with fungible vault changes

### DIFF
--- a/radix-engine-tests/tests/account.rs
+++ b/radix-engine-tests/tests/account.rs
@@ -98,12 +98,17 @@ where
     let other_account_balance: Decimal = test_runner.get_component_balance(other_account, XRD);
     let transfer_amount = other_account_balance.safe_sub(10000).unwrap() /* initial balance */;
 
-    let balance_change = test_runner
-        .sum_descendant_balance_changes(receipt.expect_commit_success(), other_account.as_node_id())
-        .get(&XRD)
-        .unwrap()
-        .clone();
-    assert_eq!(balance_change, BalanceChange::Fungible(transfer_amount));
+    assert_eq!(
+        test_runner
+            .sum_descendant_balance_changes(
+                receipt.expect_commit_success(),
+                other_account.as_node_id()
+            )
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &transfer_amount
+    );
 }
 
 fn can_withdraw_non_fungible_from_my_account_internal(use_virtual: bool) {
@@ -203,14 +208,13 @@ fn account_to_bucket_to_account_internal(use_virtual: bool) {
     );
 
     // Assert
-    let balance_change = test_runner
-        .sum_descendant_balance_changes(receipt.expect_commit_success(), account.as_node_id())
-        .get(&XRD)
-        .unwrap()
-        .clone();
     assert_eq!(
-        balance_change,
-        BalanceChange::Fungible(receipt.fee_summary.total_cost().safe_neg().unwrap())
+        test_runner
+            .sum_descendant_balance_changes(receipt.expect_commit_success(), account.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.total_cost().safe_neg().unwrap()
     );
 }
 

--- a/radix-engine-tests/tests/balance_changes.rs
+++ b/radix-engine-tests/tests/balance_changes.rs
@@ -57,34 +57,43 @@ fn test_balance_changes_when_success() {
 
     assert_eq!(
         test_runner
-            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.total_cost().safe_neg().unwrap())
-        )
+            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.total_cost().safe_neg().unwrap()
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, account.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(dec!("-1"))
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, account.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &dec!("-1")
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, component_address.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(dec!("2")) // 1 for put another 1 for component royalties
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, component_address.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &dec!("2")
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, package_address.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(dec!("2"))
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, package_address.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &dec!("2")
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.expected_reward_if_single_validator())
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.expected_reward_if_single_validator()
     );
 }
 
@@ -142,16 +151,19 @@ fn test_balance_changes_when_failure() {
 
     assert_eq!(
         test_runner
-            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id(),),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.total_cost().safe_neg().unwrap() )
-        )
+            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.total_cost().safe_neg().unwrap()
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.expected_reward_if_single_validator())
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.expected_reward_if_single_validator()
     );
 }
 
@@ -182,28 +194,35 @@ fn test_balance_changes_when_recall() {
 
     assert_eq!(
         test_runner
-            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.total_cost().safe_neg().unwrap() )
-        )
+            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.total_cost().safe_neg().unwrap()
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, other_account.as_node_id()),
-        indexmap!(
-            recallable_token => BalanceChange::Fungible(dec!(1))
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, other_account.as_node_id())
+            .remove(&recallable_token)
+            .unwrap()
+            .fungible_change(),
+        &dec!(1)
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id()),
-        indexmap!(
-            XRD => BalanceChange::Fungible(receipt.fee_summary.expected_reward_if_single_validator())
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, CONSENSUS_MANAGER.as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.expected_reward_if_single_validator()
     );
     assert_eq!(
-        test_runner.sum_descendant_balance_changes(result, account.as_node_id()),
-        indexmap!(
-            recallable_token => BalanceChange::Fungible(dec!("-1"))
-        )
+        test_runner
+            .sum_descendant_balance_changes(result, account.as_node_id())
+            .remove(&recallable_token)
+            .unwrap()
+            .fungible_change(),
+        &dec!("-1")
     );
 }
 
@@ -257,13 +276,12 @@ fn test_balance_changes_when_transferring_non_fungibles() {
     assert_eq!(other_account_added, btreeset!(transferred_non_fungible));
     assert_eq!(other_account_removed, BTreeSet::new());
 
-    let faucet_changes = test_runner
-        .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id());
-    let total_cost_in_xrd = receipt.fee_summary.total_cost();
     assert_eq!(
-        faucet_changes,
-        indexmap!(
-            XRD => BalanceChange::Fungible(total_cost_in_xrd.safe_neg().unwrap()),
-        ),
+        test_runner
+            .sum_descendant_balance_changes(result, test_runner.faucet_component().as_node_id())
+            .remove(&XRD)
+            .unwrap()
+            .fungible_change(),
+        &receipt.fee_summary.total_cost().safe_neg().unwrap()
     );
 }

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -282,7 +282,13 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
                 .vault_balance_changes
                 .get(owner_badge_vault.as_node_id())
                 .unwrap(),
-            &(created_owner_badge, BalanceChange::Fungible(1.into()))
+            &(
+                created_owner_badge,
+                BalanceChange::Fungible {
+                    change: 1.into(),
+                    resultant_balance: 1.into()
+                }
+            )
         );
     }
 
@@ -296,7 +302,13 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
             .vault_balance_changes
             .get(created_vault.as_node_id())
             .unwrap(),
-        &(created_resource, BalanceChange::Fungible(allocation_amount))
+        &(
+            created_resource,
+            BalanceChange::Fungible {
+                change: allocation_amount,
+                resultant_balance: allocation_amount
+            }
+        )
     );
 }
 
@@ -386,10 +398,12 @@ fn test_genesis_stake_allocation() {
         assert_eq!(balances.len(), 2);
         assert!(balances
             .values()
-            .any(|bal| *bal == BalanceChange::Fungible(dec!(1))));
+            .map(|balance| balance.fungible_change())
+            .any(|change| *change == dec!(1)));
         assert!(balances
             .values()
-            .any(|bal| *bal == BalanceChange::Fungible(dec!("50000"))));
+            .map(|balance| balance.fungible_change())
+            .any(|change| *change == dec!("50000")));
     }
 
     let create_validators_receipt = data_ingestion_receipts.pop().unwrap();

--- a/radix-engine-tests/tests/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/pool_multi_resource.rs
@@ -2,7 +2,7 @@ use radix_engine::errors::{SystemError, SystemModuleError};
 use radix_engine::{
     blueprints::pool::multi_resource_pool::*,
     errors::{ApplicationError, RuntimeError},
-    transaction::{BalanceChange, TransactionReceipt},
+    transaction::TransactionReceipt,
     types::*,
 };
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
@@ -169,19 +169,23 @@ fn contributing_provides_expected_amount_of_pool_units1() {
     );
     for (resource_address, amount) in expected_change.iter() {
         assert_eq!(
-            account_balance_changes.get(resource_address).cloned(),
+            account_balance_changes
+                .get(resource_address)
+                .map(|balance| balance.fungible_change())
+                .cloned(),
             if *amount == Decimal::ZERO {
                 None
             } else {
-                Some(BalanceChange::Fungible(*amount))
+                Some(*amount)
             }
         );
     }
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
 }
 
@@ -224,19 +228,23 @@ fn contributing_provides_expected_amount_of_pool_units2() {
     );
     for (resource_address, amount) in expected_change.iter() {
         assert_eq!(
-            account_balance_changes.get(resource_address).cloned(),
+            account_balance_changes
+                .get(resource_address)
+                .map(|change| change.fungible_change())
+                .cloned(),
             if *amount == Decimal::ZERO {
                 None
             } else {
-                Some(BalanceChange::Fungible(*amount))
+                Some(*amount)
             }
         );
     }
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
 }
 
@@ -279,19 +287,23 @@ fn contributing_provides_expected_amount_of_pool_units3() {
     );
     for (resource_address, amount) in expected_change.iter() {
         assert_eq!(
-            account_balance_changes.get(resource_address).cloned(),
+            account_balance_changes
+                .get(resource_address)
+                .map(|balance| balance.fungible_change())
+                .cloned(),
             if *amount == Decimal::ZERO {
                 None
             } else {
-                Some(BalanceChange::Fungible(*amount))
+                Some(*amount)
             }
         );
     }
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
 }
 
@@ -334,19 +346,23 @@ fn contributing_provides_expected_amount_of_pool_units4() {
     );
     for (resource_address, amount) in expected_change.iter() {
         assert_eq!(
-            account_balance_changes.get(resource_address).cloned(),
+            account_balance_changes
+                .get(resource_address)
+                .map(|balance| balance.fungible_change())
+                .cloned(),
             if *amount == Decimal::ZERO {
                 None
             } else {
-                Some(BalanceChange::Fungible(*amount))
+                Some(*amount)
             }
         );
     }
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
 }
 
@@ -469,11 +485,14 @@ fn redemption_of_pool_units_rounds_down_for_resources_with_divisibility_not_18()
     );
     for (resource_address, amount) in expected_change.iter() {
         assert_eq!(
-            account_balance_changes.get(resource_address).cloned(),
+            account_balance_changes
+                .get(resource_address)
+                .map(|balance| balance.fungible_change())
+                .cloned(),
             if *amount == Decimal::ZERO {
                 None
             } else {
-                Some(BalanceChange::Fungible(*amount))
+                Some(*amount)
             }
         );
     }
@@ -510,14 +529,16 @@ fn contribution_calculations_work_for_resources_with_divisibility_not_18() {
     assert_eq!(
         pool_balance_changes
             .get(&test_runner.pool_resources[0])
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.1111111111111")))
+        Some(dec!("1.1111111111111"))
     );
     assert_eq!(
         pool_balance_changes
             .get(&test_runner.pool_resources[1])
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.11")))
+        Some(dec!("1.11"))
     );
 }
 

--- a/radix-engine-tests/tests/pool_one_resource.rs
+++ b/radix-engine-tests/tests/pool_one_resource.rs
@@ -1,6 +1,6 @@
 use radix_engine::blueprints::pool::one_resource_pool::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
-use radix_engine::transaction::{BalanceChange, TransactionReceipt};
+use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::api::ObjectModuleId;
@@ -156,9 +156,10 @@ fn initial_contribution_to_pool_mints_expected_amount() {
         )
         .get(&test_runner.pool_unit_resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(100.into()));
+    assert_eq!(balance_change, 100.into());
 }
 
 #[test]
@@ -193,9 +194,10 @@ fn contribution_to_pool_mints_expected_amount_1() {
         )
         .get(&test_runner.pool_unit_resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(100.into()));
+    assert_eq!(balance_change, 100.into());
 }
 
 #[test]
@@ -217,9 +219,10 @@ fn contribution_to_pool_mints_expected_amount_2() {
         )
         .get(&test_runner.pool_unit_resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(200.into()));
+    assert_eq!(balance_change, 200.into());
 }
 
 #[test]
@@ -241,9 +244,10 @@ fn contribution_to_pool_mints_expected_amount_3() {
         )
         .get(&test_runner.pool_unit_resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(50.into()));
+    assert_eq!(balance_change, 50.into());
 }
 
 #[test]
@@ -273,9 +277,10 @@ fn contribution_to_pool_mints_expected_amount_after_all_pool_units_are_redeemed(
         )
         .get(&test_runner.pool_unit_resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(50.into()));
+    assert_eq!(balance_change, 50.into());
 }
 
 #[test]
@@ -299,9 +304,10 @@ fn redemption_of_pool_units_rounds_down_for_resources_with_divisibility_not_18()
         )
         .get(&test_runner.resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(dec!("1.11")));
+    assert_eq!(balance_change, dec!("1.11"));
 }
 
 #[test]
@@ -325,11 +331,12 @@ fn redeem_and_get_redemption_value_agree_on_amount_to_get_when_redeeming() {
         )
         .get(&test_runner.resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
     assert_eq!(
         balance_change,
-        BalanceChange::Fungible(test_runner.get_redemption_value(dec!("1.111111111111"), false))
+        test_runner.get_redemption_value(dec!("1.111111111111"), false)
     );
 }
 
@@ -362,11 +369,12 @@ fn redeem_and_get_redemption_value_agree_on_amount_to_get_when_redeeming_after_p
         )
         .get(&test_runner.resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
     assert_eq!(
         balance_change,
-        BalanceChange::Fungible(test_runner.get_redemption_value(amount_to_redeem, false))
+        test_runner.get_redemption_value(amount_to_redeem, false)
     );
 }
 
@@ -391,9 +399,10 @@ fn protected_withdraw_from_the_pool_lowers_how_much_resources_the_pool_units_are
         )
         .get(&test_runner.resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(50.into()));
+    assert_eq!(balance_change, 50.into());
 }
 
 #[test]
@@ -418,9 +427,10 @@ fn protected_deposit_into_the_pool_increases_how_much_resources_the_pool_units_a
         )
         .get(&test_runner.resource_address)
         .unwrap()
+        .fungible_change()
         .clone();
 
-    assert_eq!(balance_change, BalanceChange::Fungible(150.into()));
+    assert_eq!(balance_change, 150.into());
 }
 
 #[test]

--- a/radix-engine-tests/tests/pool_two_resource.rs
+++ b/radix-engine-tests/tests/pool_two_resource.rs
@@ -1,6 +1,6 @@
 use radix_engine::blueprints::pool::two_resource_pool::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
-use radix_engine::transaction::{BalanceChange, TransactionReceipt};
+use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::api::ObjectModuleId;
@@ -162,27 +162,30 @@ pub fn contribution_provides_expected_pool_unit_resources1() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change1 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change1.into()))
+            Some(expected_change1.into())
         }
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change2 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change2.into()))
+            Some(expected_change2.into())
         }
     );
 }
@@ -220,27 +223,30 @@ pub fn contribution_provides_expected_pool_unit_resources2() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change1 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change1.into()))
+            Some(expected_change1.into())
         }
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change2 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change2.into()))
+            Some(expected_change2.into())
         }
     );
 }
@@ -277,27 +283,30 @@ pub fn contribution_provides_expected_pool_unit_resources3() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change1 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change1.into()))
+            Some(expected_change1.into())
         }
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change2 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change2.into()))
+            Some(expected_change2.into())
         }
     );
 }
@@ -334,27 +343,30 @@ pub fn contribution_provides_expected_pool_unit_resources4() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change1 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change1.into()))
+            Some(expected_change1.into())
         }
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change2 == Decimal::ZERO {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change2.into()))
+            Some(expected_change2.into())
         }
     );
 }
@@ -394,27 +406,30 @@ pub fn contribution_provides_expected_pool_unit_resources5() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_unit_resource_address)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(expected_pool_units.into()))
+        Some(expected_pool_units.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change1 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change1.into()))
+            Some(expected_change1.into())
         }
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
         if expected_change2 == 0 {
             None
         } else {
-            Some(BalanceChange::Fungible(expected_change2.into()))
+            Some(expected_change2.into())
         }
     );
 }
@@ -505,14 +520,16 @@ fn redemption_of_pool_units_rounds_down_for_resources_with_divisibility_not_18()
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.11111111111111")))
+        Some(dec!("1.11111111111111"))
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.11")))
+        Some(dec!("1.11"))
     );
 }
 
@@ -542,14 +559,16 @@ fn contribution_calculations_work_for_resources_with_divisibility_not_18() {
     assert_eq!(
         pool_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.1111111111111")))
+        Some(dec!("1.1111111111111"))
     );
     assert_eq!(
         pool_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(dec!("1.11")))
+        Some(dec!("1.11"))
     );
 }
 
@@ -769,14 +788,16 @@ fn redemption_after_protected_deposit_redeems_expected_amount() {
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource1)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(600.into()))
+        Some(600.into())
     );
     assert_eq!(
         account_balance_changes
             .get(&test_runner.pool_resource2)
+            .map(|balance| balance.fungible_change())
             .cloned(),
-        Some(BalanceChange::Fungible(100.into()))
+        Some(100.into())
     );
 }
 
@@ -800,20 +821,21 @@ pub fn test_complete_interactions() {
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_unit_resource_address)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
-            Some(BalanceChange::Fungible(
-                (dec!("500").safe_mul(dec!("200")).unwrap()).sqrt().unwrap()
-            ))
+            Some((dec!("500").safe_mul(dec!("200")).unwrap()).sqrt().unwrap())
         );
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_resource1)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
             None
         );
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_resource2)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
             None
         );
@@ -835,20 +857,23 @@ pub fn test_complete_interactions() {
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_unit_resource_address)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
-            Some(BalanceChange::Fungible(dec!("442.718872423573106478")))
+            Some(dec!("442.718872423573106478"))
         );
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_resource1)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
             None
         );
         assert_eq!(
             account_balance_changes
                 .get(&test_runner.pool_resource2)
+                .map(|balance| balance.fungible_change())
                 .cloned(),
-            Some(BalanceChange::Fungible(420.into()))
+            Some(420.into())
         );
     }
 }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -727,7 +727,12 @@ impl<'a> ContextualDisplay<TransactionReceiptDisplayContext<'a>> for Transaction
                     vault_id.display(address_display_context),
                     resource.display(address_display_context),
                     match delta {
-                        BalanceChange::Fungible(d) => format!("{}", d),
+                        BalanceChange::Fungible {
+                            change,
+                            resultant_balance,
+                        } => {
+                            format!("{} (resultant balance: {})", change, resultant_balance)
+                        }
                         BalanceChange::NonFungible { added, removed } => {
                             format!("+{:?}, -{:?}", added, removed)
                         }


### PR DESCRIPTION
This is a minor change to the fungible `BalanceChange`s returned in the receipt: include the resultant balance.

It will greatly simplify the Node's LTS endpoint's "account balance changes" calculation, see https://github.com/radixdlt/babylon-node/pull/636#discussion_r1310031671