### PR TITLE
Add `PackageLoader` to the `radix-engine-tests` crate

### DIFF
--- a/assets/blueprints/faucet/Cargo.toml
+++ b/assets/blueprints/faucet/Cargo.toml
@@ -13,4 +13,5 @@ radix-engine = { path = "../../../radix-engine" }
 scrypto-unit = { path = "../../../scrypto-unit" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/flash_loan/Cargo.toml
+++ b/assets/blueprints/flash_loan/Cargo.toml
@@ -13,4 +13,5 @@ radix-engine = { path = "../../../radix-engine" }
 scrypto-unit = { path = "../../../scrypto-unit" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/genesis_helper/Cargo.toml
+++ b/assets/blueprints/genesis_helper/Cargo.toml
@@ -14,4 +14,5 @@ scrypto-unit = { path = "../../../scrypto-unit" }
 native-sdk = { path = "../../../native-sdk" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/global_n_owned/Cargo.toml
+++ b/assets/blueprints/global_n_owned/Cargo.toml
@@ -13,4 +13,5 @@ radix-engine = { path = "../../../radix-engine" }
 scrypto-unit = { path = "../../../scrypto-unit" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/metadata/Cargo.toml
+++ b/assets/blueprints/metadata/Cargo.toml
@@ -14,4 +14,5 @@ scrypto-unit = { path = "../../../scrypto-unit" }
 native-sdk = { path = "../../../native-sdk" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/radiswap/Cargo.toml
+++ b/assets/blueprints/radiswap/Cargo.toml
@@ -20,4 +20,5 @@ default = []
 test = []
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/assets/blueprints/test_environment/Cargo.toml
+++ b/assets/blueprints/test_environment/Cargo.toml
@@ -13,4 +13,5 @@ radix-engine = { path = "../../../radix-engine" }
 scrypto-unit = { path = "../../../scrypto-unit" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/examples/everything/Cargo.toml
+++ b/examples/everything/Cargo.toml
@@ -22,6 +22,7 @@ strip = true           # Strip the symbols.
 overflow-checks = true # Panic in the case of an overflow.
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]
 
 [workspace]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -21,6 +21,7 @@ strip = true           # Strip the symbols.
 overflow-checks = true # Panic in the case of an overflow.
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]
 
 [workspace]

--- a/examples/no-std/Cargo.toml
+++ b/examples/no-std/Cargo.toml
@@ -17,6 +17,7 @@ strip = true           # Strip the symbols.
 overflow-checks = true # Panic in the case of an overflow.
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]
 
 [workspace]

--- a/native-sdk/Cargo.toml
+++ b/native-sdk/Cargo.toml
@@ -18,4 +18,5 @@ alloc = ["sbor/alloc", "radix-engine-interface/alloc", "radix-engine-derive/allo
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -53,4 +53,5 @@ full_math_benches = [ "dep:rug", "dep:ethnum"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-derive/Cargo.toml
+++ b/radix-engine-derive/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [lib]
+doctest = false
 proc-macro = true
 bench = false
 

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -35,4 +35,5 @@ radix_engine_fuzzing = ["arbitrary"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-macros/Cargo.toml
+++ b/radix-engine-macros/Cargo.toml
@@ -9,5 +9,6 @@ quote = "1.0.33"
 syn = { git = "https://github.com/dtolnay/syn.git", tag = "1.0.93", features = ["full", "extra-traits"] }
 
 [lib]
+doctest = false
 proc-macro = true
 bench = false

--- a/radix-engine-profiling/Cargo.toml
+++ b/radix-engine-profiling/Cargo.toml
@@ -15,6 +15,7 @@ blake2 = { version = "0.10.6", default-features = false, optional = true }
 rand = { version = "0.8.5", optional = true }
 
 [lib]
+doctest = false
 bench = false
 
 [features]

--- a/radix-engine-profiling/resources-tracker-macro/Cargo.toml
+++ b/radix-engine-profiling/resources-tracker-macro/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [lib]
+doctest = false
 proc-macro = true
 bench = false
 

--- a/radix-engine-queries/Cargo.toml
+++ b/radix-engine-queries/Cargo.toml
@@ -25,4 +25,5 @@ lru = ["radix-engine/lru"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-store-interface/Cargo.toml
+++ b/radix-engine-store-interface/Cargo.toml
@@ -20,4 +20,5 @@ alloc = ["hex/alloc", "utils/alloc", "sbor/alloc", "radix-engine-derive/alloc", 
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-stores/Cargo.toml
+++ b/radix-engine-stores/Cargo.toml
@@ -22,4 +22,5 @@ rocksdb = ["dep:rocksdb"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine-tests/Cargo.toml
+++ b/radix-engine-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "radix-engine-tests"
 version = "0.13.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 native-sdk = { path = "../native-sdk", default-features = false }
@@ -34,7 +35,12 @@ serde_json = { version = "1.0.81", default-features = false }
 crossbeam = { version = "0.8.2" }
 walkdir = { version = "2.3.3" }
 paste = { version = "1.0.13" }
+lazy_static = { version = "1.4.0" }
 
+[build-dependencies]
+walkdir = { version = "2.3.3", optional = true }
+cargo_toml = { version = "0.15.3", optional = true }
+scrypto-test = { path = "../scrypto-test", default-features = false }
 
 [[bench]]
 name = "costing"
@@ -73,3 +79,7 @@ resource_tracker = ["dep:radix-engine-profiling", "resources-tracker-macro/resou
 dump_manifest_to_file = ["transaction/dump_manifest_to_file"]
 rocksdb = ["scrypto-unit/rocksdb"]
 post_run_db_check = ["scrypto-unit/post_run_db_check"]
+
+# If this feature is enabled, this crate will compile all of the blueprints ahead of time and make
+# them available for use.
+compile-blueprints-at-build-time = ["dep:walkdir", "dep:cargo_toml"]

--- a/radix-engine-tests/Cargo.toml
+++ b/radix-engine-tests/Cargo.toml
@@ -40,7 +40,8 @@ lazy_static = { version = "1.4.0" }
 [build-dependencies]
 walkdir = { version = "2.3.3", optional = true }
 cargo_toml = { version = "0.15.3", optional = true }
-scrypto-test = { path = "../scrypto-test", default-features = false }
+scrypto = { path = "../scrypto", default-features = false }
+scrypto-unit = { path = "../scrypto-unit", default-features = false }
 
 [[bench]]
 name = "costing"

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -200,8 +200,7 @@ fn bench_prepare_wasm(c: &mut Criterion) {
         b.iter(|| {
             let (pk1, _, _) = test_runner.new_allocated_account();
             test_runner.publish_package(
-                code.clone(),
-                package_definition.clone(),
+                (code.clone(), package_definition.clone()),
                 btreemap!(),
                 OwnerRole::Updatable(rule!(require(NonFungibleGlobalId::from_public_key(&pk1)))),
             );

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -44,8 +44,10 @@ fn bench_radiswap(c: &mut Criterion) {
     // Create account and publish package
     let (pk, _, account) = test_runner.new_allocated_account();
     let package_address = test_runner.publish_package(
-        include_bytes!("../../assets/radiswap.wasm").to_vec(),
-        manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap(),
+        (
+            include_bytes!("../../assets/radiswap.wasm").to_vec(),
+            manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap(),
+        ),
         btreemap!(),
         OwnerRole::Updatable(rule!(require(NonFungibleGlobalId::from_public_key(&pk)))),
     );

--- a/radix-engine-tests/build.rs
+++ b/radix-engine-tests/build.rs
@@ -17,17 +17,24 @@ fn main() {
 
     let mut packages = HashMap::new();
     for entry in walkdir::WalkDir::new(blueprints_dir) {
-        let Ok(entry) = entry else { 
-            continue; 
+        let Ok(entry) = entry else {
+            continue;
         };
         let path = entry.path();
-        if !path.file_name().map_or(false, |file_name| file_name == "Cargo.toml") {
-            continue
+        if !path
+            .file_name()
+            .map_or(false, |file_name| file_name == "Cargo.toml")
+        {
+            continue;
         }
 
         let manifest = Manifest::from_path(path).unwrap();
-        if !manifest.dependencies.into_iter().any(|(name, _)| name == "scrypto") {
-            continue
+        if !manifest
+            .dependencies
+            .into_iter()
+            .any(|(name, _)| name == "scrypto")
+        {
+            continue;
         }
 
         let Some(Package { name, .. }) = manifest.package else {

--- a/radix-engine-tests/build.rs
+++ b/radix-engine-tests/build.rs
@@ -1,0 +1,46 @@
+#[cfg(not(feature = "compile-blueprints-at-build-time"))]
+fn main() {}
+
+#[cfg(feature = "compile-blueprints-at-build-time")]
+fn main() {
+    use std::collections::HashMap;
+    use std::env;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+
+    use cargo_toml::{Manifest, Package};
+    use scrypto_test::prelude::scrypto_encode;
+
+    let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
+    let blueprints_dir = manifest_dir.join("tests").join("blueprints");
+    println!("cargo:rerun-if-changed=\"{:?}\"", blueprints_dir);
+
+    let mut packages = HashMap::new();
+    for entry in walkdir::WalkDir::new(blueprints_dir) {
+        let Ok(entry) = entry else { 
+            continue; 
+        };
+        let path = entry.path();
+        if !path.file_name().map_or(false, |file_name| file_name == "Cargo.toml") {
+            continue
+        }
+
+        let manifest = Manifest::from_path(path).unwrap();
+        if !manifest.dependencies.into_iter().any(|(name, _)| name == "scrypto") {
+            continue
+        }
+
+        let Some(Package { name, .. }) = manifest.package else {
+            continue;
+        };
+
+        let (code, definition) = scrypto_test::prelude::Package::compile(path.parent().unwrap());
+        packages.insert(name, (code, definition));
+    }
+
+    let out_dir = PathBuf::from_str(env::var("OUT_DIR").unwrap().as_str()).unwrap();
+    let compilation_path = out_dir.join("compiled_packages.bin");
+
+    let encoded_packages = scrypto_encode(&packages).unwrap();
+    std::fs::write(compilation_path, encoded_packages).unwrap();
+}

--- a/radix-engine-tests/tests/address.rs
+++ b/radix-engine-tests/tests/address.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{KernelError, RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::account::ACCOUNT_BLUEPRINT;
@@ -10,7 +13,7 @@ use transaction::prelude::*;
 fn get_global_address_in_local_in_function_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -48,7 +51,7 @@ fn get_global_address_in_local_in_function_should_fail() {
 fn get_global_address_in_local_in_method_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -97,7 +100,7 @@ fn get_global_address_in_local_in_method_should_fail() {
 fn get_global_address_in_parent_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -139,7 +142,7 @@ fn get_global_address_in_parent_should_succeed() {
 fn get_global_address_in_child_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -180,7 +183,7 @@ fn get_global_address_in_child_should_succeed() {
 fn test_call_component_address_protected_method(caller_child: bool, callee_child: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -250,7 +253,7 @@ enum AssertAgainst {
 fn test_assert(package: AssertAgainst, child: bool, should_succeed: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -377,7 +380,7 @@ mod global_caller_actor_badge {
 fn call_component_address_protected_method_in_parent_with_wrong_address_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -426,7 +429,7 @@ fn call_component_address_protected_method_in_parent_with_wrong_address_should_f
 fn can_instantiate_with_preallocated_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
     // Act + Assert
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -444,7 +447,7 @@ fn can_instantiate_with_preallocated_address() {
 fn errors_if_unused_preallocated_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
 
     // Act + Assert 1
     let receipt = test_runner.execute_manifest_ignoring_fee(
@@ -479,7 +482,7 @@ fn errors_if_unused_preallocated_address() {
 fn errors_if_assigns_same_address_to_two_components() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
 
     // Act + Assert
     let receipt = test_runner.execute_manifest_ignoring_fee(
@@ -501,7 +504,7 @@ fn test_pass_named_global_addresses() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -562,7 +565,7 @@ fn test_pass_static_global_addresses() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/address.rs
+++ b/radix-engine-tests/tests/address.rs
@@ -13,7 +13,7 @@ use transaction::prelude::*;
 fn get_global_address_in_local_in_function_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -51,7 +51,7 @@ fn get_global_address_in_local_in_function_should_fail() {
 fn get_global_address_in_local_in_method_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -100,7 +100,7 @@ fn get_global_address_in_local_in_method_should_fail() {
 fn get_global_address_in_parent_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -142,7 +142,7 @@ fn get_global_address_in_parent_should_succeed() {
 fn get_global_address_in_child_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -183,7 +183,7 @@ fn get_global_address_in_child_should_succeed() {
 fn test_call_component_address_protected_method(caller_child: bool, callee_child: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -253,7 +253,7 @@ enum AssertAgainst {
 fn test_assert(package: AssertAgainst, child: bool, should_succeed: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -380,7 +380,7 @@ mod global_caller_actor_badge {
 fn call_component_address_protected_method_in_parent_with_wrong_address_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -429,7 +429,7 @@ fn call_component_address_protected_method_in_parent_with_wrong_address_should_f
 fn can_instantiate_with_preallocated_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     // Act + Assert
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -447,7 +447,7 @@ fn can_instantiate_with_preallocated_address() {
 fn errors_if_unused_preallocated_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act + Assert 1
     let receipt = test_runner.execute_manifest_ignoring_fee(
@@ -482,7 +482,7 @@ fn errors_if_unused_preallocated_address() {
 fn errors_if_assigns_same_address_to_two_components() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act + Assert
     let receipt = test_runner.execute_manifest_ignoring_fee(
@@ -504,7 +504,7 @@ fn test_pass_named_global_addresses() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -565,7 +565,7 @@ fn test_pass_static_global_addresses() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("address"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/allocated_address.rs
+++ b/radix-engine-tests/tests/allocated_address.rs
@@ -12,7 +12,7 @@ use transaction::prelude::*;
 fn test_create_and_return() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -36,7 +36,7 @@ fn test_create_and_return() {
 fn test_create_and_pass_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -58,7 +58,7 @@ fn test_create_and_pass_address() {
 fn test_create_and_call() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -82,7 +82,7 @@ fn test_create_and_call() {
 fn test_create_and_consume_within_frame() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -104,7 +104,7 @@ fn test_create_and_consume_within_frame() {
 fn test_create_and_consume_with_mismatching_blueprint() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -133,7 +133,7 @@ fn test_create_and_consume_with_mismatching_blueprint() {
 fn test_create_and_consume_in_another_frame() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -155,7 +155,7 @@ fn test_create_and_consume_in_another_frame() {
 fn test_create_and_store_in_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -177,7 +177,7 @@ fn test_create_and_store_in_key_value_store() {
 fn test_create_and_store_in_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/allocated_address.rs
+++ b/radix-engine-tests/tests/allocated_address.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{CannotGlobalizeError, KernelError, RuntimeError, SystemError},
     types::*,
@@ -9,7 +12,7 @@ use transaction::prelude::*;
 fn test_create_and_return() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -33,7 +36,7 @@ fn test_create_and_return() {
 fn test_create_and_pass_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -55,7 +58,7 @@ fn test_create_and_pass_address() {
 fn test_create_and_call() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -79,7 +82,7 @@ fn test_create_and_call() {
 fn test_create_and_consume_within_frame() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -101,7 +104,7 @@ fn test_create_and_consume_within_frame() {
 fn test_create_and_consume_with_mismatching_blueprint() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -130,7 +133,7 @@ fn test_create_and_consume_with_mismatching_blueprint() {
 fn test_create_and_consume_in_another_frame() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -152,7 +155,7 @@ fn test_create_and_consume_in_another_frame() {
 fn test_create_and_store_in_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -174,7 +177,7 @@ fn test_create_and_store_in_key_value_store() {
 fn test_create_and_store_in_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/allocated_address");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("allocated_address"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/arguments.rs
+++ b/radix-engine-tests/tests/arguments.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 fn vector_of_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -32,7 +35,7 @@ fn vector_of_buckets_argument_should_succeed() {
 fn tuple_of_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -58,7 +61,7 @@ fn tuple_of_buckets_argument_should_succeed() {
 fn treemap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -87,7 +90,7 @@ fn treemap_of_strings_and_buckets_argument_should_succeed() {
 fn hashmap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -116,7 +119,7 @@ fn hashmap_of_strings_and_buckets_argument_should_succeed() {
 fn some_optional_bucket_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -141,7 +144,7 @@ fn some_optional_bucket_argument_should_succeed() {
 fn none_optional_bucket_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/arguments");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/arguments.rs
+++ b/radix-engine-tests/tests/arguments.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 fn vector_of_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -35,7 +35,7 @@ fn vector_of_buckets_argument_should_succeed() {
 fn tuple_of_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -61,7 +61,7 @@ fn tuple_of_buckets_argument_should_succeed() {
 fn treemap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -90,7 +90,7 @@ fn treemap_of_strings_and_buckets_argument_should_succeed() {
 fn hashmap_of_strings_and_buckets_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -119,7 +119,7 @@ fn hashmap_of_strings_and_buckets_argument_should_succeed() {
 fn some_optional_bucket_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -144,7 +144,7 @@ fn some_optional_bucket_argument_should_succeed() {
 fn none_optional_bucket_argument_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("arguments"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("arguments"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/auth_component.rs
+++ b/radix-engine-tests/tests/auth_component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use radix_engine_interface::rule;
@@ -59,7 +62,7 @@ fn cannot_make_cross_component_call_without_correct_global_caller_authorization(
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
     let badge =
         NonFungibleGlobalId::global_caller_badge(GlobalCaller::GlobalObject(account.into()));
     let secured_component = create_secured_component(&mut test_runner, badge, package_address);
@@ -84,7 +87,7 @@ fn cannot_make_cross_component_call_without_correct_global_caller_authorization(
 fn can_make_cross_component_call_with_correct_global_caller_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
     let my_component = create_component(&mut test_runner, package_address);
     let badge =
         NonFungibleGlobalId::global_caller_badge(GlobalCaller::GlobalObject(my_component.into()));
@@ -110,7 +113,7 @@ fn cannot_make_cross_component_call_without_resource_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
     let (secured_component, _) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);
@@ -135,7 +138,7 @@ fn can_make_cross_component_call_with_resource_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
     let (secured_component, auth_id) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);
@@ -178,7 +181,7 @@ fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
     let (secured_component, auth_id) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);

--- a/radix-engine-tests/tests/auth_component.rs
+++ b/radix-engine-tests/tests/auth_component.rs
@@ -62,7 +62,7 @@ fn cannot_make_cross_component_call_without_correct_global_caller_authorization(
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("component"));
     let badge =
         NonFungibleGlobalId::global_caller_badge(GlobalCaller::GlobalObject(account.into()));
     let secured_component = create_secured_component(&mut test_runner, badge, package_address);
@@ -87,7 +87,7 @@ fn cannot_make_cross_component_call_without_correct_global_caller_authorization(
 fn can_make_cross_component_call_with_correct_global_caller_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("component"));
     let my_component = create_component(&mut test_runner, package_address);
     let badge =
         NonFungibleGlobalId::global_caller_badge(GlobalCaller::GlobalObject(my_component.into()));
@@ -113,7 +113,7 @@ fn cannot_make_cross_component_call_without_resource_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("component"));
     let (secured_component, _) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);
@@ -138,7 +138,7 @@ fn can_make_cross_component_call_with_resource_authorization() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("component"));
     let (secured_component, auth_id) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);
@@ -181,7 +181,7 @@ fn root_auth_zone_does_not_carry_over_cross_component_calls() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("component"));
     let (secured_component, auth_id) =
         create_resource_secured_component(&mut test_runner, account, package_address);
     let my_component = create_component(&mut test_runner, package_address);

--- a/radix-engine-tests/tests/auth_package_token.rs
+++ b/radix-engine-tests/tests/auth_package_token.rs
@@ -11,7 +11,7 @@ use transaction::prelude::*;
 fn can_call_self_with_package_token() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_token"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("package_token"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -28,7 +28,7 @@ fn can_call_self_with_package_token() {
 fn cannot_call_package_protected_function_without_package_token() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_token"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("package_token"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "Factory", "create_raw", manifest_args!())

--- a/radix-engine-tests/tests/auth_package_token.rs
+++ b/radix-engine-tests/tests/auth_package_token.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
@@ -8,7 +11,7 @@ use transaction::prelude::*;
 fn can_call_self_with_package_token() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/package_token");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_token"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -25,7 +28,7 @@ fn can_call_self_with_package_token() {
 fn cannot_call_package_protected_function_without_package_token() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/package_token");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_token"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "Factory", "create_raw", manifest_args!())

--- a/radix-engine-tests/tests/auth_scenarios.rs
+++ b/radix-engine-tests/tests/auth_scenarios.rs
@@ -84,7 +84,7 @@ impl AuthScenariosEnv {
         );
 
         let package_address =
-            test_runner.publish_package_tuple(PackageLoader::get("auth_scenarios"));
+            test_runner.publish_package_simple(PackageLoader::get("auth_scenarios"));
 
         let manifest = ManifestBuilder::new()
             .call_function(package_address, "Swappy", "create", manifest_args!(cerb))

--- a/radix-engine-tests/tests/auth_scenarios.rs
+++ b/radix-engine-tests/tests/auth_scenarios.rs
@@ -1,4 +1,7 @@
+mod package_loader;
+
 use crate::node_modules::auth::RoleDefinition;
+use package_loader::PackageLoader;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::node_modules::auth::ToRoleEntry;
@@ -80,7 +83,8 @@ impl AuthScenariosEnv {
             vec![],
         );
 
-        let package_address = test_runner.compile_and_publish("./tests/blueprints/auth_scenarios");
+        let package_address =
+            test_runner.publish_package_tuple(PackageLoader::get("auth_scenarios"));
 
         let manifest = ManifestBuilder::new()
             .call_function(package_address, "Swappy", "create", manifest_args!(cerb))

--- a/radix-engine-tests/tests/balance_changes.rs
+++ b/radix-engine-tests/tests/balance_changes.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{transaction::BalanceChange, types::*};
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
@@ -13,8 +16,8 @@ fn test_balance_changes_when_success() {
     let owner_badge_resource = test_runner.create_non_fungible_resource(account);
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
-    let package_address = test_runner.compile_and_publish_with_owner(
-        "./tests/blueprints/balance_changes",
+    let package_address = test_runner.publish_package_with_owner(
+        PackageLoader::get("balance_changes"),
         owner_badge_addr.clone(),
     );
 
@@ -98,8 +101,8 @@ fn test_balance_changes_when_failure() {
     let owner_badge_resource = test_runner.create_non_fungible_resource(account);
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
-    let package_address = test_runner.compile_and_publish_with_owner(
-        "./tests/blueprints/balance_changes",
+    let package_address = test_runner.publish_package_with_owner(
+        PackageLoader::get("balance_changes"),
         owner_badge_addr.clone(),
     );
 

--- a/radix-engine-tests/tests/blueprints/address/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/address/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/address_reservation/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/address_reservation/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/allocated_address/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/allocated_address/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/arguments/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/arguments/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/auth_scenarios/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/auth_scenarios/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/balance_changes/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/balance_changes/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/bucket/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/bucket/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/cast/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/cast/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/clock/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/clock/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/component/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/component/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/consensus_manager/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/consensus_manager/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/core/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/core/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/costing/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/costing/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/data_validation/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/data_validation/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/deep_sbor/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/deep_sbor/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/events/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/events/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/events_invalid/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/events_invalid/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/execution_trace/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/execution_trace/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/external_blueprint_caller/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/external_blueprint_caller/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/fake_bucket/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/fake_bucket/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/fee/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/fee/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/fee_reserve_states/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/fee_reserve_states/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/kv_store/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/kv_store/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/large_package/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/large_package/Cargo.toml
@@ -19,4 +19,5 @@ package = { path = "../package" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/leaks/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/leaks/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/local_component/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/local_component/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/local_recursion/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/local_recursion/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/logger/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/logger/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/metadata_component/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/metadata_component/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/module/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/module/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/non_fungible/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/non_fungible/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/package/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/package/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/package_invalid/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/package_invalid/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/package_schema/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/package_schema/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/package_token/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/package_token/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/proof/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/proof/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/proof_creation/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/proof_creation/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/publish_package/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/publish_package/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/recall/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/recall/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/recursion/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/recursion/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/reentrancy/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/reentrancy/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/reference/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/reference/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/remote_generic_args/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/remote_generic_args/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/resource/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/resource/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/role_assignment/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/role_assignment/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/royalty-auth/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/royalty-auth/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/royalty/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/royalty/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/scrypto_env/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/scrypto_env/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/static_dependencies/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/static_dependencies/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/static_dependencies2/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/static_dependencies2/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/storage/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/storage/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/stored_external_component/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/stored_external_component/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/stored_resource/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/stored_resource/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/stored_values/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/stored_values/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/transaction_limits/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/transaction_limits/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/transaction_runtime/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/transaction_runtime/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/tx_processor_access/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/tx_processor_access/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/validator/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/validator/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/vault/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/vault/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/wasm_non_mvp/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/wasm_non_mvp/Cargo.toml
@@ -11,4 +11,5 @@ scrypto = { path = "../../../../scrypto" }
 radix-engine = { path = "../../../../radix-engine" }
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/bucket.rs
+++ b/radix-engine-tests/tests/bucket.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::SystemError;
 use radix_engine::{
     blueprints::resource::BucketError,
@@ -13,7 +16,7 @@ fn test_bucket_internal(method_name: &str, args: ManifestValue, expect_success: 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -106,7 +109,7 @@ fn test_bucket_empty_non_fungible() {
 fn test_bucket_of_badges() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account)
@@ -129,7 +132,7 @@ fn test_take_with_invalid_granularity() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -167,7 +170,7 @@ fn test_take_with_negative_amount() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -235,7 +238,7 @@ fn test_drop_locked_fungible_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -270,7 +273,7 @@ fn test_drop_locked_non_fungible_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -305,7 +308,7 @@ fn test_bucket_combine_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -336,7 +339,7 @@ fn test_bucket_combine_non_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -367,7 +370,7 @@ fn test_vault_combine_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -398,7 +401,7 @@ fn test_vault_combine_non_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/bucket");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/bucket.rs
+++ b/radix-engine-tests/tests/bucket.rs
@@ -16,7 +16,7 @@ fn test_bucket_internal(method_name: &str, args: ManifestValue, expect_success: 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -109,7 +109,7 @@ fn test_bucket_empty_non_fungible() {
 fn test_bucket_of_badges() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     let manifest = ManifestBuilder::new()
         .lock_standard_test_fee(account)
@@ -132,7 +132,7 @@ fn test_take_with_invalid_granularity() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -170,7 +170,7 @@ fn test_take_with_negative_amount() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(100.into(), 2, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -238,7 +238,7 @@ fn test_drop_locked_fungible_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -273,7 +273,7 @@ fn test_drop_locked_non_fungible_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -308,7 +308,7 @@ fn test_bucket_combine_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -339,7 +339,7 @@ fn test_bucket_combine_non_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -370,7 +370,7 @@ fn test_vault_combine_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -401,7 +401,7 @@ fn test_vault_combine_non_fungible_invalid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("bucket"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("bucket"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/clock.rs
+++ b/radix-engine-tests/tests/clock.rs
@@ -18,7 +18,7 @@ fn sdk_clock_reads_timestamp_set_by_validator_next_round() {
             CustomGenesis::default_consensus_manager_config(),
         ))
         .build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("clock"));
 
     let time_to_set_ms = 1669663688996;
     let expected_unix_time_rounded_to_minutes = 1669663680;
@@ -52,7 +52,7 @@ fn sdk_clock_reads_timestamp_set_by_validator_next_round() {
 fn no_auth_required_to_get_current_time_rounded_to_minutes() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -80,7 +80,7 @@ fn sdk_clock_compares_against_timestamp_set_by_validator_next_round() {
             CustomGenesis::default_consensus_manager_config(),
         ))
         .build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -107,7 +107,7 @@ fn sdk_clock_compares_against_timestamp_set_by_validator_next_round() {
 fn test_date_time_conversions() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/clock.rs
+++ b/radix-engine-tests/tests/clock.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::blueprints::consensus_manager::{
@@ -15,7 +18,7 @@ fn sdk_clock_reads_timestamp_set_by_validator_next_round() {
             CustomGenesis::default_consensus_manager_config(),
         ))
         .build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
 
     let time_to_set_ms = 1669663688996;
     let expected_unix_time_rounded_to_minutes = 1669663680;
@@ -49,7 +52,7 @@ fn sdk_clock_reads_timestamp_set_by_validator_next_round() {
 fn no_auth_required_to_get_current_time_rounded_to_minutes() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -77,7 +80,7 @@ fn sdk_clock_compares_against_timestamp_set_by_validator_next_round() {
             CustomGenesis::default_consensus_manager_config(),
         ))
         .build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -104,7 +107,7 @@ fn sdk_clock_compares_against_timestamp_set_by_validator_next_round() {
 fn test_date_time_conversions() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/clock");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("clock"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/component.rs
+++ b/radix-engine-tests/tests/component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::RuntimeError;
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 #[test]
 fn test_component() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("component"));
 
     // Create component
     let manifest1 = ManifestBuilder::new()
@@ -26,7 +29,7 @@ fn test_component() {
 fn invalid_blueprint_name_should_cause_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_addr = test_runner.compile_and_publish("./tests/blueprints/component");
+    let package_addr = test_runner.publish_package_tuple(PackageLoader::get("component"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/component.rs
+++ b/radix-engine-tests/tests/component.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 #[test]
 fn test_component() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("component"));
 
     // Create component
     let manifest1 = ManifestBuilder::new()
@@ -29,7 +29,7 @@ fn test_component() {
 fn invalid_blueprint_name_should_cause_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_addr = test_runner.publish_package_tuple(PackageLoader::get("component"));
+    let package_addr = test_runner.publish_package_simple(PackageLoader::get("component"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::consensus_manager::{
     Validator, ValidatorEmissionAppliedEvent, ValidatorError,
 };
@@ -127,7 +130,8 @@ fn genesis_epoch_has_correct_initial_validators() {
 fn get_epoch_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/consensus_manager");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("consensus_manager"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -150,7 +154,8 @@ fn get_epoch_should_succeed() {
 fn next_round_without_supervisor_auth_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/consensus_manager");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("consensus_manager"));
 
     // Act
     let round = Round::of(9876);

--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -131,7 +131,7 @@ fn get_epoch_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("consensus_manager"));
+        test_runner.publish_package_simple(PackageLoader::get("consensus_manager"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -155,7 +155,7 @@ fn next_round_without_supervisor_auth_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("consensus_manager"));
+        test_runner.publish_package_simple(PackageLoader::get("consensus_manager"));
 
     // Act
     let round = Round::of(9876);

--- a/radix-engine-tests/tests/core.rs
+++ b/radix-engine-tests/tests/core.rs
@@ -13,7 +13,7 @@ use transaction::prelude::*;
 fn test_call() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -31,8 +31,8 @@ fn test_call() {
 #[test]
 fn cant_globalize_in_another_package() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address1 = test_runner.publish_package_tuple(PackageLoader::get("core"));
-    let package_address2 = test_runner.publish_package_tuple(PackageLoader::get("core"));
+    let package_address1 = test_runner.publish_package_simple(PackageLoader::get("core"));
+    let package_address2 = test_runner.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -54,7 +54,7 @@ fn cant_globalize_in_another_package() {
 
 fn call_function_and_assert_error(blueprint: &str, function: &str, expected_error: &str) {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -142,7 +142,7 @@ fn cant_store_role_assignment() {
 #[test]
 fn test_globalize_with_very_deep_own() {
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()

--- a/radix-engine-tests/tests/core.rs
+++ b/radix-engine-tests/tests/core.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{RuntimeError, SystemError},
     types::*,
@@ -10,7 +13,7 @@ use transaction::prelude::*;
 fn test_call() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/core");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -28,8 +31,8 @@ fn test_call() {
 #[test]
 fn cant_globalize_in_another_package() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address1 = test_runner.compile_and_publish("./tests/blueprints/core");
-    let package_address2 = test_runner.compile_and_publish("./tests/blueprints/core");
+    let package_address1 = test_runner.publish_package_tuple(PackageLoader::get("core"));
+    let package_address2 = test_runner.publish_package_tuple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -51,7 +54,7 @@ fn cant_globalize_in_another_package() {
 
 fn call_function_and_assert_error(blueprint: &str, function: &str, expected_error: &str) {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/core");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -139,7 +142,7 @@ fn cant_store_role_assignment() {
 #[test]
 fn test_globalize_with_very_deep_own() {
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/core");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()

--- a/radix-engine-tests/tests/data_validation.rs
+++ b/radix-engine-tests/tests/data_validation.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::system::system_type_checker::TypeCheckError;
 use radix_engine::{
     errors::{CallFrameError, KernelError, RuntimeError, SystemError},
@@ -9,7 +12,7 @@ use scrypto_unit::*;
 use transaction::prelude::*;
 
 fn setup_component(test_runner: &mut DefaultTestRunner) -> ComponentAddress {
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/data_validation");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
 
     let setup_manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -220,7 +223,7 @@ fn cannot_return_bucket_for_proof() {
 fn cannot_create_object_with_mismatching_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/data_validation");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -349,7 +352,7 @@ fn test_receive_reference_not_of_specific_blueprint() {
 fn vec_of_u8_underflow_should_not_cause_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("tests/blueprints/data_validation");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/data_validation.rs
+++ b/radix-engine-tests/tests/data_validation.rs
@@ -12,7 +12,7 @@ use scrypto_unit::*;
 use transaction::prelude::*;
 
 fn setup_component(test_runner: &mut DefaultTestRunner) -> ComponentAddress {
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("data_validation"));
 
     let setup_manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -223,7 +223,7 @@ fn cannot_return_bucket_for_proof() {
 fn cannot_create_object_with_mismatching_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("data_validation"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -352,7 +352,7 @@ fn test_receive_reference_not_of_specific_blueprint() {
 fn vec_of_u8_underflow_should_not_cause_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("data_validation"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("data_validation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/deep_sbor.rs
+++ b/radix-engine-tests/tests/deep_sbor.rs
@@ -11,7 +11,7 @@ use transaction::prelude::*;
 fn deep_auth_rules_on_component_create_creation_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("deep_sbor"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("deep_sbor"));
 
     // Act 1 - Small Depth
     let depth = 10usize;
@@ -52,7 +52,7 @@ fn deep_auth_rules_on_component_create_creation_fails() {
 fn setting_struct_with_deep_recursive_data_panics_inside_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("deep_sbor"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("deep_sbor"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -108,8 +108,7 @@ fn publish_wasm_with_deep_sbor_response_and_execute_it(depth: usize) -> Transact
         &include_str!("wasm/deep_sbor_response.wat").replace("${depth}", &depth.to_string()),
     );
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );

--- a/radix-engine-tests/tests/deep_sbor.rs
+++ b/radix-engine-tests/tests/deep_sbor.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -8,7 +11,7 @@ use transaction::prelude::*;
 fn deep_auth_rules_on_component_create_creation_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("deep_sbor"));
 
     // Act 1 - Small Depth
     let depth = 10usize;
@@ -49,7 +52,7 @@ fn deep_auth_rules_on_component_create_creation_fails() {
 fn setting_struct_with_deep_recursive_data_panics_inside_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/deep_sbor");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("deep_sbor"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()

--- a/radix-engine-tests/tests/determinism.rs
+++ b/radix-engine-tests/tests/determinism.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto::resource::DIVISIBILITY_MAXIMUM;
 use scrypto_unit::*;
@@ -42,7 +45,7 @@ fn create_and_pass_multiple_proofs() -> Hash {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let mut builder = ManifestBuilder::new();

--- a/radix-engine-tests/tests/determinism.rs
+++ b/radix-engine-tests/tests/determinism.rs
@@ -45,7 +45,7 @@ fn create_and_pass_multiple_proofs() -> Hash {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let mut builder = ManifestBuilder::new();

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::consensus_manager::{
     ClaimXrdEvent, EpochChangeEvent, RegisterValidatorEvent, RoundChangeEvent, StakeEvent,
     UnregisterValidatorEvent, UnstakeEvent, UpdateAcceptingStakeDelegationStateEvent,
@@ -211,7 +214,7 @@ fn create_proof_emits_correct_events() {
 fn scrypto_cant_emit_unregistered_event() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/events");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -241,7 +244,7 @@ fn scrypto_cant_emit_unregistered_event() {
 fn scrypto_can_emit_registered_events() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/events");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET, 500)

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -214,7 +214,7 @@ fn create_proof_emits_correct_events() {
 fn scrypto_cant_emit_unregistered_event() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("events"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -244,7 +244,7 @@ fn scrypto_cant_emit_unregistered_event() {
 fn scrypto_can_emit_registered_events() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("events"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET, 500)
@@ -295,7 +295,7 @@ fn cant_publish_a_package_with_non_struct_or_enum_event() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
 
-    let (code, definition) = Compile::compile("./tests/blueprints/events_invalid");
+    let (code, definition) = PackageLoader::get("events_invalid");
     let manifest = ManifestBuilder::new()
         .lock_fee(FAUCET, 500)
         .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
@@ -320,7 +320,7 @@ fn local_type_id_with_misleading_name_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
 
-    let (code, mut definition) = Compile::compile("./tests/blueprints/events");
+    let (code, mut definition) = PackageLoader::get("events");
     let blueprint_setup = definition.blueprints.get_mut("ScryptoEvents").unwrap();
     blueprint_setup.schema.events.event_schema.insert(
         "HelloHelloEvent".to_string(),

--- a/radix-engine-tests/tests/execution_trace.rs
+++ b/radix-engine-tests/tests/execution_trace.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::system::system_modules::execution_trace::{
     ApplicationFnIdentifier, ExecutionTrace, ResourceSpecifier, TraceOrigin, WorktopChange,
 };
@@ -11,7 +14,7 @@ fn test_trace_resource_transfers() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
     let transfer_amount = 10u8;
 
     // Act
@@ -129,7 +132,7 @@ fn test_trace_resource_transfers() {
 fn test_trace_fee_payments() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
 
     // Prepare the component that will pay the fee
     let manifest_prepare = ManifestBuilder::new()
@@ -188,7 +191,7 @@ fn test_trace_fee_payments() {
 fn test_instruction_traces() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/execution_trace");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()

--- a/radix-engine-tests/tests/execution_trace.rs
+++ b/radix-engine-tests/tests/execution_trace.rs
@@ -14,7 +14,7 @@ fn test_trace_resource_transfers() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("execution_trace"));
     let transfer_amount = 10u8;
 
     // Act
@@ -132,7 +132,7 @@ fn test_trace_resource_transfers() {
 fn test_trace_fee_payments() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("execution_trace"));
 
     // Prepare the component that will pay the fee
     let manifest_prepare = ManifestBuilder::new()
@@ -191,7 +191,7 @@ fn test_trace_fee_payments() {
 fn test_instruction_traces() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("execution_trace"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("execution_trace"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()

--- a/radix-engine-tests/tests/external_bridge.rs
+++ b/radix-engine-tests/tests/external_bridge.rs
@@ -17,14 +17,14 @@ fn test_external_bridges() {
 
     // Part 1 - Upload the target and caller packages
     // Note - we put them in separate packages so that we test that the package call is to an external package
-    test_runner.compile_and_publish_at_address(
-        "./tests/blueprints/component",
+    test_runner.publish_package_at_address(
+        PackageLoader::get("component"),
         PackageAddress::new_or_panic(TARGET_PACKAGE_ADDRESS),
     );
     let target_package_address = PackageAddress::new_or_panic(TARGET_PACKAGE_ADDRESS);
 
     let caller_package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("external_blueprint_caller"));
+        test_runner.publish_package_simple(PackageLoader::get("external_blueprint_caller"));
 
     // Part 2 - Get a target component address
     let manifest1 = ManifestBuilder::new()

--- a/radix-engine-tests/tests/external_bridge.rs
+++ b/radix-engine-tests/tests/external_bridge.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -21,7 +24,7 @@ fn test_external_bridges() {
     let target_package_address = PackageAddress::new_or_panic(TARGET_PACKAGE_ADDRESS);
 
     let caller_package_address =
-        test_runner.compile_and_publish("./tests/blueprints/external_blueprint_caller");
+        test_runner.publish_package_tuple(PackageLoader::get("external_blueprint_caller"));
 
     // Part 2 - Get a target component address
     let manifest1 = ManifestBuilder::new()

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::WorktopError;
 use radix_engine::errors::RuntimeError;
 use radix_engine::errors::{ApplicationError, CallFrameError, KernelError};
@@ -27,7 +30,7 @@ fn setup_test_runner() -> (DefaultTestRunner, ComponentAddress) {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package and instantiate component
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/fee");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("fee"));
     let receipt1 = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_standard_test_fee(account)

--- a/radix-engine-tests/tests/fee.rs
+++ b/radix-engine-tests/tests/fee.rs
@@ -30,7 +30,7 @@ fn setup_test_runner() -> (DefaultTestRunner, ComponentAddress) {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package and instantiate component
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("fee"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("fee"));
     let receipt1 = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_standard_test_fee(account)

--- a/radix-engine-tests/tests/fee_reserve_states.rs
+++ b/radix-engine-tests/tests/fee_reserve_states.rs
@@ -14,7 +14,7 @@ fn test_fee_states() {
 
     // Publish package
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("fee_reserve_states"));
+        test_runner.publish_package_simple(PackageLoader::get("fee_reserve_states"));
 
     // Run test case
     let fee_locked = dec!(500);

--- a/radix-engine-tests/tests/fee_reserve_states.rs
+++ b/radix-engine-tests/tests/fee_reserve_states.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
@@ -10,7 +13,8 @@ fn test_fee_states() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/fee_reserve_states");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("fee_reserve_states"));
 
     // Run test case
     let fee_locked = dec!(500);

--- a/radix-engine-tests/tests/frame.rs
+++ b/radix-engine-tests/tests/frame.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::limits::TransactionLimitsError;
 use radix_engine::types::*;
@@ -9,7 +12,7 @@ use transaction::prelude::*;
 fn test_max_call_depth_success() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recursion"));
 
     // Act
     // ============================
@@ -38,7 +41,7 @@ fn test_max_call_depth_success() {
 fn test_max_call_depth_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/frame.rs
+++ b/radix-engine-tests/tests/frame.rs
@@ -12,7 +12,7 @@ use transaction::prelude::*;
 fn test_max_call_depth_success() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recursion"));
 
     // Act
     // ============================
@@ -41,7 +41,7 @@ fn test_max_call_depth_success() {
 fn test_max_call_depth_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/invalid_stored_values.rs
+++ b/radix-engine-tests/tests/invalid_stored_values.rs
@@ -11,7 +11,7 @@ use transaction::prelude::*;
 fn stored_bucket_in_committed_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("stored_values"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("stored_values"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -42,7 +42,7 @@ fn stored_bucket_in_committed_component_should_fail() {
 fn stored_bucket_in_owned_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("stored_values"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("stored_values"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/invalid_stored_values.rs
+++ b/radix-engine-tests/tests/invalid_stored_values.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::{MovePartitionError, PersistNodeError};
 use radix_engine::types::*;
@@ -8,7 +11,7 @@ use transaction::prelude::*;
 fn stored_bucket_in_committed_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/stored_values");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("stored_values"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -39,7 +42,7 @@ fn stored_bucket_in_committed_component_should_fail() {
 fn stored_bucket_in_owned_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/stored_values");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("stored_values"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/kv_store.rs
+++ b/radix-engine-tests/tests/kv_store.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::{
     CreateNodeError, OpenSubstateError, ProcessSubstateError, TakeNodeError, WriteSubstateError,
@@ -10,7 +13,7 @@ use transaction::prelude::*;
 fn can_insert_in_child_nodes() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -32,7 +35,7 @@ fn can_insert_in_child_nodes() {
 fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -54,7 +57,7 @@ fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
 fn cyclic_map_fails_execution() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -78,7 +81,7 @@ fn cyclic_map_fails_execution() {
 fn self_cyclic_map_fails_execution() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -109,7 +112,7 @@ fn self_cyclic_map_fails_execution() {
 fn cannot_remove_kv_stores() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -146,7 +149,7 @@ fn cannot_remove_kv_stores() {
 fn cannot_overwrite_kv_stores() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -183,7 +186,7 @@ fn cannot_overwrite_kv_stores() {
 fn create_kv_store_and_get() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -205,7 +208,7 @@ fn create_kv_store_and_get() {
 fn create_kv_store_and_put() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -227,7 +230,7 @@ fn create_kv_store_and_put() {
 fn can_reference_in_memory_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -249,7 +252,7 @@ fn can_reference_in_memory_vault() {
 fn can_reference_deep_in_memory_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -271,7 +274,7 @@ fn can_reference_deep_in_memory_value() {
 fn can_reference_deep_in_memory_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -293,7 +296,7 @@ fn can_reference_deep_in_memory_vault() {
 fn cannot_directly_reference_inserted_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -322,7 +325,7 @@ fn cannot_directly_reference_inserted_vault() {
 fn cannot_directly_reference_vault_after_container_moved() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -351,7 +354,7 @@ fn cannot_directly_reference_vault_after_container_moved() {
 fn cannot_directly_reference_vault_after_container_stored() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -380,7 +383,7 @@ fn cannot_directly_reference_vault_after_container_stored() {
 fn multiple_reads_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -397,7 +400,7 @@ fn multiple_reads_should_work() {
 fn remove_from_local_map_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -419,7 +422,7 @@ fn remove_from_local_map_should_work() {
 fn remove_from_stored_map_when_empty_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "Basic", "new", manifest_args!())
@@ -449,7 +452,7 @@ fn remove_from_stored_map_when_empty_should_work() {
 fn remove_from_stored_map_when_not_empty_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -480,7 +483,7 @@ fn remove_from_stored_map_when_not_empty_should_work() {
 fn remove_from_stored_map_when_contain_vault_should_not_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "KVVault", "new", manifest_args!())
@@ -512,7 +515,7 @@ fn remove_from_stored_map_when_contain_vault_should_not_work() {
 fn nested_kv_stores_works() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/kv_store");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/kv_store.rs
+++ b/radix-engine-tests/tests/kv_store.rs
@@ -13,7 +13,7 @@ use transaction::prelude::*;
 fn can_insert_in_child_nodes() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -35,7 +35,7 @@ fn can_insert_in_child_nodes() {
 fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -57,7 +57,7 @@ fn create_mutable_kv_store_into_map_and_referencing_before_storing() {
 fn cyclic_map_fails_execution() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -81,7 +81,7 @@ fn cyclic_map_fails_execution() {
 fn self_cyclic_map_fails_execution() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -112,7 +112,7 @@ fn self_cyclic_map_fails_execution() {
 fn cannot_remove_kv_stores() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -149,7 +149,7 @@ fn cannot_remove_kv_stores() {
 fn cannot_overwrite_kv_stores() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -186,7 +186,7 @@ fn cannot_overwrite_kv_stores() {
 fn create_kv_store_and_get() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -208,7 +208,7 @@ fn create_kv_store_and_get() {
 fn create_kv_store_and_put() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -230,7 +230,7 @@ fn create_kv_store_and_put() {
 fn can_reference_in_memory_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -252,7 +252,7 @@ fn can_reference_in_memory_vault() {
 fn can_reference_deep_in_memory_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -274,7 +274,7 @@ fn can_reference_deep_in_memory_value() {
 fn can_reference_deep_in_memory_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -296,7 +296,7 @@ fn can_reference_deep_in_memory_vault() {
 fn cannot_directly_reference_inserted_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -325,7 +325,7 @@ fn cannot_directly_reference_inserted_vault() {
 fn cannot_directly_reference_vault_after_container_moved() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -354,7 +354,7 @@ fn cannot_directly_reference_vault_after_container_moved() {
 fn cannot_directly_reference_vault_after_container_stored() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -383,7 +383,7 @@ fn cannot_directly_reference_vault_after_container_stored() {
 fn multiple_reads_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -400,7 +400,7 @@ fn multiple_reads_should_work() {
 fn remove_from_local_map_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -422,7 +422,7 @@ fn remove_from_local_map_should_work() {
 fn remove_from_stored_map_when_empty_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "Basic", "new", manifest_args!())
@@ -452,7 +452,7 @@ fn remove_from_stored_map_when_empty_should_work() {
 fn remove_from_stored_map_when_not_empty_should_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -483,7 +483,7 @@ fn remove_from_stored_map_when_not_empty_should_work() {
 fn remove_from_stored_map_when_contain_vault_should_not_work() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "KVVault", "new", manifest_args!())
@@ -515,7 +515,7 @@ fn remove_from_stored_map_when_contain_vault_should_not_work() {
 fn nested_kv_stores_works() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("kv_store"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("kv_store"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/leaks.rs
+++ b/radix-engine-tests/tests/leaks.rs
@@ -11,7 +11,7 @@ use transaction::prelude::*;
 fn dangling_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -35,7 +35,7 @@ fn dangling_component_should_fail() {
 fn dangling_bucket_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -59,7 +59,7 @@ fn dangling_bucket_should_fail() {
 fn dangling_vault_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -78,7 +78,7 @@ fn dangling_vault_should_fail() {
 fn dangling_worktop_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -102,7 +102,7 @@ fn dangling_worktop_should_fail() {
 fn dangling_kv_store_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -126,7 +126,7 @@ fn dangling_kv_store_should_fail() {
 fn dangling_bucket_with_proof_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/leaks.rs
+++ b/radix-engine-tests/tests/leaks.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::FungibleResourceManagerError;
 use radix_engine::errors::{ApplicationError, KernelError, RuntimeError};
 use radix_engine::types::*;
@@ -8,7 +11,7 @@ use transaction::prelude::*;
 fn dangling_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -32,7 +35,7 @@ fn dangling_component_should_fail() {
 fn dangling_bucket_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -56,7 +59,7 @@ fn dangling_bucket_should_fail() {
 fn dangling_vault_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -75,7 +78,7 @@ fn dangling_vault_should_fail() {
 fn dangling_worktop_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -99,7 +102,7 @@ fn dangling_worktop_should_fail() {
 fn dangling_kv_store_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -123,7 +126,7 @@ fn dangling_kv_store_should_fail() {
 fn dangling_bucket_with_proof_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/leaks");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("leaks"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/local_component.rs
+++ b/radix-engine-tests/tests/local_component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::limits::TransactionLimitsError;
 use radix_engine::types::*;
@@ -9,7 +12,7 @@ use transaction::prelude::*;
 fn local_component_should_be_callable_read_only() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -31,7 +34,7 @@ fn local_component_should_be_callable_read_only() {
 fn local_component_should_be_callable_with_write() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -54,7 +57,7 @@ fn recursion_bomb() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
@@ -86,7 +89,7 @@ fn recursion_bomb_to_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -124,7 +127,7 @@ fn recursion_bomb_2() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
@@ -156,7 +159,7 @@ fn recursion_bomb_2_to_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_recursion");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/local_component.rs
+++ b/radix-engine-tests/tests/local_component.rs
@@ -12,7 +12,7 @@ use transaction::prelude::*;
 fn local_component_should_be_callable_read_only() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -34,7 +34,7 @@ fn local_component_should_be_callable_read_only() {
 fn local_component_should_be_callable_with_write() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -57,7 +57,7 @@ fn recursion_bomb() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_recursion"));
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
@@ -89,7 +89,7 @@ fn recursion_bomb_to_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -127,7 +127,7 @@ fn recursion_bomb_2() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_recursion"));
 
     // Act
     // Note: currently SEGFAULT occurs if bucket with too much in it is sent. My guess the issue is a native stack overflow.
@@ -159,7 +159,7 @@ fn recursion_bomb_2_to_failure() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_recursion"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_recursion"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/logging.rs
+++ b/radix-engine-tests/tests/logging.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{ApplicationError, RuntimeError},
     transaction::TransactionReceipt,
@@ -9,7 +12,7 @@ use transaction::prelude::*;
 
 fn call<S: AsRef<str>>(function_name: &str, message: S) -> TransactionReceipt {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/logger");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("logger"));
 
     let manifest = ManifestBuilder::new()
         .call_function(

--- a/radix-engine-tests/tests/logging.rs
+++ b/radix-engine-tests/tests/logging.rs
@@ -12,7 +12,7 @@ use transaction::prelude::*;
 
 fn call<S: AsRef<str>>(function_name: &str, message: S) -> TransactionReceipt {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("logger"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("logger"));
 
     let manifest = ManifestBuilder::new()
         .call_function(

--- a/radix-engine-tests/tests/logging_limits.rs
+++ b/radix-engine-tests/tests/logging_limits.rs
@@ -70,8 +70,7 @@ fn test_emit_log(message_size: usize, iterations: usize, expected_err: Option<Ru
     let code = prepare_code(message_size, iterations);
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );

--- a/radix-engine-tests/tests/metadata_component.rs
+++ b/radix-engine-tests/tests/metadata_component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_queries::typed_substate_layout::{MetadataError, MetadataValidationError};
@@ -8,7 +11,8 @@ use transaction::prelude::*;
 fn cannot_create_metadata_with_invalid_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -37,7 +41,8 @@ fn cannot_create_metadata_with_invalid_value() {
 fn cannot_set_metadata_with_invalid_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -99,7 +104,8 @@ fn cannot_set_metadata_with_invalid_value() {
 fn can_globalize_with_component_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -125,7 +131,8 @@ fn can_globalize_with_component_metadata() {
 fn can_set_metadata_after_globalized() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -152,7 +159,8 @@ fn can_set_metadata_after_globalized() {
 fn can_remove_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -186,7 +194,8 @@ fn can_remove_metadata() {
 fn can_set_metadata_through_manifest(entry: MetadataValue) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -258,7 +267,8 @@ fn can_set_decimal_metadata_through_manifest() {
 fn can_set_address_metadata_through_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
     let key = Secp256k1PrivateKey::from_u64(1u64).unwrap().public_key();
     let address = test_runner
         .create_non_fungible_resource(ComponentAddress::virtual_account_from_public_key(&key));
@@ -296,7 +306,8 @@ fn can_set_address_metadata_through_manifest() {
 fn cannot_set_address_metadata_after_freezing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/metadata_component");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
     let key = Secp256k1PrivateKey::from_u64(1u64).unwrap().public_key();
     let address = test_runner
         .create_non_fungible_resource(ComponentAddress::virtual_account_from_public_key(&key));

--- a/radix-engine-tests/tests/metadata_component.rs
+++ b/radix-engine-tests/tests/metadata_component.rs
@@ -12,7 +12,7 @@ fn cannot_create_metadata_with_invalid_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -42,7 +42,7 @@ fn cannot_set_metadata_with_invalid_value() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -105,7 +105,7 @@ fn can_globalize_with_component_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -132,7 +132,7 @@ fn can_set_metadata_after_globalized() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -160,7 +160,7 @@ fn can_remove_metadata() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -195,7 +195,7 @@ fn can_set_metadata_through_manifest(entry: MetadataValue) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -268,7 +268,7 @@ fn can_set_address_metadata_through_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
     let key = Secp256k1PrivateKey::from_u64(1u64).unwrap().public_key();
     let address = test_runner
         .create_non_fungible_resource(ComponentAddress::virtual_account_from_public_key(&key));
@@ -307,7 +307,7 @@ fn cannot_set_address_metadata_after_freezing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("metadata_component"));
+        test_runner.publish_package_simple(PackageLoader::get("metadata_component"));
     let key = Secp256k1PrivateKey::from_u64(1u64).unwrap().public_key();
     let address = test_runner
         .create_non_fungible_resource(ComponentAddress::virtual_account_from_public_key(&key));

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::RejectionReason;
 use radix_engine::transaction::CostingParameters;
 use radix_engine::transaction::ExecutionConfig;
@@ -771,7 +774,7 @@ fn setup_test_runner_with_fee_blueprint_component() -> (DefaultTestRunner, Compo
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package and instantiate component
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/fee");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("fee"));
     let receipt1 = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_standard_test_fee(account)

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -413,8 +413,10 @@ fn run_radiswap(mode: Mode) {
 
     // Publish package
     let package_address = test_runner.publish_package(
-        include_bytes!("../../assets/radiswap.wasm").to_vec(),
-        manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap(),
+        (
+            include_bytes!("../../assets/radiswap.wasm").to_vec(),
+            manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap(),
+        ),
         btreemap!(),
         OwnerRole::Fixed(rule!(require(NonFungibleGlobalId::from_public_key(&pk1)))),
     );
@@ -513,8 +515,10 @@ fn run_flash_loan(mode: Mode) {
 
     // Publish package
     let package_address = test_runner.publish_package(
-        include_bytes!("../../assets/flash_loan.wasm").to_vec(),
-        manifest_decode(include_bytes!("../../assets/flash_loan.rpd")).unwrap(),
+        (
+            include_bytes!("../../assets/flash_loan.wasm").to_vec(),
+            manifest_decode(include_bytes!("../../assets/flash_loan.rpd")).unwrap(),
+        ),
         btreemap!(),
         OwnerRole::Fixed(rule!(require(NonFungibleGlobalId::from_public_key(&pk1)))),
     );
@@ -774,7 +778,7 @@ fn setup_test_runner_with_fee_blueprint_component() -> (DefaultTestRunner, Compo
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package and instantiate component
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("fee"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("fee"));
     let receipt1 = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_standard_test_fee(account)
@@ -840,13 +844,13 @@ impl NonFungibleData for TestNonFungibleData {
 #[test]
 fn publish_package_1mib() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let (code, definition) = Compile::compile("./tests/blueprints/large_package");
+    let (code, definition) = PackageLoader::get("large_package");
     println!("Code size: {}", code.len());
     assert!(code.len() <= 1000 * 1024);
     assert!(code.len() >= 900 * 1024);
 
     // internally validates if publish succeeded
-    test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+    test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
 }
 
 /// Based on product requirements, system loan should be just enough to cover:

--- a/radix-engine-tests/tests/module.rs
+++ b/radix-engine-tests/tests/module.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -7,7 +10,7 @@ use transaction::prelude::*;
 fn mixed_up_modules_causes_type_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/module");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("module"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/module.rs
+++ b/radix-engine-tests/tests/module.rs
@@ -10,7 +10,7 @@ use transaction::prelude::*;
 fn mixed_up_modules_causes_type_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("module"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("module"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -16,7 +16,7 @@ fn can_mint_non_fungible_with_global() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -43,7 +43,7 @@ fn create_non_fungible_mutable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -70,7 +70,7 @@ fn can_burn_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -120,7 +120,7 @@ fn test_take_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -144,7 +144,7 @@ fn test_take_non_fungibles() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -167,7 +167,7 @@ fn test_take_non_fungibles() {
 fn can_update_non_fungible_when_mutable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -189,7 +189,7 @@ fn can_update_non_fungible_when_mutable() {
 fn cannot_update_non_fungible_when_not_mutable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -218,7 +218,7 @@ fn cannot_update_non_fungible_when_not_mutable() {
 fn cannot_update_non_fungible_when_does_not_exist() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -254,7 +254,7 @@ fn can_call_non_fungible_data_reference() {
         "test_value",
         NonFungibleGlobalId::from_public_key(&public_key),
     );
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -293,7 +293,7 @@ fn can_call_non_fungible_data_reference() {
 fn cannot_have_non_fungible_data_ownership() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -322,7 +322,7 @@ fn cannot_have_non_fungible_data_ownership() {
 fn can_update_and_get_non_fungible() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -344,7 +344,7 @@ fn can_update_and_get_non_fungible() {
 fn can_update_and_get_non_fungible_reference() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -367,7 +367,7 @@ fn can_check_if_contains_non_fungible_in_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -394,7 +394,7 @@ fn can_check_if_contains_non_fungible_in_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -420,7 +420,7 @@ fn can_check_if_contains_non_fungible_in_bucket() {
 fn test_non_fungible_part_1() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -461,7 +461,7 @@ fn test_non_fungible_part_1() {
 fn test_non_fungible_part_2() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -496,7 +496,7 @@ fn test_non_fungible_part_2() {
 fn test_singleton_non_fungible() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -521,7 +521,7 @@ fn test_singleton_non_fungible() {
 fn test_mint_update_and_withdraw() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // create non-fungible
     let manifest = ManifestBuilder::new()
@@ -591,7 +591,7 @@ fn create_non_fungible_with_id_type_different_than_in_initial_supply() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -618,7 +618,7 @@ fn create_bytes_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -642,7 +642,7 @@ fn create_string_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -666,7 +666,7 @@ fn create_ruid_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -692,7 +692,7 @@ fn create_ruid_non_fungible() {
 fn can_get_total_supply() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -716,7 +716,7 @@ fn can_mint_ruid_non_fungible_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -755,7 +755,7 @@ fn can_mint_ruid_non_fungible_with_reference_in_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -795,7 +795,7 @@ fn can_mint_ruid_non_fungible_in_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -835,7 +835,7 @@ fn cant_burn_non_fungible_with_wrong_non_fungible_local_id_type() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::NonFungibleResourceManagerError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::system::system_type_checker::TypeCheckError;
@@ -13,7 +16,7 @@ fn can_mint_non_fungible_with_global() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -40,7 +43,7 @@ fn create_non_fungible_mutable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -67,7 +70,7 @@ fn can_burn_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -117,7 +120,7 @@ fn test_take_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -141,7 +144,7 @@ fn test_take_non_fungibles() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -164,7 +167,7 @@ fn test_take_non_fungibles() {
 fn can_update_non_fungible_when_mutable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -186,7 +189,7 @@ fn can_update_non_fungible_when_mutable() {
 fn cannot_update_non_fungible_when_not_mutable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -215,7 +218,7 @@ fn cannot_update_non_fungible_when_not_mutable() {
 fn cannot_update_non_fungible_when_does_not_exist() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -251,7 +254,7 @@ fn can_call_non_fungible_data_reference() {
         "test_value",
         NonFungibleGlobalId::from_public_key(&public_key),
     );
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -290,7 +293,7 @@ fn can_call_non_fungible_data_reference() {
 fn cannot_have_non_fungible_data_ownership() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -319,7 +322,7 @@ fn cannot_have_non_fungible_data_ownership() {
 fn can_update_and_get_non_fungible() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -341,7 +344,7 @@ fn can_update_and_get_non_fungible() {
 fn can_update_and_get_non_fungible_reference() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -364,7 +367,7 @@ fn can_check_if_contains_non_fungible_in_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -391,7 +394,7 @@ fn can_check_if_contains_non_fungible_in_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -417,7 +420,7 @@ fn can_check_if_contains_non_fungible_in_bucket() {
 fn test_non_fungible_part_1() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -458,7 +461,7 @@ fn test_non_fungible_part_1() {
 fn test_non_fungible_part_2() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -493,7 +496,7 @@ fn test_non_fungible_part_2() {
 fn test_singleton_non_fungible() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -518,7 +521,7 @@ fn test_singleton_non_fungible() {
 fn test_mint_update_and_withdraw() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // create non-fungible
     let manifest = ManifestBuilder::new()
@@ -588,7 +591,7 @@ fn create_non_fungible_with_id_type_different_than_in_initial_supply() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -615,7 +618,7 @@ fn create_bytes_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -639,7 +642,7 @@ fn create_string_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -663,7 +666,7 @@ fn create_ruid_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -689,7 +692,7 @@ fn create_ruid_non_fungible() {
 fn can_get_total_supply() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -713,7 +716,7 @@ fn can_mint_ruid_non_fungible_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -752,7 +755,7 @@ fn can_mint_ruid_non_fungible_with_reference_in_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -792,7 +795,7 @@ fn can_mint_ruid_non_fungible_in_manifest() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -832,7 +835,7 @@ fn cant_burn_non_fungible_with_wrong_non_fungible_local_id_type() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/non_fungible_add_remove.rs
+++ b/radix-engine-tests/tests/non_fungible_add_remove.rs
@@ -10,7 +10,7 @@ use transaction::prelude::*;
 fn add_and_remove_of_non_fungible_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "AddAndRemove", "new", manifest_args!())
@@ -34,7 +34,7 @@ fn add_and_remove_of_non_fungible_should_succeed() {
 fn mint_and_burn_of_non_fungible_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())
@@ -58,7 +58,7 @@ fn mint_and_burn_of_non_fungible_should_succeed() {
 fn mint_and_burn_of_non_fungible_2x_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())
@@ -87,7 +87,7 @@ fn mint_and_burn_of_non_fungible_2x_should_fail() {
 fn mint_of_previously_minted_burned_non_fungible_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())

--- a/radix-engine-tests/tests/non_fungible_add_remove.rs
+++ b/radix-engine-tests/tests/non_fungible_add_remove.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -7,7 +10,7 @@ use transaction::prelude::*;
 fn add_and_remove_of_non_fungible_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "AddAndRemove", "new", manifest_args!())
@@ -31,7 +34,7 @@ fn add_and_remove_of_non_fungible_should_succeed() {
 fn mint_and_burn_of_non_fungible_should_succeed() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())
@@ -55,7 +58,7 @@ fn mint_and_burn_of_non_fungible_should_succeed() {
 fn mint_and_burn_of_non_fungible_2x_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())
@@ -84,7 +87,7 @@ fn mint_and_burn_of_non_fungible_2x_should_fail() {
 fn mint_of_previously_minted_burned_non_fungible_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "MintAndBurn", "new", manifest_args!())

--- a/radix-engine-tests/tests/non_fungible_big_vault.rs
+++ b/radix-engine-tests/tests/non_fungible_big_vault.rs
@@ -10,7 +10,7 @@ use transaction::prelude::*;
 fn get_non_fungibles_on_big_vault(size: u32, expect_success: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "BigVault", "new", manifest_args!())

--- a/radix-engine-tests/tests/non_fungible_big_vault.rs
+++ b/radix-engine-tests/tests/non_fungible_big_vault.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::costing::CostingError;
 use radix_engine::types::*;
@@ -7,7 +10,7 @@ use transaction::prelude::*;
 fn get_non_fungibles_on_big_vault(size: u32, expect_success: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "BigVault", "new", manifest_args!())

--- a/radix-engine-tests/tests/non_fungible_vault.rs
+++ b/radix-engine-tests/tests/non_fungible_vault.rs
@@ -10,7 +10,7 @@ use transaction::prelude::*;
 fn get_non_fungibles_on_vault(vault_size: usize, non_fungibles_size: u32, expected_size: usize) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "BigVault", "new", manifest_args!())
@@ -56,7 +56,7 @@ fn get_non_fungibles_on_vault_with_size_less_than_vault_size_should_return() {
 fn withdraw_1_from_empty_non_fungible_vault_should_return_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/non_fungible_vault.rs
+++ b/radix-engine-tests/tests/non_fungible_vault.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::NonFungibleVaultError;
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::types::*;
@@ -7,7 +10,7 @@ use transaction::prelude::*;
 fn get_non_fungibles_on_vault(vault_size: usize, non_fungibles_size: u32, expected_size: usize) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/non_fungible");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("non_fungible"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "BigVault", "new", manifest_args!())
@@ -53,7 +56,7 @@ fn get_non_fungibles_on_vault_with_size_less_than_vault_size_should_return() {
 fn withdraw_1_from_empty_non_fungible_vault_should_return_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/package.rs
+++ b/radix-engine-tests/tests/package.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::package::PackageError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError, VmError};
 use radix_engine::system::system_modules::auth::AuthError;
@@ -61,7 +64,7 @@ fn missing_memory_should_cause_error() {
 fn large_return_len_should_cause_memory_access_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -84,7 +87,7 @@ fn large_return_len_should_cause_memory_access_error() {
 fn overflow_return_len_should_cause_memory_access_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -107,7 +110,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
 fn zero_return_len_should_cause_data_validation_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -241,7 +244,7 @@ fn bad_function_schema_should_fail() {
 fn should_not_be_able_to_publish_wasm_package_outside_of_transaction_processor() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/publish_package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -271,7 +274,7 @@ fn should_not_be_able_to_publish_wasm_package_outside_of_transaction_processor()
 fn should_not_be_able_to_publish_advanced_wasm_package_outside_of_transaction_processor() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/publish_package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -334,7 +337,7 @@ fn should_not_be_able_to_publish_native_packages() {
 fn should_not_be_able_to_publish_native_packages_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/publish_package");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/package.rs
+++ b/radix-engine-tests/tests/package.rs
@@ -64,7 +64,7 @@ fn missing_memory_should_cause_error() {
 fn large_return_len_should_cause_memory_access_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -87,7 +87,7 @@ fn large_return_len_should_cause_memory_access_error() {
 fn overflow_return_len_should_cause_memory_access_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -110,7 +110,7 @@ fn overflow_return_len_should_cause_memory_access_error() {
 fn zero_return_len_should_cause_data_validation_error() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -221,7 +221,7 @@ fn bad_function_schema_should_fail() {
     let mut test_runner = TestRunnerBuilder::new().build();
 
     // Act
-    let (code, definition) = Compile::compile("./tests/blueprints/package_invalid");
+    let (code, definition) = PackageLoader::get("package_invalid");
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .publish_package_advanced(None, code, definition, BTreeMap::new(), OwnerRole::None)
@@ -244,7 +244,7 @@ fn bad_function_schema_should_fail() {
 fn should_not_be_able_to_publish_wasm_package_outside_of_transaction_processor() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -274,7 +274,7 @@ fn should_not_be_able_to_publish_wasm_package_outside_of_transaction_processor()
 fn should_not_be_able_to_publish_advanced_wasm_package_outside_of_transaction_processor() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -337,7 +337,7 @@ fn should_not_be_able_to_publish_native_packages() {
 fn should_not_be_able_to_publish_native_packages_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("publish_package"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("publish_package"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -367,7 +367,7 @@ fn should_not_be_able_to_publish_native_packages_in_scrypto() {
 fn name_validation_blueprint() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+    let (code, mut definition) = PackageLoader::get("publish_package");
 
     definition.blueprints = indexmap![
        String::from("wrong_bluepint_name_*") =>
@@ -402,7 +402,7 @@ fn name_validation_blueprint() {
 fn name_validation_feature_set() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+    let (code, mut definition) = PackageLoader::get("publish_package");
 
     definition
         .blueprints
@@ -436,7 +436,7 @@ fn name_validation_function() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
 
-    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+    let (code, mut definition) = PackageLoader::get("publish_package");
 
     definition
         .blueprints
@@ -480,7 +480,7 @@ fn well_known_types_in_schema_are_validated() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
 
-    let (code, mut definition) = Compile::compile("./tests/blueprints/publish_package");
+    let (code, mut definition) = PackageLoader::get("publish_package");
 
     let method_definition = definition
         .blueprints

--- a/radix-engine-tests/tests/package_loader.rs
+++ b/radix-engine-tests/tests/package_loader.rs
@@ -1,0 +1,44 @@
+#[cfg(feature = "compile-blueprints-at-build-time")]
+mod package_loader {
+    use radix_engine_common::prelude::*;
+    use radix_engine_queries::typed_substate_layout::*;
+    use std::collections::HashMap;
+
+    const PACKAGES_BINARY: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/compiled_packages.bin"));
+
+    lazy_static::lazy_static! {
+        static ref PACKAGES: HashMap<String, (Vec<u8>, PackageDefinition)> = {
+            scrypto_decode(PACKAGES_BINARY).unwrap()
+        };
+    }
+
+    pub struct PackageLoader;
+    impl PackageLoader {
+        pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
+            if let Some(rtn) = PACKAGES.get(name) {
+                rtn.clone()
+            } else {
+                panic!("Package \"{}\" not found. Are you sure that this package is: a) in the blueprints folder, b) that this is the same as the package name in the Cargo.toml file?", name)
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "compile-blueprints-at-build-time"))]
+mod package_loader {
+    use radix_engine_common::prelude::*;
+    use radix_engine_queries::typed_substate_layout::*;
+    use std::path::PathBuf;
+
+    pub struct PackageLoader;
+    impl PackageLoader {
+        pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
+            let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
+            let package_dir = manifest_dir.join("tests").join("blueprints").join(name);
+            scrypto_unit::Compile::compile(package_dir)
+        }
+    }
+}
+
+pub use package_loader::PackageLoader;

--- a/radix-engine-tests/tests/package_loader.rs
+++ b/radix-engine-tests/tests/package_loader.rs
@@ -2,7 +2,7 @@
 mod package_loader {
     use radix_engine_common::prelude::*;
     use radix_engine_queries::typed_substate_layout::*;
-    use std::collections::HashMap;
+    use sbor::prelude::*;
 
     const PACKAGES_BINARY: &[u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/compiled_packages.bin"));

--- a/radix-engine-tests/tests/package_schema.rs
+++ b/radix-engine-tests/tests/package_schema.rs
@@ -16,7 +16,7 @@ enum ExpectedResult {
 fn test_arg(method_name: &str, args: ManifestValue, expected_result: ExpectedResult) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_schema"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("package_schema"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/package_schema.rs
+++ b/radix-engine-tests/tests/package_schema.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -13,7 +16,7 @@ enum ExpectedResult {
 fn test_arg(method_name: &str, args: ManifestValue, expected_result: ExpectedResult) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/package_schema");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("package_schema"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/proof.rs
+++ b/radix-engine-tests/tests/proof.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
@@ -12,7 +15,7 @@ fn can_create_clone_and_drop_bucket_proof() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -49,7 +52,7 @@ fn can_create_clone_and_drop_vault_proof_by_amount() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -93,7 +96,7 @@ fn can_create_clone_and_drop_vault_proof_by_ids() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -140,7 +143,7 @@ fn can_use_bucket_for_authorization() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -177,7 +180,7 @@ fn can_use_vault_for_authorization() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -225,7 +228,7 @@ fn can_create_proof_from_account_and_pass_on() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -258,7 +261,7 @@ fn cant_move_restricted_proof_to_auth_zone() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -297,7 +300,7 @@ fn cant_move_restricted_proof_to_scrypto_function_aka_barrier() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -336,7 +339,7 @@ fn can_move_restricted_proof_to_proof_function_aka_non_barrier() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -365,7 +368,7 @@ fn can_move_restricted_proof_to_proof_function_aka_non_barrier() {
 fn can_move_restricted_proofs_internally() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let (public_key, _, account) = test_runner.new_allocated_account();
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -403,7 +406,7 @@ fn can_move_locked_bucket() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -436,7 +439,7 @@ fn can_compose_bucket_and_vault_proof_by_amount() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -482,7 +485,7 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -552,7 +555,7 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -607,7 +610,7 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
 fn can_not_call_vault_lock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -641,7 +644,7 @@ fn can_not_call_vault_lock_fungible_amount_directly() {
 fn can_not_call_vault_unlock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -675,7 +678,7 @@ fn can_not_call_vault_unlock_fungible_amount_directly() {
 fn can_not_call_vault_lock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -709,7 +712,7 @@ fn can_not_call_vault_lock_non_fungibles_directly() {
 fn can_not_call_vault_unlock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -743,7 +746,7 @@ fn can_not_call_vault_unlock_non_fungibles_directly() {
 fn can_not_call_bucket_lock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -770,7 +773,7 @@ fn can_not_call_bucket_lock_fungible_amount_directly() {
 fn can_not_call_bucket_unlock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -797,7 +800,7 @@ fn can_not_call_bucket_unlock_fungible_amount_directly() {
 fn can_not_call_bucket_lock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -824,7 +827,7 @@ fn can_not_call_bucket_lock_non_fungibles_directly() {
 fn can_not_call_bucket_unlock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -853,7 +856,7 @@ fn test_proof_check() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(dec!(100), 0, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -887,7 +890,7 @@ fn test_proof_check_with_message() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(dec!(100), 0, account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/proof.rs
+++ b/radix-engine-tests/tests/proof.rs
@@ -15,7 +15,7 @@ fn can_create_clone_and_drop_bucket_proof() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -52,7 +52,7 @@ fn can_create_clone_and_drop_vault_proof_by_amount() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -96,7 +96,7 @@ fn can_create_clone_and_drop_vault_proof_by_ids() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -143,7 +143,7 @@ fn can_use_bucket_for_authorization() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -180,7 +180,7 @@ fn can_use_vault_for_authorization() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let (auth_resource_address, burnable_resource_address) =
         test_runner.create_restricted_burn_token(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -228,7 +228,7 @@ fn can_create_proof_from_account_and_pass_on() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -261,7 +261,7 @@ fn cant_move_restricted_proof_to_auth_zone() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -300,7 +300,7 @@ fn cant_move_restricted_proof_to_scrypto_function_aka_barrier() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -339,7 +339,7 @@ fn can_move_restricted_proof_to_proof_function_aka_non_barrier() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -368,7 +368,7 @@ fn can_move_restricted_proof_to_proof_function_aka_non_barrier() {
 fn can_move_restricted_proofs_internally() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let (public_key, _, account) = test_runner.new_allocated_account();
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -406,7 +406,7 @@ fn can_move_locked_bucket() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -439,7 +439,7 @@ fn can_compose_bucket_and_vault_proof_by_amount() {
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address =
         test_runner.create_fungible_resource(100u32.into(), DIVISIBILITY_MAXIMUM, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -485,7 +485,7 @@ fn can_compose_bucket_and_vault_proof_by_ids() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(
         btreeset![NonFungibleGlobalId::from_public_key(&public_key)],
         |builder| {
@@ -555,7 +555,7 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_non_fungible_resource(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -610,7 +610,7 @@ fn can_create_auth_zone_proof_by_amount_from_non_fungibles() {
 fn can_not_call_vault_lock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -644,7 +644,7 @@ fn can_not_call_vault_lock_fungible_amount_directly() {
 fn can_not_call_vault_unlock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -678,7 +678,7 @@ fn can_not_call_vault_unlock_fungible_amount_directly() {
 fn can_not_call_vault_lock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -712,7 +712,7 @@ fn can_not_call_vault_lock_non_fungibles_directly() {
 fn can_not_call_vault_unlock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let component_address = test_runner.new_component(btreeset![], |builder| {
         builder.call_function(
             package_address,
@@ -746,7 +746,7 @@ fn can_not_call_vault_unlock_non_fungibles_directly() {
 fn can_not_call_bucket_lock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -773,7 +773,7 @@ fn can_not_call_bucket_lock_fungible_amount_directly() {
 fn can_not_call_bucket_unlock_fungible_amount_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -800,7 +800,7 @@ fn can_not_call_bucket_unlock_fungible_amount_directly() {
 fn can_not_call_bucket_lock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -827,7 +827,7 @@ fn can_not_call_bucket_lock_non_fungibles_directly() {
 fn can_not_call_bucket_unlock_non_fungibles_directly() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -856,7 +856,7 @@ fn test_proof_check() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(dec!(100), 0, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -890,7 +890,7 @@ fn test_proof_check_with_message() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let resource_address = test_runner.create_fungible_resource(dec!(100), 0, account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/proof_creation.rs
+++ b/radix-engine-tests/tests/proof_creation.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{ApplicationError, RuntimeError},
     types::*,
@@ -9,7 +12,7 @@ use transaction::prelude::*;
 fn create_proof_internal(function_name: &str, error: Option<&str>) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof_creation");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof_creation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/proof_creation.rs
+++ b/radix-engine-tests/tests/proof_creation.rs
@@ -12,7 +12,7 @@ use transaction::prelude::*;
 fn create_proof_internal(function_name: &str, error: Option<&str>) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof_creation"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof_creation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/recallable.rs
+++ b/radix-engine-tests/tests/recallable.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{
     CallFrameError, KernelError, RejectionReason, RuntimeError, SystemModuleError,
 };
@@ -115,7 +118,7 @@ fn test_recall_on_internal_vault() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recall");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(
@@ -159,7 +162,7 @@ fn test_recall_on_received_direct_access_reference() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let recallable_token_address = test_runner.create_recallable_token(account);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recall");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
     let vault_id = test_runner.get_component_vaults(account, recallable_token_address)[0];
 
     // Act
@@ -187,7 +190,7 @@ fn test_recall_on_received_direct_access_reference_which_is_same_as_self() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
 
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recall");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_fee(test_runner.faucet_component(), 500u32)

--- a/radix-engine-tests/tests/recallable.rs
+++ b/radix-engine-tests/tests/recallable.rs
@@ -118,7 +118,7 @@ fn test_recall_on_internal_vault() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recall"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(
@@ -162,7 +162,7 @@ fn test_recall_on_received_direct_access_reference() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
     let recallable_token_address = test_runner.create_recallable_token(account);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recall"));
     let vault_id = test_runner.get_component_vaults(account, recallable_token_address)[0];
 
     // Act
@@ -190,7 +190,7 @@ fn test_recall_on_received_direct_access_reference_which_is_same_as_self() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
 
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recall"));
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_fee(test_runner.faucet_component(), 500u32)

--- a/radix-engine-tests/tests/reentrancy.rs
+++ b/radix-engine-tests/tests/reentrancy.rs
@@ -11,7 +11,7 @@ use transaction::prelude::*;
 fn mut_reentrancy_should_not_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -50,7 +50,7 @@ fn mut_reentrancy_should_not_be_possible() {
 fn read_reentrancy_should_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -82,7 +82,7 @@ fn read_reentrancy_should_be_possible() {
 fn read_then_mut_reentrancy_should_not_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/reentrancy.rs
+++ b/radix-engine-tests/tests/reentrancy.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::types::*;
@@ -8,7 +11,7 @@ use transaction::prelude::*;
 fn mut_reentrancy_should_not_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/reentrancy");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -47,7 +50,7 @@ fn mut_reentrancy_should_not_be_possible() {
 fn read_reentrancy_should_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/reentrancy");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -79,7 +82,7 @@ fn read_reentrancy_should_be_possible() {
 fn read_then_mut_reentrancy_should_not_be_possible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/reentrancy");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reentrancy"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/reference.rs
+++ b/radix-engine-tests/tests/reference.rs
@@ -15,7 +15,7 @@ fn test_create_global_node_with_local_ref() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reference"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("reference"));
 
     // Call function
     let receipt = test_runner.execute_manifest(
@@ -47,7 +47,7 @@ fn test_add_local_ref_to_stored_substate() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reference"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("reference"));
 
     // Instantiate component
     let component_address = {

--- a/radix-engine-tests/tests/reference.rs
+++ b/radix-engine-tests/tests/reference.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::SystemError;
 use radix_engine::system::system_type_checker::TypeCheckError;
 use radix_engine::{errors::RuntimeError, types::*};
@@ -12,7 +15,7 @@ fn test_create_global_node_with_local_ref() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/reference");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reference"));
 
     // Call function
     let receipt = test_runner.execute_manifest(
@@ -44,7 +47,7 @@ fn test_add_local_ref_to_stored_substate() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/reference");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("reference"));
 
     // Instantiate component
     let component_address = {

--- a/radix-engine-tests/tests/remote_generic_args.rs
+++ b/radix-engine-tests/tests/remote_generic_args.rs
@@ -10,7 +10,7 @@ fn test_same_package_remote_generic_arg_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -29,7 +29,7 @@ fn test_same_package_remote_generic_arg_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -48,9 +48,9 @@ fn test_different_package_remote_generic_arg_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -69,9 +69,9 @@ fn test_different_package_remote_generic_arg_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -90,9 +90,9 @@ fn test_invalid_remote_types_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -111,9 +111,9 @@ fn test_invalid_remote_types_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
+        test_runner.publish_package_simple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/remote_generic_args.rs
+++ b/radix-engine-tests/tests/remote_generic_args.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,8 @@ use transaction::prelude::*;
 fn test_same_package_remote_generic_arg_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -24,7 +28,8 @@ fn test_same_package_remote_generic_arg_for_non_fungible_data() {
 fn test_same_package_remote_generic_arg_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -43,9 +48,9 @@ fn test_different_package_remote_generic_arg_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -64,9 +69,9 @@ fn test_different_package_remote_generic_arg_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -85,9 +90,9 @@ fn test_invalid_remote_types_for_non_fungible_data() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -106,9 +111,9 @@ fn test_invalid_remote_types_for_key_value_store() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let package_address2 =
-        test_runner.compile_and_publish("./tests/blueprints/remote_generic_args");
+        test_runner.publish_package_tuple(PackageLoader::get("remote_generic_args"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::FungibleResourceManagerError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
@@ -36,7 +39,7 @@ fn test_set_mintable_with_self_resource_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -62,7 +65,7 @@ fn test_resource_manager() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -97,7 +100,7 @@ fn mint_with_bad_granularity_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -133,7 +136,7 @@ fn create_fungible_too_high_granularity_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let _package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let _package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -170,7 +173,7 @@ fn mint_too_much_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -208,7 +211,7 @@ fn can_mint_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -242,7 +245,7 @@ fn cannot_mint_in_component_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -283,7 +286,7 @@ fn can_burn_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -317,7 +320,7 @@ fn cannot_burn_in_component_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -361,7 +364,7 @@ fn test_fungible_resource_amount_for_withdrawal() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -385,7 +388,7 @@ fn test_non_fungible_resource_amount_for_withdrawal() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -409,7 +412,7 @@ fn test_fungible_resource_take_advanced() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -432,7 +435,7 @@ fn test_fungible_resource_take_advanced() {
 fn fungible_bucket_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -454,7 +457,7 @@ fn fungible_bucket_take_advanced_max_should_not_panic() {
 fn fungible_vault_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -476,7 +479,7 @@ fn fungible_vault_take_advanced_max_should_not_panic() {
 fn non_fungible_bucket_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -498,7 +501,7 @@ fn non_fungible_bucket_take_advanced_max_should_not_panic() {
 fn non_fungible_vault_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -521,7 +524,7 @@ fn test_non_fungible_resource_take_advanced() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -545,7 +548,7 @@ fn can_use_fungible_types_in_interface() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -569,7 +572,7 @@ fn can_use_non_fungible_types_in_interface() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/resource");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/resource.rs
+++ b/radix-engine-tests/tests/resource.rs
@@ -39,7 +39,7 @@ fn test_set_mintable_with_self_resource_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -65,7 +65,7 @@ fn test_resource_manager() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -100,7 +100,7 @@ fn mint_with_bad_granularity_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -136,7 +136,7 @@ fn create_fungible_too_high_granularity_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let _package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let _package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -173,7 +173,7 @@ fn mint_too_much_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -211,7 +211,7 @@ fn can_mint_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -245,7 +245,7 @@ fn cannot_mint_in_component_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -286,7 +286,7 @@ fn can_burn_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -320,7 +320,7 @@ fn cannot_burn_in_component_with_proof_in_root() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "AuthResource", "create", manifest_args!())
@@ -364,7 +364,7 @@ fn test_fungible_resource_amount_for_withdrawal() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -388,7 +388,7 @@ fn test_non_fungible_resource_amount_for_withdrawal() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -412,7 +412,7 @@ fn test_fungible_resource_take_advanced() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -435,7 +435,7 @@ fn test_fungible_resource_take_advanced() {
 fn fungible_bucket_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -457,7 +457,7 @@ fn fungible_bucket_take_advanced_max_should_not_panic() {
 fn fungible_vault_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -479,7 +479,7 @@ fn fungible_vault_take_advanced_max_should_not_panic() {
 fn non_fungible_bucket_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -501,7 +501,7 @@ fn non_fungible_bucket_take_advanced_max_should_not_panic() {
 fn non_fungible_vault_take_advanced_max_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -524,7 +524,7 @@ fn test_non_fungible_resource_take_advanced() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -548,7 +548,7 @@ fn can_use_fungible_types_in_interface() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -572,7 +572,7 @@ fn can_use_non_fungible_types_in_interface() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("resource"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("resource"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -17,7 +17,7 @@ use transaction::prelude::*;
 fn can_call_public_function() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
     // Act
     let receipt = test_runner.call_function(
@@ -35,7 +35,7 @@ fn can_call_public_function() {
 fn cannot_call_protected_function_without_auth() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
     // Act
     let receipt = test_runner.call_function(
@@ -60,7 +60,7 @@ fn cannot_call_protected_function_without_auth() {
 fn can_call_protected_function_with_auth() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
     let (key, _priv, account) = test_runner.new_account(true);
 
     // Act
@@ -191,7 +191,7 @@ fn component_role_assignment_can_be_mutated_to_non_fungible_resource_through_man
 fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
     let component_address = {
         let manifest = ManifestBuilder::new()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
@@ -228,7 +228,7 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
     let (public_key, _, account) = test_runner.new_account(false);
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -335,7 +335,7 @@ impl MutableRolesTestRunner {
         test_runner: &mut DefaultTestRunner,
     ) -> TransactionReceipt {
         let package_address =
-            test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+            test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
         let manifest = ManifestBuilder::new()
             .call_function(
@@ -353,7 +353,7 @@ impl MutableRolesTestRunner {
         test_runner: &mut DefaultTestRunner,
     ) -> TransactionReceipt {
         let package_address =
-            test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
+            test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
         let manifest = ManifestBuilder::new()
             .call_function(

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
@@ -14,7 +17,7 @@ use transaction::prelude::*;
 fn can_call_public_function() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
 
     // Act
     let receipt = test_runner.call_function(
@@ -32,7 +35,7 @@ fn can_call_public_function() {
 fn cannot_call_protected_function_without_auth() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
 
     // Act
     let receipt = test_runner.call_function(
@@ -57,7 +60,7 @@ fn cannot_call_protected_function_without_auth() {
 fn can_call_protected_function_with_auth() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
     let (key, _priv, account) = test_runner.new_account(true);
 
     // Act
@@ -188,7 +191,7 @@ fn component_role_assignment_can_be_mutated_to_non_fungible_resource_through_man
 fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
     let component_address = {
         let manifest = ManifestBuilder::new()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
@@ -225,7 +228,7 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
     let (public_key, _, account) = test_runner.new_account(false);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
 
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -331,7 +334,8 @@ impl MutableRolesTestRunner {
         roles: RoleAssignmentInit,
         test_runner: &mut DefaultTestRunner,
     ) -> TransactionReceipt {
-        let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+        let package_address =
+            test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
 
         let manifest = ManifestBuilder::new()
             .call_function(
@@ -348,7 +352,8 @@ impl MutableRolesTestRunner {
         owner_role: OwnerRole,
         test_runner: &mut DefaultTestRunner,
     ) -> TransactionReceipt {
-        let package_address = test_runner.compile_and_publish("./tests/blueprints/role_assignment");
+        let package_address =
+            test_runner.publish_package_tuple(PackageLoader::get("role_assignment"));
 
         let manifest = ManifestBuilder::new()
             .call_function(

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::package::PackageError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::system::node_modules::royalty::ComponentRoyaltyError;
@@ -14,7 +17,7 @@ fn test_component_royalty() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/royalty");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("royalty"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(
@@ -70,7 +73,7 @@ fn test_component_royalty_in_usd() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/royalty");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("royalty"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -17,7 +17,7 @@ fn test_component_royalty() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("royalty"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("royalty"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(
@@ -73,7 +73,7 @@ fn test_component_royalty_in_usd() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("royalty"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("royalty"));
 
     // Instantiate component
     let receipt = test_runner.execute_manifest(
@@ -298,7 +298,7 @@ fn cannot_initialize_package_royalty_if_greater_than_allowed(royalty_amount: Roy
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
 
     // Act
-    let (code, mut definition) = Compile::compile("./tests/blueprints/royalty");
+    let (code, mut definition) = PackageLoader::get("royalty");
     let blueprint_def = definition.blueprints.get_mut("RoyaltyTest").unwrap();
     match &mut blueprint_def.royalty_config {
         PackageRoyaltyConfig::Enabled(royalties) => {
@@ -353,7 +353,7 @@ fn cannot_initialize_component_royalty_if_greater_than_allowed() {
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
     let package_address =
-        test_runner.compile_and_publish_with_owner("./tests/blueprints/royalty", owner_badge_addr);
+        test_runner.publish_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
 
     // Act
     let max_royalty_allowed = Decimal::try_from(MAX_PER_FUNCTION_ROYALTY_IN_XRD).unwrap();
@@ -492,7 +492,7 @@ fn set_up_package_and_component() -> (
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
     let package_address =
-        test_runner.compile_and_publish_with_owner("./tests/blueprints/royalty", owner_badge_addr);
+        test_runner.compile_and_publish_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
 
     // Enable package royalty
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/royalty.rs
+++ b/radix-engine-tests/tests/royalty.rs
@@ -353,7 +353,7 @@ fn cannot_initialize_component_royalty_if_greater_than_allowed() {
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
     let package_address =
-        test_runner.publish_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
+        test_runner.publish_package_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
 
     // Act
     let max_royalty_allowed = Decimal::try_from(MAX_PER_FUNCTION_ROYALTY_IN_XRD).unwrap();
@@ -492,7 +492,7 @@ fn set_up_package_and_component() -> (
     let owner_badge_addr =
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
     let package_address =
-        test_runner.compile_and_publish_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
+        test_runner.publish_package_with_owner(PackageLoader::get("royalty"), owner_badge_addr);
 
     // Enable package royalty
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/royalty_auth.rs
+++ b/radix-engine-tests/tests/royalty_auth.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
@@ -184,7 +187,7 @@ fn set_up_package_and_component() -> (
         NonFungibleGlobalId::new(owner_badge_resource, NonFungibleLocalId::integer(1));
 
     // Publish package
-    let (code, definition) = Compile::compile("./tests/blueprints/royalty-auth");
+    let (code, definition) = PackageLoader::get("royalty-auth");
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_standard_test_fee(account)

--- a/radix-engine-tests/tests/schema_sanity_check.rs
+++ b/radix-engine-tests/tests/schema_sanity_check.rs
@@ -401,7 +401,7 @@ pub fn test_fake_bucket() {
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Publish package
-    let (code, mut definition) = test_runner.compile("./tests/blueprints/fake_bucket");
+    let (code, mut definition) = PackageLoader::get("fake_bucket");
     definition
         .blueprints
         .get_mut("FakeBucket")
@@ -411,7 +411,7 @@ pub fn test_fake_bucket() {
         .fields[0]
         .field = TypeRef::Static(LocalTypeId::WellKnown(DECIMAL_TYPE));
     let package_address =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
 
     // Test abusing vault put method
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/schema_sanity_check.rs
+++ b/radix-engine-tests/tests/schema_sanity_check.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{RuntimeError, SystemError},
     system::system_modules::costing::{

--- a/radix-engine-tests/tests/scrypto_address_reservation.rs
+++ b/radix-engine-tests/tests/scrypto_address_reservation.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,8 @@ use transaction::prelude::*;
 fn should_be_able_to_get_address_of_an_address_reservation() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/address_reservation");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("address_reservation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_address_reservation.rs
+++ b/radix-engine-tests/tests/scrypto_address_reservation.rs
@@ -10,7 +10,7 @@ fn should_be_able_to_get_address_of_an_address_reservation() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("address_reservation"));
+        test_runner.publish_package_simple(PackageLoader::get("address_reservation"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_cast.rs
+++ b/radix-engine-tests/tests/scrypto_cast.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::types::*;
 use scrypto_unit::*;
@@ -7,7 +10,7 @@ use transaction::prelude::*;
 fn should_error_if_trying_to_cast_to_invalid_type() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/cast");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("cast"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -34,7 +37,7 @@ fn should_error_if_trying_to_cast_to_invalid_type() {
 fn should_succeed_if_trying_to_cast_to_any() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/cast");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("cast"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_cast.rs
+++ b/radix-engine-tests/tests/scrypto_cast.rs
@@ -10,7 +10,7 @@ use transaction::prelude::*;
 fn should_error_if_trying_to_cast_to_invalid_type() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("cast"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("cast"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -37,7 +37,7 @@ fn should_error_if_trying_to_cast_to_invalid_type() {
 fn should_succeed_if_trying_to_cast_to_any() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("cast"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("cast"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_costing.rs
+++ b/radix-engine-tests/tests/scrypto_costing.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 fn can_call_usd_price() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/costing");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("costing"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_costing.rs
+++ b/radix-engine-tests/tests/scrypto_costing.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 fn can_call_usd_price() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("costing"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("costing"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_env.rs
+++ b/radix-engine-tests/tests/scrypto_env.rs
@@ -29,7 +29,7 @@ fn create_payload_of_depth(n: usize) -> Vec<u8> {
 fn test_write_kv_store_entry_within_depth_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -51,7 +51,7 @@ fn test_write_kv_store_entry_within_depth_limit() {
 fn test_write_kv_store_entry_exceeding_depth_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -75,7 +75,7 @@ fn test_write_kv_store_entry_exceeding_depth_limit() {
 fn test_pop_empty_auth_zone() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -100,7 +100,7 @@ fn test_pop_empty_auth_zone() {
 fn should_not_be_able_to_node_create_with_invalid_blueprint() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -134,7 +134,7 @@ fn should_not_be_able_to_open_mut_substate_twice_if_object_globalized() {
 fn should_not_be_able_to_open_mut_substate_twice(heap: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -161,7 +161,7 @@ fn should_not_be_able_to_open_mut_substate_twice(heap: bool) {
 fn should_be_able_to_bech32_encode_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_env.rs
+++ b/radix-engine-tests/tests/scrypto_env.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError, SystemError};
 use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::types::*;
@@ -26,7 +29,7 @@ fn create_payload_of_depth(n: usize) -> Vec<u8> {
 fn test_write_kv_store_entry_within_depth_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -48,7 +51,7 @@ fn test_write_kv_store_entry_within_depth_limit() {
 fn test_write_kv_store_entry_exceeding_depth_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -72,7 +75,7 @@ fn test_write_kv_store_entry_exceeding_depth_limit() {
 fn test_pop_empty_auth_zone() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -97,7 +100,7 @@ fn test_pop_empty_auth_zone() {
 fn should_not_be_able_to_node_create_with_invalid_blueprint() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -131,7 +134,7 @@ fn should_not_be_able_to_open_mut_substate_twice_if_object_globalized() {
 fn should_not_be_able_to_open_mut_substate_twice(heap: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -158,7 +161,7 @@ fn should_not_be_able_to_open_mut_substate_twice(heap: bool) {
 fn should_be_able_to_bech32_encode_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/scrypto_env");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("scrypto_env"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_validator.rs
+++ b/radix-engine-tests/tests/scrypto_validator.rs
@@ -10,7 +10,7 @@ fn can_call_accepts_delegated_stake_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
 
     // Act
@@ -38,7 +38,7 @@ fn can_call_total_stake_xrd_amount_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
@@ -82,7 +82,7 @@ fn can_call_total_stake_unit_supply_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
@@ -126,7 +126,7 @@ fn can_call_validator_get_redemption_value_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()

--- a/radix-engine-tests/tests/scrypto_validator.rs
+++ b/radix-engine-tests/tests/scrypto_validator.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -7,7 +10,7 @@ fn can_call_accepts_delegated_stake_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/validator");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
 
     // Act
@@ -35,7 +38,7 @@ fn can_call_total_stake_xrd_amount_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/validator");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
@@ -79,7 +82,7 @@ fn can_call_total_stake_unit_supply_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/validator");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
@@ -123,7 +126,7 @@ fn can_call_validator_get_redemption_value_in_scrypto() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/validator");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("validator"));
     let validator_address = test_runner.new_validator_with_pub_key(pub_key, account);
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()

--- a/radix-engine-tests/tests/static_dependencies.rs
+++ b/radix-engine-tests/tests/static_dependencies.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::account::ACCOUNT_DEPOSIT_BATCH_IDENT;
@@ -22,7 +25,7 @@ fn test_static_package_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.compile_and_publish("./tests/blueprints/static_dependencies");
+        test_runner.publish_package_tuple(PackageLoader::get("static_dependencies"));
 
     let (mut code, mut definition) = Compile::compile("./tests/blueprints/static_dependencies");
     let place_holder: GlobalAddress =
@@ -59,7 +62,8 @@ fn test_static_package_address() {
 fn test_static_component_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/static_dependencies");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("static_dependencies"));
     let (key, _priv, account) = test_runner.new_account(false);
 
     // Act

--- a/radix-engine-tests/tests/static_dependencies.rs
+++ b/radix-engine-tests/tests/static_dependencies.rs
@@ -25,9 +25,9 @@ fn test_static_package_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address1 =
-        test_runner.publish_package_tuple(PackageLoader::get("static_dependencies"));
+        test_runner.publish_package_simple(PackageLoader::get("static_dependencies"));
 
-    let (mut code, mut definition) = Compile::compile("./tests/blueprints/static_dependencies");
+    let (mut code, mut definition) = PackageLoader::get("static_dependencies");
     let place_holder: GlobalAddress =
         PackageAddress::new_or_panic(PACKAGE_ADDRESS_PLACE_HOLDER).into();
     for (_, blueprint) in &mut definition.blueprints {
@@ -41,7 +41,7 @@ fn test_static_package_address() {
     code[start..start + PACKAGE_ADDRESS_PLACE_HOLDER.len()]
         .copy_from_slice(package_address1.as_ref());
     let package_address2 =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -63,7 +63,7 @@ fn test_static_component_address() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("static_dependencies"));
+        test_runner.publish_package_simple(PackageLoader::get("static_dependencies"));
     let (key, _priv, account) = test_runner.new_account(false);
 
     // Act
@@ -97,7 +97,7 @@ fn static_component_should_be_callable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = PackageAddress::new_or_panic(PRE_ALLOCATED_PACKAGE);
     test_runner
-        .compile_and_publish_at_address("./tests/blueprints/static_dependencies", package_address);
+        .compile_and_publish_at_address(PackageLoader::get("static_dependencies"), package_address);
     let receipt = test_runner.execute_system_transaction_with_preallocated_addresses(
         vec![InstructionV1::CallFunction {
             package_address: package_address.into(),
@@ -115,8 +115,8 @@ fn static_component_should_be_callable() {
     receipt.expect_commit_success();
 
     // Act
-    let package_address2 = test_runner.compile_and_publish_retain_blueprints(
-        "./tests/blueprints/static_dependencies2",
+    let package_address2 = test_runner.publish_retain_blueprints(
+        PackageLoader::get("static_dependencies2"),
         |blueprint, _| blueprint.eq("PreallocatedCall"),
     );
     let manifest = ManifestBuilder::new()
@@ -183,8 +183,8 @@ fn static_resource_should_be_callable() {
     receipt.expect_commit_success();
 
     // Act
-    let package_address2 = test_runner.compile_and_publish_retain_blueprints(
-        "./tests/blueprints/static_dependencies2",
+    let package_address2 = test_runner.publish_retain_blueprints(
+        PackageLoader::get("static_dependencies2"),
         |blueprint, _| blueprint.eq("SomeResource"),
     );
     let manifest = ManifestBuilder::new()
@@ -209,13 +209,13 @@ fn static_package_should_be_callable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     test_runner.compile_and_publish_at_address(
-        "./tests/blueprints/static_dependencies",
+        PackageLoader::get("static_dependencies"),
         PackageAddress::new_or_panic(PRE_ALLOCATED_PACKAGE),
     );
 
     // Act
-    let package_address2 = test_runner.compile_and_publish_retain_blueprints(
-        "./tests/blueprints/static_dependencies2",
+    let package_address2 = test_runner.publish_retain_blueprints(
+        PackageLoader::get("static_dependencies2"),
         |blueprint, _| blueprint.eq("SomePackage"),
     );
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/static_dependencies.rs
+++ b/radix-engine-tests/tests/static_dependencies.rs
@@ -97,7 +97,7 @@ fn static_component_should_be_callable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = PackageAddress::new_or_panic(PRE_ALLOCATED_PACKAGE);
     test_runner
-        .compile_and_publish_at_address(PackageLoader::get("static_dependencies"), package_address);
+        .publish_package_at_address(PackageLoader::get("static_dependencies"), package_address);
     let receipt = test_runner.execute_system_transaction_with_preallocated_addresses(
         vec![InstructionV1::CallFunction {
             package_address: package_address.into(),
@@ -208,7 +208,7 @@ fn static_resource_should_be_callable() {
 fn static_package_should_be_callable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    test_runner.compile_and_publish_at_address(
+    test_runner.publish_package_at_address(
         PackageLoader::get("static_dependencies"),
         PackageAddress::new_or_panic(PRE_ALLOCATED_PACKAGE),
     );

--- a/radix-engine-tests/tests/storage.rs
+++ b/radix-engine-tests/tests/storage.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 fn test_kv_store_with_many_large_keys() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.compile_and_publish("tests/blueprints/storage");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("storage"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/storage.rs
+++ b/radix-engine-tests/tests/storage.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 fn test_kv_store_with_many_large_keys() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("storage"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("storage"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/stored_external_component.rs
+++ b/radix-engine-tests/tests/stored_external_component.rs
@@ -11,7 +11,7 @@ fn stored_component_addresses_in_non_globalized_component_are_invokable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package =
-        test_runner.publish_package_tuple(PackageLoader::get("stored_external_component"));
+        test_runner.publish_package_simple(PackageLoader::get("stored_external_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -34,7 +34,7 @@ fn stored_component_addresses_are_invokable() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
     let package =
-        test_runner.publish_package_tuple(PackageLoader::get("stored_external_component"));
+        test_runner.publish_package_simple(PackageLoader::get("stored_external_component"));
     let manifest1 = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "ExternalComponent", "create", manifest_args!())

--- a/radix-engine-tests/tests/stored_external_component.rs
+++ b/radix-engine-tests/tests/stored_external_component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
@@ -7,7 +10,8 @@ use transaction::prelude::*;
 fn stored_component_addresses_in_non_globalized_component_are_invokable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/stored_external_component");
+    let package =
+        test_runner.publish_package_tuple(PackageLoader::get("stored_external_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -29,7 +33,8 @@ fn stored_component_addresses_are_invokable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package = test_runner.compile_and_publish("./tests/blueprints/stored_external_component");
+    let package =
+        test_runner.publish_package_tuple(PackageLoader::get("stored_external_component"));
     let manifest1 = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "ExternalComponent", "create", manifest_args!())

--- a/radix-engine-tests/tests/stored_local_component.rs
+++ b/radix-engine-tests/tests/stored_local_component.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -28,7 +31,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component()
 fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -50,7 +53,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component(
 fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -79,7 +82,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
 fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -113,7 +116,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -135,7 +138,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_componen
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -157,7 +160,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_compone
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -186,7 +189,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/local_component");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/stored_local_component.rs
+++ b/radix-engine-tests/tests/stored_local_component.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -31,7 +31,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component()
 fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -53,7 +53,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_owned_component(
 fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -82,7 +82,7 @@ fn should_be_able_to_call_read_method_on_a_stored_component_in_global_component(
 fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -116,7 +116,7 @@ fn should_be_able_to_call_write_method_on_a_stored_component_in_global_component
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -138,7 +138,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_owned_componen
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -160,7 +160,7 @@ fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_owned_compone
 fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -189,7 +189,7 @@ fn should_be_able_to_call_read_method_on_a_kv_stored_component_in_global_compone
 fn should_be_able_to_call_write_method_on_a_kv_stored_component_in_global_component() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("local_component"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("local_component"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(

--- a/radix-engine-tests/tests/stored_resource.rs
+++ b/radix-engine-tests/tests/stored_resource.rs
@@ -9,7 +9,7 @@ use transaction::prelude::*;
 fn stored_resource_is_invokeable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.publish_package_tuple(PackageLoader::get("stored_resource"));
+    let package = test_runner.publish_package_simple(PackageLoader::get("stored_resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "StoredResource", "create", manifest_args!())

--- a/radix-engine-tests/tests/stored_resource.rs
+++ b/radix-engine-tests/tests/stored_resource.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
@@ -6,7 +9,7 @@ use transaction::prelude::*;
 fn stored_resource_is_invokeable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package = test_runner.compile_and_publish("./tests/blueprints/stored_resource");
+    let package = test_runner.publish_package_tuple(PackageLoader::get("stored_resource"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package, "StoredResource", "create", manifest_args!())

--- a/radix-engine-tests/tests/system_global_address.rs
+++ b/radix-engine-tests/tests/system_global_address.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::ResourceNativePackage;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
@@ -119,7 +122,7 @@ fn global_address_access_from_direct_access_methods_should_fail_even_with_borrow
 
     let (public_key, _, account) = test_runner.new_allocated_account();
 
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/recall");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_fee(test_runner.faucet_component(), 500u32)

--- a/radix-engine-tests/tests/system_global_address.rs
+++ b/radix-engine-tests/tests/system_global_address.rs
@@ -122,7 +122,7 @@ fn global_address_access_from_direct_access_methods_should_fail_even_with_borrow
 
     let (public_key, _, account) = test_runner.new_allocated_account();
 
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("recall"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("recall"));
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
             .lock_fee(test_runner.faucet_component(), 500u32)

--- a/radix-engine-tests/tests/test_environment.rs
+++ b/radix-engine-tests/tests/test_environment.rs
@@ -101,8 +101,11 @@ fn references_read_from_state_are_visible_in_tests() {
     )
     .unwrap();
 
-    let radiswap_package =
-        Package::compile_and_publish("../assets/blueprints/radiswap", &mut env).unwrap();
+    let code = include_bytes!("../../assets/radiswap.wasm");
+    let definition = scrypto_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
+
+    let (radiswap_package, _) =
+        Package::publish(code.to_vec(), definition, Default::default(), &mut env).unwrap();
 
     let radiswap_component = env
         .call_function_typed::<_, ComponentAddress>(
@@ -154,8 +157,11 @@ fn references_read_from_state_are_visible_in_tests1() {
     )
     .unwrap();
 
-    let radiswap_package =
-        Package::compile_and_publish("../assets/blueprints/radiswap", &mut env).unwrap();
+    let code = include_bytes!("../../assets/radiswap.wasm");
+    let definition = scrypto_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
+
+    let (radiswap_package, _) =
+        Package::publish(code.to_vec(), definition, Default::default(), &mut env).unwrap();
 
     let radiswap_component = env
         .call_function_typed::<_, ComponentAddress>(

--- a/radix-engine-tests/tests/test_environment.rs
+++ b/radix-engine-tests/tests/test_environment.rs
@@ -102,7 +102,7 @@ fn references_read_from_state_are_visible_in_tests() {
     .unwrap();
 
     let code = include_bytes!("../../assets/radiswap.wasm");
-    let definition = scrypto_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
+    let definition = manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
 
     let (radiswap_package, _) =
         Package::publish(code.to_vec(), definition, Default::default(), &mut env).unwrap();
@@ -158,7 +158,7 @@ fn references_read_from_state_are_visible_in_tests1() {
     .unwrap();
 
     let code = include_bytes!("../../assets/radiswap.wasm");
-    let definition = scrypto_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
+    let definition = manifest_decode(include_bytes!("../../assets/radiswap.rpd")).unwrap();
 
     let (radiswap_package, _) =
         Package::publish(code.to_vec(), definition, Default::default(), &mut env).unwrap();

--- a/radix-engine-tests/tests/transaction.rs
+++ b/radix-engine-tests/tests/transaction.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::transaction_processor::TransactionProcessorError;
 use radix_engine::errors::ApplicationError;
 use radix_engine::errors::KernelError;
@@ -150,7 +153,7 @@ fn test_entire_auth_zone() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/proof");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/transaction.rs
+++ b/radix-engine-tests/tests/transaction.rs
@@ -149,7 +149,7 @@ fn test_entire_auth_zone() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("proof"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/transaction_limits.rs
+++ b/radix-engine-tests/tests/transaction_limits.rs
@@ -13,14 +13,14 @@ use transaction::prelude::*;
 
 #[test]
 fn test_read_non_existent_entries_from_kv_store_exceeding_limit() {
-    let (code, definition) = Compile::compile("tests/blueprints/transaction_limits");
+    let (code, definition) = PackageLoader::get("transaction_limits");
     let code_len = code.len();
     let definition_len = scrypto_encode(&definition).unwrap().len();
 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
     let component_address = test_runner
         .execute_manifest(
             ManifestBuilder::new()
@@ -71,14 +71,14 @@ fn test_read_non_existent_entries_from_kv_store_exceeding_limit() {
 
 #[test]
 fn test_write_entries_to_kv_store_exceeding_limit() {
-    let (code, definition) = Compile::compile("tests/blueprints/transaction_limits");
+    let (code, definition) = PackageLoader::get("transaction_limits");
     let code_len = code.len();
     let definition_len = scrypto_encode(&definition).unwrap().len();
 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
     let component_address = test_runner
         .execute_manifest(
             ManifestBuilder::new()
@@ -129,12 +129,12 @@ fn test_write_entries_to_kv_store_exceeding_limit() {
 
 #[test]
 fn test_write_entries_to_heap_kv_store_exceeding_limit() {
-    let (code, definition) = Compile::compile("tests/blueprints/transaction_limits");
+    let (code, definition) = PackageLoader::get("transaction_limits");
 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -174,7 +174,7 @@ fn test_default_substate_size_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -231,7 +231,7 @@ fn test_default_invoke_payload_size_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -272,7 +272,7 @@ fn test_default_invoke_payload_size_limit() {
 fn verify_log_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -298,7 +298,7 @@ fn verify_log_size_limit() {
 fn verify_event_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -324,7 +324,7 @@ fn verify_event_size_limit() {
 fn verify_panic_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -348,12 +348,12 @@ fn verify_panic_size_limit() {
 
 #[test]
 fn test_allocating_buffers_exceeding_limit() {
-    let (code, definition) = Compile::compile("tests/blueprints/transaction_limits");
+    let (code, definition) = PackageLoader::get("transaction_limits");
 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package(code, definition, BTreeMap::new(), OwnerRole::None);
+        test_runner.publish_package((code, definition), BTreeMap::new(), OwnerRole::None);
     let component_address = test_runner
         .execute_manifest(
             ManifestBuilder::new()

--- a/radix-engine-tests/tests/transaction_limits.rs
+++ b/radix-engine-tests/tests/transaction_limits.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::{
     errors::{RuntimeError, SystemModuleError, VmError},
     system::system_modules::limits::TransactionLimitsError,
@@ -170,7 +173,8 @@ fn test_write_entries_to_heap_kv_store_exceeding_limit() {
 fn test_default_substate_size_limit() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("tests/blueprints/transaction_limits");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -226,7 +230,8 @@ fn test_default_invoke_payload_size_limit() {
 
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("tests/blueprints/transaction_limits");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
     // Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -266,7 +271,8 @@ fn test_default_invoke_payload_size_limit() {
 #[test]
 fn verify_log_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/transaction_limits");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -291,7 +297,8 @@ fn verify_log_size_limit() {
 #[test]
 fn verify_event_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/transaction_limits");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(
@@ -316,7 +323,8 @@ fn verify_event_size_limit() {
 #[test]
 fn verify_panic_size_limit() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/transaction_limits");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_limits"));
 
     let manifest = ManifestBuilder::new()
         .call_function(

--- a/radix-engine-tests/tests/transaction_runtime.rs
+++ b/radix-engine-tests/tests/transaction_runtime.rs
@@ -12,7 +12,7 @@ fn test_query_transaction_runtime_info() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_runtime"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_runtime"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -39,7 +39,7 @@ fn test_generate_ruid() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("transaction_runtime"));
+        test_runner.publish_package_simple(PackageLoader::get("transaction_runtime"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/transaction_runtime.rs
+++ b/radix-engine-tests/tests/transaction_runtime.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_unit::*;
@@ -8,7 +11,8 @@ fn test_query_transaction_runtime_info() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/transaction_runtime");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_runtime"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -34,7 +38,8 @@ fn test_generate_ruid() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/transaction_runtime");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("transaction_runtime"));
 
     // Act
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/tx_processor_access.rs
+++ b/radix-engine-tests/tests/tx_processor_access.rs
@@ -59,7 +59,7 @@ fn calling_transaction_processor_from_scrypto_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("tx_processor_access"));
+        test_runner.publish_package_simple(PackageLoader::get("tx_processor_access"));
 
     // Act
     let manifest_encoded_instructions: Vec<u8> = vec![0u8];
@@ -86,7 +86,7 @@ fn should_not_be_able_to_steal_money_through_tx_processor_call() {
     let (pub_key, _, account0) = test_runner.new_account(true);
     let (_, _, account1) = test_runner.new_account(true);
     let package_address =
-        test_runner.publish_package_tuple(PackageLoader::get("tx_processor_access"));
+        test_runner.publish_package_simple(PackageLoader::get("tx_processor_access"));
     let initial_balance = test_runner.get_component_balance(account0, XRD);
     let instructions = ManifestBuilder::new()
         .withdraw_from_account(account0, XRD, 10)

--- a/radix-engine-tests/tests/tx_processor_access.rs
+++ b/radix-engine-tests/tests/tx_processor_access.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
@@ -55,7 +58,8 @@ fn should_not_be_able_to_call_tx_processor_in_tx_processor() {
 fn calling_transaction_processor_from_scrypto_should_not_panic() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/tx_processor_access");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("tx_processor_access"));
 
     // Act
     let manifest_encoded_instructions: Vec<u8> = vec![0u8];
@@ -81,7 +85,8 @@ fn should_not_be_able_to_steal_money_through_tx_processor_call() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let (pub_key, _, account0) = test_runner.new_account(true);
     let (_, _, account1) = test_runner.new_account(true);
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/tx_processor_access");
+    let package_address =
+        test_runner.publish_package_tuple(PackageLoader::get("tx_processor_access"));
     let initial_balance = test_runner.get_component_balance(account0, XRD);
     let instructions = ManifestBuilder::new()
         .withdraw_from_account(account0, XRD, 10)

--- a/radix-engine-tests/tests/vault.rs
+++ b/radix-engine-tests/tests/vault.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::blueprints::resource::VaultError;
 use radix_engine::errors::{
     ApplicationError, CallFrameError, KernelError, RuntimeError, SystemError,
@@ -20,7 +23,7 @@ fn test_deposit_event_when_creating_vault_with_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -52,7 +55,7 @@ fn test_deposit_event_when_creating_vault_with_bucket() {
 fn non_existent_vault_in_component_creation_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -79,7 +82,7 @@ fn non_existent_vault_in_component_creation_should_fail() {
 fn non_existent_vault_in_committed_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "NonExistentVault", "new", manifest_args!())
@@ -111,7 +114,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
 fn non_existent_vault_in_kv_store_creation_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -140,7 +143,7 @@ fn non_existent_vault_in_kv_store_creation_should_fail() {
 fn non_existent_vault_in_committed_kv_store_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "NonExistentVault", "new", manifest_args!())
@@ -174,7 +177,7 @@ fn non_existent_vault_in_committed_kv_store_should_fail() {
 fn create_mutable_vault_into_map() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -196,7 +199,7 @@ fn create_mutable_vault_into_map() {
 fn invalid_double_ownership_of_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -227,7 +230,7 @@ fn invalid_double_ownership_of_vault() {
 fn create_mutable_vault_into_map_and_referencing_before_storing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -249,7 +252,7 @@ fn create_mutable_vault_into_map_and_referencing_before_storing() {
 fn cannot_overwrite_vault_in_map() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -290,7 +293,7 @@ fn cannot_overwrite_vault_in_map() {
 fn create_mutable_vault_into_vector() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -312,7 +315,7 @@ fn create_mutable_vault_into_vector() {
 fn cannot_remove_vaults() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -349,7 +352,7 @@ fn cannot_remove_vaults() {
 fn can_push_vault_into_vector() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -381,7 +384,7 @@ fn can_push_vault_into_vector() {
 fn create_fungible_vault_with_take() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -403,7 +406,7 @@ fn create_fungible_vault_with_take() {
 fn create_non_fungible_vault_with_take() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -425,7 +428,7 @@ fn create_non_fungible_vault_with_take() {
 fn create_non_fungible_vault_with_take_twice() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -447,7 +450,7 @@ fn create_non_fungible_vault_with_take_twice() {
 fn create_non_fungible_vault_with_take_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -469,7 +472,7 @@ fn create_non_fungible_vault_with_take_non_fungible() {
 fn create_mutable_vault_with_get_nonfungible_ids() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -491,7 +494,7 @@ fn create_mutable_vault_with_get_nonfungible_ids() {
 fn create_mutable_vault_with_get_nonfungible_id() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -513,7 +516,7 @@ fn create_mutable_vault_with_get_nonfungible_id() {
 fn create_mutable_vault_with_get_amount() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -535,7 +538,7 @@ fn create_mutable_vault_with_get_amount() {
 fn create_mutable_vault_with_get_resource_manager() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -557,7 +560,7 @@ fn create_mutable_vault_with_get_resource_manager() {
 fn take_on_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -585,7 +588,7 @@ fn take_on_non_fungible_vault() {
 fn take_twice_on_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -662,7 +665,7 @@ fn create_proof_with_over_specified_divisibility_should_result_in_error() {
 fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/vault.rs
+++ b/radix-engine-tests/tests/vault.rs
@@ -23,7 +23,7 @@ fn test_deposit_event_when_creating_vault_with_bucket() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (public_key, _, _) = test_runner.new_allocated_account();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -55,7 +55,7 @@ fn test_deposit_event_when_creating_vault_with_bucket() {
 fn non_existent_vault_in_component_creation_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -82,7 +82,7 @@ fn non_existent_vault_in_component_creation_should_fail() {
 fn non_existent_vault_in_committed_component_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "NonExistentVault", "new", manifest_args!())
@@ -114,7 +114,7 @@ fn non_existent_vault_in_committed_component_should_fail() {
 fn non_existent_vault_in_kv_store_creation_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -143,7 +143,7 @@ fn non_existent_vault_in_kv_store_creation_should_fail() {
 fn non_existent_vault_in_committed_kv_store_should_fail() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "NonExistentVault", "new", manifest_args!())
@@ -177,7 +177,7 @@ fn non_existent_vault_in_committed_kv_store_should_fail() {
 fn create_mutable_vault_into_map() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -199,7 +199,7 @@ fn create_mutable_vault_into_map() {
 fn invalid_double_ownership_of_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -230,7 +230,7 @@ fn invalid_double_ownership_of_vault() {
 fn create_mutable_vault_into_map_and_referencing_before_storing() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -252,7 +252,7 @@ fn create_mutable_vault_into_map_and_referencing_before_storing() {
 fn cannot_overwrite_vault_in_map() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -293,7 +293,7 @@ fn cannot_overwrite_vault_in_map() {
 fn create_mutable_vault_into_vector() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -315,7 +315,7 @@ fn create_mutable_vault_into_vector() {
 fn cannot_remove_vaults() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -352,7 +352,7 @@ fn cannot_remove_vaults() {
 fn can_push_vault_into_vector() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -384,7 +384,7 @@ fn can_push_vault_into_vector() {
 fn create_fungible_vault_with_take() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -406,7 +406,7 @@ fn create_fungible_vault_with_take() {
 fn create_non_fungible_vault_with_take() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -428,7 +428,7 @@ fn create_non_fungible_vault_with_take() {
 fn create_non_fungible_vault_with_take_twice() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -450,7 +450,7 @@ fn create_non_fungible_vault_with_take_twice() {
 fn create_non_fungible_vault_with_take_non_fungible() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -472,7 +472,7 @@ fn create_non_fungible_vault_with_take_non_fungible() {
 fn create_mutable_vault_with_get_nonfungible_ids() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -494,7 +494,7 @@ fn create_mutable_vault_with_get_nonfungible_ids() {
 fn create_mutable_vault_with_get_nonfungible_id() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -516,7 +516,7 @@ fn create_mutable_vault_with_get_nonfungible_id() {
 fn create_mutable_vault_with_get_amount() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -538,7 +538,7 @@ fn create_mutable_vault_with_get_amount() {
 fn create_mutable_vault_with_get_resource_manager() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -560,7 +560,7 @@ fn create_mutable_vault_with_get_resource_manager() {
 fn take_on_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -588,7 +588,7 @@ fn take_on_non_fungible_vault() {
 fn take_twice_on_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(
@@ -665,7 +665,7 @@ fn create_proof_with_over_specified_divisibility_should_result_in_error() {
 fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/vault_burn.rs
+++ b/radix-engine-tests/tests/vault_burn.rs
@@ -53,7 +53,7 @@ fn package_burn_is_only_callable_within_resource_package() {
 fn can_burn_by_amount_from_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_fungible_resource(
@@ -109,7 +109,7 @@ fn can_burn_by_amount_from_fungible_vault() {
 fn can_burn_by_amount_from_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -169,7 +169,7 @@ fn can_burn_by_amount_from_non_fungible_vault() {
 fn can_burn_by_ids_from_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -235,7 +235,7 @@ fn can_burn_by_ids_from_non_fungible_vault() {
 fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -295,7 +295,7 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
 fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -359,7 +359,7 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
 fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -429,7 +429,7 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
 fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -488,7 +488,7 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
 fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -551,7 +551,7 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
 fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -620,7 +620,7 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
 fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_fungible_resource(
@@ -676,7 +676,7 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
 fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -736,7 +736,7 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
 fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(

--- a/radix-engine-tests/tests/vault_burn.rs
+++ b/radix-engine-tests/tests/vault_burn.rs
@@ -1,3 +1,6 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
@@ -50,7 +53,7 @@ fn package_burn_is_only_callable_within_resource_package() {
 fn can_burn_by_amount_from_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_fungible_resource(
@@ -106,7 +109,7 @@ fn can_burn_by_amount_from_fungible_vault() {
 fn can_burn_by_amount_from_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -166,7 +169,7 @@ fn can_burn_by_amount_from_non_fungible_vault() {
 fn can_burn_by_ids_from_non_fungible_vault() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -232,7 +235,7 @@ fn can_burn_by_ids_from_non_fungible_vault() {
 fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -292,7 +295,7 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
 fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -356,7 +359,7 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
 fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -426,7 +429,7 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
 fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -485,7 +488,7 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
 fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -548,7 +551,7 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
 fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulfilled() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let (public_key, _, _) = test_runner.new_account(false);
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
@@ -617,7 +620,7 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
 fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_fungible_resource(
@@ -673,7 +676,7 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
 fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(
@@ -733,7 +736,7 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
 fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
-    let package_address = test_runner.compile_and_publish("./tests/blueprints/vault");
+    let package_address = test_runner.publish_package_tuple(PackageLoader::get("vault"));
     let resource_address = {
         let manifest = ManifestBuilder::new()
             .create_non_fungible_resource(

--- a/radix-engine-tests/tests/wasm_metering.rs
+++ b/radix-engine-tests/tests/wasm_metering.rs
@@ -14,8 +14,7 @@ fn test_loop() {
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "1000"));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -38,8 +37,7 @@ fn test_finish_before_system_loan_limit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "1"));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -61,8 +59,7 @@ fn test_loop_out_of_cost_unit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/loop.wat").replace("${n}", "2000000"));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -86,8 +83,7 @@ fn test_recursion() {
     // In this test case, each call frame costs 4 stack units
     let code = wat2wasm(&include_str!("wasm/recursion.wat").replace("${n}", "256"));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -109,8 +105,7 @@ fn test_recursion_stack_overflow() {
     // Act
     let code = wat2wasm(&include_str!("wasm/recursion.wat").replace("${n}", "257"));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -136,8 +131,7 @@ fn test_grow_memory_within_limit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -163,8 +157,7 @@ fn test_grow_memory_beyond_limit() {
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );
@@ -196,8 +189,7 @@ fn test_grow_memory_by_more_than_65536() {
     // Act
     let code = wat2wasm(&include_str!("wasm/memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );

--- a/radix-engine-tests/tests/wasm_non_mvp.rs
+++ b/radix-engine-tests/tests/wasm_non_mvp.rs
@@ -33,8 +33,7 @@ macro_rules! assert_sign_extensions {
 
                 let mut test_runner = TestRunnerBuilder::new().build();
                 let package_address = test_runner.publish_package(
-                    code,
-                    single_function_package_definition("Test", "f"),
+                    (code, single_function_package_definition("Test", "f")),
                     BTreeMap::new(),
                     OwnerRole::None,
                 );
@@ -94,8 +93,7 @@ fn test_wasm_non_mvp_mutable_globals_export() {
     // Act
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package(
-        code,
-        single_function_package_definition("Test", "f"),
+        (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
         OwnerRole::None,
     );

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -91,4 +91,5 @@ full_wasm_benchmarks = []
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/radix-engine/wasm-benchmarks-lib/Cargo.toml
+++ b/radix-engine/wasm-benchmarks-lib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "rlib"]
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false

--- a/resource-tests/Cargo.toml
+++ b/resource-tests/Cargo.toml
@@ -40,4 +40,5 @@ rocksdb = ["scrypto-unit/rocksdb"]
 post_run_db_check = ["scrypto-unit/post_run_db_check"]
 
 [lib]
+doctest = false
 bench = false

--- a/run-code-coverage.sh
+++ b/run-code-coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+set -e
+
+CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo nextest run --features compile-blueprints-at-build-time --no-fail-fast
+
+grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html

--- a/run-code-coverage.sh
+++ b/run-code-coverage.sh
@@ -3,6 +3,6 @@
 set -x
 set -e
 
-CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo nextest run --features compile-blueprints-at-build-time --no-fail-fast
+CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test --features compile-blueprints-at-build-time --no-fail-fast
 
 grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html

--- a/sbor-derive-common/Cargo.toml
+++ b/sbor-derive-common/Cargo.toml
@@ -14,4 +14,5 @@ itertools = { version = "0.10.3" }
 trace = []
 
 [lib]
+doctest = false
 bench = false

--- a/sbor-derive/Cargo.toml
+++ b/sbor-derive/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [lib]
+doctest = false
 proc-macro = true
 bench = false
 

--- a/sbor-tests/Cargo.toml
+++ b/sbor-tests/Cargo.toml
@@ -20,4 +20,5 @@ std = ["serde/std", "serde_json/std", "bincode/std", "sbor/std", "sbor/std", "sb
 alloc = ["serde/alloc", "serde_json/alloc", "bincode/alloc", "sbor/alloc", "sbor/alloc", "sbor/serde"]
 
 [lib]
+doctest = false
 bench = false

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -33,4 +33,5 @@ trace = ["sbor-derive/trace"]
 radix_engine_fuzzing = ["arbitrary"]
 
 [lib]
+doctest = false
 bench = false

--- a/scrypto-derive/Cargo.toml
+++ b/scrypto-derive/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [lib]
+doctest = false
 proc-macro = true
 bench = false
 

--- a/scrypto-schema/Cargo.toml
+++ b/scrypto-schema/Cargo.toml
@@ -19,4 +19,5 @@ alloc = ["sbor/alloc", "radix-engine-common/alloc", "serde?/alloc"]
 serde = ["serde/derive", "sbor/serde", "radix-engine-common/serde"]
 
 [lib]
+doctest = false
 bench = false

--- a/scrypto-test/Cargo.toml
+++ b/scrypto-test/Cargo.toml
@@ -34,4 +34,5 @@ moka = ["radix-engine/moka"]
 lru = ["radix-engine/lru"]
 
 [lib]
+doctest = false
 bench = false

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -161,7 +161,7 @@ use crate::prelude::*;
 /// would be through simple factory and destructor methods.
 ///
 /// ## Full Examples
-/// ```
+/// ```norun
 #[doc = include_str!("../../../assets/blueprints/radiswap/tests/lib.rs")]
 /// ```
 pub struct TestEnvironment(pub(super) EncapsulatedRadixEngine);

--- a/scrypto-unit/Cargo.toml
+++ b/scrypto-unit/Cargo.toml
@@ -30,4 +30,5 @@ rocksdb = ["radix-engine-stores/rocksdb"]
 post_run_db_check = []
 
 [lib]
+doctest = false
 bench = false

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -1191,6 +1191,13 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         self.publish_package(code, definition, BTreeMap::new(), OwnerRole::None)
     }
 
+    pub fn publish_package_tuple(
+        &mut self,
+        (code, definition): (Vec<u8>, PackageDefinition),
+    ) -> PackageAddress {
+        self.publish_package(code, definition, BTreeMap::new(), OwnerRole::None)
+    }
+
     pub fn compile_and_publish_at_address<P: AsRef<Path>>(
         &mut self,
         package_dir: P,

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -33,4 +33,5 @@ trace = ["scrypto-derive/trace"]
 no-schema = ["scrypto-derive/no-schema"]
 
 [lib]
+doctest = false
 bench = false

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -57,4 +57,5 @@ path = "src/bin/scrypto_bindgen.rs"
 bench = false
 
 [lib]
+doctest = false
 bench = false

--- a/simulator/tests/blueprints/Cargo.toml
+++ b/simulator/tests/blueprints/Cargo.toml
@@ -19,6 +19,7 @@ strip = true           # Strip the symbols.
 overflow-checks = true # Panic in the case of an overflow.
 
 [lib]
+doctest = false
 crate-type = ["cdylib", "lib"]
 
 [workspace]

--- a/transaction-scenarios/Cargo.toml
+++ b/transaction-scenarios/Cargo.toml
@@ -24,4 +24,5 @@ alloc = ["hex/alloc", "sbor/alloc", "scrypto/alloc", "transaction/alloc", "radix
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
+doctest = false
 bench = false

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -34,4 +34,5 @@ dump_manifest_to_file = []
 radix_engine_fuzzing = []
 
 [lib]
+doctest = false
 bench = false

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -22,4 +22,5 @@ serde = ["serde/derive", "indexmap/serde"]
 radix_engine_fuzzing= ["indexmap/arbitrary"]
 
 [lib]
+doctest = false
 bench = false


### PR DESCRIPTION
## Summary

This PR adds a `PackageLoader` struct to the `radix-engine-tests` crate.

## Description

This PR is made to fix some issues we have faced when running tests locally. These issues have been made more apparent now that we're integrating code coverage in our development pipeline.

A very common issue that myself and others run into quite often when running tests locally is the following error:
```
'Failed to read built WASM from path "path/some.wasm" - Os { code: 2, kind: NotFound, message: "No such file or directory" }'
```

We believe that this issue is caused by multiple tests trying to read the same WASM file and some contention happening after the compilation finishes. 

The solution to this issue is implemented in this PR. A `compile-blueprints-at-build-time` feature flag has been added to the `radix-engine-tests` crate which when enabled, will build all of the blueprints at the crates compilation time and make the compiled packages available in tests through the `PackageLoader` struct. The build script compiles all of the blueprints, writes them to the `OUT_DIR` and then they're read by the `PackageLoader` _at compile time_ from the `OUT_DIR`.

If `compile-blueprints-at-build-time` feature is not enabled then the package will be compiled on the fly when you try to load it.

## Note for Reviewers

This diff is quite big and full of various renames and small items that might not be the best use of your time. The following are the files I recommend you review:

* `radix-engine-tests/build.rs`
* `radix-engine-tests/tests/package_loader.rs`
* `radix-engine-tests/Cargo.toml`
* `.github/workflows/ci.yml`
* `scrypto_unit/src/test_runner.rs`
* `run-code-coverage.sh`

## Update Recommendations

### For Internal Integrators

This is not quite for internal integrators, but for the Builder's Team:

* Do not set the `compile-blueprints-at-build-time` as a default feature in the `radix-engine-tests` crate. It will lead to a painfully slow rust analyzer.
* If you're running a single test or even a single module you do not need `compile-blueprints-at-build-time`. 
* Pass `--features compile-blueprints-at-build-time` to `cargo test` or `cargo nextest run` if you want to run all of the tests without the flakyness of reading files from the file system.
* `PackageLoader::get` takes the name of the Cargo package and **NOT** the name of the directory. 