### PR TITLE
Adjust limits for RCNet v3 (Part 1)

### DIFF
--- a/radix-engine-common/src/constants/transaction_execution.rs
+++ b/radix-engine-common/src/constants/transaction_execution.rs
@@ -1,5 +1,5 @@
 /// The execution cost units loaned from system
-pub const EXECUTION_COST_UNIT_LOAN: u32 = 10_000_000;
+pub const EXECUTION_COST_UNIT_LOAN: u32 = 4_000_000;
 
 /// The execution cost unit limit.
 pub const EXECUTION_COST_UNIT_LIMIT: u32 = 100_000_000;

--- a/radix-engine-common/src/constants/transaction_execution.rs
+++ b/radix-engine-common/src/constants/transaction_execution.rs
@@ -61,7 +61,13 @@ pub const MAX_NUMBER_OF_LOGS: usize = 256;
 pub const MAX_METADATA_KEY_STRING_LEN: usize = 100;
 
 /// The max SBOR size of metadata value
-pub const MAX_METADATA_VALUE_SBOR_LEN: usize = 512;
+pub const MAX_METADATA_VALUE_SBOR_LEN: usize = 4096;
+
+/// The max length of a URL in metadata
+pub const MAX_URL_LENGTH: usize = 1024;
+
+/// The max length of an Origin in metadata
+pub const MAX_ORIGIN_LENGTH: usize = 512;
 
 /// The max depth of an access rule, to protect unbounded native stack useage
 pub const MAX_ACCESS_RULE_DEPTH: usize = 8;

--- a/radix-engine-common/src/constants/transaction_execution.rs
+++ b/radix-engine-common/src/constants/transaction_execution.rs
@@ -67,7 +67,7 @@ pub const MAX_METADATA_VALUE_SBOR_LEN: usize = 4096;
 pub const MAX_URL_LENGTH: usize = 1024;
 
 /// The max length of an Origin in metadata
-pub const MAX_ORIGIN_LENGTH: usize = 512;
+pub const MAX_ORIGIN_LENGTH: usize = 1024;
 
 /// The max depth of an access rule, to protect unbounded native stack useage
 pub const MAX_ACCESS_RULE_DEPTH: usize = 8;

--- a/radix-engine-common/src/constants/transaction_validation.rs
+++ b/radix-engine-common/src/constants/transaction_validation.rs
@@ -5,9 +5,13 @@ pub const MAX_NUMBER_OF_INTENT_SIGNATURES: usize = 16;
 pub const MAX_NUMBER_OF_BLOBS: usize = 64;
 
 /// The minimum value of tip percentage
+///
+/// 100 means 100%
 pub const MIN_TIP_PERCENTAGE: u16 = 0;
 
 /// The maximum value of tip percentage
+///
+/// 100 means 100%
 pub const MAX_TIP_PERCENTAGE: u16 = u16::MAX;
 
 /// The max epoch range

--- a/radix-engine-common/src/constants/wasm.rs
+++ b/radix-engine-common/src/constants/wasm.rs
@@ -21,7 +21,3 @@ pub const MAX_NUMBER_OF_FUNCTION_LOCALS: u32 = 128;
 
 /// The number of entries in the engine cache
 pub const WASM_ENGINE_CACHE_SIZE: usize = 1000;
-
-pub const MAX_URL_LENGTH: usize = 1024;
-
-pub const MAX_ORIGIN_LENGTH: usize = 512;

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -1,6 +1,6 @@
 use radix_engine::blueprints::resource::WorktopError;
+use radix_engine::errors::RuntimeError;
 use radix_engine::errors::{ApplicationError, CallFrameError, KernelError};
-use radix_engine::errors::{RejectionReason, RuntimeError};
 use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::transaction::{FeeLocks, TransactionReceipt};
 use radix_engine::types::*;
@@ -145,11 +145,9 @@ fn should_be_rejected_when_lock_fee_with_temp_vault() {
             .build()
     });
 
-    receipt.expect_specific_rejection(|e| match e {
-        RejectionReason::ErrorBeforeFeeLoanRepaid(RuntimeError::KernelError(
-            KernelError::CallFrameError(CallFrameError::OpenSubstateError(
-                OpenSubstateError::LockUnmodifiedBaseOnHeapNode,
-            )),
+    receipt.expect_specific_failure(|e| match e {
+        RuntimeError::KernelError(KernelError::CallFrameError(
+            CallFrameError::OpenSubstateError(OpenSubstateError::LockUnmodifiedBaseOnHeapNode),
         )) => true,
         _ => false,
     });
@@ -184,11 +182,11 @@ fn should_be_rejected_when_mutate_vault_and_lock_fee() {
             .build()
     });
 
-    receipt.expect_specific_rejection(|e| match e {
-        RejectionReason::ErrorBeforeFeeLoanRepaid(RuntimeError::KernelError(
-            KernelError::CallFrameError(CallFrameError::OpenSubstateError(
+    receipt.expect_specific_failure(|e| match e {
+        RuntimeError::KernelError(KernelError::CallFrameError(
+            CallFrameError::OpenSubstateError(
                 OpenSubstateError::LockUnmodifiedBaseOnOnUpdatedSubstate(..),
-            )),
+            ),
         )) => true,
         _ => false,
     });

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -74,11 +74,8 @@ fn should_be_aborted_when_loan_repaid() {
 
 #[test]
 fn should_succeed_when_fee_is_paid() {
-    let receipt = run_manifest(|component_address| {
-        ManifestBuilder::new()
-            .lock_fee(component_address, 500u32)
-            .build()
-    });
+    let receipt =
+        run_manifest(|_component_address| ManifestBuilder::new().lock_fee_from_faucet().build());
 
     receipt.expect_commit_success();
 }
@@ -139,6 +136,7 @@ fn should_be_rejected_when_system_loan_is_not_fully_repaid() {
 fn should_be_rejected_when_lock_fee_with_temp_vault() {
     let receipt = run_manifest(|component_address| {
         ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 component_address,
                 "lock_fee_with_temp_vault",
@@ -161,6 +159,7 @@ fn should_be_rejected_when_lock_fee_with_temp_vault() {
 fn should_be_success_when_query_vault_and_lock_fee() {
     let receipt = run_manifest(|component_address| {
         ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 component_address,
                 "query_vault_and_lock_fee",
@@ -176,6 +175,7 @@ fn should_be_success_when_query_vault_and_lock_fee() {
 fn should_be_rejected_when_mutate_vault_and_lock_fee() {
     let receipt = run_manifest(|component_address| {
         ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 component_address,
                 "update_vault_and_lock_fee",
@@ -198,6 +198,7 @@ fn should_be_rejected_when_mutate_vault_and_lock_fee() {
 fn should_succeed_when_lock_fee_and_query_vault() {
     let receipt = run_manifest(|component_address| {
         ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 component_address,
                 "lock_fee_and_query_vault",

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -878,7 +878,7 @@ fn system_loan_should_cover_intended_use_case() {
         &mut test_runner,
         &network,
         manifest1,
-        vec![&sk1, &sk2, &sk3], // no sign
+        vec![&sk1, &sk2, &sk3], // sign
         &sk4,                   // notarize
         false,
     );

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -1,7 +1,10 @@
+use radix_engine::transaction::CostingParameters;
+use radix_engine::transaction::ExecutionConfig;
 use radix_engine::transaction::TransactionFeeDetails;
 use radix_engine::transaction::TransactionFeeSummary;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine_interface::blueprints::access_controller::ACCESS_CONTROLLER_CREATE_PROOF_IDENT;
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto::api::node_modules::ModuleConfig;
 use scrypto::prelude::metadata;
@@ -840,4 +843,51 @@ fn publish_package_1mib() {
 
     // internally validates if publish succeeded
     test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+}
+
+/// Based on product requirements, system loan should be just enough to cover:
+/// 1. Notary + 3 signatures in TX
+/// 2. Ask AccessController to produce a badge
+/// 3. Call withdraw_and_lock_fee on Account
+#[test]
+fn system_loan_should_cover_intended_use_case() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().build();
+    let network = NetworkDefinition::simulator();
+    let (_pk1, sk1, _pk2, sk2, _pk3, sk3, _pk4, sk4, account, access_controller) =
+        test_runner.new_ed25519_virtual_account_with_access_controller(3);
+
+    let manifest1 = ManifestBuilder::new()
+        .call_method(
+            access_controller,
+            ACCESS_CONTROLLER_CREATE_PROOF_IDENT,
+            manifest_args!(),
+        )
+        .lock_fee_and_withdraw(account, dec!(10), XRD, dec!(10))
+        .then(|mut builder| {
+            // Artificial workload
+            for _ in 0..10 {
+                builder = builder
+                    .withdraw_from_account(account, XRD, 1)
+                    .try_deposit_entire_worktop_or_abort(account, None);
+            }
+            builder
+        })
+        .build();
+    let tx1 = create_notarized_transaction_advanced(
+        &mut test_runner,
+        &network,
+        manifest1,
+        vec![&sk1, &sk2, &sk3], // no sign
+        &sk4,                   // notarize
+        false,
+    );
+    let receipt = test_runner.execute_transaction(
+        validate_notarized_transaction(&network, &tx1).get_executable(),
+        CostingParameters::default(),
+        ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
+            .with_cost_breakdown(true),
+    );
+    receipt.expect_commit_success();
+    println!("\n{:?}", receipt);
 }

--- a/radix-engine-tests/tests/native_vm.rs
+++ b/radix-engine-tests/tests/native_vm.rs
@@ -18,7 +18,6 @@ use radix_engine_interface::blueprints::test_utils::invocations::*;
 use radix_engine_interface::prelude::*;
 use radix_engine_store_interface::db_key_mapper::*;
 use radix_engine_stores::memory_db::*;
-use scrypto::prelude::*;
 use scrypto_unit::TestRunnerBuilder;
 use transaction::prelude::*;
 


### PR DESCRIPTION
## Summary

- Reduced system loan amount to 4,000,000
- Updated metadata key and value size limit to 100 and 4096 respectively
- Restricted URL and origin length limit to 1024