### PR TITLE
Test: Transaction Processor

### DIFF
--- a/radix-engine-common/src/data/manifest/model/manifest_proof.rs
+++ b/radix-engine-common/src/data/manifest/model/manifest_proof.rs
@@ -10,7 +10,7 @@ use crate::data::manifest::*;
 use crate::*;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[must_use]
 pub struct ManifestProof(pub u32);
 

--- a/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
+++ b/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
@@ -59,73 +59,46 @@ pub enum TransactionProcessorError {
     NotPackageAddress(NodeId),
     NotGlobalAddress(NodeId),
     AuthZoneIsEmpty,
+    InvocationOutputDecodeError(DecodeError),
+    ArgsEncodeError(EncodeError),
+}
+
+impl From<TransactionProcessorError> for RuntimeError {
+    fn from(value: TransactionProcessorError) -> Self {
+        Self::ApplicationError(ApplicationError::TransactionProcessorError(value))
+    }
+}
+
+fn handle_invocation<'a, 'p, 'w, F, Y, L>(
+    api: &'a mut Y,
+    processor: &'p mut TransactionProcessor,
+    worktop: &'w mut Worktop,
+    args: ManifestValue,
+    invocation_handler: F,
+) -> Result<InstructionOutput, RuntimeError>
+where
+    Y: ClientApi<RuntimeError> + KernelSubstateApi<L>,
+    F: FnOnce(&mut Y, ScryptoValue) -> Result<Vec<u8>, RuntimeError>,
+    L: Default,
+{
+    let scrypto_value = {
+        let mut processor_with_api = TransactionProcessorWithApi {
+            worktop,
+            processor,
+            api,
+        };
+        transform(args, &mut processor_with_api)?
+    };
+
+    let rtn = invocation_handler(api, scrypto_value)?;
+
+    let result = IndexedScryptoValue::from_vec(rtn)
+        .map_err(|error| TransactionProcessorError::InvocationOutputDecodeError(error))?;
+    processor.handle_call_return_data(&result, &worktop, api)?;
+    Ok(InstructionOutput::CallReturn(result.into()))
 }
 
 pub struct TransactionProcessorBlueprint;
-
-macro_rules! handle_call_method {
-    ($node_id:expr, $method_name:expr, $args:expr, $worktop:expr, $processor:expr, $api:expr) => {{
-        let mut processor_with_api = TransactionProcessorWithApi {
-            worktop: $worktop,
-            processor: $processor,
-            api: $api,
-        };
-        let scrypto_value = transform($args, &mut processor_with_api)?;
-        $processor = processor_with_api.processor;
-
-        let rtn = $api.call_method(
-            $node_id,
-            &$method_name,
-            scrypto_encode(&scrypto_value).unwrap(),
-        )?;
-        let result = IndexedScryptoValue::from_vec(rtn).unwrap();
-        $processor.handle_call_return_data(&result, &$worktop, $api)?;
-        InstructionOutput::CallReturn(result.into())
-    }};
-}
-
-macro_rules! handle_call_direct_method {
-    ($node_id:expr, $method_name:expr, $args:expr, $worktop:expr, $processor:expr, $api:expr) => {{
-        let mut processor_with_api = TransactionProcessorWithApi {
-            worktop: $worktop,
-            processor: $processor,
-            api: $api,
-        };
-        let scrypto_value = transform($args, &mut processor_with_api)?;
-        $processor = processor_with_api.processor;
-
-        let rtn = $api.call_direct_access_method(
-            $node_id,
-            &$method_name,
-            scrypto_encode(&scrypto_value).unwrap(),
-        )?;
-        let result = IndexedScryptoValue::from_vec(rtn).unwrap();
-        $processor.handle_call_return_data(&result, &$worktop, $api)?;
-        InstructionOutput::CallReturn(result.into())
-    }};
-}
-
-macro_rules! handle_call_module_method {
-    ($module_id:expr, $node_id:expr, $method_name:expr, $args:expr, $worktop:expr, $processor:expr, $api:expr) => {{
-        let mut processor_with_api = TransactionProcessorWithApi {
-            worktop: $worktop,
-            processor: $processor,
-            api: $api,
-        };
-        let scrypto_value = transform($args, &mut processor_with_api)?;
-        $processor = processor_with_api.processor;
-
-        let rtn = $api.call_module_method(
-            $node_id,
-            $module_id,
-            &$method_name,
-            scrypto_encode(&scrypto_value).unwrap(),
-        )?;
-        let result = IndexedScryptoValue::from_vec(rtn).unwrap();
-        $processor.handle_call_return_data(&result, &$worktop, $api)?;
-        InstructionOutput::CallReturn(result.into())
-    }};
-}
 
 impl TransactionProcessorBlueprint {
     pub(crate) fn run<Y, L: Default>(
@@ -162,7 +135,7 @@ impl TransactionProcessorBlueprint {
         )?;
         api.kernel_pin_node(worktop_node_id)?;
 
-        let worktop = Worktop(Own(worktop_node_id));
+        let mut worktop = Worktop(Own(worktop_node_id));
         let instructions = manifest_decode::<Vec<InstructionV1>>(&manifest_encoded_instructions)
             .map_err(|e| {
                 // This error should never occur if being called from root since this is constructed
@@ -324,25 +297,16 @@ impl TransactionProcessorBlueprint {
                     function_name,
                     args,
                 } => {
-                    let mut processor_with_api = TransactionProcessorWithApi {
-                        worktop,
-                        processor,
-                        api,
-                    };
-                    let scrypto_value = transform(args, &mut processor_with_api)?;
-                    processor = processor_with_api.processor;
-
                     let package_address = processor.resolve_package_address(package_address)?;
-                    let rtn = api.call_function(
-                        package_address,
-                        &blueprint_name,
-                        &function_name,
-                        scrypto_encode(&scrypto_value).unwrap(),
-                    )?;
-
-                    let result = IndexedScryptoValue::from_vec(rtn).unwrap();
-                    processor.handle_call_return_data(&result, &worktop, api)?;
-                    InstructionOutput::CallReturn(result.into())
+                    handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                        api.call_function(
+                            package_address,
+                            &blueprint_name,
+                            &function_name,
+                            scrypto_encode(&args)
+                                .map_err(TransactionProcessorError::ArgsEncodeError)?,
+                        )
+                    })?
                 }
                 InstructionV1::CallMethod {
                     address,
@@ -350,14 +314,14 @@ impl TransactionProcessorBlueprint {
                     args,
                 } => {
                     let address = processor.resolve_global_address(address)?;
-                    handle_call_method!(
-                        address.as_node_id(),
-                        method_name,
-                        args,
-                        worktop,
-                        processor,
-                        api
-                    )
+                    handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                        api.call_method(
+                            address.as_node_id(),
+                            &method_name,
+                            scrypto_encode(&args)
+                                .map_err(TransactionProcessorError::ArgsEncodeError)?,
+                        )
+                    })?
                 }
                 InstructionV1::CallRoyaltyMethod {
                     address,
@@ -365,15 +329,15 @@ impl TransactionProcessorBlueprint {
                     args,
                 } => {
                     let address = processor.resolve_global_address(address)?;
-                    handle_call_module_method!(
-                        AttachedModuleId::Royalty,
-                        address.as_node_id(),
-                        method_name,
-                        args,
-                        worktop,
-                        processor,
-                        api
-                    )
+                    handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                        api.call_module_method(
+                            address.as_node_id(),
+                            AttachedModuleId::Royalty,
+                            &method_name,
+                            scrypto_encode(&args)
+                                .map_err(TransactionProcessorError::ArgsEncodeError)?,
+                        )
+                    })?
                 }
                 InstructionV1::CallMetadataMethod {
                     address,
@@ -381,15 +345,15 @@ impl TransactionProcessorBlueprint {
                     args,
                 } => {
                     let address = processor.resolve_global_address(address)?;
-                    handle_call_module_method!(
-                        AttachedModuleId::Metadata,
-                        address.as_node_id(),
-                        method_name,
-                        args,
-                        worktop,
-                        processor,
-                        api
-                    )
+                    handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                        api.call_module_method(
+                            address.as_node_id(),
+                            AttachedModuleId::Metadata,
+                            &method_name,
+                            scrypto_encode(&args)
+                                .map_err(TransactionProcessorError::ArgsEncodeError)?,
+                        )
+                    })?
                 }
                 InstructionV1::CallRoleAssignmentMethod {
                     address,
@@ -397,30 +361,28 @@ impl TransactionProcessorBlueprint {
                     args,
                 } => {
                     let address = processor.resolve_global_address(address)?;
-                    handle_call_module_method!(
-                        AttachedModuleId::RoleAssignment,
-                        address.as_node_id(),
-                        method_name,
-                        args,
-                        worktop,
-                        processor,
-                        api
-                    )
+                    handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                        api.call_module_method(
+                            address.as_node_id(),
+                            AttachedModuleId::RoleAssignment,
+                            &method_name,
+                            scrypto_encode(&args)
+                                .map_err(TransactionProcessorError::ArgsEncodeError)?,
+                        )
+                    })?
                 }
                 InstructionV1::CallDirectVaultMethod {
                     address,
                     method_name,
                     args,
-                } => {
-                    handle_call_direct_method!(
+                } => handle_invocation(api, &mut processor, &mut worktop, args, |api, args| {
+                    api.call_direct_access_method(
                         address.as_node_id(),
-                        method_name,
-                        args,
-                        worktop,
-                        processor,
-                        api
+                        &method_name,
+                        scrypto_encode(&args)
+                            .map_err(TransactionProcessorError::ArgsEncodeError)?,
                     )
-                }
+                })?,
                 InstructionV1::DropNamedProofs => {
                     for (_, real_id) in processor.proof_mapping.drain(..) {
                         let proof = Proof(Own(real_id));
@@ -648,7 +610,7 @@ impl TransactionProcessor {
         api: &mut Y,
     ) -> Result<(), RuntimeError>
     where
-        Y: KernelNodeApi + KernelSubstateApi<L> + ClientApi<RuntimeError>,
+        Y: KernelSubstateApi<L> + ClientApi<RuntimeError>,
     {
         // Auto move into worktop & auth_zone
         for node_id in value.owned_nodes() {
@@ -684,14 +646,14 @@ impl TransactionProcessor {
     }
 }
 
-struct TransactionProcessorWithApi<'a, Y: ClientApi<RuntimeError>> {
-    worktop: Worktop,
-    processor: TransactionProcessor,
+struct TransactionProcessorWithApi<'a, 'p, 'w, Y: ClientApi<RuntimeError>> {
+    worktop: &'w mut Worktop,
+    processor: &'p mut TransactionProcessor,
     api: &'a mut Y,
 }
 
-impl<'a, Y: ClientApi<RuntimeError>> TransformHandler<RuntimeError>
-    for TransactionProcessorWithApi<'a, Y>
+impl<'a, 'p, 'w, Y: ClientApi<RuntimeError>> TransformHandler<RuntimeError>
+    for TransactionProcessorWithApi<'a, 'p, 'w, Y>
 {
     fn replace_bucket(&mut self, b: ManifestBucket) -> Result<Own, RuntimeError> {
         self.processor.take_bucket(&b).map(|x| x.0)

--- a/transaction/src/model/executable.rs
+++ b/transaction/src/model/executable.rs
@@ -1,6 +1,6 @@
 use crate::internal_prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
+#[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, Default)]
 pub struct AuthZoneParams {
     pub initial_proofs: BTreeSet<NonFungibleGlobalId>,
     pub virtual_resources: BTreeSet<ResourceAddress>,

--- a/transaction/src/validation/id_validator.rs
+++ b/transaction/src/validation/id_validator.rs
@@ -26,7 +26,7 @@ pub struct ManifestValidator {
     /// Bucket id -> lock count
     bucket_ids: NonIterMap<ManifestBucket, usize>,
     /// Proof id to proof info
-    proof_ids: NonIterMap<ManifestProof, ProofKind>,
+    proof_ids: BTreeMap<ManifestProof, ProofKind>,
     /// Set of active allocated global address reservation ids
     address_reservation_ids: IndexSet<ManifestAddressReservation>,
     /// Set of named global address ids
@@ -119,7 +119,10 @@ impl ManifestValidator {
     }
 
     pub fn drop_all_named_proofs(&mut self) -> Result<(), ManifestIdValidationError> {
-        self.proof_ids.clear();
+        let proof_ids = self.proof_ids.keys().copied().collect::<Vec<_>>();
+        for proof_id in proof_ids {
+            self.drop_proof(&proof_id)?
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

This PR makes some minor clean ups to the transaction processor, fixes a bug in the transaction validator that caused some transactions to be rejected, and adds some tests for the transaction processor. 

## Details

Cleaned up the invocation logic in the transaction processor so that it all goes through a single `handle_invocation` function instead of multiple different macros that can go out of sync.

Fixed a bug in the transaction validator whereby instructions like `DROP_NAMED_PROOFS` and `DROP_ALL_PROOFS` dropped the proofs without reducing the ref count in the bucket, this lead the bucket to remain locked and for the transaction to be rejected (this is a rejection and not a failure because this was a bug in the transaction validator, not the engine itself).

The following is an example manifest that can be used to reproduce this bug.
```ruby
CALL_METHOD
    Address("account_sim168v2uak8e622vre9g3j3vxup7wdk32k75u2p73vepvyre7c0s839xs")
    "withdraw"
    Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
    Decimal("73")
;
TAKE_FROM_WORKTOP
    Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
    Decimal("73")
    Bucket("bucket1")
;
CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
    Bucket("bucket1")
    Decimal("73")
    Proof("proof1")
;
DROP_ALL_PROOFS;

# Even though we have called the `DROP_ALL_PROOFS` instruction above, `bucket1`
# is still locked from the prespective of the transaction validator. This is 
# because the validator didn't reduce the ref-count on the bucket when the proof
# was dropped and therefore it doesn't permit the following instruction to take
# the bucket.
CALL_METHOD
    Address("account_sim168v2uak8e622vre9g3j3vxup7wdk32k75u2p73vepvyre7c0s839xs")
    "try_deposit_or_abort"
    Bucket("bucket1")
    Enum<0u8>()
;
```

The following are two tests that would fail without this fix:
* `creating_proof_and_then_dropping_it_should_not_keep_bucket_locked`
* `creating_proof_and_then_dropping_it_should_not_keep_bucket_locked2`