### PR TITLE
Feature/rename types v2

### DIFF
--- a/assets/blueprints/genesis_helper/src/lib.rs
+++ b/assets/blueprints/genesis_helper/src/lib.rs
@@ -133,7 +133,7 @@ mod genesis_helper {
             for (key, value) in validator.metadata {
                 ScryptoVmV1Api::object_call_module(
                     &validator_component.address().into_node_id(),
-                    ModuleId::Metadata,
+                    AttachedModuleId::Metadata,
                     METADATA_SET_IDENT,
                     scrypto_encode(&MetadataSetInput { key, value }).unwrap(),
                 );

--- a/native-sdk/src/component/object.rs
+++ b/native-sdk/src/component/object.rs
@@ -1,7 +1,7 @@
 use radix_engine_interface::api::node_modules::metadata::{
     MetadataSetInput, MetadataVal, METADATA_SET_IDENT,
 };
-use radix_engine_interface::api::{ClientApi, ModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi};
 use radix_engine_interface::data::scrypto::{scrypto_encode, ScryptoDecode};
 use radix_engine_interface::types::NodeId;
 use sbor::rust::prelude::{Debug, ToOwned};
@@ -26,7 +26,7 @@ impl BorrowedObject {
     {
         api.call_module_method(
             &self.0,
-            ModuleId::Metadata,
+            AttachedModuleId::Metadata,
             METADATA_SET_IDENT,
             scrypto_encode(&MetadataSetInput {
                 key: key.as_ref().to_owned(),

--- a/native-sdk/src/modules/role_assignment/role_assignment.rs
+++ b/native-sdk/src/modules/role_assignment/role_assignment.rs
@@ -3,8 +3,8 @@ use radix_engine_interface::api::node_modules::auth::{
     ROLE_ASSIGNMENT_BLUEPRINT, ROLE_ASSIGNMENT_CREATE_IDENT, ROLE_ASSIGNMENT_SET_IDENT,
     ROLE_ASSIGNMENT_SET_OWNER_IDENT,
 };
-use radix_engine_interface::api::object_api::ObjectModuleId;
-use radix_engine_interface::api::{ClientApi, ModuleId};
+use radix_engine_interface::api::object_api::ModuleId;
+use radix_engine_interface::api::{AttachedModuleId, ClientApi};
 use radix_engine_interface::blueprints::resource::{
     AccessRule, OwnerRoleEntry, RoleAssignmentInit, RoleKey,
 };
@@ -20,7 +20,7 @@ pub struct RoleAssignment(pub Own);
 impl RoleAssignment {
     pub fn create<Y, R: Into<OwnerRoleEntry>, E: Debug + ScryptoDecode>(
         owner_role: R,
-        roles: IndexMap<ObjectModuleId, RoleAssignmentInit>,
+        roles: IndexMap<ModuleId, RoleAssignmentInit>,
         api: &mut Y,
     ) -> Result<Self, E>
     where
@@ -44,7 +44,7 @@ impl RoleAssignment {
 }
 
 impl RoleAssignmentObject for RoleAssignment {
-    fn self_id(&self) -> (&NodeId, Option<ModuleId>) {
+    fn self_id(&self) -> (&NodeId, Option<AttachedModuleId>) {
         (&self.0 .0, None)
     }
 }
@@ -52,13 +52,13 @@ impl RoleAssignmentObject for RoleAssignment {
 pub struct AttachedRoleAssignment(pub NodeId);
 
 impl RoleAssignmentObject for AttachedRoleAssignment {
-    fn self_id(&self) -> (&NodeId, Option<ModuleId>) {
-        (&self.0, Some(ModuleId::RoleAssignment))
+    fn self_id(&self) -> (&NodeId, Option<AttachedModuleId>) {
+        (&self.0, Some(AttachedModuleId::RoleAssignment))
     }
 }
 
 pub trait RoleAssignmentObject {
-    fn self_id(&self) -> (&NodeId, Option<ModuleId>);
+    fn self_id(&self) -> (&NodeId, Option<AttachedModuleId>);
 
     fn set_owner_role<Y: ClientApi<E>, E: Debug + ScryptoDecode, A: Into<AccessRule>>(
         &self,
@@ -94,7 +94,7 @@ pub trait RoleAssignmentObject {
         A: Into<AccessRule>,
     >(
         &self,
-        module: ObjectModuleId,
+        module: ModuleId,
         role_key: R,
         rule: A,
         api: &mut Y,

--- a/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
+++ b/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
@@ -442,8 +442,7 @@ create_well_known_lookup!(
             ACCESS_RULE,
             ROLE_ASSIGNMENT_TYPES_START + 0,
             named_enum(
-                // This is a clearer name for UIs, but not time to change in the code right now
-                "Rule",
+                "AccessRule",
                 [
                     (0u8, named_tuple("AllowAll", [])),
                     (1u8, named_tuple("DenyAll", [])),
@@ -455,8 +454,7 @@ create_well_known_lookup!(
             ACCESS_RULE_NODE,
             ROLE_ASSIGNMENT_TYPES_START + 1,
             named_enum(
-                // This is a clearer name for UIs, but not time to change in the code right now
-                "RuleNode",
+                "AccessRuleNode",
                 [
                     (0u8, named_tuple("ProofRule", [PROOF_RULE_TYPE])),
                     (1u8, named_tuple("AnyOf", [ACCESS_RULE_NODE_LIST_TYPE])),
@@ -536,7 +534,6 @@ create_well_known_lookup!(
             MODULE_ID,
             OTHER_MODULE_TYPES_START + 0,
             named_enum(
-                // This is a clearer name for UIs, but not time to change in the code right now
                 "ModuleId",
                 [
                     (0u8, named_tuple("Main", [])),
@@ -550,7 +547,6 @@ create_well_known_lookup!(
             ATTACHED_MODULE_ID,
             OTHER_MODULE_TYPES_START + 1,
             named_enum(
-                // This is a clearer name for UIs, but not time to change in the code right now
                 "AttachedModuleId",
                 [
                     (1u8, named_tuple("Metadata", [])),

--- a/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
+++ b/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
@@ -533,7 +533,7 @@ create_well_known_lookup!(
         ),
         // OTHER MODULE TYPES
         (
-            OBJECT_MODULE_ID,
+            MODULE_ID,
             OTHER_MODULE_TYPES_START + 0,
             named_enum(
                 // This is a clearer name for UIs, but not time to change in the code right now
@@ -547,11 +547,11 @@ create_well_known_lookup!(
             )
         ),
         (
-            MODULE_ID,
+            ATTACHED_MODULE_ID,
             OTHER_MODULE_TYPES_START + 1,
             named_enum(
                 // This is a clearer name for UIs, but not time to change in the code right now
-                "NativeModuleId",
+                "AttachedModuleId",
                 [
                     (1u8, named_tuple("Metadata", [])),
                     (2u8, named_tuple("Royalty", [])),

--- a/radix-engine-interface/src/api/node_modules/auth/role_assignment/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/auth/role_assignment/invocations.rs
@@ -1,4 +1,4 @@
-use crate::api::ObjectModuleId;
+use crate::api::ModuleId;
 use crate::blueprints::resource::*;
 use crate::*;
 #[cfg(feature = "radix_engine_fuzzing")]
@@ -17,7 +17,7 @@ pub const ROLE_ASSIGNMENT_CREATE_IDENT: &str = "create";
 )]
 pub struct RoleAssignmentCreateInput {
     pub owner_role: OwnerRoleEntry,
-    pub roles: IndexMap<ObjectModuleId, RoleAssignmentInit>,
+    pub roles: IndexMap<ModuleId, RoleAssignmentInit>,
 }
 
 pub type RoleAssignmentCreateOutput = Own;
@@ -29,7 +29,7 @@ pub const ROLE_ASSIGNMENT_SET_IDENT: &str = "set";
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
 pub struct RoleAssignmentSetInput {
-    pub module: ObjectModuleId,
+    pub module: ModuleId,
     pub role_key: RoleKey,
     pub rule: AccessRule,
 }
@@ -65,7 +65,7 @@ pub const ROLE_ASSIGNMENT_GET_IDENT: &str = "get";
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
 pub struct RoleAssignmentGetInput {
-    pub module: ObjectModuleId,
+    pub module: ModuleId,
     pub role_key: RoleKey,
 }
 

--- a/radix-engine-interface/src/api/object_api.rs
+++ b/radix-engine-interface/src/api/object_api.rs
@@ -42,6 +42,7 @@ pub enum ModuleId {
     RoleAssignment,
 }
 
+/// Notes: This is to be deprecated, please use `ModuleId` instead
 pub type ObjectModuleId = ModuleId;
 
 impl Describe<ScryptoCustomTypeKind> for ModuleId {

--- a/radix-engine-interface/src/api/object_api.rs
+++ b/radix-engine-interface/src/api/object_api.rs
@@ -35,69 +35,69 @@ use sbor::rust::vec::Vec;
     ScryptoEncode,
     ScryptoDecode,
 )]
-pub enum ObjectModuleId {
+pub enum ModuleId {
     Main,
     Metadata,
     Royalty,
     RoleAssignment,
 }
 
-impl Describe<ScryptoCustomTypeKind> for ObjectModuleId {
+impl Describe<ScryptoCustomTypeKind> for ModuleId {
     const TYPE_ID: RustTypeId =
-        RustTypeId::WellKnown(well_known_scrypto_custom_types::OBJECT_MODULE_ID_TYPE);
+        RustTypeId::WellKnown(well_known_scrypto_custom_types::MODULE_ID_TYPE);
 
     fn type_data() -> ScryptoTypeData<RustTypeId> {
-        well_known_scrypto_custom_types::object_module_id_type_data()
+        well_known_scrypto_custom_types::module_id_type_data()
     }
 }
 
-impl From<Option<ModuleId>> for ObjectModuleId {
-    fn from(value: Option<ModuleId>) -> Self {
+impl From<Option<AttachedModuleId>> for ModuleId {
+    fn from(value: Option<AttachedModuleId>) -> Self {
         match value {
-            None => ObjectModuleId::Main,
-            Some(ModuleId::Metadata) => ObjectModuleId::Metadata,
-            Some(ModuleId::Royalty) => ObjectModuleId::Royalty,
-            Some(ModuleId::RoleAssignment) => ObjectModuleId::RoleAssignment,
+            None => ModuleId::Main,
+            Some(AttachedModuleId::Metadata) => ModuleId::Metadata,
+            Some(AttachedModuleId::Royalty) => ModuleId::Royalty,
+            Some(AttachedModuleId::RoleAssignment) => ModuleId::RoleAssignment,
         }
     }
 }
 
-impl Into<Option<ModuleId>> for ObjectModuleId {
-    fn into(self) -> Option<ModuleId> {
+impl Into<Option<AttachedModuleId>> for ModuleId {
+    fn into(self) -> Option<AttachedModuleId> {
         match self {
-            ObjectModuleId::Main => None,
-            ObjectModuleId::Metadata => Some(ModuleId::Metadata),
-            ObjectModuleId::Royalty => Some(ModuleId::Royalty),
-            ObjectModuleId::RoleAssignment => Some(ModuleId::RoleAssignment),
+            ModuleId::Main => None,
+            ModuleId::Metadata => Some(AttachedModuleId::Metadata),
+            ModuleId::Royalty => Some(AttachedModuleId::Royalty),
+            ModuleId::RoleAssignment => Some(AttachedModuleId::RoleAssignment),
         }
     }
 }
 
-impl ObjectModuleId {
+impl ModuleId {
     pub fn base_partition_num(&self) -> PartitionNumber {
         match self {
-            ObjectModuleId::Metadata => METADATA_BASE_PARTITION,
-            ObjectModuleId::Royalty => ROYALTY_BASE_PARTITION,
-            ObjectModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
-            ObjectModuleId::Main => MAIN_BASE_PARTITION,
+            ModuleId::Metadata => METADATA_BASE_PARTITION,
+            ModuleId::Royalty => ROYALTY_BASE_PARTITION,
+            ModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
+            ModuleId::Main => MAIN_BASE_PARTITION,
         }
     }
 
     pub fn static_blueprint(&self) -> Option<BlueprintId> {
         match self {
-            ObjectModuleId::Metadata => Some(BlueprintId::new(
+            ModuleId::Metadata => Some(BlueprintId::new(
                 &METADATA_MODULE_PACKAGE,
                 METADATA_BLUEPRINT,
             )),
-            ObjectModuleId::Royalty => Some(BlueprintId::new(
+            ModuleId::Royalty => Some(BlueprintId::new(
                 &ROYALTY_MODULE_PACKAGE,
                 COMPONENT_ROYALTY_BLUEPRINT,
             )),
-            ObjectModuleId::RoleAssignment => Some(BlueprintId::new(
+            ModuleId::RoleAssignment => Some(BlueprintId::new(
                 &ROLE_ASSIGNMENT_MODULE_PACKAGE,
                 ROLE_ASSIGNMENT_BLUEPRINT,
             )),
-            ObjectModuleId::Main => None,
+            ModuleId::Main => None,
         }
     }
 }
@@ -121,41 +121,43 @@ impl ObjectModuleId {
     ScryptoDecode,
 )]
 #[sbor(use_repr_discriminators)]
-pub enum ModuleId {
+pub enum AttachedModuleId {
     Metadata = 1,
     Royalty = 2,
     RoleAssignment = 3,
 }
 
-impl Describe<ScryptoCustomTypeKind> for ModuleId {
+impl Describe<ScryptoCustomTypeKind> for AttachedModuleId {
     const TYPE_ID: RustTypeId =
-        RustTypeId::WellKnown(well_known_scrypto_custom_types::MODULE_ID_TYPE);
+        RustTypeId::WellKnown(well_known_scrypto_custom_types::ATTACHED_MODULE_ID_TYPE);
 
     fn type_data() -> ScryptoTypeData<RustTypeId> {
         well_known_scrypto_custom_types::module_id_type_data()
     }
 }
 
-impl ModuleId {
+impl AttachedModuleId {
     pub fn static_blueprint(&self) -> BlueprintId {
         match self {
-            ModuleId::Metadata => BlueprintId::new(&METADATA_MODULE_PACKAGE, METADATA_BLUEPRINT),
-            ModuleId::Royalty => {
+            AttachedModuleId::Metadata => {
+                BlueprintId::new(&METADATA_MODULE_PACKAGE, METADATA_BLUEPRINT)
+            }
+            AttachedModuleId::Royalty => {
                 BlueprintId::new(&ROYALTY_MODULE_PACKAGE, COMPONENT_ROYALTY_BLUEPRINT)
             }
-            ModuleId::RoleAssignment => {
+            AttachedModuleId::RoleAssignment => {
                 BlueprintId::new(&ROLE_ASSIGNMENT_MODULE_PACKAGE, ROLE_ASSIGNMENT_BLUEPRINT)
             }
         }
     }
 }
 
-impl Into<ObjectModuleId> for ModuleId {
-    fn into(self) -> ObjectModuleId {
+impl Into<ModuleId> for AttachedModuleId {
+    fn into(self) -> ModuleId {
         match self {
-            ModuleId::Metadata => ObjectModuleId::Metadata,
-            ModuleId::Royalty => ObjectModuleId::Royalty,
-            ModuleId::RoleAssignment => ObjectModuleId::RoleAssignment,
+            AttachedModuleId::Metadata => ModuleId::Metadata,
+            AttachedModuleId::Royalty => ModuleId::Royalty,
+            AttachedModuleId::RoleAssignment => ModuleId::RoleAssignment,
         }
     }
 }
@@ -249,14 +251,14 @@ pub trait ClientObjectApi<E> {
     fn globalize(
         &mut self,
         node_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         address_reservation: Option<GlobalAddressReservation>,
     ) -> Result<GlobalAddress, E>;
 
     fn globalize_with_address_and_create_inner_object_and_emit_event(
         &mut self,
         node_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         address_reservation: GlobalAddressReservation,
         inner_object_blueprint: &str,
         inner_object_fields: IndexMap<u8, FieldValue>,
@@ -283,7 +285,7 @@ pub trait ClientObjectApi<E> {
     fn call_module_method(
         &mut self,
         receiver: &NodeId,
-        module_id: ModuleId,
+        module_id: AttachedModuleId,
         method_name: &str,
         args: Vec<u8>,
     ) -> Result<Vec<u8>, E>;

--- a/radix-engine-interface/src/api/object_api.rs
+++ b/radix-engine-interface/src/api/object_api.rs
@@ -42,6 +42,8 @@ pub enum ModuleId {
     RoleAssignment,
 }
 
+pub type ObjectModuleId = ModuleId;
+
 impl Describe<ScryptoCustomTypeKind> for ModuleId {
     const TYPE_ID: RustTypeId =
         RustTypeId::WellKnown(well_known_scrypto_custom_types::MODULE_ID_TYPE);

--- a/radix-engine-interface/src/blueprints/resource/role_assignment.rs
+++ b/radix-engine-interface/src/blueprints/resource/role_assignment.rs
@@ -64,12 +64,12 @@ impl From<RoleList> for MethodAccessibility {
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ScryptoSbor, ManifestSbor)]
 pub struct ModuleRoleKey {
-    pub module: ObjectModuleId,
+    pub module: ModuleId,
     pub key: RoleKey,
 }
 
 impl ModuleRoleKey {
-    pub fn new<K: Into<RoleKey>>(module: ObjectModuleId, key: K) -> Self {
+    pub fn new<K: Into<RoleKey>>(module: ModuleId, key: K) -> Self {
         Self {
             module,
             key: key.into(),

--- a/radix-engine-interface/src/types/blueprint.rs
+++ b/radix-engine-interface/src/types/blueprint.rs
@@ -6,7 +6,7 @@ use radix_engine_common::address::{AddressDisplayContext, NO_NETWORK};
 use radix_engine_common::types::PackageAddress;
 use radix_engine_common::types::{GenericSubstitution, GlobalAddress};
 use radix_engine_derive::ManifestSbor;
-use radix_engine_interface::api::ModuleId;
+use radix_engine_interface::api::AttachedModuleId;
 use sbor::rust::prelude::*;
 use scrypto_schema::KeyValueStoreGenericSubstitutions;
 use utils::ContextualDisplay;
@@ -45,7 +45,7 @@ pub struct BlueprintInfo {
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ObjectType {
     Global {
-        modules: IndexMap<ModuleId, BlueprintVersion>,
+        modules: IndexMap<AttachedModuleId, BlueprintVersion>,
     },
     Owned,
 }

--- a/radix-engine-interface/src/types/event_id.rs
+++ b/radix-engine-interface/src/types/event_id.rs
@@ -1,4 +1,4 @@
-use crate::api::ObjectModuleId;
+use crate::api::ModuleId;
 use crate::types::BlueprintId;
 use crate::ScryptoSbor;
 use radix_engine_common::address::AddressDisplayContext;
@@ -21,7 +21,7 @@ pub struct EventTypeIdentifier(pub Emitter, pub String);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum Emitter {
     Function(BlueprintId),
-    Method(NodeId, ObjectModuleId),
+    Method(NodeId, ModuleId),
 }
 
 impl<'a> ContextualDisplay<AddressDisplayContext<'a>> for Emitter {

--- a/radix-engine-interface/src/types/interface_well_known_types.rs
+++ b/radix-engine-interface/src/types/interface_well_known_types.rs
@@ -43,8 +43,8 @@ mod tests {
         test_equivalence(ROLE_KEY_TYPE, RoleKey::from("MyRoleName"));
 
         // OTHER MODULE TYPES
-        test_equivalence(OBJECT_MODULE_ID_TYPE, ObjectModuleId::Main);
-        test_equivalence(MODULE_ID_TYPE, ModuleId::Metadata);
+        test_equivalence(MODULE_ID_TYPE, ModuleId::Main);
+        test_equivalence(ATTACHED_MODULE_ID_TYPE, AttachedModuleId::Metadata);
         test_equivalence(ROYALTY_AMOUNT_TYPE, RoyaltyAmount::Free);
         test_equivalence(ROYALTY_AMOUNT_TYPE, RoyaltyAmount::Usd(dec!("1.6")));
         test_equivalence(ROYALTY_AMOUNT_TYPE, RoyaltyAmount::Xrd(dec!("1.6")));

--- a/radix-engine-queries/src/query/traverse.rs
+++ b/radix-engine-queries/src/query/traverse.rs
@@ -5,7 +5,7 @@ use radix_engine::system::node_modules::royalty::{
 };
 use radix_engine::system::system_db_reader::SystemDatabaseReader;
 use radix_engine::system::type_info::TypeInfoSubstate;
-use radix_engine_interface::api::{ModuleId, ObjectModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ModuleId};
 use radix_engine_interface::blueprints::resource::{
     LiquidNonFungibleVault, FUNGIBLE_VAULT_BLUEPRINT, NON_FUNGIBLE_VAULT_BLUEPRINT,
 };
@@ -126,7 +126,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                     let liquid: VersionedFungibleVaultBalance = system_db_reader
                         .read_typed_object_field(
                             &node_id,
-                            ObjectModuleId::Main,
+                            ModuleId::Main,
                             FungibleVaultField::Balance.into(),
                         )
                         .expect("Broken database");
@@ -147,7 +147,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                     let liquid: VersionedNonFungibleVaultBalance = system_db_reader
                         .read_typed_object_field(
                             &node_id,
-                            ObjectModuleId::Main,
+                            ModuleId::Main,
                             NonFungibleVaultField::Balance.into(),
                         )
                         .expect("Broken database");
@@ -165,7 +165,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                     for (key, _value) in system_db_reader
                         .collection_iter(
                             &node_id,
-                            ObjectModuleId::Main,
+                            ModuleId::Main,
                             NonFungibleVaultCollection::NonFungibleIndex.collection_index(),
                         )
                         .unwrap()
@@ -184,7 +184,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                         ObjectType::Global { modules } => {
                             for (module_id, _) in modules {
                                 match &module_id {
-                                    ModuleId::Royalty => {
+                                    AttachedModuleId::Royalty => {
                                         let royalty = system_db_reader
                                             .read_typed_object_field::<ComponentRoyaltyAccumulatorFieldPayload>(
                                                 &node_id,
@@ -224,11 +224,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                         for (index, _field) in fields.iter().enumerate() {
                             // TODO: what if the field is conditional?
                             let (field_value, partition_number) = system_db_reader
-                                .read_object_field_advanced(
-                                    &node_id,
-                                    ObjectModuleId::Main,
-                                    index as u8,
-                                )
+                                .read_object_field_advanced(&node_id, ModuleId::Main, index as u8)
                                 .expect("Broken database");
                             let (_, owned_nodes, _) = field_value.unpack();
                             for child_node_id in owned_nodes {
@@ -252,7 +248,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                         blueprint_def.interface.state.collections.iter().enumerate()
                     {
                         let (iter, partition_number) = system_db_reader
-                            .collection_iter_advanced(&node_id, ObjectModuleId::Main, index as u8)
+                            .collection_iter_advanced(&node_id, ModuleId::Main, index as u8)
                             .unwrap();
 
                         for (substate_key, value) in iter {

--- a/radix-engine-queries/src/typed_native_events.rs
+++ b/radix-engine-queries/src/typed_native_events.rs
@@ -25,13 +25,13 @@ fn resolve_typed_event_key_from_event_type_identifier(
 
     match &event_type_identifier.0 {
         /* Method or Function emitter on a known node module */
-        Emitter::Method(_, ObjectModuleId::RoleAssignment) => {
+        Emitter::Method(_, ModuleId::RoleAssignment) => {
             TypedRoleAssignmentBlueprintEventKey::new(&event_name).map(TypedNativeEventKey::from)
         }
-        Emitter::Method(_, ObjectModuleId::Metadata) => {
+        Emitter::Method(_, ModuleId::Metadata) => {
             TypedMetadataBlueprintEventKey::new(&event_name).map(TypedNativeEventKey::from)
         }
-        Emitter::Method(_, ObjectModuleId::Royalty) => {
+        Emitter::Method(_, ModuleId::Royalty) => {
             TypedComponentRoyaltyBlueprintEventKey::new(&event_name).map(TypedNativeEventKey::from)
         }
 
@@ -115,7 +115,7 @@ fn resolve_typed_event_key_from_event_type_identifier(
         },
 
         /* Methods on non-generic components */
-        Emitter::Method(node_id, ObjectModuleId::Main) => match node_id.entity_type().unwrap() {
+        Emitter::Method(node_id, ModuleId::Main) => match node_id.entity_type().unwrap() {
             EntityType::GlobalPackage => {
                 TypedPackageBlueprintEventKey::new(&event_name).map(TypedNativeEventKey::from)
             }

--- a/radix-engine-tests/tests/auth_account.rs
+++ b/radix-engine-tests/tests/auth_account.rs
@@ -1,7 +1,7 @@
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::api::ModuleId;
+use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::rule;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -335,7 +335,9 @@ fn cannot_set_royalty_on_accounts() {
     receipt.expect_specific_failure(|e| {
         matches!(
             e,
-            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(ModuleId::Royalty))
+            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(
+                AttachedModuleId::Royalty
+            ))
         )
     });
 }

--- a/radix-engine-tests/tests/auth_mutability.rs
+++ b/radix-engine-tests/tests/auth_mutability.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use radix_engine::types::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -80,13 +80,13 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     updater_role_key,
                     rule!(require(admin_auth)),
                 )
@@ -108,13 +108,13 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     updater_role_key,
                     rule!(require(admin_auth)),
                 )
@@ -134,12 +134,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                         admin_auth,
                         [NonFungibleLocalId::integer(1)],
                     )
-                    .set_role(
-                        token_address,
-                        ObjectModuleId::Main,
-                        role_key,
-                        AccessRule::DenyAll,
-                    )
+                    .set_role(token_address, ModuleId::Main, role_key, AccessRule::DenyAll)
                     .build(),
                 vec![NonFungibleGlobalId::from_public_key(&public_key)],
             )
@@ -158,7 +153,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )
@@ -178,7 +173,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
                 )
                 .set_role(
                     token_address,
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     role_key,
                     rule!(require(admin_auth)),
                 )

--- a/radix-engine-tests/tests/auth_resource.rs
+++ b/radix-engine-tests/tests/auth_resource.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use radix_engine::types::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -16,14 +16,14 @@ enum Action {
 }
 
 impl Action {
-    fn get_role(&self) -> (ObjectModuleId, RoleKey) {
+    fn get_role(&self) -> (ModuleId, RoleKey) {
         match self {
-            Action::Mint => (ObjectModuleId::Main, RoleKey::new(MINTER_ROLE)),
-            Action::Burn => (ObjectModuleId::Main, RoleKey::new(BURNER_ROLE)),
-            Action::Withdraw => (ObjectModuleId::Main, RoleKey::new(WITHDRAWER_ROLE)),
-            Action::Deposit => (ObjectModuleId::Main, RoleKey::new(DEPOSITOR_ROLE)),
-            Action::Recall => (ObjectModuleId::Main, RoleKey::new(RECALLER_ROLE)),
-            Action::Freeze => (ObjectModuleId::Main, RoleKey::new(FREEZER_ROLE)),
+            Action::Mint => (ModuleId::Main, RoleKey::new(MINTER_ROLE)),
+            Action::Burn => (ModuleId::Main, RoleKey::new(BURNER_ROLE)),
+            Action::Withdraw => (ModuleId::Main, RoleKey::new(WITHDRAWER_ROLE)),
+            Action::Deposit => (ModuleId::Main, RoleKey::new(DEPOSITOR_ROLE)),
+            Action::Recall => (ModuleId::Main, RoleKey::new(RECALLER_ROLE)),
+            Action::Freeze => (ModuleId::Main, RoleKey::new(FREEZER_ROLE)),
         }
     }
 }

--- a/radix-engine-tests/tests/blueprints/core/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/core/src/lib.rs
@@ -10,8 +10,8 @@ mod globalize_test {
     impl GlobalizeTest {
         pub fn globalize(x: Own) {
             let modules = indexmap!(
-                ModuleId::Metadata => Metadata::new().0.as_node_id().clone(),
-                ModuleId::Royalty => Royalty::new(ComponentRoyaltyConfig::default()).0.as_node_id().clone(),
+                AttachedModuleId::Metadata => Metadata::new().0.as_node_id().clone(),
+                AttachedModuleId::Royalty => Royalty::new(ComponentRoyaltyConfig::default()).0.as_node_id().clone(),
             );
 
             ScryptoVmV1Api::object_globalize(x.0, modules, None);

--- a/radix-engine-tests/tests/blueprints/module/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/module/src/lib.rs
@@ -43,9 +43,9 @@ mod component_module {
             let address = ScryptoVmV1Api::object_globalize(
                 *component.0.handle().as_node_id(),
                 indexmap!(
-                    ModuleId::RoleAssignment => metadata.0,
-                    ModuleId::Metadata => royalty.0,
-                    ModuleId::Royalty => role_assignment.0,
+                    AttachedModuleId::RoleAssignment => metadata.0,
+                    AttachedModuleId::Metadata => royalty.0,
+                    AttachedModuleId::Royalty => role_assignment.0,
                 ),
                 None,
             );

--- a/radix-engine-tests/tests/bootstrap.rs
+++ b/radix-engine-tests/tests/bootstrap.rs
@@ -281,7 +281,7 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
     let entry = reader
         .read_object_collection_entry::<_, MetadataEntryEntryPayload>(
             resource_address.as_node_id(),
-            ObjectModuleId::Metadata,
+            ModuleId::Metadata,
             ObjectCollectionKey::KeyValue(
                 MetadataCollection::EntryKeyValue.collection_index(),
                 &"symbol".to_string(),
@@ -442,7 +442,7 @@ fn test_genesis_stake_allocation() {
             let validator_url_entry = reader
                 .read_object_collection_entry::<_, MetadataEntryEntryPayload>(
                     &new_validators[index].as_node_id(),
-                    ObjectModuleId::Metadata,
+                    ModuleId::Metadata,
                     ObjectCollectionKey::KeyValue(
                         MetadataCollection::EntryKeyValue.collection_index(),
                         &"url".to_string(),
@@ -487,7 +487,7 @@ fn test_genesis_time() {
     let timestamp = reader
         .read_typed_object_field::<ConsensusManagerProposerMinuteTimestampFieldPayload>(
             CONSENSUS_MANAGER.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ConsensusManagerField::ProposerMinuteTimestamp.field_index(),
         )
         .unwrap()

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -12,7 +12,7 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::{RoleDefinition, ToRoleEntry};
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::api::node_modules::ModuleConfig;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::account::ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::consensus_manager::{
@@ -52,7 +52,7 @@ fn test_events_of_commit_failure() {
     assert_eq!(events.len(), 4);
     assert!(match events.get(0) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
             && is_decoded_equal(
@@ -64,7 +64,7 @@ fn test_events_of_commit_failure() {
     });
     assert!(match events.get(1) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::PayFeeEvent>(event_identifier)
             && is_decoded_equal(
@@ -78,7 +78,7 @@ fn test_events_of_commit_failure() {
     });
     assert!(match events.get(2) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier)
             && is_decoded_equal(
@@ -102,7 +102,7 @@ fn test_events_of_commit_failure() {
     });
     assert!(match events.get(3) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<BurnFungibleResourceEvent>(event_identifier)
             && is_decoded_equal(
@@ -139,7 +139,7 @@ fn create_proof_emits_correct_events() {
     assert_eq!(events.len(), 4);
     assert!(match events.get(0) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
             && is_decoded_equal(
@@ -151,7 +151,7 @@ fn create_proof_emits_correct_events() {
     });
     assert!(match events.get(1) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::PayFeeEvent>(event_identifier)
             && is_decoded_equal(
@@ -165,7 +165,7 @@ fn create_proof_emits_correct_events() {
     });
     assert!(match events.get(2) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier)
             && is_decoded_equal(
@@ -189,7 +189,7 @@ fn create_proof_emits_correct_events() {
     });
     assert!(match events.get(3) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<BurnFungibleResourceEvent>(event_identifier)
             && is_decoded_equal(
@@ -264,7 +264,7 @@ fn scrypto_can_emit_registered_events() {
     }
     assert!(match events.get(0) {
         Some((
-            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+            event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
             ref event_data,
         )) if test_runner.is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
             && is_decoded_equal(
@@ -372,8 +372,7 @@ fn locking_fee_against_a_vault_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -413,8 +412,7 @@ fn vault_fungible_recall_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -427,8 +425,7 @@ fn vault_fungible_recall_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::RecallEvent>(event_identifier)
@@ -438,8 +435,7 @@ fn vault_fungible_recall_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier)
@@ -499,8 +495,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -513,8 +508,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::RecallEvent>(event_identifier)
@@ -529,8 +523,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier)
@@ -581,8 +574,7 @@ fn resource_manager_new_vault_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -596,7 +588,7 @@ fn resource_manager_new_vault_emits_correct_events() {
         assert!(match events.get(1) {
             Some((
                 event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_node_id, ObjectModuleId::Main),
+                    Emitter::Method(_node_id, ModuleId::Main),
                     ..,
                 ),
                 ..,
@@ -608,7 +600,7 @@ fn resource_manager_new_vault_emits_correct_events() {
         assert!(match events.get(2) {
             Some((
                 event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_node_id, ObjectModuleId::Main),
+                    Emitter::Method(_node_id, ModuleId::Main),
                     ..,
                 ),
                 ..,
@@ -617,8 +609,7 @@ fn resource_manager_new_vault_emits_correct_events() {
         });
         assert!(match events.get(3) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier)
@@ -679,8 +670,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -693,8 +683,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<MintFungibleResourceEvent>(event_identifier)
@@ -707,8 +696,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<BurnFungibleResourceEvent>(event_identifier)
@@ -773,8 +761,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -787,8 +774,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<MintNonFungibleResourceEvent>(event_identifier)
@@ -803,8 +789,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<BurnNonFungibleResourceEvent>(event_identifier)
@@ -883,8 +868,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -897,8 +881,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<MintNonFungibleResourceEvent>(event_identifier)
@@ -913,16 +896,14 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 _,
             )) if test_runner.is_event_name_equal::<VaultCreationEvent>(event_identifier) => true,
             _ => false,
         });
         assert!(match events.get(3) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier)
@@ -935,8 +916,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         });
         assert!(match events.get(4) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<account::DepositEvent>(event_identifier)
                 && is_decoded_equal(
@@ -951,8 +931,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         });
         assert!(match events.get(5) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::WithdrawEvent>(event_identifier)
@@ -965,8 +944,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
         });
         assert!(match events.get(7) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier)
@@ -1020,8 +998,7 @@ fn consensus_manager_round_update_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<RoundChangeEvent>(event_identifier)
                 && is_decoded_equal(
@@ -1174,8 +1151,7 @@ fn validator_registration_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1188,8 +1164,7 @@ fn validator_registration_emits_correct_event() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<RegisterValidatorEvent>(event_identifier) =>
                 true,
@@ -1252,8 +1227,7 @@ fn validator_unregistration_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1266,8 +1240,7 @@ fn validator_unregistration_emits_correct_event() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<UnregisterValidatorEvent>(event_identifier) =>
                 true,
@@ -1333,8 +1306,7 @@ fn validator_staking_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1347,8 +1319,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::WithdrawEvent>(event_identifier)
@@ -1361,8 +1332,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<account::WithdrawEvent>(event_identifier)
                 && is_decoded_equal(
@@ -1374,8 +1344,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(3) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<MintFungibleResourceEvent>(event_identifier) =>
@@ -1384,8 +1353,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(4) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier)
@@ -1395,8 +1363,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(5) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<StakeEvent>(event_identifier)
                 && is_decoded_equal(
@@ -1411,7 +1378,7 @@ fn validator_staking_emits_correct_event() {
         assert!(match events.get(6) {
             Some((
                 event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_node_id, ObjectModuleId::Main),
+                    Emitter::Method(_node_id, ModuleId::Main),
                     ..,
                 ),
                 ..,
@@ -1420,8 +1387,7 @@ fn validator_staking_emits_correct_event() {
         });
         assert!(match events.get(7) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier) =>
@@ -1477,8 +1443,7 @@ fn validator_unstake_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1491,8 +1456,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::WithdrawEvent>(event_identifier)
@@ -1502,8 +1466,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<account::WithdrawEvent>(event_identifier)
                 && is_decoded_equal(
@@ -1518,8 +1481,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(3) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<BurnFungibleResourceEvent>(event_identifier)
@@ -1532,8 +1494,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(4) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::WithdrawEvent>(event_identifier) =>
@@ -1542,8 +1503,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(5) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier) =>
@@ -1552,10 +1512,8 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(6) {
             Some((
-                event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(node_id, ObjectModuleId::Main),
-                    ..,
-                ),
+                event_identifier
+                @ EventTypeIdentifier(Emitter::Method(node_id, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<MintNonFungibleResourceEvent>(event_identifier)
@@ -1565,8 +1523,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(7) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<UnstakeEvent>(event_identifier) => true,
             _ => false,
@@ -1574,7 +1531,7 @@ fn validator_unstake_emits_correct_events() {
         assert!(match events.get(8) {
             Some((
                 event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_node_id, ObjectModuleId::Main),
+                    Emitter::Method(_node_id, ModuleId::Main),
                     ..,
                 ),
                 ..,
@@ -1583,8 +1540,7 @@ fn validator_unstake_emits_correct_events() {
         });
         assert!(match events.get(9) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier) =>
@@ -1651,8 +1607,7 @@ fn validator_claim_xrd_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1665,8 +1620,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::WithdrawEvent>(event_identifier) =>
@@ -1675,8 +1629,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(2) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<account::WithdrawEvent>(event_identifier) =>
                 true,
@@ -1684,8 +1637,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(3) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<BurnNonFungibleResourceEvent>(event_identifier) =>
@@ -1694,8 +1646,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(4) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::WithdrawEvent>(event_identifier) =>
@@ -1704,8 +1655,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(5) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<ClaimXrdEvent>(event_identifier) => true,
             _ => false,
@@ -1713,7 +1663,7 @@ fn validator_claim_xrd_emits_correct_events() {
         assert!(match events.get(6) {
             Some((
                 event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_node_id, ObjectModuleId::Main),
+                    Emitter::Method(_node_id, ModuleId::Main),
                     ..,
                 ),
                 ..,
@@ -1722,8 +1672,7 @@ fn validator_claim_xrd_emits_correct_events() {
         });
         assert!(match events.get(7) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ..,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::DepositEvent>(event_identifier) =>
@@ -1792,8 +1741,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1806,8 +1754,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner.is_event_name_equal::<UpdateAcceptingStakeDelegationStateEvent>(
                 event_identifier
@@ -1850,8 +1797,7 @@ fn setting_metadata_emits_correct_events() {
         }
         assert!(match events.get(0) {
             Some((
-                event_identifier
-                @ EventTypeIdentifier(Emitter::Method(_, ObjectModuleId::Main), ..),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Main), ..),
                 ref event_data,
             )) if test_runner
                 .is_event_name_equal::<fungible_vault::LockFeeEvent>(event_identifier)
@@ -1864,10 +1810,7 @@ fn setting_metadata_emits_correct_events() {
         });
         assert!(match events.get(1) {
             Some((
-                event_identifier @ EventTypeIdentifier(
-                    Emitter::Method(_, ObjectModuleId::Metadata),
-                    ..,
-                ),
+                event_identifier @ EventTypeIdentifier(Emitter::Method(_, ModuleId::Metadata), ..),
                 ..,
             )) if test_runner.is_event_name_equal::<SetMetadataEvent>(event_identifier) => true,
             _ => false,
@@ -2425,7 +2368,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             set_resource_preference_allowed_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&set_resource_preference_allowed_event.0),
@@ -2445,7 +2388,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             set_resource_preference_disallowed_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&set_resource_preference_disallowed_event.0),
@@ -2465,7 +2408,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             remove_resource_preference_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&remove_resource_preference_event.0),
@@ -2482,7 +2425,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             set_default_deposit_rule_accept_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&set_default_deposit_rule_accept_event.0),
@@ -2501,7 +2444,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             set_default_deposit_rule_reject_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&set_default_deposit_rule_reject_event.0),
@@ -2520,7 +2463,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             set_default_deposit_rule_allow_existing_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&set_default_deposit_rule_allow_existing_event.0),
@@ -2539,7 +2482,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             add_authorized_depositor_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&add_authorized_depositor_event.0),
@@ -2558,7 +2501,7 @@ fn account_configuration_emits_expected_events() {
     {
         assert_eq!(
             remove_authorized_depositor_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&remove_authorized_depositor_event.0),
@@ -2635,7 +2578,7 @@ fn account_deposit_batch_emits_expected_events() {
         {
             assert_eq!(
                 xrd_deposit_event.0 .0,
-                Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+                Emitter::Method(account.into_node_id(), ModuleId::Main)
             );
             assert_eq!(
                 test_runner.event_name(&xrd_deposit_event.0),
@@ -2649,7 +2592,7 @@ fn account_deposit_batch_emits_expected_events() {
         {
             assert_eq!(
                 nfts_deposit_event.0 .0,
-                Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+                Emitter::Method(account.into_node_id(), ModuleId::Main)
             );
             assert_eq!(
                 test_runner.event_name(&nfts_deposit_event.0),
@@ -2723,7 +2666,7 @@ fn account_deposit_batch_methods_emits_expected_events_when_deposit_fails() {
     {
         assert_eq!(
             xrd_rejected_deposit_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&xrd_rejected_deposit_event.0),
@@ -2737,7 +2680,7 @@ fn account_deposit_batch_methods_emits_expected_events_when_deposit_fails() {
     {
         assert_eq!(
             nfts_rejected_deposit_event.0 .0,
-            Emitter::Method(account.into_node_id(), ObjectModuleId::Main)
+            Emitter::Method(account.into_node_id(), ModuleId::Main)
         );
         assert_eq!(
             test_runner.event_name(&nfts_rejected_deposit_event.0),

--- a/radix-engine-tests/tests/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/pool_multi_resource.rs
@@ -6,7 +6,7 @@ use radix_engine::{
     types::*,
 };
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::pool::*;
 use scrypto::prelude::Pow;
 use scrypto_unit::{is_auth_error, DefaultTestRunner, TestRunnerBuilder};
@@ -804,7 +804,7 @@ fn get_redemption_value_should_not_panic_on_large_values() {
 
 fn is_pool_emitter(event_type_identifier: &EventTypeIdentifier) -> bool {
     match event_type_identifier.0 {
-        Emitter::Method(node_id, ObjectModuleId::Main) => match node_id.entity_type() {
+        Emitter::Method(node_id, ModuleId::Main) => match node_id.entity_type() {
             Some(
                 EntityType::GlobalOneResourcePool
                 | EntityType::GlobalTwoResourcePool

--- a/radix-engine-tests/tests/pool_one_resource.rs
+++ b/radix-engine-tests/tests/pool_one_resource.rs
@@ -3,7 +3,7 @@ use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemMo
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::pool::*;
 use scrypto::prelude::Pow;
 use scrypto_unit::*;
@@ -671,7 +671,7 @@ fn get_redemption_value_should_not_panic_on_large_values() {
 
 fn is_pool_emitter(event_type_identifier: &EventTypeIdentifier) -> bool {
     match event_type_identifier.0 {
-        Emitter::Method(node_id, ObjectModuleId::Main) => match node_id.entity_type() {
+        Emitter::Method(node_id, ModuleId::Main) => match node_id.entity_type() {
             Some(
                 EntityType::GlobalOneResourcePool
                 | EntityType::GlobalTwoResourcePool

--- a/radix-engine-tests/tests/pool_two_resource.rs
+++ b/radix-engine-tests/tests/pool_two_resource.rs
@@ -3,7 +3,7 @@ use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemMo
 use radix_engine::transaction::{BalanceChange, TransactionReceipt};
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::pool::*;
 use radix_engine_queries::typed_substate_layout::FungibleResourceManagerError;
 use scrypto::prelude::Pow;
@@ -1018,7 +1018,7 @@ fn contributing_to_a_pool_with_very_large_difference_in_reserves_succeeds() {
 
 fn is_pool_emitter(event_type_identifier: &EventTypeIdentifier) -> bool {
     match event_type_identifier.0 {
-        Emitter::Method(node_id, ObjectModuleId::Main) => match node_id.entity_type() {
+        Emitter::Method(node_id, ModuleId::Main) => match node_id.entity_type() {
             Some(
                 EntityType::GlobalOneResourcePool
                 | EntityType::GlobalTwoResourcePool

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -3,7 +3,7 @@ use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
 use radix_engine_interface::rule;
@@ -412,7 +412,7 @@ impl MutableRolesTestRunner {
         let manifest = Self::manifest_builder()
             .set_role(
                 self.component_address,
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 role_key,
                 access_rule,
             )
@@ -422,7 +422,7 @@ impl MutableRolesTestRunner {
 
     pub fn get_role(&mut self, role_key: RoleKey) -> TransactionReceipt {
         let manifest = Self::manifest_builder()
-            .get_role(self.component_address, ObjectModuleId::Main, role_key)
+            .get_role(self.component_address, ModuleId::Main, role_key)
             .build();
         self.execute_manifest(manifest)
     }

--- a/radix-engine-tests/tests/schema_sanity_check.rs
+++ b/radix-engine-tests/tests/schema_sanity_check.rs
@@ -352,8 +352,8 @@ fn is_safe_well_known_type(
         RESOURCE_OR_NON_FUNGIBLE_LIST_TYPE => true,
         OWNER_ROLE_TYPE => true,
         ROLE_KEY_TYPE => true,
-        OBJECT_MODULE_ID_TYPE => true,
         MODULE_ID_TYPE => true,
+        ATTACHED_MODULE_ID_TYPE => true,
         ROYALTY_AMOUNT_TYPE => true,
         t => panic!("Unexpected well-known type id: {:?}", t),
     };

--- a/radix-engine-tests/tests/system_access_rule.rs
+++ b/radix-engine-tests/tests/system_access_rule.rs
@@ -5,7 +5,7 @@ use radix_engine::system::node_modules::role_assignment::RoleAssignmentError;
 use radix_engine::system::system_callback::SystemLockData;
 use radix_engine::types::*;
 use radix_engine::vm::{OverridePackageCode, VmInvoke};
-use radix_engine_interface::api::{ClientApi, ObjectModuleId};
+use radix_engine_interface::api::{ClientApi, ModuleId};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
@@ -201,7 +201,7 @@ fn creating_an_access_rule_which_is_beyond_the_depth_limit_should_error<F>(
                     AccessRuleCreation::RoleCreation => {
                         RoleAssignment::create(
                             OwnerRole::None,
-                            indexmap!(ObjectModuleId::Main => roles2!("test" => self.1.clone();)),
+                            indexmap!(ModuleId::Main => roles2!("test" => self.1.clone();)),
                             api,
                         )?;
                     }
@@ -220,7 +220,7 @@ fn creating_an_access_rule_which_is_beyond_the_depth_limit_should_error<F>(
                             api,
                         )?;
                         role_assignment.set_role(
-                            ObjectModuleId::Main,
+                            ModuleId::Main,
                             RoleKey::new("test"),
                             self.1.clone(),
                             api,

--- a/radix-engine-tests/tests/system_actor_collection.rs
+++ b/radix-engine-tests/tests/system_actor_collection.rs
@@ -5,7 +5,7 @@ use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
 use radix_engine::system::system_callback::SystemLockData;
 use radix_engine::types::*;
 use radix_engine::vm::{OverridePackageCode, VmInvoke};
-use radix_engine_interface::api::{ClientApi, LockFlags, ModuleId, ACTOR_STATE_SELF};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi, LockFlags, ACTOR_STATE_SELF};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use radix_engine_store_interface::interface::DatabaseUpdate;
 use scrypto_unit::*;
@@ -44,8 +44,8 @@ fn opening_read_only_key_value_entry_should_not_create_substates() {
                     api.globalize(
                         node_id,
                         indexmap!(
-                            ModuleId::Metadata => metadata.0,
-                            ModuleId::RoleAssignment => access_rules.0.0,
+                            AttachedModuleId::Metadata => metadata.0,
+                            AttachedModuleId::RoleAssignment => access_rules.0.0,
                         ),
                         None,
                     )?;

--- a/radix-engine-tests/tests/system_actor_field.rs
+++ b/radix-engine-tests/tests/system_actor_field.rs
@@ -5,7 +5,9 @@ use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
 use radix_engine::system::system_callback::SystemLockData;
 use radix_engine::types::*;
 use radix_engine::vm::{OverridePackageCode, VmInvoke};
-use radix_engine_interface::api::{ClientApi, LockFlags, ModuleId, ACTOR_STATE_OUTER_OBJECT};
+use radix_engine_interface::api::{
+    AttachedModuleId, ClientApi, LockFlags, ACTOR_STATE_OUTER_OBJECT,
+};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
@@ -38,8 +40,8 @@ fn opening_non_existent_outer_object_fields_should_not_panic() {
                     api.globalize(
                         node_id,
                         indexmap!(
-                            ModuleId::Metadata => metadata.0,
-                            ModuleId::RoleAssignment => access_rules.0.0,
+                            AttachedModuleId::Metadata => metadata.0,
+                            AttachedModuleId::RoleAssignment => access_rules.0.0,
                         ),
                         None,
                     )?;

--- a/radix-engine-tests/tests/system_module_methods.rs
+++ b/radix-engine-tests/tests/system_module_methods.rs
@@ -8,7 +8,9 @@ use radix_engine::vm::{OverridePackageCode, VmInvoke};
 use radix_engine_interface::api::node_modules::royalty::{
     ComponentRoyaltySetInput, COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
 };
-use radix_engine_interface::api::{ClientApi, FieldValue, LockFlags, ModuleId, ACTOR_STATE_SELF};
+use radix_engine_interface::api::{
+    AttachedModuleId, ClientApi, FieldValue, LockFlags, ACTOR_STATE_SELF,
+};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto_unit::*;
 use transaction::builder::ManifestBuilder;
@@ -34,7 +36,7 @@ fn should_not_be_able_to_call_royalty_methods(resource: bool) {
             let node_id = input.references()[0];
             let _ = api.call_module_method(
                 &node_id,
-                ModuleId::Royalty,
+                AttachedModuleId::Royalty,
                 COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
                 scrypto_encode(&ComponentRoyaltySetInput {
                     method: "some_method".to_string(),
@@ -78,7 +80,9 @@ fn should_not_be_able_to_call_royalty_methods(resource: bool) {
     receipt.expect_specific_failure(|e| {
         matches!(
             e,
-            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(ModuleId::Royalty))
+            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(
+                AttachedModuleId::Royalty
+            ))
         )
     });
 }
@@ -116,7 +120,7 @@ fn should_not_be_able_to_call_metadata_methods_on_frame_owned_object() {
                     let node_id = api.new_simple_object(BLUEPRINT_NAME, indexmap![])?;
                     let _ = api.call_module_method(
                         &node_id,
-                        ModuleId::Metadata,
+                        AttachedModuleId::Metadata,
                         METADATA_SET_IDENT,
                         scrypto_encode(&MetadataSetInput {
                             key: "key".to_string(),
@@ -155,7 +159,9 @@ fn should_not_be_able_to_call_metadata_methods_on_frame_owned_object() {
     receipt.expect_specific_failure(|e| {
         matches!(
             e,
-            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(ModuleId::Metadata))
+            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(
+                AttachedModuleId::Metadata
+            ))
         )
     });
 }
@@ -202,8 +208,8 @@ fn should_not_be_able_to_call_metadata_methods_on_child_object(globalized_parent
                         let address = api.globalize(
                             parent,
                             indexmap!(
-                                ModuleId::Metadata => metadata.0,
-                                ModuleId::RoleAssignment => role_assignment.0.0,
+                                AttachedModuleId::Metadata => metadata.0,
+                                AttachedModuleId::RoleAssignment => role_assignment.0.0,
                             ),
                             None,
                         )?;
@@ -223,7 +229,7 @@ fn should_not_be_able_to_call_metadata_methods_on_child_object(globalized_parent
 
                     let _ = api.call_module_method(
                         &child.unwrap().0,
-                        ModuleId::Metadata,
+                        AttachedModuleId::Metadata,
                         METADATA_SET_IDENT,
                         scrypto_encode(&MetadataSetInput {
                             key: "key".to_string(),
@@ -268,7 +274,9 @@ fn should_not_be_able_to_call_metadata_methods_on_child_object(globalized_parent
     receipt.expect_specific_failure(|e| {
         matches!(
             e,
-            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(ModuleId::Metadata))
+            RuntimeError::SystemError(SystemError::ObjectModuleDoesNotExist(
+                AttachedModuleId::Metadata
+            ))
         )
     });
 }

--- a/radix-engine/src/blueprints/access_controller/blueprint.rs
+++ b/radix-engine/src/blueprints/access_controller/blueprint.rs
@@ -17,7 +17,7 @@ use radix_engine_interface::api::node_modules::auth::RoleDefinition;
 use radix_engine_interface::api::node_modules::auth::ToRoleEntry;
 use radix_engine_interface::api::node_modules::metadata::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
-use radix_engine_interface::api::object_api::ObjectModuleId;
+use radix_engine_interface::api::object_api::ModuleId;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::package::{
     AuthConfig, BlueprintDefinitionInit, BlueprintType, FunctionAuth, MethodAuthTemplate,
@@ -602,7 +602,7 @@ impl AccessControllerBlueprint {
         )?;
 
         let roles = init_roles_from_rule_set(input.rule_set);
-        let roles = indexmap!(ObjectModuleId::Main => roles);
+        let roles = indexmap!(ModuleId::Main => roles);
         let role_assignment = RoleAssignment::create(OwnerRole::None, roles, api)?.0;
 
         let metadata = Metadata::create_with_data(
@@ -617,9 +617,9 @@ impl AccessControllerBlueprint {
         api.globalize(
             object_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
-                ModuleId::Royalty => royalty.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
+                AttachedModuleId::Royalty => royalty.0,
             ),
             Some(address_reservation),
         )?;
@@ -1232,19 +1232,19 @@ where
 {
     let attached = AttachedRoleAssignment(receiver.clone());
     attached.set_role(
-        ObjectModuleId::Main,
+        ModuleId::Main,
         RoleKey::new("primary"),
         rule_set.primary_role.clone(),
         api,
     )?;
     attached.set_role(
-        ObjectModuleId::Main,
+        ModuleId::Main,
         RoleKey::new("recovery"),
         rule_set.recovery_role.clone(),
         api,
     )?;
     attached.set_role(
-        ObjectModuleId::Main,
+        ModuleId::Main,
         RoleKey::new("confirmation"),
         rule_set.confirmation_role.clone(),
         api,

--- a/radix-engine/src/blueprints/account/blueprint.rs
+++ b/radix-engine/src/blueprints/account/blueprint.rs
@@ -14,7 +14,7 @@ use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_interface::api::node_modules::metadata::*;
 use radix_engine_interface::api::FieldValue;
-use radix_engine_interface::api::{ClientApi, GenericArgs, ModuleId, ACTOR_STATE_SELF};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi, GenericArgs, ACTOR_STATE_SELF};
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::resource::{Bucket, Proof};
 use radix_engine_interface::hooks::OnVirtualizeInput;
@@ -561,7 +561,7 @@ impl AccountBlueprint {
         role_assignment: RoleAssignment,
         metadata_init: MetadataInit,
         api: &mut Y,
-    ) -> Result<IndexMap<ModuleId, Own>, RuntimeError>
+    ) -> Result<IndexMap<AttachedModuleId, Own>, RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
@@ -569,8 +569,8 @@ impl AccountBlueprint {
 
         // No component royalties
         let modules = indexmap!(
-            ModuleId::RoleAssignment => role_assignment.0,
-            ModuleId::Metadata => metadata,
+            AttachedModuleId::RoleAssignment => role_assignment.0,
+            AttachedModuleId::Metadata => metadata,
         );
 
         Ok(modules)

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -15,9 +15,9 @@ use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::api::node_modules::auth::RoleDefinition;
 use radix_engine_interface::api::node_modules::auth::ToRoleEntry;
 use radix_engine_interface::api::node_modules::metadata::UncheckedUrl;
-use radix_engine_interface::api::object_api::ObjectModuleId;
+use radix_engine_interface::api::object_api::ModuleId;
 use radix_engine_interface::api::{
-    ClientApi, CollectionIndex, FieldValue, ModuleId, ACTOR_STATE_SELF,
+    AttachedModuleId, ClientApi, CollectionIndex, FieldValue, ACTOR_STATE_SELF,
 };
 use radix_engine_interface::blueprints::consensus_manager::*;
 use radix_engine_interface::blueprints::package::BlueprintDefinitionInit;
@@ -601,7 +601,7 @@ impl ConsensusManagerBlueprint {
             VALIDATOR_ROLE => rule!(require(AuthAddresses::validator_role()));
         };
 
-        let roles = indexmap!(ObjectModuleId::Main => role_definitions);
+        let roles = indexmap!(ModuleId::Main => role_definitions);
         let role_assignment = RoleAssignment::create(OwnerRole::None, roles, api)?.0;
         let metadata = Metadata::create_with_data(
             metadata_init! {
@@ -614,8 +614,8 @@ impl ConsensusManagerBlueprint {
         api.globalize(
             consensus_manager_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
             ),
             Some(consensus_manager_address_reservation),
         )?;

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -15,7 +15,8 @@ use radix_engine_interface::api::node_modules::auth::RoleDefinition;
 use radix_engine_interface::api::node_modules::auth::ToRoleEntry;
 use radix_engine_interface::api::node_modules::metadata::UncheckedUrl;
 use radix_engine_interface::api::{
-    ClientApi, FieldValue, ModuleId, ACTOR_REF_GLOBAL, ACTOR_STATE_OUTER_OBJECT, ACTOR_STATE_SELF,
+    AttachedModuleId, ClientApi, FieldValue, ACTOR_REF_GLOBAL, ACTOR_STATE_OUTER_OBJECT,
+    ACTOR_STATE_SELF,
 };
 use radix_engine_interface::blueprints::consensus_manager::*;
 use radix_engine_interface::blueprints::package::{
@@ -1847,8 +1848,8 @@ impl ValidatorCreator {
         api.globalize(
             validator_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0.0,
-                ModuleId::Metadata => metadata.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0.0,
+                AttachedModuleId::Metadata => metadata.0,
             ),
             Some(address_reservation),
         )?;

--- a/radix-engine/src/blueprints/identity/package.rs
+++ b/radix-engine/src/blueprints/identity/package.rs
@@ -7,7 +7,7 @@ use native_sdk::modules::role_assignment::RoleAssignment;
 use native_sdk::modules::royalty::ComponentRoyalty;
 use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::node_modules::metadata::*;
-use radix_engine_interface::api::{ClientApi, ModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi};
 use radix_engine_interface::blueprints::identity::*;
 use radix_engine_interface::blueprints::package::{
     AuthConfig, BlueprintDefinitionInit, BlueprintType, FunctionAuth, MethodAuthTemplate,
@@ -331,7 +331,7 @@ impl IdentityBlueprint {
         role_assignment: RoleAssignment,
         metadata_init: MetadataInit,
         api: &mut Y,
-    ) -> Result<(NodeId, IndexMap<ModuleId, Own>), RuntimeError>
+    ) -> Result<(NodeId, IndexMap<AttachedModuleId, Own>), RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {
@@ -341,9 +341,9 @@ impl IdentityBlueprint {
         let object_id = api.new_simple_object(IDENTITY_BLUEPRINT, indexmap!())?;
 
         let modules = indexmap!(
-            ModuleId::RoleAssignment => role_assignment.0,
-            ModuleId::Metadata => metadata,
-            ModuleId::Royalty => royalty,
+            AttachedModuleId::RoleAssignment => role_assignment.0,
+            AttachedModuleId::Metadata => metadata,
+            AttachedModuleId::Royalty => royalty,
         );
 
         Ok((object_id, modules))

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -710,8 +710,8 @@ pub fn create_bootstrap_package_partitions(
                 },
                 object_type: ObjectType::Global {
                     modules: indexmap!(
-                        ModuleId::Metadata => BlueprintVersion::default(),
-                        ModuleId::RoleAssignment => BlueprintVersion::default(),
+                        AttachedModuleId::Metadata => BlueprintVersion::default(),
+                        AttachedModuleId::RoleAssignment => BlueprintVersion::default(),
                     ),
                 },
             })),
@@ -747,8 +747,8 @@ where
     let address = api.globalize(
         package_object,
         indexmap!(
-            ModuleId::Metadata => metadata.0,
-            ModuleId::RoleAssignment => role_assignment.0.0,
+            AttachedModuleId::Metadata => metadata.0,
+            AttachedModuleId::RoleAssignment => role_assignment.0.0,
         ),
         package_address_reservation,
     )?;

--- a/radix-engine/src/blueprints/pool/multi_resource_pool/blueprint.rs
+++ b/radix-engine/src/blueprints/pool/multi_resource_pool/blueprint.rs
@@ -289,7 +289,7 @@ impl MultiResourcePoolBlueprint {
         let role_assignment = RoleAssignment::create(
             owner_role,
             indexmap! {
-                ObjectModuleId::Main => roles_init! {
+                ModuleId::Main => roles_init! {
                     RoleKey { key: POOL_MANAGER_ROLE.to_owned() } => pool_manager_rule;
                 }
             },
@@ -326,9 +326,9 @@ impl MultiResourcePoolBlueprint {
         api.globalize(
             object_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
-                ModuleId::Royalty => royalty.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
+                AttachedModuleId::Royalty => royalty.0,
             ),
             Some(address_reservation),
         )?;

--- a/radix-engine/src/blueprints/pool/one_resource_pool/blueprint.rs
+++ b/radix-engine/src/blueprints/pool/one_resource_pool/blueprint.rs
@@ -273,7 +273,7 @@ impl OneResourcePoolBlueprint {
         let role_assignment = RoleAssignment::create(
             owner_role,
             indexmap! {
-                ObjectModuleId::Main => roles_init! {
+                ModuleId::Main => roles_init! {
                     RoleKey { key: POOL_MANAGER_ROLE.to_owned() } => pool_manager_rule;
                 }
             },
@@ -306,9 +306,9 @@ impl OneResourcePoolBlueprint {
         api.globalize(
             object_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
-                ModuleId::Royalty => royalty.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
+                AttachedModuleId::Royalty => royalty.0,
             ),
             Some(address_reservation),
         )?;

--- a/radix-engine/src/blueprints/pool/two_resource_pool/blueprint.rs
+++ b/radix-engine/src/blueprints/pool/two_resource_pool/blueprint.rs
@@ -287,7 +287,7 @@ impl TwoResourcePoolBlueprint {
         let role_assignment = RoleAssignment::create(
             owner_role,
             indexmap! {
-                ObjectModuleId::Main => roles_init! {
+                ModuleId::Main => roles_init! {
                     RoleKey { key: POOL_MANAGER_ROLE.to_owned() } => pool_manager_rule;
                 }
             },
@@ -326,9 +326,9 @@ impl TwoResourcePoolBlueprint {
         api.globalize(
             object_id,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
-                ModuleId::Royalty => royalty.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
+                AttachedModuleId::Royalty => royalty.0,
             ),
             Some(address_reservation),
         )?;

--- a/radix-engine/src/blueprints/resource/resource_manager_common.rs
+++ b/radix-engine/src/blueprints/resource/resource_manager_common.rs
@@ -4,8 +4,8 @@ use native_sdk::modules::metadata::Metadata;
 use native_sdk::modules::role_assignment::RoleAssignment;
 use radix_engine_interface::api::node_modules::metadata::MetadataInit;
 use radix_engine_interface::api::node_modules::ModuleConfig;
-use radix_engine_interface::api::object_api::ObjectModuleId;
-use radix_engine_interface::api::{ClientApi, FieldValue, ModuleId};
+use radix_engine_interface::api::object_api::ModuleId;
+use radix_engine_interface::api::{AttachedModuleId, ClientApi, FieldValue};
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::*;
 
@@ -23,8 +23,8 @@ where
     Y: ClientApi<RuntimeError>,
 {
     let roles = indexmap!(
-        ObjectModuleId::Main => main_roles,
-        ObjectModuleId::Metadata => metadata.roles,
+        ModuleId::Main => main_roles,
+        ModuleId::Metadata => metadata.roles,
     );
 
     let role_assignment = RoleAssignment::create(owner_role, roles, api)?.0;
@@ -34,8 +34,8 @@ where
     let address = api.globalize(
         object_id,
         indexmap!(
-            ModuleId::RoleAssignment => role_assignment.0,
-            ModuleId::Metadata => metadata.0,
+            AttachedModuleId::RoleAssignment => role_assignment.0,
+            AttachedModuleId::Metadata => metadata.0,
         ),
         Some(resource_address_reservation),
     )?;
@@ -56,15 +56,15 @@ where
     Y: ClientApi<RuntimeError>,
 {
     let roles = indexmap!(
-        ObjectModuleId::Main => main_roles,
-        ObjectModuleId::Metadata => metadata.roles,
+        ModuleId::Main => main_roles,
+        ModuleId::Metadata => metadata.roles,
     );
     let role_assignment = RoleAssignment::create(owner_role, roles, api)?.0;
     let metadata = Metadata::create_with_data(metadata.init, api)?;
 
     let modules = indexmap!(
-        ModuleId::RoleAssignment => role_assignment.0,
-        ModuleId::Metadata => metadata.0,
+        AttachedModuleId::RoleAssignment => role_assignment.0,
+        AttachedModuleId::Metadata => metadata.0,
     );
 
     let (address, bucket_id) = api.globalize_with_address_and_create_inner_object_and_emit_event(
@@ -102,8 +102,8 @@ where
     Y: ClientApi<RuntimeError>,
 {
     let roles = indexmap!(
-        ObjectModuleId::Main => main_roles,
-        ObjectModuleId::Metadata => metadata.roles,
+        ModuleId::Main => main_roles,
+        ModuleId::Metadata => metadata.roles,
     );
     let role_assignment = RoleAssignment::create(owner_role, roles, api)?.0;
 
@@ -112,8 +112,8 @@ where
     let (address, bucket_id) = api.globalize_with_address_and_create_inner_object_and_emit_event(
         object_id,
         indexmap!(
-            ModuleId::RoleAssignment => role_assignment.0,
-            ModuleId::Metadata => metadata.0,
+            AttachedModuleId::RoleAssignment => role_assignment.0,
+            AttachedModuleId::Metadata => metadata.0,
         ),
         resource_address_reservation,
         NON_FUNGIBLE_BUCKET_BLUEPRINT,

--- a/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
+++ b/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
@@ -12,7 +12,7 @@ use native_sdk::resource::NativeFungibleBucket;
 use native_sdk::resource::NativeNonFungibleBucket;
 use native_sdk::resource::{NativeBucket, NativeProof, Worktop};
 use native_sdk::runtime::LocalAuthZone;
-use radix_engine_interface::api::{ClientApi, ModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi};
 use radix_engine_interface::blueprints::package::BlueprintVersion;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::blueprints::transaction_processor::*;
@@ -366,7 +366,7 @@ impl TransactionProcessorBlueprint {
                 } => {
                     let address = processor.resolve_global_address(address)?;
                     handle_call_module_method!(
-                        ModuleId::Royalty,
+                        AttachedModuleId::Royalty,
                         address.as_node_id(),
                         method_name,
                         args,
@@ -382,7 +382,7 @@ impl TransactionProcessorBlueprint {
                 } => {
                     let address = processor.resolve_global_address(address)?;
                     handle_call_module_method!(
-                        ModuleId::Metadata,
+                        AttachedModuleId::Metadata,
                         address.as_node_id(),
                         method_name,
                         args,
@@ -398,7 +398,7 @@ impl TransactionProcessorBlueprint {
                 } => {
                     let address = processor.resolve_global_address(address)?;
                     handle_call_module_method!(
-                        ModuleId::RoleAssignment,
+                        AttachedModuleId::RoleAssignment,
                         address.as_node_id(),
                         method_name,
                         args,

--- a/radix-engine/src/blueprints/transaction_tracker/package.rs
+++ b/radix-engine/src/blueprints/transaction_tracker/package.rs
@@ -4,7 +4,7 @@ use native_sdk::modules::metadata::Metadata;
 use native_sdk::modules::role_assignment::RoleAssignment;
 use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::api::{ClientApi, FieldValue, ModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ClientApi, FieldValue};
 use radix_engine_interface::blueprints::package::{
     AuthConfig, BlueprintDefinitionInit, BlueprintType, FunctionAuth, MethodAuthTemplate,
     PackageDefinition,
@@ -267,8 +267,8 @@ impl TransactionTrackerBlueprint {
         let address = api.globalize(
             intent_store,
             indexmap!(
-                ModuleId::RoleAssignment => role_assignment.0,
-                ModuleId::Metadata => metadata.0,
+                AttachedModuleId::RoleAssignment => role_assignment.0,
+                AttachedModuleId::Metadata => metadata.0,
             ),
             Some(address_reservation),
         )?;

--- a/radix-engine/src/blueprints/util/securify.rs
+++ b/radix-engine/src/blueprints/util/securify.rs
@@ -4,7 +4,7 @@ use native_sdk::modules::role_assignment::{
     AttachedRoleAssignment, RoleAssignment, RoleAssignmentObject,
 };
 use native_sdk::resource::ResourceManager;
-use radix_engine_interface::api::{ClientApi, ObjectModuleId};
+use radix_engine_interface::api::{ClientApi, ModuleId};
 use radix_engine_interface::blueprints::resource::*;
 
 pub trait SecurifiedRoleAssignment {
@@ -20,7 +20,7 @@ pub trait SecurifiedRoleAssignment {
         if let Some(securify_role) = Self::SECURIFY_ROLE {
             roles.define_role(RoleKey::new(securify_role), AccessRule::DenyAll);
         }
-        let roles = indexmap!(ObjectModuleId::Main => roles);
+        let roles = indexmap!(ModuleId::Main => roles);
         let role_assignment = RoleAssignment::create(owner_role, roles, api)?;
         Ok(role_assignment)
     }
@@ -36,7 +36,7 @@ pub trait SecurifiedRoleAssignment {
         if let Some(securify_role) = Self::SECURIFY_ROLE {
             roles.define_role(RoleKey::new(securify_role), AccessRule::DenyAll);
         }
-        let roles = indexmap!(ObjectModuleId::Main => roles);
+        let roles = indexmap!(ModuleId::Main => roles);
         let role_assignment = RoleAssignment::create(OwnerRole::Fixed(owner_role), roles, api)?;
         Ok((role_assignment, bucket))
     }
@@ -77,7 +77,7 @@ pub trait PresecurifiedRoleAssignment: SecurifiedRoleAssignment {
         }
 
         let roles = indexmap!(
-            ObjectModuleId::Main => roles,
+            ModuleId::Main => roles,
         );
 
         let role_assignment = RoleAssignment::create(
@@ -100,7 +100,7 @@ pub trait PresecurifiedRoleAssignment: SecurifiedRoleAssignment {
         let role_assignment = AttachedRoleAssignment(*receiver);
         if let Some(securify_role) = Self::SECURIFY_ROLE {
             role_assignment.set_role(
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 RoleKey::new(securify_role),
                 AccessRule::DenyAll,
                 api,

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -28,8 +28,8 @@ use crate::system::system_type_checker::TypeCheckError;
 use crate::transaction::AbortReason;
 use crate::types::*;
 use crate::vm::wasm::WasmRuntimeError;
-use radix_engine_interface::api::object_api::ObjectModuleId;
-use radix_engine_interface::api::{ActorStateHandle, ModuleId};
+use radix_engine_interface::api::object_api::ModuleId;
+use radix_engine_interface::api::{ActorStateHandle, AttachedModuleId};
 use radix_engine_interface::blueprints::package::{BlueprintPartitionType, CanonicalBlueprintId};
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
@@ -235,11 +235,11 @@ pub enum SystemError {
     ),
     MutatingImmutableSubstate,
     MutatingImmutableFieldSubstate(ActorStateHandle, u8),
-    ObjectModuleDoesNotExist(ModuleId),
+    ObjectModuleDoesNotExist(AttachedModuleId),
     NotAKeyValueWriteLock,
     InvalidLockFlags,
     CannotGlobalize(CannotGlobalizeError),
-    MissingModule(ObjectModuleId),
+    MissingModule(ModuleId),
     InvalidGlobalAddressReservation,
     InvalidChildObjectCreation,
     InvalidModuleType(Box<InvalidModuleType>),

--- a/radix-engine/src/kernel/actor.rs
+++ b/radix-engine/src/kernel/actor.rs
@@ -1,6 +1,6 @@
 use crate::kernel::kernel_callback_api::CallFrameReferences;
 use crate::types::*;
-use radix_engine_interface::api::{ModuleId, ObjectModuleId};
+use radix_engine_interface::api::{AttachedModuleId, ModuleId};
 use radix_engine_interface::blueprints::resource::AUTH_ZONE_BLUEPRINT;
 use radix_engine_interface::blueprints::transaction_processor::TRANSACTION_PROCESSOR_BLUEPRINT;
 
@@ -13,14 +13,14 @@ pub struct InstanceContext {
 pub enum MethodType {
     Main,
     Direct,
-    Module(ModuleId),
+    Module(AttachedModuleId),
 }
 
 impl MethodType {
-    pub fn module_id(&self) -> ObjectModuleId {
+    pub fn module_id(&self) -> ModuleId {
         match self {
             MethodType::Module(module_id) => module_id.clone().into(),
-            MethodType::Main | MethodType::Direct => ObjectModuleId::Main,
+            MethodType::Main | MethodType::Direct => ModuleId::Main,
         }
     }
 }
@@ -194,7 +194,7 @@ impl Actor {
         }
     }
 
-    pub fn get_object_id(&self) -> Option<(NodeId, Option<ModuleId>)> {
+    pub fn get_object_id(&self) -> Option<(NodeId, Option<AttachedModuleId>)> {
         match self {
             Actor::Method(method_actor) => Some((
                 method_actor.node_id,

--- a/radix-engine/src/system/checkers/resource_event_checker.rs
+++ b/radix-engine/src/system/checkers/resource_event_checker.rs
@@ -7,7 +7,7 @@ use radix_engine_common::constants::RESOURCE_PACKAGE;
 use radix_engine_common::math::{CheckedAdd, CheckedSub, Decimal};
 use radix_engine_common::prelude::{scrypto_decode, ResourceAddress};
 use radix_engine_common::types::NodeId;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::{
     FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT, FUNGIBLE_VAULT_BLUEPRINT,
     NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT, NON_FUNGIBLE_VAULT_BLUEPRINT,
@@ -45,7 +45,7 @@ impl ApplicationEventChecker for ResourceEventChecker {
 
         match info.blueprint_id.blueprint_name.as_str() {
             FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT => match event_id {
-                EventTypeIdentifier(Emitter::Method(node_id, ObjectModuleId::Main), event_name) => {
+                EventTypeIdentifier(Emitter::Method(node_id, ModuleId::Main), event_name) => {
                     let address = ResourceAddress::new_or_panic(node_id.0);
                     match event_name.as_str() {
                         MintFungibleResourceEvent::EVENT_NAME => {
@@ -70,7 +70,7 @@ impl ApplicationEventChecker for ResourceEventChecker {
                 _ => {}
             },
             NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT => match event_id {
-                EventTypeIdentifier(Emitter::Method(node_id, ObjectModuleId::Main), event_name) => {
+                EventTypeIdentifier(Emitter::Method(node_id, ModuleId::Main), event_name) => {
                     let address = ResourceAddress::new_or_panic(node_id.0);
                     match event_name.as_str() {
                         MintNonFungibleResourceEvent::EVENT_NAME => {
@@ -97,7 +97,7 @@ impl ApplicationEventChecker for ResourceEventChecker {
                 _ => {}
             },
             FUNGIBLE_VAULT_BLUEPRINT => match event_id {
-                EventTypeIdentifier(Emitter::Method(node_id, ObjectModuleId::Main), event_name) => {
+                EventTypeIdentifier(Emitter::Method(node_id, ModuleId::Main), event_name) => {
                     match event_name.as_str() {
                         fungible_vault::DepositEvent::EVENT_NAME => {
                             let event: fungible_vault::DepositEvent =
@@ -138,7 +138,7 @@ impl ApplicationEventChecker for ResourceEventChecker {
                 _ => {}
             },
             NON_FUNGIBLE_VAULT_BLUEPRINT => match event_id {
-                EventTypeIdentifier(Emitter::Method(node_id, ObjectModuleId::Main), event_name) => {
+                EventTypeIdentifier(Emitter::Method(node_id, ModuleId::Main), event_name) => {
                     match event_name.as_str() {
                         non_fungible_vault::DepositEvent::EVENT_NAME => {
                             let event: non_fungible_vault::DepositEvent =

--- a/radix-engine/src/system/checkers/system_db_checker.rs
+++ b/radix-engine/src/system/checkers/system_db_checker.rs
@@ -8,7 +8,7 @@ use crate::types::Condition;
 use radix_engine_common::prelude::{
     scrypto_decode, scrypto_encode, Hash, ScryptoValue, VersionedScryptoSchema,
 };
-use radix_engine_interface::api::{FieldIndex, ObjectModuleId};
+use radix_engine_interface::api::{FieldIndex, ModuleId};
 use radix_engine_interface::blueprints::package::{
     BlueprintDefinition, BlueprintPayloadIdentifier, BlueprintType, KeyOrValue,
 };
@@ -28,7 +28,7 @@ pub enum SystemNodeType {
     Object {
         object_info: ObjectInfo,
         bp_definition: BlueprintDefinition,
-        expected_fields: BTreeSet<(ObjectModuleId, FieldIndex)>,
+        expected_fields: BTreeSet<(ModuleId, FieldIndex)>,
         excluded_fields: BTreeSet<FieldIndex>,
     },
     KeyValueStore,
@@ -310,7 +310,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                     for (field_index, field_schema) in fields.iter().enumerate() {
                         match &field_schema.condition {
                             Condition::Always => {
-                                expected_fields.insert((ObjectModuleId::Main, field_index as u8));
+                                expected_fields.insert((ModuleId::Main, field_index as u8));
                             }
                             Condition::IfFeature(feature) => {
                                 if object_info
@@ -318,8 +318,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .features
                                     .contains(feature.as_str())
                                 {
-                                    expected_fields
-                                        .insert((ObjectModuleId::Main, field_index as u8));
+                                    expected_fields.insert((ModuleId::Main, field_index as u8));
                                 } else {
                                     excluded_fields.insert(field_index as u8);
                                 }
@@ -332,8 +331,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .features
                                     .contains(feature.as_str())
                                 {
-                                    expected_fields
-                                        .insert((ObjectModuleId::Main, field_index as u8));
+                                    expected_fields.insert((ModuleId::Main, field_index as u8));
                                 } else {
                                     excluded_fields.insert(field_index as u8);
                                 }
@@ -353,10 +351,8 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                 for (field_index, field_schema) in fields.iter().enumerate() {
                                     match &field_schema.condition {
                                         Condition::Always => {
-                                            let object_module_id: ObjectModuleId =
-                                                (*module_id).into();
-                                            expected_fields
-                                                .insert((object_module_id, field_index as u8));
+                                            let module_id: ModuleId = (*module_id).into();
+                                            expected_fields.insert((module_id, field_index as u8));
                                         }
                                         _ => {
                                             return Err(SystemNodeCheckError::FoundModuleWithConditionalFields);
@@ -543,7 +539,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                 };
 
                                 expected_fields.remove(&(module_id, field_index));
-                                if module_id.eq(&ObjectModuleId::Main)
+                                if module_id.eq(&ModuleId::Main)
                                     && excluded_fields.contains(&field_index)
                                 {
                                     return Err(
@@ -571,7 +567,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .map_err(|_| SystemPartitionCheckError::InvalidFieldValue)?;
 
                                 match module_id {
-                                    ObjectModuleId::Main => self.application_checker.on_field(
+                                    ModuleId::Main => self.application_checker.on_field(
                                         object_info.blueprint_info.clone(),
                                         node_checker_state.node_id,
                                         field_index,
@@ -656,15 +652,13 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                 };
 
                                 match module_id {
-                                    ObjectModuleId::Main => {
-                                        self.application_checker.on_collection_entry(
-                                            object_info.blueprint_info.clone(),
-                                            node_checker_state.node_id,
-                                            collection_index,
-                                            &key,
-                                            &value,
-                                        )
-                                    }
+                                    ModuleId::Main => self.application_checker.on_collection_entry(
+                                        object_info.blueprint_info.clone(),
+                                        node_checker_state.node_id,
+                                        collection_index,
+                                        &key,
+                                        &value,
+                                    ),
                                     _ => {}
                                 }
 
@@ -732,7 +726,7 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                             .map_err(|_| SystemPartitionCheckError::InvalidKeyValueCollectionValue)?;
 
                                         match module_id {
-                                            ObjectModuleId::Main => {
+                                            ModuleId::Main => {
                                                 self.application_checker.on_collection_entry(
                                                     object_info.blueprint_info.clone(),
                                                     node_checker_state.node_id,
@@ -816,15 +810,13 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                 };
 
                                 match module_id {
-                                    ObjectModuleId::Main => {
-                                        self.application_checker.on_collection_entry(
-                                            object_info.blueprint_info.clone(),
-                                            node_checker_state.node_id,
-                                            collection_index,
-                                            &key,
-                                            &value,
-                                        )
-                                    }
+                                    ModuleId::Main => self.application_checker.on_collection_entry(
+                                        object_info.blueprint_info.clone(),
+                                        node_checker_state.node_id,
+                                        collection_index,
+                                        &key,
+                                        &value,
+                                    ),
                                     _ => {}
                                 }
 

--- a/radix-engine/src/system/node_modules/role_assignment/package.rs
+++ b/radix-engine/src/system/node_modules/role_assignment/package.rs
@@ -14,7 +14,7 @@ use native_sdk::runtime::Runtime;
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_interface::api::node_modules::auth::*;
 use radix_engine_interface::api::{
-    ClientApi, FieldValue, GenericArgs, KVEntry, ObjectModuleId, ACTOR_STATE_SELF,
+    ClientApi, FieldValue, GenericArgs, KVEntry, ModuleId, ACTOR_STATE_SELF,
 };
 use radix_engine_interface::blueprints::package::{
     AuthConfig, BlueprintDefinitionInit, BlueprintType, BlueprintVersionKey, FunctionAuth,
@@ -357,7 +357,7 @@ impl RoleAssignmentNativePackage {
         V: SystemCallbackObject,
     >(
         receiver: &NodeId,
-        module: ObjectModuleId,
+        module: ModuleId,
         role_key: &RoleKey,
         api: &mut SystemService<Y, V>,
     ) -> Result<RoleList, RuntimeError> {
@@ -390,7 +390,7 @@ impl RoleAssignmentNativePackage {
 
     pub fn init_system_struct(
         owner_role: OwnerRoleEntry,
-        roles: IndexMap<ObjectModuleId, RoleAssignmentInit>,
+        roles: IndexMap<ModuleId, RoleAssignmentInit>,
     ) -> Result<
         (
             IndexMap<u8, FieldValue>,
@@ -398,7 +398,7 @@ impl RoleAssignmentNativePackage {
         ),
         RoleAssignmentError,
     > {
-        if roles.contains_key(&ObjectModuleId::RoleAssignment) {
+        if roles.contains_key(&ModuleId::RoleAssignment) {
             return Err(RoleAssignmentError::UsedReservedSpace);
         }
 
@@ -464,7 +464,7 @@ impl RoleAssignmentNativePackage {
 
     pub(crate) fn create<Y>(
         owner_role: OwnerRoleEntry,
-        roles: IndexMap<ObjectModuleId, RoleAssignmentInit>,
+        roles: IndexMap<ModuleId, RoleAssignmentInit>,
         api: &mut Y,
     ) -> Result<Own, RuntimeError>
     where
@@ -532,7 +532,7 @@ impl RoleAssignmentNativePackage {
     }
 
     fn set_role<Y>(
-        module: ObjectModuleId,
+        module: ModuleId,
         role_key: RoleKey,
         rule: AccessRule,
         api: &mut Y,
@@ -541,7 +541,7 @@ impl RoleAssignmentNativePackage {
         Y: ClientApi<RuntimeError>,
     {
         if Self::is_reserved_role_key(&role_key) {
-            if !module.eq(&ObjectModuleId::RoleAssignment) {
+            if !module.eq(&ModuleId::RoleAssignment) {
                 return Err(RuntimeError::ApplicationError(
                     ApplicationError::RoleAssignmentError(RoleAssignmentError::UsedReservedRole(
                         role_key.key.to_string(),
@@ -587,7 +587,7 @@ impl RoleAssignmentNativePackage {
     }
 
     pub(crate) fn get_role<Y>(
-        module: ObjectModuleId,
+        module: ModuleId,
         role_key: RoleKey,
         api: &mut Y,
     ) -> Result<Option<AccessRule>, RuntimeError>

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -35,7 +35,7 @@ use radix_engine_interface::api::key_value_entry_api::{
 use radix_engine_interface::api::key_value_store_api::{
     ClientKeyValueStoreApi, KeyValueStoreDataSchema,
 };
-use radix_engine_interface::api::object_api::ObjectModuleId;
+use radix_engine_interface::api::object_api::ModuleId;
 use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::blueprints::resource::*;
@@ -94,7 +94,7 @@ impl TryFrom<ActorRefHandle> for ActorObjectRef {
 
 enum EmitterActor {
     CurrentActor,
-    AsObject(NodeId, Option<ModuleId>),
+    AsObject(NodeId, Option<AttachedModuleId>),
 }
 
 impl<'a, Y, V> SystemService<'a, Y, V>
@@ -637,7 +637,7 @@ where
     pub fn get_blueprint_info(
         &mut self,
         node_id: &NodeId,
-        module_id: Option<ModuleId>,
+        module_id: Option<AttachedModuleId>,
     ) -> Result<BlueprintInfo, RuntimeError> {
         let info = match module_id {
             None => self.get_object_info(node_id)?.blueprint_info,
@@ -693,7 +693,7 @@ where
     fn get_actor_object_id(
         &mut self,
         actor_object_type: ActorStateRef,
-    ) -> Result<(NodeId, Option<ModuleId>), RuntimeError> {
+    ) -> Result<(NodeId, Option<AttachedModuleId>), RuntimeError> {
         let actor = self.current_actor()?;
         let object_id = actor
             .get_object_id()
@@ -762,7 +762,7 @@ where
                     let base = match module_id {
                         None => MAIN_BASE_PARTITION,
                         Some(module_id) => {
-                            let object_module: ObjectModuleId = module_id.into();
+                            let object_module: ModuleId = module_id.into();
                             object_module.base_partition_num()
                         }
                     };
@@ -777,7 +777,15 @@ where
     fn get_actor_info(
         &mut self,
         actor_object_type: ActorStateRef,
-    ) -> Result<(NodeId, Option<ModuleId>, BlueprintInterface, BlueprintInfo), RuntimeError> {
+    ) -> Result<
+        (
+            NodeId,
+            Option<AttachedModuleId>,
+            BlueprintInterface,
+            BlueprintInfo,
+        ),
+        RuntimeError,
+    > {
         let (node_id, module_id) = self.get_actor_object_id(actor_object_type)?;
         let blueprint_info = self.get_blueprint_info(&node_id, module_id)?;
         let blueprint_interface =
@@ -834,7 +842,7 @@ where
                 let base = match module_id {
                     None => MAIN_BASE_PARTITION,
                     Some(module_id) => {
-                        let object_module: ObjectModuleId = module_id.into();
+                        let object_module: ModuleId = module_id.into();
                         object_module.base_partition_num()
                     }
                 };
@@ -851,7 +859,7 @@ where
     fn globalize_with_address_internal(
         &mut self,
         node_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         global_address_reservation: GlobalAddressReservation,
     ) -> Result<GlobalAddress, RuntimeError> {
         // Check global address reservation
@@ -907,14 +915,14 @@ where
         }
 
         // Check for required modules
-        if !modules.contains_key(&ModuleId::RoleAssignment) {
+        if !modules.contains_key(&AttachedModuleId::RoleAssignment) {
             return Err(RuntimeError::SystemError(SystemError::MissingModule(
-                ObjectModuleId::RoleAssignment,
+                ModuleId::RoleAssignment,
             )));
         }
-        if !modules.contains_key(&ModuleId::Metadata) {
+        if !modules.contains_key(&AttachedModuleId::Metadata) {
             return Err(RuntimeError::SystemError(SystemError::MissingModule(
-                ObjectModuleId::Metadata,
+                ModuleId::Metadata,
             )));
         }
 
@@ -923,8 +931,8 @@ where
             .system
             .modules
             .add_replacement(
-                (node_id, ObjectModuleId::Main),
-                (*global_address.as_node_id(), ObjectModuleId::Main),
+                (node_id, ModuleId::Main),
+                (*global_address.as_node_id(), ModuleId::Main),
             );
 
         // Read the type info
@@ -999,7 +1007,9 @@ where
         // Move other modules, and drop
         for (module_id, node_id) in modules {
             match module_id {
-                ModuleId::RoleAssignment | ModuleId::Metadata | ModuleId::Royalty => {
+                AttachedModuleId::RoleAssignment
+                | AttachedModuleId::Metadata
+                | AttachedModuleId::Royalty => {
                     let blueprint_id = self.get_object_info(&node_id)?.blueprint_info.blueprint_id;
                     let expected_blueprint = module_id.static_blueprint();
                     if !blueprint_id.eq(&expected_blueprint) {
@@ -1016,7 +1026,7 @@ where
                         .system
                         .modules
                         .add_replacement(
-                            (node_id, ObjectModuleId::Main),
+                            (node_id, ModuleId::Main),
                             (*global_address.as_node_id(), module_id.into()),
                         );
 
@@ -1024,8 +1034,8 @@ where
                     let interface = self.get_blueprint_default_interface(blueprint_id.clone())?;
                     let num_logical_partitions = interface.state.num_logical_partitions();
 
-                    let object_module_id: ObjectModuleId = module_id.into();
-                    let module_base_partition = object_module_id.base_partition_num();
+                    let module_id: ModuleId = module_id.into();
+                    let module_base_partition = module_id.base_partition_num();
                     for offset in 0u8..num_logical_partitions {
                         let src = MAIN_BASE_PARTITION
                             .at_offset(PartitionOffset(offset))
@@ -1071,7 +1081,7 @@ where
     pub fn is_feature_enabled(
         &mut self,
         node_id: &NodeId,
-        module_id: Option<ModuleId>,
+        module_id: Option<AttachedModuleId>,
         feature: &str,
     ) -> Result<bool, RuntimeError> {
         match module_id {
@@ -1259,7 +1269,7 @@ where
     fn globalize(
         &mut self,
         node_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         address_reservation: Option<GlobalAddressReservation>,
     ) -> Result<GlobalAddress, RuntimeError> {
         // TODO: optimize by skipping address allocation
@@ -1282,7 +1292,7 @@ where
     fn globalize_with_address_and_create_inner_object_and_emit_event(
         &mut self,
         node_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         address_reservation: GlobalAddressReservation,
         inner_object_blueprint: &str,
         inner_object_fields: IndexMap<u8, FieldValue>,
@@ -1334,7 +1344,7 @@ where
         let auth_actor_info = SystemModuleMixer::on_call_method(
             self,
             receiver,
-            ObjectModuleId::Main,
+            ModuleId::Main,
             false,
             method_name,
             &args,
@@ -1375,7 +1385,7 @@ where
         let auth_actor_info = SystemModuleMixer::on_call_method(
             self,
             receiver,
-            ObjectModuleId::Main,
+            ModuleId::Main,
             true,
             method_name,
             &args,
@@ -1406,7 +1416,7 @@ where
     fn call_module_method(
         &mut self,
         receiver: &NodeId,
-        module_id: ModuleId,
+        module_id: AttachedModuleId,
         method_name: &str,
         args: Vec<u8>,
     ) -> Result<Vec<u8>, RuntimeError> {

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -3,7 +3,7 @@ use radix_engine_common::prelude::{
     scrypto_decode, scrypto_encode, ScryptoCustomExtension, ScryptoEncode, ScryptoValue,
     VersionedScryptoSchema,
 };
-use radix_engine_interface::api::{CollectionIndex, ModuleId, ObjectModuleId};
+use radix_engine_interface::api::{AttachedModuleId, CollectionIndex, ModuleId};
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::types::*;
 use radix_engine_interface::*;
@@ -40,7 +40,7 @@ use crate::types::BlueprintCollectionSchema;
 pub enum SystemPartitionDescription {
     TypeInfo,
     Schema,
-    Module(ObjectModuleId, PartitionOffset),
+    Module(ModuleId, PartitionOffset),
 }
 
 #[derive(Clone, Debug)]
@@ -56,7 +56,7 @@ pub enum SystemPartitionDescriptor {
     TypeInfo,
     Schema,
     KeyValueStore,
-    Object(ObjectModuleId, ObjectPartitionDescriptor),
+    Object(ModuleId, ObjectPartitionDescriptor),
 }
 
 pub struct ResolvedPayloadSchema {
@@ -163,7 +163,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn read_object_field(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         field_index: u8,
     ) -> Result<IndexedScryptoValue, SystemReaderError> {
         self.read_object_field_advanced(node_id, module_id, field_index)
@@ -173,7 +173,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn read_object_field_advanced(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         field_index: u8,
     ) -> Result<(IndexedScryptoValue, PartitionNumber), SystemReaderError> {
         let blueprint_id = self.get_blueprint_id(node_id, module_id)?;
@@ -187,10 +187,10 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         let partition_number = match partition_description {
             PartitionDescription::Logical(offset) => {
                 let base_partition = match module_id {
-                    ObjectModuleId::Main => MAIN_BASE_PARTITION,
-                    ObjectModuleId::Metadata => METADATA_BASE_PARTITION,
-                    ObjectModuleId::Royalty => ROYALTY_BASE_PARTITION,
-                    ObjectModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
+                    ModuleId::Main => MAIN_BASE_PARTITION,
+                    ModuleId::Metadata => METADATA_BASE_PARTITION,
+                    ModuleId::Royalty => ROYALTY_BASE_PARTITION,
+                    ModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
                 };
                 base_partition.at_offset(*offset).unwrap()
             }
@@ -230,7 +230,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn read_typed_object_field<V: ScryptoDecode>(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         field_index: u8,
     ) -> Result<V, SystemReaderError> {
         let blueprint_id = self.get_blueprint_id(node_id, module_id)?;
@@ -244,10 +244,10 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         let partition_number = match partition_description {
             PartitionDescription::Logical(offset) => {
                 let base_partition = match module_id {
-                    ObjectModuleId::Main => MAIN_BASE_PARTITION,
-                    ObjectModuleId::Metadata => METADATA_BASE_PARTITION,
-                    ObjectModuleId::Royalty => ROYALTY_BASE_PARTITION,
-                    ObjectModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
+                    ModuleId::Main => MAIN_BASE_PARTITION,
+                    ModuleId::Metadata => METADATA_BASE_PARTITION,
+                    ModuleId::Royalty => ROYALTY_BASE_PARTITION,
+                    ModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
                 };
                 base_partition.at_offset(*offset).unwrap()
             }
@@ -269,7 +269,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn read_object_collection_entry<K: ScryptoEncode, V: ScryptoDecode>(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         collection_key: ObjectCollectionKey<K>,
     ) -> Result<Option<V>, SystemReaderError> {
         let blueprint_id = self.get_blueprint_id(node_id, module_id)?;
@@ -285,10 +285,10 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         let partition_number = match partition_description {
             PartitionDescription::Logical(offset) => {
                 let base_partition = match module_id {
-                    ObjectModuleId::Main => MAIN_BASE_PARTITION,
-                    ObjectModuleId::Metadata => METADATA_BASE_PARTITION,
-                    ObjectModuleId::Royalty => ROYALTY_BASE_PARTITION,
-                    ObjectModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
+                    ModuleId::Main => MAIN_BASE_PARTITION,
+                    ModuleId::Metadata => METADATA_BASE_PARTITION,
+                    ModuleId::Royalty => ROYALTY_BASE_PARTITION,
+                    ModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
                 };
                 base_partition.at_offset(*offset).unwrap()
             }
@@ -361,7 +361,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn collection_iter(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         collection_index: CollectionIndex,
     ) -> Result<Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>, SystemReaderError> {
         self.collection_iter_advanced(node_id, module_id, collection_index)
@@ -371,7 +371,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn collection_iter_advanced(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         collection_index: CollectionIndex,
     ) -> Result<
         (
@@ -455,7 +455,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn get_blueprint_id(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
     ) -> Result<BlueprintId, SystemReaderError> {
         let type_info = self
             .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
@@ -472,7 +472,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
             }
         };
 
-        let module_id: Option<ModuleId> = module_id.into();
+        let module_id: Option<AttachedModuleId> = module_id.into();
         if let Some(module_id) = module_id {
             match object_info.object_type {
                 ObjectType::Global { modules } => {
@@ -532,7 +532,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
     pub fn get_blueprint_type_target(
         &self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
     ) -> Result<BlueprintTypeTarget, SystemReaderError> {
         let type_info = self
             .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
@@ -547,7 +547,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
             _ => return Err(SystemReaderError::NotAnObject),
         };
 
-        let module_id: Option<ModuleId> = module_id.into();
+        let module_id: Option<AttachedModuleId> = module_id.into();
         let target = if let Some(module_id) = module_id {
             let blueprint_id = module_id.static_blueprint();
             match object_info.object_type {
@@ -912,46 +912,46 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
             TypeInfoSubstate::Object(object_info) => {
                 let (module_id, partition_offset) = if partition_num.ge(&MAIN_BASE_PARTITION) {
                     let partition_offset = PartitionOffset(partition_num.0 - MAIN_BASE_PARTITION.0);
-                    (ObjectModuleId::Main, Some(partition_offset))
+                    (ModuleId::Main, Some(partition_offset))
                 } else {
                     match object_info.object_type {
                         ObjectType::Global { modules } => {
                             if partition_num.ge(&ROLE_ASSIGNMENT_BASE_PARTITION) {
-                                if modules.contains_key(&ModuleId::RoleAssignment) {
+                                if modules.contains_key(&AttachedModuleId::RoleAssignment) {
                                     let partition_offset = PartitionOffset(
                                         partition_num.0 - ROLE_ASSIGNMENT_BASE_PARTITION.0,
                                     );
-                                    (ObjectModuleId::RoleAssignment, Some(partition_offset))
+                                    (ModuleId::RoleAssignment, Some(partition_offset))
                                 } else {
-                                    (ObjectModuleId::Main, None)
+                                    (ModuleId::Main, None)
                                 }
                             } else if partition_num.ge(&ROYALTY_BASE_PARTITION) {
-                                if modules.contains_key(&ModuleId::Royalty) {
+                                if modules.contains_key(&AttachedModuleId::Royalty) {
                                     let partition_offset =
                                         PartitionOffset(partition_num.0 - ROYALTY_BASE_PARTITION.0);
-                                    (ObjectModuleId::Royalty, Some(partition_offset))
+                                    (ModuleId::Royalty, Some(partition_offset))
                                 } else {
-                                    (ObjectModuleId::Main, None)
+                                    (ModuleId::Main, None)
                                 }
                             } else if partition_num.ge(&METADATA_BASE_PARTITION) {
-                                if modules.contains_key(&ModuleId::Metadata) {
+                                if modules.contains_key(&AttachedModuleId::Metadata) {
                                     let partition_offset = PartitionOffset(
                                         partition_num.0 - METADATA_BASE_PARTITION.0,
                                     );
-                                    (ObjectModuleId::Metadata, Some(partition_offset))
+                                    (ModuleId::Metadata, Some(partition_offset))
                                 } else {
-                                    (ObjectModuleId::Main, None)
+                                    (ModuleId::Main, None)
                                 }
                             } else {
-                                (ObjectModuleId::Main, None)
+                                (ModuleId::Main, None)
                             }
                         }
-                        ObjectType::Owned => (ObjectModuleId::Main, None),
+                        ObjectType::Owned => (ModuleId::Main, None),
                     }
                 };
 
                 let blueprint_id = match module_id {
-                    ObjectModuleId::Main => object_info.blueprint_info.blueprint_id,
+                    ModuleId::Main => object_info.blueprint_info.blueprint_id,
                     _ => module_id.static_blueprint().unwrap(),
                 };
 
@@ -1111,7 +1111,7 @@ impl<'a, S: SubstateDatabase + CommittableSubstateDatabase> SystemDatabaseWriter
     pub fn write_typed_object_field<V: ScryptoEncode>(
         &mut self,
         node_id: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         field_index: u8,
         value: V,
     ) -> Result<(), SystemReaderError> {
@@ -1127,10 +1127,10 @@ impl<'a, S: SubstateDatabase + CommittableSubstateDatabase> SystemDatabaseWriter
         let partition_number = match partition_description {
             PartitionDescription::Logical(offset) => {
                 let base_partition = match module_id {
-                    ObjectModuleId::Main => MAIN_BASE_PARTITION,
-                    ObjectModuleId::Metadata => METADATA_BASE_PARTITION,
-                    ObjectModuleId::Royalty => ROYALTY_BASE_PARTITION,
-                    ObjectModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
+                    ModuleId::Main => MAIN_BASE_PARTITION,
+                    ModuleId::Metadata => METADATA_BASE_PARTITION,
+                    ModuleId::Royalty => ROYALTY_BASE_PARTITION,
+                    ModuleId::RoleAssignment => ROLE_ASSIGNMENT_BASE_PARTITION,
                 };
                 base_partition.at_offset(*offset).unwrap()
             }

--- a/radix-engine/src/system/system_modules/auth/authorization.rs
+++ b/radix-engine/src/system/system_modules/auth/authorization.rs
@@ -11,7 +11,7 @@ use crate::system::system_substates::FieldSubstate;
 use crate::system::system_substates::KeyValueEntrySubstate;
 use crate::types::*;
 use native_sdk::resource::{NativeNonFungibleProof, NativeProof};
-use radix_engine_interface::api::{ClientObjectApi, LockFlags, ObjectModuleId};
+use radix_engine_interface::api::{ClientObjectApi, LockFlags, ModuleId};
 use radix_engine_interface::blueprints::resource::*;
 use sbor::rust::ops::Fn;
 
@@ -405,7 +405,7 @@ impl Authorization {
     >(
         auth_zone: &NodeId,
         role_assignment_of: &GlobalAddress,
-        module: ObjectModuleId,
+        module: ModuleId,
         role_list: &RoleList,
         api: &mut Y,
     ) -> Result<AuthorityListAuthorizationResult, RuntimeError> {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -17,7 +17,7 @@ use crate::{
     errors::{CanBeAbortion, RuntimeError, SystemModuleError},
     transaction::AbortReason,
 };
-use radix_engine_interface::api::ModuleId;
+use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::blueprints::package::BlueprintVersionKey;
 use radix_engine_interface::blueprints::resource::LiquidFungibleResource;
 use radix_engine_interface::{types::NodeId, *};
@@ -260,7 +260,7 @@ impl<V: SystemCallbackObject> SystemModule<SystemConfig<V>> for CostingModule {
 
                     match &object_info.object_type {
                         ObjectType::Global { modules }
-                            if modules.contains_key(&ModuleId::Royalty) =>
+                            if modules.contains_key(&AttachedModuleId::Royalty) =>
                         {
                             (Some(node_id.clone()), ident)
                         }

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -28,7 +28,7 @@ use crate::transaction::ExecutionConfig;
 use crate::types::*;
 use bitflags::bitflags;
 use paste::paste;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::crypto::Hash;
 use resources_tracker_macro::trace_resources;
 use transaction::model::AuthZoneParams;
@@ -397,7 +397,7 @@ impl SystemModuleMixer {
     pub fn on_call_method<Y, V>(
         api: &mut SystemService<Y, V>,
         receiver: &NodeId,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         direct_access: bool,
         ident: &str,
         args: &IndexedScryptoValue,
@@ -549,11 +549,7 @@ impl SystemModuleMixer {
         Ok(())
     }
 
-    pub fn add_replacement(
-        &mut self,
-        old: (NodeId, ObjectModuleId),
-        new: (NodeId, ObjectModuleId),
-    ) {
+    pub fn add_replacement(&mut self, old: (NodeId, ModuleId), new: (NodeId, ModuleId)) {
         if self
             .enabled_modules
             .contains(EnabledModules::TRANSACTION_RUNTIME)

--- a/radix-engine/src/system/system_modules/transaction_runtime/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_runtime/module.rs
@@ -2,7 +2,7 @@ use crate::kernel::kernel_callback_api::KernelCallbackObject;
 use crate::system::module::SystemModule;
 use crate::types::*;
 use radix_engine_interface::api::actor_api::EventFlags;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::crypto::Hash;
 
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ pub struct TransactionRuntimeModule {
     pub next_id: u32,
     pub logs: Vec<(Level, String)>,
     pub events: Vec<Event>,
-    pub replacements: IndexMap<(NodeId, ObjectModuleId), (NodeId, ObjectModuleId)>,
+    pub replacements: IndexMap<(NodeId, ModuleId), (NodeId, ModuleId)>,
 }
 
 impl TransactionRuntimeModule {
@@ -51,11 +51,7 @@ impl TransactionRuntimeModule {
         self.events.push(event)
     }
 
-    pub fn add_replacement(
-        &mut self,
-        old: (NodeId, ObjectModuleId),
-        new: (NodeId, ObjectModuleId),
-    ) {
+    pub fn add_replacement(&mut self, old: (NodeId, ModuleId), new: (NodeId, ModuleId)) {
         self.replacements.insert(old, new);
     }
 

--- a/radix-engine/src/transaction/system_structure.rs
+++ b/radix-engine/src/transaction/system_structure.rs
@@ -379,7 +379,7 @@ impl<'a, S: SubstateDatabase> EventSchemaMapper<'a, S> {
             let blueprint_id = match &event_type_identifier.0 {
                 Emitter::Function(blueprint_id) => blueprint_id.clone(),
                 Emitter::Method(node_id, module_id) => {
-                    if let ObjectModuleId::Main = module_id {
+                    if let ModuleId::Main = module_id {
                         let main_type_info = self.system_reader.get_type_info(node_id).unwrap();
                         match main_type_info {
                             TypeInfoSubstate::Object(info) => info.blueprint_info.blueprint_id,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -28,7 +28,7 @@ use crate::track::{to_state_updates, Track};
 use crate::transaction::*;
 use crate::types::*;
 use radix_engine_common::constants::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::LiquidFungibleResource;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
 use radix_engine_store_interface::{db_key_mapper::SpreadPrefixKeyMapper, interface::*};
@@ -760,7 +760,7 @@ where
                 .unwrap();
             events.push((
                 EventTypeIdentifier(
-                    Emitter::Method(node_id, ObjectModuleId::Main),
+                    Emitter::Method(node_id, ModuleId::Main),
                     DepositEvent::EVENT_NAME.to_string(),
                 ),
                 scrypto_encode(&DepositEvent { amount }).unwrap(),
@@ -824,7 +824,7 @@ where
 
             events.push((
                 EventTypeIdentifier(
-                    Emitter::Method(vault_id, ObjectModuleId::Main),
+                    Emitter::Method(vault_id, ModuleId::Main),
                     PayFeeEvent::EVENT_NAME.to_string(),
                 ),
                 scrypto_encode(&PayFeeEvent { amount }).unwrap(),
@@ -941,7 +941,7 @@ where
 
             events.push((
                 EventTypeIdentifier(
-                    Emitter::Method(vault_node_id, ObjectModuleId::Main),
+                    Emitter::Method(vault_node_id, ModuleId::Main),
                     DepositEvent::EVENT_NAME.to_string(),
                 ),
                 scrypto_encode(&DepositEvent {
@@ -954,7 +954,7 @@ where
         if to_burn.is_positive() {
             events.push((
                 EventTypeIdentifier(
-                    Emitter::Method(XRD.into_node_id(), ObjectModuleId::Main),
+                    Emitter::Method(XRD.into_node_id(), ModuleId::Main),
                     "BurnFungibleResourceEvent".to_string(),
                 ),
                 scrypto_encode(&BurnFungibleResourceEvent { amount: to_burn }).unwrap(),

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -189,7 +189,7 @@ impl CommitResult {
         // Note: Node should use a well-known index id
         for (ref event_type_id, ref event_data) in self.application_events.iter() {
             let is_consensus_manager = match &event_type_id.0 {
-                Emitter::Method(node_id, ObjectModuleId::Main)
+                Emitter::Method(node_id, ModuleId::Main)
                     if node_id.entity_type() == Some(EntityType::GlobalConsensusManager) =>
                 {
                     true

--- a/radix-engine/src/utils/native_blueprint_call_validator.rs
+++ b/radix-engine/src/utils/native_blueprint_call_validator.rs
@@ -8,7 +8,7 @@ use radix_engine_common::prelude::*;
 use radix_engine_interface::api::node_modules::auth::*;
 use radix_engine_interface::api::node_modules::metadata::*;
 use radix_engine_interface::api::node_modules::royalty::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::consensus_manager::*;
@@ -40,7 +40,7 @@ pub fn validate_call_arguments_to_native_components(
                 method_name,
                 args,
             } => (
-                Invocation::Method(*address, ObjectModuleId::Main, method_name.to_owned()),
+                Invocation::Method(*address, ModuleId::Main, method_name.to_owned()),
                 args,
             ),
             InstructionV1::CallMetadataMethod {
@@ -48,7 +48,7 @@ pub fn validate_call_arguments_to_native_components(
                 method_name,
                 args,
             } => (
-                Invocation::Method(*address, ObjectModuleId::Metadata, method_name.to_owned()),
+                Invocation::Method(*address, ModuleId::Metadata, method_name.to_owned()),
                 args,
             ),
             InstructionV1::CallRoyaltyMethod {
@@ -56,7 +56,7 @@ pub fn validate_call_arguments_to_native_components(
                 method_name,
                 args,
             } => (
-                Invocation::Method(*address, ObjectModuleId::Royalty, method_name.to_owned()),
+                Invocation::Method(*address, ModuleId::Royalty, method_name.to_owned()),
                 args,
             ),
             InstructionV1::CallRoleAssignmentMethod {
@@ -64,11 +64,7 @@ pub fn validate_call_arguments_to_native_components(
                 method_name,
                 args,
             } => (
-                Invocation::Method(
-                    *address,
-                    ObjectModuleId::RoleAssignment,
-                    method_name.to_owned(),
-                ),
+                Invocation::Method(*address, ModuleId::RoleAssignment, method_name.to_owned()),
                 args,
             ),
             InstructionV1::CallDirectVaultMethod {
@@ -197,7 +193,7 @@ fn get_arguments_schema<'s>(
         )
         .map(Some)?,
         Invocation::Function(..) => None,
-        Invocation::Method(_, ObjectModuleId::Main, _) | Invocation::DirectMethod(..) => {
+        Invocation::Method(_, ModuleId::Main, _) | Invocation::DirectMethod(..) => {
             match entity_type {
                 EntityType::GlobalPackage => {
                     PACKAGE_PACKAGE_DEFINITION.blueprints.get(PACKAGE_BLUEPRINT)
@@ -258,15 +254,13 @@ fn get_arguments_schema<'s>(
                 | EntityType::InternalKeyValueStore => None,
             }
         }
-        Invocation::Method(_, ObjectModuleId::Metadata, _) => METADATA_PACKAGE_DEFINITION
+        Invocation::Method(_, ModuleId::Metadata, _) => METADATA_PACKAGE_DEFINITION
             .blueprints
             .get(METADATA_BLUEPRINT),
-        Invocation::Method(_, ObjectModuleId::RoleAssignment, _) => {
-            ROLE_ASSIGNMENT_PACKAGE_DEFINITION
-                .blueprints
-                .get(ROLE_ASSIGNMENT_BLUEPRINT)
-        }
-        Invocation::Method(_, ObjectModuleId::Royalty, _) => ROYALTY_PACKAGE_DEFINITION
+        Invocation::Method(_, ModuleId::RoleAssignment, _) => ROLE_ASSIGNMENT_PACKAGE_DEFINITION
+            .blueprints
+            .get(ROLE_ASSIGNMENT_BLUEPRINT),
+        Invocation::Method(_, ModuleId::Royalty, _) => ROYALTY_PACKAGE_DEFINITION
             .blueprints
             .get(COMPONENT_ROYALTY_BLUEPRINT),
     };
@@ -329,7 +323,7 @@ fn is_function_receiver(receiver: &Option<ReceiverInfo>) -> bool {
 #[derive(Clone, Debug)]
 enum Invocation {
     DirectMethod(InternalAddress, String),
-    Method(GlobalAddress, ObjectModuleId, String),
+    Method(GlobalAddress, ModuleId, String),
     Function(PackageAddress, String, String),
 }
 

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -122,7 +122,7 @@ pub enum WasmRuntimeError {
     InvalidReferenceType(u32),
 
     /// Invalid RE module ID
-    InvalidModuleId(u32),
+    InvalidAttachedModuleId(u32),
 
     /// Invalid initial app states
     InvalidObjectStates(DecodeError),

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -5,7 +5,7 @@ use crate::vm::wasm::*;
 use radix_engine_interface::api::actor_api::EventFlags;
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_interface::api::key_value_store_api::KeyValueStoreDataSchema;
-use radix_engine_interface::api::{ActorRefHandle, ClientApi, FieldValue, ModuleId};
+use radix_engine_interface::api::{ActorRefHandle, AttachedModuleId, ClientApi, FieldValue};
 use radix_engine_interface::types::ClientCostingEntry;
 use radix_engine_interface::types::Level;
 use sbor::rust::vec::Vec;
@@ -116,8 +116,8 @@ where
         let ident = String::from_utf8(ident).map_err(|_| WasmRuntimeError::InvalidString)?;
         let module_id = u8::try_from(module_id)
             .ok()
-            .and_then(|x| ModuleId::from_repr(x))
-            .ok_or(WasmRuntimeError::InvalidModuleId(module_id))?;
+            .and_then(|x| AttachedModuleId::from_repr(x))
+            .ok_or(WasmRuntimeError::InvalidAttachedModuleId(module_id))?;
 
         let return_data =
             self.api
@@ -226,7 +226,7 @@ where
             TryInto::<[u8; NodeId::LENGTH]>::try_into(node_id.as_ref())
                 .map_err(|_| WasmRuntimeError::InvalidNodeId)?,
         );
-        let modules = scrypto_decode::<IndexMap<ModuleId, NodeId>>(&modules)
+        let modules = scrypto_decode::<IndexMap<AttachedModuleId, NodeId>>(&modules)
             .map_err(WasmRuntimeError::InvalidModules)?;
         let address_reservation =
             scrypto_decode::<Option<GlobalAddressReservation>>(&address_reservation)

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -901,7 +901,7 @@ fn generate_methods_struct(method_idents: Vec<Ident>) -> TokenStream {
             }
 
             impl<T> MethodMapping<T> for Methods<T> {
-                const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
+                const MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                 fn to_mapping(self) -> Vec<(String, T)> {
                     vec![]
@@ -922,7 +922,7 @@ fn generate_methods_struct(method_idents: Vec<Ident>) -> TokenStream {
             }
 
             impl<T> MethodMapping<T> for Methods<T> {
-                const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
+                const MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                 fn to_mapping(self) -> Vec<(String, T)> {
                     vec![
@@ -1686,7 +1686,7 @@ mod tests {
                     }
 
                     impl<T> MethodMapping<T> for Methods<T> {
-                        const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
+                        const MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                         fn to_mapping(self) -> Vec<(String, T)> {
                             vec![

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -901,7 +901,7 @@ fn generate_methods_struct(method_idents: Vec<Ident>) -> TokenStream {
             }
 
             impl<T> MethodMapping<T> for Methods<T> {
-                const MODULE_ID: scrypto::api::ObjectModuleId = scrypto::api::ObjectModuleId::Main;
+                const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                 fn to_mapping(self) -> Vec<(String, T)> {
                     vec![]
@@ -922,7 +922,7 @@ fn generate_methods_struct(method_idents: Vec<Ident>) -> TokenStream {
             }
 
             impl<T> MethodMapping<T> for Methods<T> {
-                const MODULE_ID: scrypto::api::ObjectModuleId = scrypto::api::ObjectModuleId::Main;
+                const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                 fn to_mapping(self) -> Vec<(String, T)> {
                     vec![
@@ -1686,7 +1686,7 @@ mod tests {
                     }
 
                     impl<T> MethodMapping<T> for Methods<T> {
-                        const MODULE_ID: scrypto::api::ObjectModuleId = scrypto::api::ObjectModuleId::Main;
+                        const ATTACHED_MODULE_ID: scrypto::api::ModuleId = scrypto::api::ModuleId::Main;
 
                         fn to_mapping(self) -> Vec<(String, T)> {
                             vec![

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -215,13 +215,13 @@ implement_client_api! {
         globalize: (
             &mut self,
             node_id: NodeId,
-            modules: IndexMap<ModuleId, NodeId>,
+            modules: IndexMap<AttachedModuleId, NodeId>,
             address_reservation: Option<GlobalAddressReservation>,
         ) -> Result<GlobalAddress, RuntimeError>,
         globalize_with_address_and_create_inner_object_and_emit_event: (
             &mut self,
             node_id: NodeId,
-            modules: IndexMap<ModuleId, NodeId>,
+            modules: IndexMap<AttachedModuleId, NodeId>,
             address_reservation: GlobalAddressReservation,
             inner_object_blueprint: &str,
             inner_object_fields: IndexMap<u8, FieldValue>,
@@ -243,7 +243,7 @@ implement_client_api! {
         call_module_method: (
             &mut self,
             receiver: &NodeId,
-            module_id: ModuleId,
+            module_id: AttachedModuleId,
             method_name: &str,
             args: Vec<u8>,
         ) -> Result<Vec<u8>, RuntimeError>,

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -409,7 +409,7 @@ impl TestEnvironment {
     ///
     /// * `node_id`: `T` - The node to invoke the method on. This is a generic argument that's
     /// fulfilled by any type that implements [`Into<NodeId>`], thus, any address type can be used.
-    /// * `module`: [`ModuleId`] - The module id.
+    /// * `module`: [`AttachedModuleId`] - The module id.
     /// * `method_name`: [`&str`] - The name of the method to invoke.
     /// * `args`: `&I` - The arguments to invoke the method with. This is a generic arguments that
     /// is fulfilled by any type that implements [`ScryptoEncode`].
@@ -432,7 +432,7 @@ impl TestEnvironment {
     pub fn call_module_method_typed<N, I, O>(
         &mut self,
         node_id: N,
-        module: ModuleId,
+        module: AttachedModuleId,
         method_name: &str,
         args: &I,
     ) -> Result<O, RuntimeError>
@@ -758,7 +758,7 @@ impl TestEnvironment {
     pub fn set_current_epoch(&mut self, epoch: Epoch) {
         self.as_method_actor(
             CONSENSUS_MANAGER,
-            ObjectModuleId::Main,
+            ModuleId::Main,
             CONSENSUS_MANAGER_NEXT_ROUND_IDENT,
             |env: &mut TestEnvironment| -> Result<(), RuntimeError> {
                 let manager_handle = env
@@ -793,7 +793,7 @@ impl TestEnvironment {
     pub fn set_current_time(&mut self, instant: Instant) {
         self.as_method_actor(
             CONSENSUS_MANAGER,
-            ObjectModuleId::Main,
+            ModuleId::Main,
             CONSENSUS_MANAGER_NEXT_ROUND_IDENT,
             |env: &mut TestEnvironment| -> Result<(), RuntimeError> {
                 let handle = env.actor_open_field(
@@ -830,7 +830,7 @@ impl TestEnvironment {
     pub(crate) fn as_method_actor<N, F, O>(
         &mut self,
         node_id: N,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         method_ident: &str,
         callback: F,
     ) -> Result<O, RuntimeError>
@@ -860,10 +860,10 @@ impl TestEnvironment {
         })?;
         let actor = Actor::Method(MethodActor {
             method_type: match module_id {
-                ObjectModuleId::Main => MethodType::Main,
-                ObjectModuleId::Royalty => MethodType::Module(ModuleId::Royalty),
-                ObjectModuleId::Metadata => MethodType::Module(ModuleId::Metadata),
-                ObjectModuleId::RoleAssignment => MethodType::Module(ModuleId::RoleAssignment),
+                ModuleId::Main => MethodType::Main,
+                ModuleId::Royalty => MethodType::Module(AttachedModuleId::Royalty),
+                ModuleId::Metadata => MethodType::Module(AttachedModuleId::Metadata),
+                ModuleId::RoleAssignment => MethodType::Module(AttachedModuleId::RoleAssignment),
             },
             ident: method_ident.to_owned(),
             node_id: node_id.into(),

--- a/scrypto-test/src/sdk/resource/bucket_factory.rs
+++ b/scrypto-test/src/sdk/resource/bucket_factory.rs
@@ -72,7 +72,7 @@ impl BucketFactory {
 
                 env.as_method_actor(
                     resource_address.into_node_id(),
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     FUNGIBLE_RESOURCE_MANAGER_MINT_IDENT,
                     |env| {
                         env.new_simple_object(
@@ -93,7 +93,7 @@ impl BucketFactory {
 
                 env.as_method_actor(
                     resource_address.into_node_id(),
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     NON_FUNGIBLE_RESOURCE_MANAGER_MINT_IDENT,
                     |env| {
                         for (local_id, data) in non_fungibles.iter() {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -22,7 +22,7 @@ use radix_engine::vm::wasm::{DefaultWasmEngine, WasmValidatorConfigV1};
 use radix_engine::vm::{NativeVm, NativeVmExtension, NoExtension, ScryptoVm, Vm};
 use radix_engine_interface::api::node_modules::auth::ToRoleEntry;
 use radix_engine_interface::api::node_modules::auth::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::account::ACCOUNT_SECURIFY_IDENT;
 use radix_engine_interface::blueprints::consensus_manager::{
@@ -514,7 +514,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         reader
             .read_object_collection_entry::<_, MetadataEntryEntryPayload>(
                 address.as_node_id(),
-                ObjectModuleId::Metadata,
+                ModuleId::Metadata,
                 ObjectCollectionKey::KeyValue(
                     MetadataCollection::EntryKeyValue.collection_index(),
                     &key.to_string(),
@@ -529,7 +529,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let accumulator = reader
             .read_typed_object_field::<ComponentRoyaltyAccumulatorFieldPayload>(
                 component_address.as_node_id(),
-                ObjectModuleId::Royalty,
+                ModuleId::Royalty,
                 ComponentRoyaltyField::Accumulator.field_index(),
             )
             .unwrap()
@@ -538,7 +538,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let balance = reader
             .read_typed_object_field::<FungibleVaultBalanceFieldPayload>(
                 accumulator.royalty_vault.0.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 FungibleVaultField::Balance.field_index(),
             )
             .unwrap()
@@ -552,7 +552,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let accumulator = reader
             .read_typed_object_field::<PackageRoyaltyAccumulatorFieldPayload>(
                 package_address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 PackageField::RoyaltyAccumulator.field_index(),
             )
             .ok()?
@@ -561,7 +561,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let balance = reader
             .read_typed_object_field::<FungibleVaultBalanceFieldPayload>(
                 accumulator.royalty_vault.0.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 FungibleVaultField::Balance.field_index(),
             )
             .unwrap()
@@ -617,7 +617,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         reader
             .collection_iter(
                 package_address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 PackageCollection::SchemaKeyValue.collection_index(),
             )
             .unwrap()
@@ -638,7 +638,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         reader
             .collection_iter(
                 package_address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 PackageCollection::BlueprintVersionDefinitionKeyValue.collection_index(),
             )
             .unwrap()
@@ -701,7 +701,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let vault: Option<FungibleVaultBalanceFieldPayload> = reader
             .read_typed_object_field(
                 &vault_id,
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 FungibleVaultField::Balance.into(),
             )
             .ok();
@@ -717,7 +717,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let vault_balance: NonFungibleVaultBalanceFieldPayload = reader
             .read_typed_object_field(
                 &vault_id,
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 NonFungibleVaultField::Balance.into(),
             )
             .ok()?;
@@ -727,7 +727,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let iter: Vec<NonFungibleLocalId> = reader
             .collection_iter(
                 &vault_id,
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 NonFungibleVaultCollection::NonFungibleIndex.collection_index(),
             )
             .unwrap()
@@ -760,7 +760,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let payload = reader
             .read_object_collection_entry::<_, NonFungibleResourceManagerDataEntryPayload>(
                 resource.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ObjectCollectionKey::KeyValue(
                     NonFungibleResourceManagerCollection::DataKeyValue.collection_index(),
                     &non_fungible_id,
@@ -843,7 +843,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let substate = reader
             .read_typed_object_field::<ValidatorStateFieldPayload>(
                 address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ValidatorField::State.field_index(),
             )
             .unwrap()
@@ -857,7 +857,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let substate = reader
             .read_typed_object_field::<ConsensusManagerCurrentValidatorSetFieldPayload>(
                 CONSENSUS_MANAGER.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ConsensusManagerField::CurrentValidatorSet.field_index(),
             )
             .unwrap()
@@ -1954,7 +1954,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let mut substate = reader
             .read_typed_object_field::<ConsensusManagerStateFieldPayload>(
                 CONSENSUS_MANAGER.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ConsensusManagerField::State.field_index(),
             )
             .unwrap()
@@ -1966,7 +1966,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         writer
             .write_typed_object_field(
                 CONSENSUS_MANAGER.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ConsensusManagerField::State.field_index(),
                 ConsensusManagerStateFieldPayload::from_content_source(substate),
             )
@@ -2109,7 +2109,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         reader
             .read_typed_object_field::<ConsensusManagerProposerMilliTimestampFieldPayload>(
                 CONSENSUS_MANAGER.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ConsensusManagerField::ProposerMilliTimestamp.field_index(),
             )
             .unwrap()
@@ -2122,7 +2122,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         reader
             .read_typed_object_field::<ConsensusManagerStateFieldPayload>(
                 CONSENSUS_MANAGER.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 ConsensusManagerField::State.field_index(),
             )
             .unwrap()
@@ -2150,7 +2150,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         let (blueprint_id, name) = match event_type_identifier {
             EventTypeIdentifier(Emitter::Method(node_id, node_module), event_name) => {
                 let blueprint_id = match node_module {
-                    ObjectModuleId::Main => {
+                    ModuleId::Main => {
                         let reader = SystemDatabaseReader::new(self.substate_db());
                         let type_info = reader.get_type_info(node_id).unwrap();
                         match type_info {

--- a/scrypto/src/component/component.rs
+++ b/scrypto/src/component/component.rs
@@ -15,8 +15,8 @@ use radix_engine_interface::api::node_modules::metadata::{
     METADATA_SET_IDENT,
 };
 use radix_engine_interface::api::node_modules::ModuleConfig;
-use radix_engine_interface::api::object_api::ObjectModuleId;
-use radix_engine_interface::api::{FieldValue, ModuleId};
+use radix_engine_interface::api::object_api::ModuleId;
+use radix_engine_interface::api::{AttachedModuleId, FieldValue};
 use radix_engine_interface::blueprints::resource::{
     AccessRule, Bucket, MethodAccessibility, OwnerRole, RoleAssignmentInit,
 };
@@ -201,7 +201,7 @@ pub trait FnMapping<T> {
 }
 
 pub trait MethodMapping<T> {
-    const MODULE_ID: ObjectModuleId;
+    const ATTACHED_MODULE_ID: ModuleId;
 
     fn to_mapping(self) -> Vec<(String, T)>;
     fn methods() -> Vec<&'static str>;
@@ -214,7 +214,7 @@ pub struct MetadataMethods<T> {
 }
 
 impl<T> MethodMapping<T> for MetadataMethods<T> {
-    const MODULE_ID: ObjectModuleId = ObjectModuleId::Metadata;
+    const ATTACHED_MODULE_ID: ModuleId = ModuleId::Metadata;
 
     fn to_mapping(self) -> Vec<(String, T)> {
         vec![
@@ -295,7 +295,7 @@ impl<C: HasStub + HasMethods> Globalizing<C> {
 
         // Main
         {
-            roles.insert(ObjectModuleId::Main, self.roles);
+            roles.insert(ModuleId::Main, self.roles);
         }
 
         // Metadata
@@ -306,22 +306,28 @@ impl<C: HasStub + HasMethods> Globalizing<C> {
                 .unwrap_or_else(|| Default::default());
 
             let metadata = Metadata::new_with_data(metadata_config.init);
-            modules.insert(ModuleId::Metadata, metadata.handle().as_node_id().clone());
-            roles.insert(ObjectModuleId::Metadata, metadata_config.roles);
+            modules.insert(
+                AttachedModuleId::Metadata,
+                metadata.handle().as_node_id().clone(),
+            );
+            roles.insert(ModuleId::Metadata, metadata_config.roles);
         };
 
         // Royalties
         if let Some(royalty_config) = self.royalty_config {
-            roles.insert(ObjectModuleId::Royalty, royalty_config.roles);
+            roles.insert(ModuleId::Royalty, royalty_config.roles);
             let royalty = Royalty::new(royalty_config.init);
-            modules.insert(ModuleId::Royalty, royalty.handle().as_node_id().clone());
+            modules.insert(
+                AttachedModuleId::Royalty,
+                royalty.handle().as_node_id().clone(),
+            );
         }
 
         // Role Assignment
         {
             let role_assignment = RoleAssignment::new(self.owner_role, roles);
             modules.insert(
-                ModuleId::RoleAssignment,
+                AttachedModuleId::RoleAssignment,
                 role_assignment.handle().as_node_id().clone(),
             );
         }

--- a/scrypto/src/component/component.rs
+++ b/scrypto/src/component/component.rs
@@ -201,7 +201,7 @@ pub trait FnMapping<T> {
 }
 
 pub trait MethodMapping<T> {
-    const ATTACHED_MODULE_ID: ModuleId;
+    const MODULE_ID: ModuleId;
 
     fn to_mapping(self) -> Vec<(String, T)>;
     fn methods() -> Vec<&'static str>;
@@ -214,7 +214,7 @@ pub struct MetadataMethods<T> {
 }
 
 impl<T> MethodMapping<T> for MetadataMethods<T> {
-    const ATTACHED_MODULE_ID: ModuleId = ModuleId::Metadata;
+    const MODULE_ID: ModuleId = ModuleId::Metadata;
 
     fn to_mapping(self) -> Vec<(String, T)> {
         vec![

--- a/scrypto/src/engine/scrypto_env.rs
+++ b/scrypto/src/engine/scrypto_env.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::api::actor_api::EventFlags;
 use radix_engine_interface::api::key_value_entry_api::KeyValueEntryHandle;
 use radix_engine_interface::api::key_value_store_api::KeyValueStoreDataSchema;
 use radix_engine_interface::api::{ActorRefHandle, FieldValue};
-use radix_engine_interface::api::{FieldIndex, LockFlags, ModuleId};
+use radix_engine_interface::api::{AttachedModuleId, FieldIndex, LockFlags};
 use radix_engine_interface::crypto::Hash;
 use radix_engine_interface::data::scrypto::*;
 use radix_engine_interface::types::PackageAddress;
@@ -56,7 +56,7 @@ impl ScryptoVmV1Api {
 
     pub fn object_globalize(
         object_id: NodeId,
-        modules: IndexMap<ModuleId, NodeId>,
+        modules: IndexMap<AttachedModuleId, NodeId>,
         address_reservation: Option<GlobalAddressReservation>,
     ) -> GlobalAddress {
         let modules = scrypto_encode(&modules).unwrap();
@@ -113,7 +113,7 @@ impl ScryptoVmV1Api {
 
     pub fn object_call_module(
         receiver: &NodeId,
-        module_id: ModuleId,
+        module_id: AttachedModuleId,
         method_name: &str,
         args: Vec<u8>,
     ) -> Vec<u8> {

--- a/scrypto/src/modules/metadata.rs
+++ b/scrypto/src/modules/metadata.rs
@@ -26,7 +26,7 @@ pub trait HasMetadata {
 pub struct Metadata(pub ModuleHandle);
 
 impl Attachable for Metadata {
-    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::Metadata;
+    const MODULE_ID: AttachedModuleId = AttachedModuleId::Metadata;
 
     fn new(handle: ModuleHandle) -> Self {
         Metadata(handle)

--- a/scrypto/src/modules/metadata.rs
+++ b/scrypto/src/modules/metadata.rs
@@ -4,7 +4,7 @@ use crate::runtime::*;
 use crate::*;
 use radix_engine_common::data::scrypto::*;
 use radix_engine_interface::api::node_modules::metadata::*;
-use radix_engine_interface::api::ModuleId;
+use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::constants::METADATA_MODULE_PACKAGE;
 use radix_engine_interface::data::scrypto::{scrypto_decode, scrypto_encode};
 use sbor::rust::prelude::*;
@@ -26,7 +26,7 @@ pub trait HasMetadata {
 pub struct Metadata(pub ModuleHandle);
 
 impl Attachable for Metadata {
-    const MODULE_ID: ModuleId = ModuleId::Metadata;
+    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::Metadata;
 
     fn new(handle: ModuleHandle) -> Self {
         Metadata(handle)

--- a/scrypto/src/modules/module.rs
+++ b/scrypto/src/modules/module.rs
@@ -3,7 +3,7 @@ use crate::prelude::ScryptoEncode;
 use crate::runtime::*;
 use crate::*;
 use radix_engine_derive::ScryptoSbor;
-use radix_engine_interface::api::{ModuleId, ACTOR_REF_SELF};
+use radix_engine_interface::api::{AttachedModuleId, ACTOR_REF_SELF};
 use radix_engine_interface::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_engine_interface::types::NodeId;
 use radix_engine_interface::types::*;
@@ -15,8 +15,8 @@ use scrypto::prelude::ScryptoDecode;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, ScryptoSbor)]
 pub enum ModuleHandle {
     Own(Own),
-    Attached(GlobalAddress, ModuleId),
-    SELF(ModuleId),
+    Attached(GlobalAddress, AttachedModuleId),
+    SELF(AttachedModuleId),
 }
 
 impl ModuleHandle {
@@ -45,14 +45,14 @@ impl<'a, O> Attached<'a, O> {
 }
 
 pub trait Attachable: Sized {
-    const MODULE_ID: ModuleId;
+    const ATTACHED_MODULE_ID: AttachedModuleId;
 
     fn attached(address: GlobalAddress) -> Self {
-        Self::new(ModuleHandle::Attached(address, Self::MODULE_ID))
+        Self::new(ModuleHandle::Attached(address, Self::ATTACHED_MODULE_ID))
     }
 
     fn self_attached() -> Self {
-        Self::new(ModuleHandle::SELF(Self::MODULE_ID))
+        Self::new(ModuleHandle::SELF(Self::ATTACHED_MODULE_ID))
     }
 
     fn new(handle: ModuleHandle) -> Self;

--- a/scrypto/src/modules/module.rs
+++ b/scrypto/src/modules/module.rs
@@ -45,14 +45,14 @@ impl<'a, O> Attached<'a, O> {
 }
 
 pub trait Attachable: Sized {
-    const ATTACHED_MODULE_ID: AttachedModuleId;
+    const MODULE_ID: AttachedModuleId;
 
     fn attached(address: GlobalAddress) -> Self {
-        Self::new(ModuleHandle::Attached(address, Self::ATTACHED_MODULE_ID))
+        Self::new(ModuleHandle::Attached(address, Self::MODULE_ID))
     }
 
     fn self_attached() -> Self {
-        Self::new(ModuleHandle::SELF(Self::ATTACHED_MODULE_ID))
+        Self::new(ModuleHandle::SELF(Self::MODULE_ID))
     }
 
     fn new(handle: ModuleHandle) -> Self;

--- a/scrypto/src/modules/role_assignment.rs
+++ b/scrypto/src/modules/role_assignment.rs
@@ -111,7 +111,7 @@ impl RoleAssignment {
 }
 
 impl Attachable for RoleAssignment {
-    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::RoleAssignment;
+    const MODULE_ID: AttachedModuleId = AttachedModuleId::RoleAssignment;
 
     fn new(handle: ModuleHandle) -> Self {
         Self(handle)

--- a/scrypto/src/modules/role_assignment.rs
+++ b/scrypto/src/modules/role_assignment.rs
@@ -34,7 +34,7 @@ pub struct RoleAssignment(pub ModuleHandle);
 impl RoleAssignment {
     pub fn new<R: Into<OwnerRoleEntry>>(
         owner_role: R,
-        roles: IndexMap<ObjectModuleId, RoleAssignmentInit>,
+        roles: IndexMap<ModuleId, RoleAssignmentInit>,
     ) -> Self {
         let rtn = ScryptoVmV1Api::blueprint_call(
             ROLE_ASSIGNMENT_MODULE_PACKAGE,
@@ -64,7 +64,7 @@ impl RoleAssignment {
         );
     }
 
-    fn internal_set_role<A: Into<AccessRule>>(&self, module: ObjectModuleId, name: &str, rule: A) {
+    fn internal_set_role<A: Into<AccessRule>>(&self, module: ModuleId, name: &str, rule: A) {
         self.call_ignore_rtn(
             ROLE_ASSIGNMENT_SET_IDENT,
             &RoleAssignmentSetInput {
@@ -75,7 +75,7 @@ impl RoleAssignment {
         );
     }
 
-    fn internal_get_role(&self, module: ObjectModuleId, name: &str) -> Option<AccessRule> {
+    fn internal_get_role(&self, module: ModuleId, name: &str) -> Option<AccessRule> {
         self.call(
             ROLE_ASSIGNMENT_GET_IDENT,
             &RoleAssignmentGetInput {
@@ -86,32 +86,32 @@ impl RoleAssignment {
     }
 
     pub fn set_role<A: Into<AccessRule>>(&self, name: &str, rule: A) {
-        self.internal_set_role(ObjectModuleId::Main, name, rule);
+        self.internal_set_role(ModuleId::Main, name, rule);
     }
 
     pub fn get_role(&self, name: &str) -> Option<AccessRule> {
-        self.internal_get_role(ObjectModuleId::Main, name)
+        self.internal_get_role(ModuleId::Main, name)
     }
 
     pub fn set_metadata_role<A: Into<AccessRule>>(&self, name: &str, rule: A) {
-        self.internal_set_role(ObjectModuleId::Metadata, name, rule);
+        self.internal_set_role(ModuleId::Metadata, name, rule);
     }
 
     pub fn get_metadata_role(&self, name: &str) -> Option<AccessRule> {
-        self.internal_get_role(ObjectModuleId::Metadata, name)
+        self.internal_get_role(ModuleId::Metadata, name)
     }
 
     pub fn set_component_royalties_role<A: Into<AccessRule>>(&self, name: &str, rule: A) {
-        self.internal_set_role(ObjectModuleId::Royalty, name, rule);
+        self.internal_set_role(ModuleId::Royalty, name, rule);
     }
 
     pub fn get_component_royalties_role(&self, name: &str) -> Option<AccessRule> {
-        self.internal_get_role(ObjectModuleId::Royalty, name)
+        self.internal_get_role(ModuleId::Royalty, name)
     }
 }
 
 impl Attachable for RoleAssignment {
-    const MODULE_ID: ModuleId = ModuleId::RoleAssignment;
+    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::RoleAssignment;
 
     fn new(handle: ModuleHandle) -> Self {
         Self(handle)

--- a/scrypto/src/modules/royalty.rs
+++ b/scrypto/src/modules/royalty.rs
@@ -32,7 +32,7 @@ pub trait HasComponentRoyalties {
 pub struct Royalty(pub ModuleHandle);
 
 impl Attachable for Royalty {
-    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::Royalty;
+    const MODULE_ID: AttachedModuleId = AttachedModuleId::Royalty;
 
     fn new(handle: ModuleHandle) -> Self {
         Royalty(handle)

--- a/scrypto/src/modules/royalty.rs
+++ b/scrypto/src/modules/royalty.rs
@@ -12,7 +12,7 @@ use radix_engine_interface::api::node_modules::royalty::{
     COMPONENT_ROYALTY_SETTER_ROLE, COMPONENT_ROYALTY_SETTER_UPDATER_ROLE,
     COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
 };
-use radix_engine_interface::api::ModuleId;
+use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::blueprints::resource::Bucket;
 use radix_engine_interface::constants::ROYALTY_MODULE_PACKAGE;
 use radix_engine_interface::data::scrypto::{scrypto_decode, scrypto_encode};
@@ -32,7 +32,7 @@ pub trait HasComponentRoyalties {
 pub struct Royalty(pub ModuleHandle);
 
 impl Attachable for Royalty {
-    const MODULE_ID: ModuleId = ModuleId::Royalty;
+    const ATTACHED_MODULE_ID: AttachedModuleId = AttachedModuleId::Royalty;
 
     fn new(handle: ModuleHandle) -> Self {
         Royalty(handle)

--- a/simulator/src/ledger/dumper.rs
+++ b/simulator/src/ledger/dumper.rs
@@ -4,7 +4,7 @@ use colored::*;
 use radix_engine::blueprints::resource::*;
 use radix_engine::system::system_db_reader::SystemDatabaseReader;
 use radix_engine::types::*;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::network::NetworkDefinition;
 use radix_engine_queries::query::ResourceAccounter;
 use radix_engine_queries::typed_substate_layout::*;
@@ -189,7 +189,7 @@ pub fn dump_resource_manager<T: SubstateDatabase, O: std::io::Write>(
         let id_type: VersionedNonFungibleResourceManagerIdType = reader
             .read_typed_object_field(
                 resource_address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 NonFungibleResourceManagerField::IdType.into(),
             )
             .map_err(|_| EntityDumpError::InvalidStore("Missing NonFungible IdType".to_string()))?;
@@ -209,7 +209,7 @@ pub fn dump_resource_manager<T: SubstateDatabase, O: std::io::Write>(
             let total_supply = reader
                 .read_typed_object_field::<NonFungibleResourceManagerTotalSupplyFieldPayload>(
                     resource_address.as_node_id(),
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     NonFungibleResourceManagerField::TotalSupply.into(),
                 )
                 .map_err(|_| EntityDumpError::InvalidStore("Missing Total Supply".to_string()))?
@@ -226,7 +226,7 @@ pub fn dump_resource_manager<T: SubstateDatabase, O: std::io::Write>(
         let divisibility = reader
             .read_typed_object_field::<FungibleResourceManagerDivisibilityFieldPayload>(
                 resource_address.as_node_id(),
-                ObjectModuleId::Main,
+                ModuleId::Main,
                 FungibleResourceManagerField::Divisibility.into(),
             )
             .map_err(|_| EntityDumpError::InvalidStore("Missing Divisibility".to_string()))?
@@ -247,7 +247,7 @@ pub fn dump_resource_manager<T: SubstateDatabase, O: std::io::Write>(
             let total_supply = reader
                 .read_typed_object_field::<FungibleResourceManagerTotalSupplyFieldPayload>(
                     resource_address.as_node_id(),
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     FungibleResourceManagerField::TotalSupply.into(),
                 )
                 .map_err(|_| EntityDumpError::InvalidStore("Missing Total Supply".to_string()))?
@@ -279,7 +279,7 @@ fn get_entity_metadata<T: SubstateDatabase>(
     reader
         .collection_iter(
             entity_node_id,
-            ObjectModuleId::Metadata,
+            ModuleId::Metadata,
             MetadataCollection::EntryKeyValue.collection_index(),
         )
         .unwrap()

--- a/simulator/src/resim/mod.rs
+++ b/simulator/src/resim/mod.rs
@@ -70,7 +70,7 @@ use radix_engine::transaction::{execute_and_commit_transaction, CostingParameter
 use radix_engine::types::*;
 use radix_engine::vm::wasm::*;
 use radix_engine::vm::{DefaultNativeVm, ScryptoVm, Vm};
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::package::{
     BlueprintDefinition, BlueprintInterface, BlueprintPayloadDef, BlueprintVersionKey,
 };
@@ -435,7 +435,7 @@ pub fn get_event_schema<S: SubstateDatabase>(
     let bp_definition: VersionedPackageBlueprintVersionDefinition = system_reader
         .read_object_collection_entry(
             blueprint_id.package_address.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ObjectCollectionKey::KeyValue(
                 PackageCollection::BlueprintVersionDefinitionKeyValue.collection_index(),
                 &version_key,
@@ -453,7 +453,7 @@ pub fn get_event_schema<S: SubstateDatabase>(
             let schema: VersionedScryptoSchema = system_reader
                 .read_object_collection_entry(
                     blueprint_id.package_address.as_node_id(),
-                    ObjectModuleId::Main,
+                    ModuleId::Main,
                     ObjectCollectionKey::KeyValue(
                         PackageCollection::SchemaKeyValue.collection_index(),
                         &type_id.0,
@@ -485,7 +485,7 @@ pub fn db_upsert_timestamps(
     writer
         .write_typed_object_field(
             CONSENSUS_MANAGER.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ConsensusManagerField::ProposerMilliTimestamp.field_index(),
             ConsensusManagerProposerMilliTimestampFieldPayload::from_content_source(
                 milli_timestamp,
@@ -496,7 +496,7 @@ pub fn db_upsert_timestamps(
     writer
         .write_typed_object_field(
             CONSENSUS_MANAGER.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ConsensusManagerField::ProposerMinuteTimestamp.field_index(),
             ConsensusManagerProposerMinuteTimestampFieldPayload::from_content_source(
                 minute_timestamp,
@@ -520,7 +520,7 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
     let mut consensus_mgr_state = reader
         .read_typed_object_field::<ConsensusManagerStateFieldPayload>(
             CONSENSUS_MANAGER.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ConsensusManagerField::State.field_index(),
         )
         .unwrap_or_else(|_| {
@@ -542,7 +542,7 @@ pub fn db_upsert_epoch(epoch: Epoch) -> Result<(), Error> {
     writer
         .write_typed_object_field(
             CONSENSUS_MANAGER.as_node_id(),
-            ObjectModuleId::Main,
+            ModuleId::Main,
             ConsensusManagerField::State.field_index(),
             ConsensusManagerStateFieldPayload::from_content_source(consensus_mgr_state),
         )

--- a/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/no_initial_supply.rtm
@@ -37,7 +37,7 @@ CREATE_FUNGIBLE_RESOURCE
     Tuple(                                                                   # Metadata initialization
         Map<String, Tuple>(                                                  # Initial metadata values
             "name" => Tuple(
-                Some(Enum<Metadata::String>("MyResource")),    # Resource Name
+                Some(Enum<Metadata::String>("MyResource")),                  # Resource Name
                 true                                                         # Locked
             )
         ),

--- a/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/fungible/with_initial_supply.rtm
@@ -38,7 +38,7 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Tuple(                                                                   # Metadata initialization
         Map<String, Tuple>(                                                  # Initial metadata values
             "name" => Tuple(
-                Some(Enum<Metadata::String>("MyResource")),    # Resource Name
+                Some(Enum<Metadata::String>("MyResource")),                  # Resource Name
                 true                                                         # Locked
             )
         ),

--- a/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm
@@ -38,7 +38,7 @@ CREATE_NON_FUNGIBLE_RESOURCE
     Tuple(                                                                   # Metadata initialization
         Map<String, Tuple>(                                                  # Initial metadata values
             "name" => Tuple(
-                Some(Enum<Metadata::String>("MyResource")),    # Resource Name
+                Some(Enum<Metadata::String>("MyResource")),                  # Resource Name
                 true                                                         # Locked
             )
         ),

--- a/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/transaction/examples/resources/creation/non_fungible/with_initial_supply.rtm
@@ -41,7 +41,7 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Tuple(                                                                   # Metadata initialization
         Map<String, Tuple>(                                                  # Initial metadata values
             "name" => Tuple(
-                Some(Enum<Metadata::String>("MyResource")),    # Resource Name
+                Some(Enum<Metadata::String>("MyResource")),                  # Resource Name
                 true                                                         # Locked
             )
         ),

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -5,7 +5,7 @@ use radix_engine_interface::api::node_modules::auth::*;
 use radix_engine_interface::api::node_modules::metadata::*;
 use radix_engine_interface::api::node_modules::royalty::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
-use radix_engine_interface::api::ObjectModuleId;
+use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::consensus_manager::*;
@@ -915,7 +915,7 @@ impl ManifestBuilder {
         method_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> Self {
-        self.call_module_method(address, ObjectModuleId::Main, method_name, arguments)
+        self.call_module_method(address, ModuleId::Main, method_name, arguments)
     }
 
     pub fn call_metadata_method(
@@ -924,7 +924,7 @@ impl ManifestBuilder {
         method_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> Self {
-        self.call_module_method(address, ObjectModuleId::Metadata, method_name, arguments)
+        self.call_module_method(address, ModuleId::Metadata, method_name, arguments)
     }
 
     pub fn call_royalty_method(
@@ -933,7 +933,7 @@ impl ManifestBuilder {
         method_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> Self {
-        self.call_module_method(address, ObjectModuleId::Royalty, method_name, arguments)
+        self.call_module_method(address, ModuleId::Royalty, method_name, arguments)
     }
 
     pub fn set_owner_role(
@@ -943,7 +943,7 @@ impl ManifestBuilder {
     ) -> Self {
         self.call_module_method(
             address,
-            ObjectModuleId::RoleAssignment,
+            ModuleId::RoleAssignment,
             ROLE_ASSIGNMENT_SET_OWNER_IDENT,
             RoleAssignmentSetOwnerInput { rule: rule.into() },
         )
@@ -952,7 +952,7 @@ impl ManifestBuilder {
     pub fn lock_owner_role(self, address: impl ResolvableGlobalAddress) -> Self {
         self.call_module_method(
             address,
-            ObjectModuleId::RoleAssignment,
+            ModuleId::RoleAssignment,
             ROLE_ASSIGNMENT_LOCK_OWNER_IDENT,
             RoleAssignmentLockOwnerInput {},
         )
@@ -964,19 +964,19 @@ impl ManifestBuilder {
         role_key: impl Into<RoleKey>,
         rule: impl Into<AccessRule>,
     ) -> Self {
-        self.set_role(address, ObjectModuleId::Main, role_key, rule)
+        self.set_role(address, ModuleId::Main, role_key, rule)
     }
 
     pub fn set_role(
         self,
         address: impl ResolvableGlobalAddress,
-        role_module: ObjectModuleId,
+        role_module: ModuleId,
         role_key: impl Into<RoleKey>,
         rule: impl Into<AccessRule>,
     ) -> Self {
         self.call_module_method(
             address,
-            ObjectModuleId::RoleAssignment,
+            ModuleId::RoleAssignment,
             ROLE_ASSIGNMENT_SET_IDENT,
             RoleAssignmentSetInput {
                 module: role_module,
@@ -989,12 +989,12 @@ impl ManifestBuilder {
     pub fn get_role(
         self,
         address: impl ResolvableGlobalAddress,
-        role_module: ObjectModuleId,
+        role_module: ModuleId,
         role_key: RoleKey,
     ) -> Self {
         self.call_module_method(
             address,
-            ObjectModuleId::RoleAssignment,
+            ModuleId::RoleAssignment,
             ROLE_ASSIGNMENT_GET_IDENT,
             RoleAssignmentGetInput {
                 module: role_module,
@@ -1009,39 +1009,34 @@ impl ManifestBuilder {
         method_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> Self {
-        self.call_module_method(
-            address,
-            ObjectModuleId::RoleAssignment,
-            method_name,
-            arguments,
-        )
+        self.call_module_method(address, ModuleId::RoleAssignment, method_name, arguments)
     }
 
     pub fn call_module_method(
         self,
         address: impl ResolvableGlobalAddress,
-        module_id: ObjectModuleId,
+        module_id: ModuleId,
         method_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> Self {
         let address = address.resolve(&self.registrar);
         match module_id {
-            ObjectModuleId::Main => self.add_instruction(InstructionV1::CallMethod {
+            ModuleId::Main => self.add_instruction(InstructionV1::CallMethod {
                 address,
                 method_name: method_name.into(),
                 args: arguments.resolve(),
             }),
-            ObjectModuleId::Metadata => self.add_instruction(InstructionV1::CallMetadataMethod {
+            ModuleId::Metadata => self.add_instruction(InstructionV1::CallMetadataMethod {
                 address,
                 method_name: method_name.into(),
                 args: arguments.resolve(),
             }),
-            ObjectModuleId::Royalty => self.add_instruction(InstructionV1::CallRoyaltyMethod {
+            ModuleId::Royalty => self.add_instruction(InstructionV1::CallRoyaltyMethod {
                 address,
                 method_name: method_name.into(),
                 args: arguments.resolve(),
             }),
-            ObjectModuleId::RoleAssignment => {
+            ModuleId::RoleAssignment => {
                 self.add_instruction(InstructionV1::CallRoleAssignmentMethod {
                     address,
                     method_name: method_name.into(),

--- a/transaction/src/manifest/manifest_enums.rs
+++ b/transaction/src/manifest/manifest_enums.rs
@@ -131,9 +131,9 @@ lazy_static! {
         known_enum!(
             m,
             enum AttachedModuleId {
-                Metadata = 0;
-                Royalty = 1;
-                RoleAssignment = 2;
+                Metadata = 1;
+                Royalty = 2;
+                RoleAssignment = 3;
             }
         );
 

--- a/transaction/src/manifest/manifest_enums.rs
+++ b/transaction/src/manifest/manifest_enums.rs
@@ -117,7 +117,7 @@ lazy_static! {
             }
         );
 
-        // TODO: remove
+        // Notes: This is to be deprecated, please use `ModuleId` instead
         known_enum!(
             m,
             enum ObjectModuleId {

--- a/transaction/src/manifest/manifest_enums.rs
+++ b/transaction/src/manifest/manifest_enums.rs
@@ -109,7 +109,7 @@ lazy_static! {
 
         known_enum!(
             m,
-            enum ModuleId {
+            enum AttachedModuleId {
                 Main = 0;
                 Metadata = 1;
                 Royalty = 2;

--- a/transaction/src/manifest/manifest_enums.rs
+++ b/transaction/src/manifest/manifest_enums.rs
@@ -109,11 +109,31 @@ lazy_static! {
 
         known_enum!(
             m,
-            enum AttachedModuleId {
+            enum ModuleId {
                 Main = 0;
                 Metadata = 1;
                 Royalty = 2;
                 RoleAssignment = 3;
+            }
+        );
+
+        // TODO: remove
+        known_enum!(
+            m,
+            enum ObjectModuleId {
+                Main = 0;
+                Metadata = 1;
+                Royalty = 2;
+                RoleAssignment = 3;
+            }
+        );
+
+        known_enum!(
+            m,
+            enum AttachedModuleId {
+                Metadata = 0;
+                Royalty = 1;
+                RoleAssignment = 2;
             }
         );
 


### PR DESCRIPTION
## Summary
Renames:
* ObjectModuleId => ModuleId (with type alias of ObjectModuleId => ModuleId for backwards compat)
* ModuleId => AttachedModuleId (no type alias as wasn't used in any scrypto interfaces, and clashes with above rename)
