### PR TITLE
Restore arithmetic operands for decimal types

### DIFF
--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -1088,12 +1088,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_10_powi_16_decimal() {
         let a = Decimal(10i128.into());
         assert_eq!(
             a.safe_powi(16).unwrap().to_string(),
-            "1000000000000000000000"
+            "0"
         );
     }
 

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -623,9 +623,13 @@ impl_arith_ops!(i128);
 impl_arith_ops!(isize);
 impl_arith_ops!(I192);
 impl_arith_ops!(I256);
+impl_arith_ops!(I320);
+impl_arith_ops!(I448);
 impl_arith_ops!(I512);
 impl_arith_ops!(U192);
 impl_arith_ops!(U256);
+impl_arith_ops!(U320);
+impl_arith_ops!(U448);
 impl_arith_ops!(U512);
 
 //========
@@ -794,7 +798,7 @@ macro_rules! try_from_integer {
         )*
     };
 }
-try_from_integer!(I192, I256, I512, U192, U256, U512);
+try_from_integer!(I192, I256, I320, I448, I512, U192, U256, U320, U448, U512);
 
 #[cfg(test)]
 mod tests {
@@ -1551,10 +1555,19 @@ mod tests {
         (I192::MAX/(I192::from(10).pow(Decimal::SCALE)) + I192::ONE, 3),
         // minimal Decimal integer part - 1
         (I192::MIN/(I192::from(10).pow(Decimal::SCALE)) - I192::ONE, 4),
-        (U256::MAX, 5),
-        (I512::MAX, 6),
-        (I512::MIN, 7),
-        (U512::MAX, 8)
+        (I256::MAX, 5),
+        (I256::MIN, 6),
+        (I320::MAX, 7),
+        (I320::MIN, 8),
+        (I448::MAX, 9),
+        (I448::MIN, 10),
+        (I512::MAX, 11),
+        (I512::MIN, 12),
+        (U192::MAX, 13),
+        (U256::MAX, 14),
+        (U320::MAX, 15),
+        (U448::MAX, 16),
+        (U512::MAX, 17)
     }
 
     macro_rules! test_try_from_integer {
@@ -1574,14 +1587,23 @@ mod tests {
     test_try_from_integer! {
         (I192::ONE, "1", 1),
         (-I192::ONE, "-1", 2),
+        (I256::ONE, "1", 3),
+        (-I256::ONE, "-1", 4),
+        (I320::ONE, "1", 5),
+        (-I320::ONE, "-1", 6),
+        (I448::ONE, "1", 7),
+        (-I448::ONE, "-1", 8),
+        (I512::ONE, "1", 9),
+        (-I512::ONE, "-1", 10),
         // maximal Decimal integer part
-        (I192::MAX/(I192::from(10_u64.pow(Decimal::SCALE))), "3138550867693340381917894711603833208051", 3),
+        (I192::MAX/(I192::from(10_u64.pow(Decimal::SCALE))), "3138550867693340381917894711603833208051", 11),
         // minimal Decimal integer part
-        (I192::MIN/(I192::from(10_u64.pow(Decimal::SCALE))), "-3138550867693340381917894711603833208051", 4),
-        (U256::MIN, "0", 5),
-        (U512::MIN, "0", 6),
-        (I512::ONE, "1", 7),
-        (-I512::ONE, "-1", 8)
+        (I192::MIN/(I192::from(10_u64.pow(Decimal::SCALE))), "-3138550867693340381917894711603833208051", 12),
+        (U192::MIN, "0", 13),
+        (U256::MIN, "0", 14),
+        (U320::MIN, "0", 15),
+        (U448::MIN, "0", 16),
+        (U512::MIN, "0", 17)
     }
 
     #[test]
@@ -1913,8 +1935,12 @@ mod tests {
     test_math_operands_decimal!(isize);
     test_math_operands_decimal!(I192);
     test_math_operands_decimal!(I256);
+    test_math_operands_decimal!(I320);
+    test_math_operands_decimal!(I448);
     test_math_operands_decimal!(I512);
     test_math_operands_decimal!(U192);
     test_math_operands_decimal!(U256);
+    test_math_operands_decimal!(U320);
+    test_math_operands_decimal!(U448);
     test_math_operands_decimal!(U512);
 }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -1918,4 +1918,10 @@ mod tests {
     test_math_operands_decimal!(i64);
     test_math_operands_decimal!(i128);
     test_math_operands_decimal!(isize);
+    test_math_operands_decimal!(I192);
+    test_math_operands_decimal!(I256);
+    test_math_operands_decimal!(I512);
+    test_math_operands_decimal!(U192);
+    test_math_operands_decimal!(U256);
+    test_math_operands_decimal!(U512);
 }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -1660,6 +1660,22 @@ mod tests {
         ))
     }
 
+    #[test]
+    fn test_neg_decimal() {
+        let d = Decimal::ONE;
+        assert_eq!(-d, dec!("-1"));
+        let d = Decimal::MAX;
+        assert_eq!(-d, Decimal(I192::MIN + I192::ONE));
+    }
+
+    #[test]
+    #[should_panic(expected = "Overflow")]
+    fn test_neg_decimal_panic() {
+        let d = Decimal::MIN;
+        let _ = -d;
+    }
+
+
     // These tests make sure that any basic arithmetic operation
     // between primitive type and Decimal produces a Decimal, no matter the order.
     // Additionally result of such operation shall be equal, if operands are derived from the same

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -520,7 +520,6 @@ macro_rules! impl_arith_ops {
         impl Sub<$type> for Decimal {
             type Output = Self;
 
-
             #[inline]
             fn sub(self, other: $type) -> Self::Output {
                 self.safe_sub(other).expect("Overflow")
@@ -581,32 +580,28 @@ macro_rules! impl_arith_ops {
             }
         }
 
-        impl AddAssign<$type> for Decimal
-        {
+        impl AddAssign<$type> for Decimal {
             #[inline]
             fn add_assign(&mut self, other: $type) {
                 *self = *self + other;
             }
         }
 
-        impl SubAssign<$type> for Decimal
-        {
+        impl SubAssign<$type> for Decimal {
             #[inline]
             fn sub_assign(&mut self, other: $type) {
                 *self = *self - other;
             }
         }
 
-        impl MulAssign<$type> for Decimal
-        {
+        impl MulAssign<$type> for Decimal {
             #[inline]
             fn mul_assign(&mut self, other: $type) {
                 *self = *self * other;
             }
         }
 
-        impl DivAssign<$type> for Decimal
-        {
+        impl DivAssign<$type> for Decimal {
             #[inline]
             fn div_assign(&mut self, other: $type) {
                 *self = *self / other;
@@ -902,7 +897,8 @@ mod tests {
     #[test]
     fn test_mul_overflow_by_small_decimal() {
         assert!(Decimal::MAX
-            .safe_mul(dec!("1.000000000000000001")).is_none());
+            .safe_mul(dec!("1.000000000000000001"))
+            .is_none());
     }
 
     #[test]
@@ -915,7 +911,8 @@ mod tests {
         assert!(Decimal::MAX
             .safe_neg()
             .unwrap()
-            .safe_mul(dec!("-1.000000000000000001")).is_none());
+            .safe_mul(dec!("-1.000000000000000001"))
+            .is_none());
     }
 
     #[test]
@@ -1090,10 +1087,7 @@ mod tests {
     #[test]
     fn test_10_powi_16_decimal() {
         let a = Decimal(10i128.into());
-        assert_eq!(
-            a.safe_powi(16).unwrap().to_string(),
-            "0"
-        );
+        assert_eq!(a.safe_powi(16).unwrap().to_string(), "0");
     }
 
     #[test]
@@ -1674,7 +1668,6 @@ mod tests {
         let d = Decimal::MIN;
         let _ = -d;
     }
-
 
     // These tests make sure that any basic arithmetic operation
     // between primitive type and Decimal produces a Decimal, no matter the order.

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -412,6 +412,34 @@ impl Div<Decimal> for Decimal {
     }
 }
 
+impl AddAssign<Decimal> for Decimal {
+    #[inline]
+    fn add_assign(&mut self, other: Decimal) {
+        *self = *self + other;
+    }
+}
+
+impl SubAssign<Decimal> for Decimal {
+    #[inline]
+    fn sub_assign(&mut self, other: Decimal) {
+        *self = *self - other;
+    }
+}
+
+impl MulAssign<Decimal> for Decimal {
+    #[inline]
+    fn mul_assign(&mut self, other: Decimal) {
+        *self = *self * other;
+    }
+}
+
+impl DivAssign<Decimal> for Decimal {
+    #[inline]
+    fn div_assign(&mut self, other: Decimal) {
+        *self = *self / other;
+    }
+}
+
 macro_rules! impl_arith_ops {
     ($type:ident) => {
         impl SafeAdd<$type> for Decimal {
@@ -492,6 +520,8 @@ macro_rules! impl_arith_ops {
         impl Sub<$type> for Decimal {
             type Output = Decimal;
 
+
+            #[inline]
             fn sub(self, other: $type) -> Self::Output {
                 self.safe_sub(other).expect("Overflow")
             }
@@ -509,6 +539,7 @@ macro_rules! impl_arith_ops {
         impl Div<$type> for Decimal {
             type Output = Decimal;
 
+            #[inline]
             fn div(self, other: $type) -> Self::Output {
                 self.safe_div(other).expect("Overflow or division by zero")
             }
@@ -526,6 +557,7 @@ macro_rules! impl_arith_ops {
         impl Sub<Decimal> for $type {
             type Output = Decimal;
 
+            #[inline]
             fn sub(self, other: Decimal) -> Self::Output {
                 self.safe_sub(other).expect("Overflow")
             }
@@ -543,8 +575,41 @@ macro_rules! impl_arith_ops {
         impl Div<Decimal> for $type {
             type Output = Decimal;
 
+            #[inline]
             fn div(self, other: Decimal) -> Self::Output {
                 self.safe_div(other).expect("Overflow or division by zero")
+            }
+        }
+
+        impl AddAssign<$type> for Decimal
+        {
+            #[inline]
+            fn add_assign(&mut self, other: $type) {
+                *self = *self + other;
+            }
+        }
+
+        impl SubAssign<$type> for Decimal
+        {
+            #[inline]
+            fn sub_assign(&mut self, other: $type) {
+                *self = *self - other;
+            }
+        }
+
+        impl MulAssign<$type> for Decimal
+        {
+            #[inline]
+            fn mul_assign(&mut self, other: $type) {
+                *self = *self * other;
+            }
+        }
+
+        impl DivAssign<$type> for Decimal
+        {
+            #[inline]
+            fn div_assign(&mut self, other: $type) {
+                *self = *self / other;
             }
         }
     };
@@ -1716,6 +1781,24 @@ mod tests {
                     assert_eq!(u1 - d1, dec!("-2"));
                     assert_eq!(u1 * d1, dec!("8"));
                     assert_eq!(u1 / d1, dec!("0.5"));
+
+                    let u1 = $type::try_from(4).unwrap();
+
+                    let mut d1 = dec!("2");
+                    d1 += u1;
+                    assert_eq!(d1, dec!("6"));
+
+                    let mut d1 = dec!("2");
+                    d1 -= u1;
+                    assert_eq!(d1, dec!("-2"));
+
+                    let mut d1 = dec!("2");
+                    d1 *= u1;
+                    assert_eq!(d1, dec!("8"));
+
+                    let mut d1 = dec!("2");
+                    d1 /= u1;
+                    assert_eq!(d1, dec!("0.5"));
                 }
 
                 #[test]
@@ -1780,6 +1863,38 @@ mod tests {
                     let d1 = Decimal::ZERO;
                     let u1 = $type::try_from(1).unwrap();
                     let _ = u1 / d1;
+                }
+
+                #[test]
+                #[should_panic(expected = "Overflow")]
+                fn [<test_math_add_assign_decimal_$type:lower _panic>]() {
+                    let mut d1 = Decimal::MAX;
+                    let u1 = $type::try_from(1).unwrap();
+                    d1 += u1;
+                }
+
+                #[test]
+                #[should_panic(expected = "Overflow")]
+                fn [<test_math_sub_assign_decimal_$type:lower _panic>]() {
+                    let mut d1 = Decimal::MIN;
+                    let u1 = $type::try_from(1).unwrap();
+                    d1 -= u1;
+                }
+
+                #[test]
+                #[should_panic(expected = "Overflow")]
+                fn [<test_math_mul_assign_decimal_$type:lower _panic>]() {
+                    let mut d1 = Decimal::MAX;
+                    let u1 = $type::try_from(2).unwrap();
+                    d1 *= u1;
+                }
+
+                #[test]
+                #[should_panic(expected = "Overflow or division by zero")]
+                fn [<test_math_div_assign_decimal_$type:lower _panic>]() {
+                    let mut d1 = Decimal::MAX;
+                    let u1 = $type::try_from(0).unwrap();
+                    d1 /= u1;
                 }
             }
         };

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -377,65 +377,65 @@ impl Neg for Decimal {
 }
 
 impl Add<Decimal> for Decimal {
-    type Output = Decimal;
+    type Output = Self;
 
     #[inline]
-    fn add(self, other: Decimal) -> Self::Output {
+    fn add(self, other: Self) -> Self::Output {
         self.safe_add(other).expect("Overflow")
     }
 }
 
 impl Sub<Decimal> for Decimal {
-    type Output = Decimal;
+    type Output = Self;
 
     #[inline]
-    fn sub(self, other: Decimal) -> Self::Output {
+    fn sub(self, other: Self) -> Self::Output {
         self.safe_sub(other).expect("Overflow")
     }
 }
 
 impl Mul<Decimal> for Decimal {
-    type Output = Decimal;
+    type Output = Self;
 
     #[inline]
-    fn mul(self, other: Decimal) -> Self::Output {
+    fn mul(self, other: Self) -> Self::Output {
         self.safe_mul(other).expect("Overflow")
     }
 }
 
 impl Div<Decimal> for Decimal {
-    type Output = Decimal;
+    type Output = Self;
 
     #[inline]
-    fn div(self, other: Decimal) -> Self::Output {
+    fn div(self, other: Self) -> Self::Output {
         self.safe_div(other).expect("Overflow or division by zero")
     }
 }
 
 impl AddAssign<Decimal> for Decimal {
     #[inline]
-    fn add_assign(&mut self, other: Decimal) {
+    fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
 impl SubAssign<Decimal> for Decimal {
     #[inline]
-    fn sub_assign(&mut self, other: Decimal) {
+    fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
     }
 }
 
 impl MulAssign<Decimal> for Decimal {
     #[inline]
-    fn mul_assign(&mut self, other: Decimal) {
+    fn mul_assign(&mut self, other: Self) {
         *self = *self * other;
     }
 }
 
 impl DivAssign<Decimal> for Decimal {
     #[inline]
-    fn div_assign(&mut self, other: Decimal) {
+    fn div_assign(&mut self, other: Self) {
         *self = *self / other;
     }
 }
@@ -509,7 +509,7 @@ macro_rules! impl_arith_ops {
         }
 
         impl Add<$type> for Decimal {
-            type Output = Decimal;
+            type Output = Self;
 
             #[inline]
             fn add(self, other: $type) -> Self::Output {
@@ -518,7 +518,7 @@ macro_rules! impl_arith_ops {
         }
 
         impl Sub<$type> for Decimal {
-            type Output = Decimal;
+            type Output = Self;
 
 
             #[inline]
@@ -528,7 +528,7 @@ macro_rules! impl_arith_ops {
         }
 
         impl Mul<$type> for Decimal {
-            type Output = Decimal;
+            type Output = Self;
 
             #[inline]
             fn mul(self, other: $type) -> Self::Output {
@@ -537,7 +537,7 @@ macro_rules! impl_arith_ops {
         }
 
         impl Div<$type> for Decimal {
-            type Output = Decimal;
+            type Output = Self;
 
             #[inline]
             fn div(self, other: $type) -> Self::Output {

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -869,9 +869,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_add_overflow_decimal() {
-        let _ = Decimal::MAX.safe_add(Decimal::ONE).expect("Overflow");
+        assert!(Decimal::MAX.safe_add(Decimal::ONE).is_none());
     }
 
     #[test]
@@ -883,9 +882,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_sub_overflow_decimal() {
-        let _ = Decimal::MIN.safe_sub(Decimal::ONE).expect("Overflow");
+        assert!(Decimal::MIN.safe_sub(Decimal::ONE).is_none());
     }
 
     #[test]
@@ -902,43 +900,36 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_overflow_by_small_decimal() {
-        let _ = Decimal::MAX
-            .safe_mul(dec!("1.000000000000000001"))
-            .expect("Overflow");
+        assert!(Decimal::MAX
+            .safe_mul(dec!("1.000000000000000001")).is_none());
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_overflow_by_a_lot_decimal() {
-        let _ = Decimal::MAX.safe_mul(dec!("1.1")).expect("Overflow");
+        assert!(Decimal::MAX.safe_mul(dec!("1.1")).is_none());
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_neg_overflow_decimal() {
-        let _ = Decimal::MAX
+        assert!(Decimal::MAX
             .safe_neg()
             .unwrap()
-            .safe_mul(dec!("-1.000000000000000001"))
-            .expect("Overflow");
+            .safe_mul(dec!("-1.000000000000000001")).is_none());
     }
 
     #[test]
-    #[should_panic]
     fn test_div_by_zero_decimal() {
         let a = Decimal::from(5u32);
         let b = Decimal::from(0u32);
-        a.safe_div(b).unwrap();
+        assert!(a.safe_div(b).is_none());
     }
 
     #[test]
-    #[should_panic]
     fn test_powi_exp_overflow_decimal() {
         let a = Decimal::from(5u32);
         let b = i64::MIN;
-        assert_eq!(a.safe_powi(b).unwrap().to_string(), "0");
+        assert!(a.safe_powi(b).is_none());
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -1457,14 +1457,25 @@ mod tests {
     }
 
     test_try_from_integer_overflow! {
-        (I256::MAX, 1),
-        (I256::MIN, 2),
+        (I192::MAX, 1),
+        (I192::MIN, 2),
+        (I256::MAX, 3),
+        (I256::MIN, 4),
+        (I320::MAX, 5),
+        (I320::MIN, 6),
+        (I448::MAX, 7),
+        (I448::MIN, 8),
+        (I512::MAX, 9),
+        (I512::MIN, 10),
         // maximal PreciseDecimal integer part + 1
-        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)) + I256::ONE, 3),
+        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)) + I256::ONE, 11),
         // minimal PreciseDecimal integer part - 1
-        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)) - I256::ONE, 4),
-        (I256::MIN, 5),
-        (I256::MAX, 6)
+        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)) - I256::ONE, 12),
+        (U192::MAX, 13),
+        (U256::MAX, 14),
+        (U320::MAX, 15),
+        (U448::MAX, 16),
+        (U512::MAX, 17)
     }
 
     macro_rules! test_try_from_integer {
@@ -1482,34 +1493,25 @@ mod tests {
     }
 
     test_try_from_integer! {
-        (I256::ONE, "1", 1),
-        (-I256::ONE, "-1", 2),
-        // maximal PreciseDecimal integer part
-        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)), "57896044618658097711785492504343953926634", 3),
-        // minimal PreciseDecimal integer part
-        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)), "-57896044618658097711785492504343953926634", 4),
-        (U256::MIN, "0", 5)
-    }
-
-    macro_rules! test_from_integer {
-        ($(($from:expr, $expected:expr, $suffix:expr)),*) => {
-            paste!{
-            $(
-                #[test]
-                fn [<test_from_integer_ $suffix>]() {
-                    let dec = PreciseDecimal::from($from);
-                    assert_eq!(dec.to_string(), $expected)
-                }
-            )*
-            }
-        };
-    }
-
-    test_from_integer! {
         (I192::ONE, "1", 1),
         (-I192::ONE, "-1", 2),
-        (U192::MIN, "0", 3),
-        (U192::ONE, "1", 4)
+        (I256::ONE, "1", 3),
+        (-I256::ONE, "-1", 4),
+        (I320::ONE, "1", 5),
+        (-I320::ONE, "-1", 6),
+        (I448::ONE, "1", 7),
+        (-I448::ONE, "-1", 8),
+        (I512::ONE, "1", 9),
+        (-I512::ONE, "-1", 10),
+        // maximal PreciseDecimal integer part
+        (I256::MAX/(I256::from(10).pow(PreciseDecimal::SCALE)), "57896044618658097711785492504343953926634", 11),
+        // minimal PreciseDecimal integer part
+        (I256::MIN/(I256::from(10).pow(PreciseDecimal::SCALE)), "-57896044618658097711785492504343953926634", 12),
+        (U192::MIN, "0", 13),
+        (U256::MIN, "0", 14),
+        (U320::MIN, "0", 15),
+        (U448::MIN, "0", 16),
+        (U512::MIN, "0", 17)
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -1152,13 +1152,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_10_powi_16_precise_decimal() {
         let a = PreciseDecimal(10i128.into());
-        assert_eq!(
-            a.safe_powi(16).unwrap().to_string(),
-            "1000000000000000000000"
-        );
+        assert_eq!(a.safe_powi(16).unwrap().to_string(), "0");
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -919,11 +919,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_add_overflow_precise_decimal() {
-        let _ = PreciseDecimal::MAX
-            .safe_add(PreciseDecimal::ONE)
-            .expect("Overflow");
+        assert!(PreciseDecimal::MAX.safe_add(PreciseDecimal::ONE).is_none());
     }
 
     #[test]
@@ -935,11 +932,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_sub_overflow_precise_decimal() {
-        let _ = PreciseDecimal::MIN
-            .safe_sub(PreciseDecimal::ONE)
-            .expect("Overflow");
+        assert!(PreciseDecimal::MIN.safe_sub(PreciseDecimal::ONE).is_none());
     }
 
     #[test]
@@ -960,47 +954,38 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_overflow_by_small_precise_decimal() {
-        let _ = PreciseDecimal::MAX
+        assert!(PreciseDecimal::MAX
             .safe_mul(pdec!("1.000000000000000000000000000000000001"))
-            .expect("Overflow");
+            .is_none());
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_overflow_by_a_lot_precise_decimal() {
-        let _ = PreciseDecimal::MAX
-            .safe_mul(pdec!("1.1"))
-            .expect("Overflow");
+        assert!(PreciseDecimal::MAX.safe_mul(pdec!("1.1")).is_none());
     }
 
     #[test]
-    #[should_panic(expected = "Overflow")]
     fn test_mul_neg_overflow_precise_decimal() {
-        let p = pdec!("-1.000000000000000000000000000000000001");
-        println!("p = {}", p);
-        let _ = PreciseDecimal::MAX
+        assert!(PreciseDecimal::MAX
             .safe_neg()
             .unwrap()
             .safe_mul(pdec!("-1.000000000000000000000000000000000001"))
-            .expect("Overflow");
+            .is_none());
     }
 
     #[test]
-    #[should_panic]
     fn test_div_by_zero_precise_decimal() {
         let a = PreciseDecimal::from(5u32);
         let b = PreciseDecimal::from(0u32);
-        a.safe_div(b).unwrap();
+        assert!(a.safe_div(b).is_none());
     }
 
     #[test]
-    #[should_panic]
     fn test_powi_exp_overflow_precise_decimal() {
         let a = PreciseDecimal::from(5u32);
         let b = i64::MIN;
-        assert_eq!(a.safe_powi(b).unwrap().to_string(), "0");
+        assert!(a.safe_powi(b).is_none());
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -622,17 +622,6 @@ impl Truncate<Decimal> for PreciseDecimal {
     }
 }
 
-macro_rules! from_integer {
-    ($($t:ident),*) => {
-        $(
-            impl From<$t> for PreciseDecimal {
-                fn from(val: $t) -> Self {
-                    Self(I256::from(val) * Self::ONE.0)
-                }
-            }
-        )*
-    };
-}
 macro_rules! try_from_integer {
     ($($t:ident),*) => {
         $(
@@ -655,9 +644,8 @@ macro_rules! try_from_integer {
     };
 }
 
-from_integer!(I192, U192);
-try_from_integer!(I256, I320, I384, I448, I512);
-try_from_integer!(U256, U320, U384, U448, U512);
+try_from_integer!(I192, I256, I320, I384, I448, I512);
+try_from_integer!(U192, U256, U320, U384, U448, U512);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
This PR restores arithmetic operands for decimal types.

## Details
Following operands are available: 
- addition: `+` and `+=`
- substraction: `-` and `-=`
- multiplication: `*` and `*=`
- division: `/` and `/=`
- negation: `-`

It is possible to combine above operator for `Decimal`/`PreciseDecimal` with
- primitive integer types
- Radix Engine integer types: `I192`, `U192`, `I256`, `U256`,...

## Testing
Relevant tests have been added.

## Update Recommendations

### For dApp Developers
NOTE!
These operations will panic in case of overflow or division by zero.
