### PR TITLE
Tests: consistency of substate store vs JMT leafs after scenarios

### DIFF
--- a/radix-engine-stores/src/hash_tree/hash_tree_facade.rs
+++ b/radix-engine-stores/src/hash_tree/hash_tree_facade.rs
@@ -88,7 +88,7 @@ impl Node<Version> {
 }
 
 impl LeafNode<Version> {
-    fn from(key: &NodeKey, leaf_node: &TreeLeafNode) -> Self {
+    pub fn from(key: &NodeKey, leaf_node: &TreeLeafNode) -> Self {
         let full_key = NibblePath::from_iter(
             key.nibble_path()
                 .nibbles()

--- a/radix-engine-tests/tests/jmt_consistency.rs
+++ b/radix-engine-tests/tests/jmt_consistency.rs
@@ -22,6 +22,9 @@ fn substate_store_matches_hash_tree_after_each_scenario() {
                 NextAction::Transaction(next) => {
                     let receipt =
                         test_runner.execute_raw_transaction(&network, &next.raw_transaction);
+                    // TODO(when figured out): We could run this assert as part of the existing
+                    // `post_run_db_check` feature; however, it is tricky to implement (syntactically),
+                    // due to the assert only being available for certain `TestDatabase` impl.
                     test_runner.assert_state_hash_tree_matches_substate_store();
                     previous = Some(receipt);
                 }

--- a/scrypto-unit/src/hash_tree_support.rs
+++ b/scrypto-unit/src/hash_tree_support.rs
@@ -4,7 +4,9 @@ use radix_engine_store_interface::interface::{
     DbSubstateValue, ListableSubstateDatabase, PartitionEntry, SubstateDatabase,
 };
 use radix_engine_stores::hash_tree::tree_store::{TypedInMemoryTreeStore, Version};
-use radix_engine_stores::hash_tree::{put_at_next_version, SubstateHashChange};
+use radix_engine_stores::hash_tree::{
+    list_substate_hashes_at_version, put_at_next_version, SubstateHashChange,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HashTreeUpdatingDatabase<D> {
@@ -24,8 +26,12 @@ impl<D> HashTreeUpdatingDatabase<D> {
         }
     }
 
-    pub fn get_current(&self) -> Hash {
+    pub fn get_current_root_hash(&self) -> Hash {
         self.current_hash
+    }
+
+    pub fn list_substate_hashes(&mut self) -> IndexMap<DbPartitionKey, IndexMap<DbSortKey, Hash>> {
+        list_substate_hashes_at_version(&mut self.tree_store, self.current_version)
     }
 
     fn update_with(&mut self, db_updates: &DatabaseUpdates) {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -2295,7 +2295,26 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
 
 impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, HashTreeUpdatingDatabase<D>> {
     pub fn get_state_hash(&self) -> Hash {
-        self.database.get_current()
+        self.database.get_current_root_hash()
+    }
+
+    pub fn assert_state_hash_tree_matches_substate_store(&mut self) {
+        let hashes_from_tree = self.database.list_substate_hashes();
+        assert_eq!(
+            hashes_from_tree.keys().cloned().collect::<HashSet<_>>(),
+            self.database.list_partition_keys().collect::<HashSet<_>>(),
+            "partitions captured in the state hash tree should match those in the substate store"
+        );
+        for (db_partition_key, by_db_sort_key) in hashes_from_tree {
+            assert_eq!(
+                by_db_sort_key.into_iter().collect::<HashMap<_, _>>(),
+                self.database.list_entries(&db_partition_key)
+                    .map(|(db_sort_key, substate_value)| (db_sort_key, hash(substate_value)))
+                    .collect::<HashMap<_, _>>(),
+                "partition's {:?} substates in the state hash tree should match those in the substate store",
+                db_partition_key,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
⚠️ This relies on https://github.com/radixdlt/radixdlt-scrypto/pull/1447 

This PR only adds a test, which runs all scenarios and asserts that `substate_db.list_all_substate_values().map(::hash) == jmt.list_all_leaf_value_hashes`.

I want it since:
- we recently had a bug in JMT (which didn't break core merkle root behaviors, so it was not detected by any high-level tests [because we don't have "generate proof" feature yet])
- I am currently implementing a "delete partition" operation in substate_db and jmt and this test will also cover it nicely