### PR TITLE
Fix for JMT losing track of lower-tier version after (specific) deletes

### DIFF
--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -145,11 +145,11 @@ fn hash_computed_consistently_after_adding_higher_tier_sibling() {
     let mut store = TypedInMemoryTreeStore::new();
     put_at_next_version(&mut store, None, vec![change(2, 3, 4, Some(234))]);
     put_at_next_version(&mut store, Some(1), vec![change(1, 9, 6, Some(196))]);
-    let root_after_deletes =
+    let root_after_adding_sibling =
         put_at_next_version(&mut store, Some(2), vec![change(2, 3, 5, Some(235))]);
 
     // We did [2:3:4] + [1:9:6] + [2:3:5] = [1:9:6, 2:3:4, 2:3:5] (i.e. same state).
-    assert_eq!(root_after_deletes, reference_root);
+    assert_eq!(root_after_adding_sibling, reference_root);
 }
 
 #[test]

--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -128,6 +128,31 @@ fn hash_computed_consistently_after_higher_tier_leafs_deleted() {
 }
 
 #[test]
+fn hash_computed_consistently_after_adding_higher_tier_sibling() {
+    // Compute a "reference" hash of state containing simply [1:9:6, 2:3:4, 2:3:5].
+    let mut reference_store = TypedInMemoryTreeStore::new();
+    let reference_root = put_at_next_version(
+        &mut reference_store,
+        None,
+        vec![
+            change(1, 9, 6, Some(196)),
+            change(2, 3, 4, Some(234)),
+            change(2, 3, 5, Some(235)),
+        ],
+    );
+
+    // Compute a hash of the same state, at which we arrive after adding some sibling NodeId.
+    let mut store = TypedInMemoryTreeStore::new();
+    put_at_next_version(&mut store, None, vec![change(2, 3, 4, Some(234))]);
+    put_at_next_version(&mut store, Some(1), vec![change(1, 9, 6, Some(196))]);
+    let root_after_deletes =
+        put_at_next_version(&mut store, Some(2), vec![change(2, 3, 5, Some(235))]);
+
+    // We did [2:3:4] + [1:9:6] + [2:3:5] = [1:9:6, 2:3:4, 2:3:5] (i.e. same state).
+    assert_eq!(root_after_deletes, reference_root);
+}
+
+#[test]
 fn hash_differs_when_states_only_differ_by_node_key() {
     let mut store_1 = TypedInMemoryTreeStore::new();
     let hash_1 = put_at_next_version(&mut store_1, None, vec![change(1, 6, 3, Some(30))]);

--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -101,13 +101,10 @@ fn hash_computed_consistently_after_higher_tier_leafs_deleted() {
     let reference_root = put_at_next_version(
         &mut reference_store,
         None,
-        vec![
-            change(2, 3, 4, Some(234)),
-            change(2, 3, 5, Some(235)),
-        ],
+        vec![change(2, 3, 4, Some(234)), change(2, 3, 5, Some(235))],
     );
 
-    // Compute a hash of the same state, at which we arrive after deleting some NodeId.
+    // Compute a hash of the same state, at which we arrive after deleting some unrelated NodeId.
     let mut store = TypedInMemoryTreeStore::new();
     put_at_next_version(
         &mut store,
@@ -121,18 +118,10 @@ fn hash_computed_consistently_after_higher_tier_leafs_deleted() {
     put_at_next_version(
         &mut store,
         Some(1),
-        vec![
-            change(1, 6, 2, None),
-            change(1, 6, 3, None),
-        ],
+        vec![change(1, 6, 2, None), change(1, 6, 3, None)],
     );
-    let root_after_deletes = put_at_next_version(
-        &mut store,
-        Some(2),
-        vec![
-            change(2, 3, 5, Some(235)),
-        ],
-    );
+    let root_after_deletes =
+        put_at_next_version(&mut store, Some(2), vec![change(2, 3, 5, Some(235))]);
 
     // We did [1:6:2, 1:6:3, 2:3:4] - [1:6:2, 1:6:3] + [2:3:5] = [2:3:4, 2:3:5] (i.e. same state).
     assert_eq!(root_after_deletes, reference_root);
@@ -332,6 +321,7 @@ fn sbor_uses_custom_direct_codecs_for_nibbles() {
     let node = TreeNode::Leaf(TreeLeafNode {
         key_suffix: nibbles,
         value_hash: Hash([7; 32]),
+        last_hash_change_version: 1337,
     });
     let encoded = scrypto_encode(&node).unwrap();
     assert!(encoded
@@ -362,6 +352,7 @@ fn sbor_decodes_what_was_encoded() {
         TreeNode::Leaf(TreeLeafNode {
             key_suffix: nibbles("abc"),
             value_hash: Hash([7; 32]),
+            last_hash_change_version: 1337,
         }),
         TreeNode::Null,
     ];

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -45,6 +45,8 @@ pub struct TreeLeafNode {
     pub key_suffix: NibblePath,
     /// An externally-provided hash of the payload.
     pub value_hash: Hash,
+    /// A version at which the [`value_hash`] has most recently changed.
+    pub last_hash_change_version: Version,
 }
 
 /// The "read" part of a physical tree node storage SPI.


### PR DESCRIPTION
This PR fixes a problem discovered while implementing the "partition deletion support in JMT" (https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@2bsEvpTYSt1HioteqmFu91DtjNfFVJXfM4N) and is not its prerequisite.

The problem is exposed by a newly-added test https://github.com/radixdlt/radixdlt-scrypto/commit/90a2824a54543a73d8f3f9f4393dfb339af21a3a#diff-1af1904ec25c16634db8427a89ec05376f0d9d4973fe831f9578663c4ff9c2feR98 and described at https://github.com/radixdlt/radixdlt-scrypto/commit/b686ddacdfe0b403f1a47ad9574b64638e88d789#diff-38bf4cc229d9101c3b6f8ecb5d5d9707dcc784070c2d9c14f4cabbb3c6905031R126-R132

⚠️ The problem is **not** specific to _batch_ partition deletion.
Rather, it occurs every time _a last-but-one higher-tier leaf (e.g. partition or a ReNode) is entirely deleted (by multiple "single" deletes)_. Basically: this leaves the last higher-tier leaf without siblings, which makes JMT compact its node (promote it up, with longer prefix). This "infra" JMT operation does not change the hash of that leaf, **but it changes its version number** - and that's the source of the problem, since the logic before this PR assumed that "lower-tier root version == higher-tier leaf version" which I now see is false.