### PR TITLE
Implementing "partition delete" at storage layer (substate DB and JMT)

### DIFF
--- a/radix-engine-profiling/src/rocks_db_metrics/tests/common.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/tests/common.rs
@@ -5,7 +5,7 @@ use radix_engine_store_interface::{
     db_key_mapper::*,
     interface::{
         CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, DbPartitionKey, DbSortKey,
-        PartitionUpdates, SubstateDatabase,
+        PartitionDatabaseUpdates, SubstateDatabase,
     },
 };
 use rand::{rngs::ThreadRng, Rng};
@@ -103,7 +103,7 @@ pub fn discard_spikes(data: &mut BTreeMap<usize, Vec<Duration>>, delta_range: f3
 }
 
 pub fn generate_commit_data(
-    partition: &mut PartitionUpdates,
+    partition: &mut PartitionDatabaseUpdates,
     rng: &mut ThreadRng,
     value_size: usize,
 ) -> DbSortKey {
@@ -150,7 +150,7 @@ pub fn prepare_db<S: SubstateDatabase + CommittableSubstateDatabase>(
         let node_id = NodeId::new(EntityType::InternalKeyValueStore as u8, &node_id_value);
         let partition_key =
             SpreadPrefixKeyMapper::to_db_partition_key(&node_id, PartitionNumber(0u8));
-        let mut partition = PartitionUpdates::new();
+        let mut partition = PartitionDatabaseUpdates::new();
 
         for size in substate_size_list.iter() {
             let sort_key = generate_commit_data(&mut partition, &mut rng, *size);

--- a/radix-engine-profiling/src/rocks_db_metrics/tests/delete.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/tests/delete.rs
@@ -4,7 +4,7 @@ use linreg::linear_regression_of;
 use radix_engine_store_interface::{
     db_key_mapper::*,
     interface::{
-        CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, PartitionUpdates,
+        CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, PartitionDatabaseUpdates,
         SubstateDatabase,
     },
 };
@@ -262,7 +262,7 @@ where
     for (partition_key, sort_key, _usize) in data {
         let mut input_data = DatabaseUpdates::new();
 
-        let mut partition = PartitionUpdates::new();
+        let mut partition = PartitionDatabaseUpdates::new();
         partition.insert(sort_key, DatabaseUpdate::Delete);
 
         input_data.insert(partition_key, partition);
@@ -330,7 +330,7 @@ where
 
                 let partition_key =
                     SpreadPrefixKeyMapper::to_db_partition_key(&node_id, PartitionNumber(0u8));
-                let mut partition = PartitionUpdates::new();
+                let mut partition = PartitionDatabaseUpdates::new();
 
                 let mut sort_key_data = Vec::new();
                 for _ in 0..i {
@@ -382,7 +382,7 @@ where
             idx_vector_output.push(idx);
 
             let mut input_data = DatabaseUpdates::new();
-            let mut partition = PartitionUpdates::new();
+            let mut partition = PartitionDatabaseUpdates::new();
 
             for key in sort_keys {
                 partition.insert(key.clone(), DatabaseUpdate::Delete);

--- a/radix-engine-profiling/src/rocks_db_metrics/tests/write.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/tests/write.rs
@@ -4,7 +4,7 @@ use linreg::linear_regression_of;
 use radix_engine_store_interface::{
     db_key_mapper::*,
     interface::{
-        CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, PartitionUpdates,
+        CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, PartitionDatabaseUpdates,
         SubstateDatabase,
     },
 };
@@ -267,7 +267,7 @@ where
         let value_size = 100;
         for n in 1..=n_value {
             let mut input_data = DatabaseUpdates::new();
-            let mut partition = PartitionUpdates::new();
+            let mut partition = PartitionDatabaseUpdates::new();
 
             for j in 0..n {
                 let mut value_data: DbSubstateValue = vec![0u8; value_size];
@@ -372,7 +372,7 @@ where
 
         for substate_size in size_vector.iter() {
             let mut input_data = DatabaseUpdates::new();
-            let mut partition = PartitionUpdates::new();
+            let mut partition = PartitionDatabaseUpdates::new();
 
             generate_commit_data(&mut partition, &mut rng, *substate_size);
 

--- a/radix-engine-store-interface/src/db_key_mapper.rs
+++ b/radix-engine-store-interface/src/db_key_mapper.rs
@@ -1,5 +1,6 @@
 use crate::interface::{
-    CommittableSubstateDatabase, DatabaseUpdate, DbPartitionKey, DbSortKey, SubstateDatabase,
+    CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, DbNodeKey, DbPartitionKey,
+    DbPartitionNum, DbSortKey, SubstateDatabase,
 };
 use radix_engine_common::data::scrypto::{
     scrypto_decode, scrypto_encode, ScryptoDecode, ScryptoEncode,
@@ -12,8 +13,19 @@ use utils::copy_u8_array;
 
 /// A mapper between the business ReNode / Partition / Substate IDs and database keys.
 pub trait DatabaseKeyMapper {
-    /// Converts the given ReNode ID and Partition number to the database partition's key.
-    fn to_db_partition_key(node_id: &NodeId, partition_num: PartitionNumber) -> DbPartitionKey;
+    /// Converts the given Node ID and Partition number to the database partition's key.
+    fn to_db_partition_key(node_id: &NodeId, partition_num: PartitionNumber) -> DbPartitionKey {
+        DbPartitionKey {
+            node_key: Self::to_db_node_key(node_id),
+            partition_num: Self::to_db_partition_num(partition_num),
+        }
+    }
+
+    /// Converts the given Node ID to the database Node key.
+    fn to_db_node_key(node_id: &NodeId) -> DbNodeKey;
+
+    /// Converts the given Partition number to the database Partition number.
+    fn to_db_partition_num(partition_num: PartitionNumber) -> DbPartitionNum;
 
     /// Converts database partition's key back to ReNode ID and Partition number.
     fn from_db_partition_key(partition_key: &DbPartitionKey) -> (NodeId, PartitionNumber);
@@ -72,11 +84,12 @@ pub trait DatabaseKeyMapper {
 pub struct SpreadPrefixKeyMapper;
 
 impl DatabaseKeyMapper for SpreadPrefixKeyMapper {
-    fn to_db_partition_key(node_id: &NodeId, partition_num: PartitionNumber) -> DbPartitionKey {
-        DbPartitionKey {
-            node_key: SpreadPrefixKeyMapper::to_hash_prefixed(node_id.as_bytes()),
-            partition_num: partition_num.0,
-        }
+    fn to_db_node_key(node_id: &NodeId) -> DbNodeKey {
+        SpreadPrefixKeyMapper::to_hash_prefixed(node_id.as_bytes())
+    }
+
+    fn to_db_partition_num(partition_num: PartitionNumber) -> DbPartitionNum {
+        partition_num.0
     }
 
     fn from_db_partition_key(partition_key: &DbPartitionKey) -> (NodeId, PartitionNumber) {
@@ -213,13 +226,15 @@ impl<S: CommittableSubstateDatabase> MappedCommittableSubstateDatabase for S {
         substate_key: &SubstateKey,
         value: &E,
     ) {
-        self.commit(&indexmap!(
-            M::to_db_partition_key(node_id, partition_num) => indexmap!(
-                M::to_db_sort_key(substate_key) => DatabaseUpdate::Set(
-                    scrypto_encode(value).unwrap()
+        self.commit(&DatabaseUpdates::from_delta_maps(indexmap!(
+            M::to_db_node_key(node_id) => indexmap!(
+                M::to_db_partition_num(partition_num) => indexmap!(
+                    M::to_db_sort_key(substate_key) => DatabaseUpdate::Set(
+                        scrypto_encode(value).unwrap()
+                    )
                 )
             )
-        ))
+        )))
     }
 }
 

--- a/radix-engine-store-interface/src/interface.rs
+++ b/radix-engine-store-interface/src/interface.rs
@@ -1,4 +1,4 @@
-use radix_engine_derive::ScryptoSbor;
+use radix_engine_common::Sbor;
 use utils::rust::boxed::Box;
 use utils::rust::collections::IndexMap;
 use utils::rust::vec::Vec;
@@ -11,24 +11,34 @@ pub type DbPartitionNum = u8;
 /// Seen from the higher-level API: it represents a pair (RE Node ID, Module ID).
 /// Seen from the lower-level implementation: it is used as a key in the upper-layer tree of our
 /// two-layered JMT.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, ScryptoSbor)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Sbor)]
 pub struct DbPartitionKey {
     pub node_key: DbNodeKey,
     pub partition_num: DbPartitionNum,
 }
 
 impl DbPartitionKey {
-    pub fn into_bytes(self) -> Vec<u8> {
-        let mut bytes = self.node_key;
-        bytes.push(self.partition_num);
-        bytes
+    /// Calculates a hypothetical "next partition" key in the database.
+    /// This method is suitable for constructing an open right bound of a database key range; the
+    /// partition of the returned key may in practice not even exist in the database.
+    pub fn next(&self) -> Self {
+        self.partition_num
+            .checked_add(1)
+            .map(|next_partition_num| DbPartitionKey {
+                node_key: self.node_key.clone(),
+                partition_num: next_partition_num,
+            })
+            .unwrap_or_else(|| DbPartitionKey {
+                node_key: [self.node_key.clone(), vec![0]].concat(),
+                partition_num: 0,
+            })
     }
 }
 
 /// A database-level key of a substate within a known partition.
 /// Seen from the higher-level API: it represents a local Substate Key.
 /// Seen from the lower-level implementation: it is used as a key in the Substate-Tier JMT.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, ScryptoSbor)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Ord, PartialOrd, Sbor)]
 pub struct DbSortKey(pub Vec<u8>);
 
 /// A fully-specified key of a substate (i.e. specifying its partition and sort key).
@@ -40,17 +50,86 @@ pub type DbSubstateValue = Vec<u8>;
 /// A key-value entry of a substate within a known partition.
 pub type PartitionEntry = (DbSortKey, DbSubstateValue);
 
-/// A fully-specified set of substate value updates (aggregated by partition).
-pub type DatabaseUpdates = IndexMap<DbPartitionKey, PartitionUpdates>;
+/// A canonical description of all database updates to be applied.
+/// Note: this struct can be migrated to an enum if we ever have a need for database-wide batch
+/// changes (see [`PartitionDatabaseUpdates`] enum).
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+pub struct DatabaseUpdates {
+    /// Node-level updates.
+    pub node_updates: IndexMap<DbNodeKey, NodeDatabaseUpdates>,
+}
 
-/// A set of substate value updates within a known partition.
-pub type PartitionUpdates = IndexMap<DbSortKey, DatabaseUpdate>;
+/// A canonical description of specific Node's updates to be applied.
+/// Note: this struct can be migrated to an enum if we ever have a need for Node-wide batch changes
+/// (see [`PartitionDatabaseUpdates`] enum).
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+pub struct NodeDatabaseUpdates {
+    /// Partition-level updates.
+    pub partition_updates: IndexMap<DbPartitionNum, PartitionDatabaseUpdates>,
+}
 
-/// An update of a single substate values.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, ScryptoSbor)]
+/// A canonical description of specific Partition's updates to be applied.
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+pub enum PartitionDatabaseUpdates {
+    /// A delta change, touching just selected substates.
+    Delta {
+        substate_updates: IndexMap<DbSortKey, DatabaseUpdate>,
+    },
+    /// A batch change.
+    Batch(BatchPartitionDatabaseUpdate),
+}
+
+/// An update affecting entire Partition at once.
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+pub enum BatchPartitionDatabaseUpdate {
+    Reset {
+        new_substate_values: IndexMap<DbSortKey, DbSubstateValue>,
+    },
+}
+
+/// An update of a single substate's value.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Sbor)]
 pub enum DatabaseUpdate {
     Set(DbSubstateValue),
     Delete,
+}
+
+impl DatabaseUpdates {
+    /// Constructs an instance from the given legacy representation (a map of maps), which is only
+    /// capable of specifying "deltas" (i.e. individual substate changes; no partition deletes).
+    ///
+    /// Note: This method is only meant for tests/demos - with regular Engine usage, the
+    /// [`DatabaseUpdates`] can be obtained directly from the receipt.
+    pub fn from_delta_maps(
+        maps: IndexMap<DbNodeKey, IndexMap<DbPartitionNum, IndexMap<DbSortKey, DatabaseUpdate>>>,
+    ) -> DatabaseUpdates {
+        DatabaseUpdates {
+            node_updates: maps
+                .into_iter()
+                .map(|(node_key, node_updates)| {
+                    (node_key, NodeDatabaseUpdates::from_delta_maps(node_updates))
+                })
+                .collect(),
+        }
+    }
+}
+
+impl NodeDatabaseUpdates {
+    fn from_delta_maps(
+        maps: IndexMap<DbPartitionNum, IndexMap<DbSortKey, DatabaseUpdate>>,
+    ) -> NodeDatabaseUpdates {
+        NodeDatabaseUpdates {
+            partition_updates: maps
+                .into_iter()
+                .map(|(partition_num, substate_updates)| {
+                    (
+                        partition_num,
+                        PartitionDatabaseUpdates::Delta { substate_updates },
+                    )
+                })
+                .collect(),
+        }
+    }
 }
 
 /// A read interface between Track and a database vendor.

--- a/radix-engine-stores/src/hash_tree/jellyfish.rs
+++ b/radix-engine-stores/src/hash_tree/jellyfish.rs
@@ -617,9 +617,9 @@ impl<'a, R: 'a + TreeReader<P>, P: Clone> JellyfishMerkleTree<'a, R, P> {
         self.get_root_node(version).map(|n| n.leaf_count())
     }
 
-    pub fn get_all_nodes_referenced(&self, version: Version) -> Result<Vec<NodeKey>, StorageError> {
+    pub fn get_all_nodes_referenced(&self, key: NodeKey) -> Result<Vec<NodeKey>, StorageError> {
         let mut out_keys = vec![];
-        self.get_all_nodes_referenced_impl(NodeKey::new_empty_path(version), &mut out_keys)?;
+        self.get_all_nodes_referenced_impl(key, &mut out_keys)?;
         Ok(out_keys)
     }
 

--- a/radix-engine-stores/src/hash_tree/mod.rs
+++ b/radix-engine-stores/src/hash_tree/mod.rs
@@ -1,8 +1,10 @@
+use crate::hash_tree::tree_store::StaleTreePart;
 use crate::hash_tree::types::{LeafKey, LeafNode, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use jellyfish::JellyfishMerkleTree;
-use radix_engine_common::crypto::Hash;
+use radix_engine_common::crypto::{hash, Hash};
 use radix_engine_store_interface::interface::{
-    DbNodeKey, DbPartitionKey, DbPartitionNum, DbSortKey, DbSubstateKey,
+    BatchPartitionDatabaseUpdate, DatabaseUpdate, DatabaseUpdates, DbNodeKey, DbPartitionKey,
+    DbPartitionNum, DbSortKey, DbSubstateValue, NodeDatabaseUpdates, PartitionDatabaseUpdates,
 };
 use tree_store::{ReadableTreeStore, TreeNode, TreeStore, WriteableTreeStore};
 use types::{NibblePath, NodeKey, Version};
@@ -25,26 +27,6 @@ mod test;
 #[allow(dead_code)]
 mod types;
 
-/// A change of a hash of value associated with some ID.
-/// External API only uses it for hashes of substates (see `SubstateHashChange`), but internally we
-/// also use it for lower-level hashes of JMT nodes of different tiers.
-#[derive(Debug)]
-pub struct IdHashChange<I> {
-    /// ID.
-    id: I,
-    /// A hash after the change, or `None` if this change denotes a delete.
-    hash_change: Option<Hash>,
-}
-
-impl<I> IdHashChange<I> {
-    pub fn new(id: I, hash_change: Option<Hash>) -> Self {
-        Self { id, hash_change }
-    }
-}
-
-/// A top-level `IdHashChange`, representing an actual change of a specific substate's hash.
-pub type SubstateHashChange = IdHashChange<DbSubstateKey>;
-
 /// Inserts a new set of nodes at version `node_root_version` + 1 into the "3-Tier JMT" persisted
 /// within the given `TreeStore`.
 /// In a traditional JMT, this inserts a new leaf node for each given "change", together with an
@@ -62,55 +44,28 @@ pub type SubstateHashChange = IdHashChange<DbSubstateKey>;
 pub fn put_at_next_version<S: TreeStore>(
     node_tier_store: &mut S,
     node_root_version: Option<Version>,
-    changes: Vec<SubstateHashChange>,
+    database_updates: &DatabaseUpdates,
 ) -> Hash {
     let next_version = node_root_version.unwrap_or(0) + 1;
-    let node_changes = index_by_node_key_and_partition_num(changes)
-        .into_iter()
-        .map(|(node_key, substate_changes_by_partition)| {
-            let partition_root_version =
-                get_lower_tier_root_version(node_tier_store, node_root_version, &node_key);
-            let mut partition_tier_store = NestedTreeStore::new(node_tier_store, node_key.clone());
-            let partition_changes = substate_changes_by_partition
-                .into_iter()
-                .map(|(partition_num, substate_changes)| {
-                    let partition_key = vec![partition_num];
-                    let substate_root_version = get_lower_tier_root_version(
-                        &partition_tier_store,
-                        partition_root_version,
-                        &partition_key,
-                    );
-                    let mut substate_tier_store =
-                        NestedTreeStore::new(&mut partition_tier_store, partition_key);
-                    let partition_hash = put_id_hash_changes(
-                        &mut substate_tier_store,
-                        substate_root_version,
-                        next_version,
-                        substate_changes
-                            .into_iter()
-                            .map(|change| IdHashChange::new(change.id.0, change.hash_change))
-                            .collect(),
-                    );
-                    IdHashChange::new(partition_num, partition_hash)
-                })
-                .collect::<Vec<_>>();
-            let node_hash_change = put_id_hash_changes(
-                &mut partition_tier_store,
-                partition_root_version,
+    let node_hash_changes = database_updates
+        .node_updates
+        .iter()
+        .map(|(node_key, node_database_updates)| LeafHashChange {
+            key_bytes: node_key.clone(),
+            hash_change: apply_node_database_updates(
+                node_tier_store,
+                node_root_version,
+                node_key,
+                node_database_updates,
                 next_version,
-                partition_changes
-                    .into_iter()
-                    .map(|change| IdHashChange::new(vec![change.id], change.hash_change))
-                    .collect(),
-            );
-            IdHashChange::new(node_key, node_hash_change)
+            ),
         })
         .collect::<Vec<_>>();
-    put_id_hash_changes(
+    put_leaf_hash_changes(
         node_tier_store,
         node_root_version,
         next_version,
-        node_changes,
+        node_hash_changes,
     )
     .unwrap_or(SPARSE_MERKLE_PLACEHOLDER_HASH)
 }
@@ -188,6 +143,84 @@ fn list_leaves_recursively<S: ReadableTreeStore>(
     };
 }
 
+fn apply_node_database_updates<S: TreeStore>(
+    node_tier_store: &mut S,
+    node_root_version: Option<Version>,
+    node_key: &DbNodeKey,
+    node_database_updates: &NodeDatabaseUpdates,
+    next_version: Version,
+) -> Option<Hash> {
+    let partition_root_version =
+        get_lower_tier_root_version(node_tier_store, node_root_version, node_key);
+    let mut partition_tier_store = NestedTreeStore::new(node_tier_store, node_key.clone());
+    let partition_hash_changes = node_database_updates
+        .partition_updates
+        .iter()
+        .map(
+            |(partition_num, partition_database_updates)| LeafHashChange {
+                key_bytes: vec![*partition_num],
+                hash_change: apply_partition_database_updates(
+                    &mut partition_tier_store,
+                    partition_root_version,
+                    partition_num,
+                    partition_database_updates,
+                    next_version,
+                ),
+            },
+        )
+        .collect::<Vec<_>>();
+    put_leaf_hash_changes(
+        &mut partition_tier_store,
+        partition_root_version,
+        next_version,
+        partition_hash_changes,
+    )
+}
+
+fn apply_partition_database_updates<S: TreeStore>(
+    partition_tier_store: &mut S,
+    partition_root_version: Option<Version>,
+    partition_num: &DbPartitionNum,
+    partition_database_updates: &PartitionDatabaseUpdates,
+    next_version: Version,
+) -> Option<Hash> {
+    let partition_key = vec![*partition_num];
+    let substate_root_version =
+        get_lower_tier_root_version(partition_tier_store, partition_root_version, &partition_key);
+    let mut substate_tier_store = NestedTreeStore::new(partition_tier_store, partition_key);
+    match partition_database_updates {
+        PartitionDatabaseUpdates::Delta { substate_updates } => put_leaf_hash_changes(
+            &mut substate_tier_store,
+            substate_root_version,
+            next_version,
+            substate_updates
+                .into_iter()
+                .map(|(sort_key, update)| LeafHashChange::from_update(sort_key, update))
+                .collect(),
+        ),
+        PartitionDatabaseUpdates::Batch(batch) => match batch {
+            BatchPartitionDatabaseUpdate::Reset {
+                new_substate_values,
+            } => {
+                if let Some(substate_root_version) = substate_root_version {
+                    substate_tier_store.record_stale_tree_part(StaleTreePart::Subtree(
+                        NodeKey::new_empty_path(substate_root_version),
+                    ));
+                }
+                put_leaf_hash_changes(
+                    &mut substate_tier_store,
+                    None,
+                    next_version,
+                    new_substate_values
+                        .into_iter()
+                        .map(|(sort_key, value)| LeafHashChange::from_value(sort_key, value))
+                        .collect(),
+                )
+            }
+        },
+    }
+}
+
 fn get_lower_tier_root_version<S: ReadableTreeStore>(
     store: &S,
     version: Option<Version>,
@@ -202,33 +235,44 @@ fn get_lower_tier_root_version<S: ReadableTreeStore>(
     })
 }
 
-fn index_by_node_key_and_partition_num(
-    changes: Vec<SubstateHashChange>,
-) -> IndexMap<DbNodeKey, IndexMap<DbPartitionNum, Vec<IdHashChange<DbSortKey>>>> {
-    let mut by_db_node_key = index_map_new();
-    for IdHashChange { id, hash_change } in changes {
-        let (
-            DbPartitionKey {
-                node_key,
-                partition_num,
-            },
-            sort_key,
-        ) = id;
-        by_db_node_key
-            .entry(node_key)
-            .or_insert_with(|| index_map_new())
-            .entry(partition_num)
-            .or_insert_with(|| Vec::new())
-            .push(IdHashChange::new(sort_key, hash_change));
-    }
-    by_db_node_key
+struct LeafHashChange {
+    key_bytes: Vec<u8>,
+    hash_change: Option<Hash>,
 }
 
-fn put_id_hash_changes<S: TreeStore>(
+impl LeafHashChange {
+    pub fn from_update(sort_key: &DbSortKey, update: &DatabaseUpdate) -> Self {
+        Self {
+            key_bytes: sort_key.0.clone(),
+            hash_change: match update {
+                DatabaseUpdate::Set(value) => Some(hash(value)),
+                DatabaseUpdate::Delete => None,
+            },
+        }
+    }
+
+    pub fn from_value(sort_key: &DbSortKey, value: &DbSubstateValue) -> Self {
+        Self {
+            key_bytes: sort_key.0.clone(),
+            hash_change: Some(hash(value)),
+        }
+    }
+
+    pub fn to_leaf_change(self, version: Version) -> LeafChange {
+        LeafChange {
+            key: LeafKey {
+                bytes: self.key_bytes,
+            },
+            new_payload: self.hash_change.map(|value_hash| (value_hash, version)),
+        }
+    }
+}
+
+fn put_leaf_hash_changes<S: TreeStore>(
     store: &mut S,
     current_version: Option<Version>,
     next_version: Version,
-    changes: Vec<IdHashChange<Vec<u8>>>,
+    changes: Vec<LeafHashChange>,
 ) -> Option<Hash> {
     let root_hash = put_leaf_changes(
         store,
@@ -236,20 +280,13 @@ fn put_id_hash_changes<S: TreeStore>(
         next_version,
         changes
             .into_iter()
-            .map(|change| to_leaf_change(change, next_version))
+            .map(|change| change.to_leaf_change(next_version))
             .collect(),
     );
     if root_hash == SPARSE_MERKLE_PLACEHOLDER_HASH {
         None
     } else {
         Some(root_hash)
-    }
-}
-
-fn to_leaf_change(change: IdHashChange<Vec<u8>>, version: Version) -> LeafChange {
-    LeafChange {
-        key: LeafKey { bytes: change.id },
-        new_payload: change.hash_change.map(|value_hash| (value_hash, version)),
     }
 }
 
@@ -280,7 +317,7 @@ fn put_leaf_changes<S: TreeStore>(
         store.insert_node(key, node)
     }
     for key in update_result.stale_node_index_batch.into_iter().flatten() {
-        store.record_stale_node(key.node_key);
+        store.record_stale_tree_part(StaleTreePart::Node(key.node_key));
     }
     root_hash
 }
@@ -325,7 +362,10 @@ impl<'s, S: WriteableTreeStore> WriteableTreeStore for NestedTreeStore<'s, S> {
         self.underlying.insert_node(self.prefixed(&key), node);
     }
 
-    fn record_stale_node(&mut self, key: NodeKey) {
-        self.underlying.record_stale_node(self.prefixed(&key));
+    fn record_stale_tree_part(&mut self, part: StaleTreePart) {
+        self.underlying.record_stale_tree_part(match part {
+            StaleTreePart::Node(key) => StaleTreePart::Node(self.prefixed(&key)),
+            StaleTreePart::Subtree(key) => StaleTreePart::Subtree(self.prefixed(&key)),
+        });
     }
 }

--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -1,127 +1,100 @@
 use super::types::{Nibble, NibblePath, Version, SPARSE_MERKLE_PLACEHOLDER_HASH};
+use crate::hash_tree::jellyfish::JellyfishMerkleTree;
+use crate::hash_tree::put_at_next_version;
 use crate::hash_tree::tree_store::{
-    SerializedInMemoryTreeStore, TreeChildEntry, TreeInternalNode, TreeLeafNode, TreeNode,
-    TypedInMemoryTreeStore,
+    SerializedInMemoryTreeStore, StaleTreePart, TreeChildEntry, TreeInternalNode, TreeLeafNode,
+    TreeNode, TreeStore, TypedInMemoryTreeStore,
 };
 use crate::hash_tree::types::{LeafKey, NodeKey};
-use crate::hash_tree::{put_at_next_version, SubstateHashChange};
 use itertools::Itertools;
 use radix_engine_common::crypto::{hash, Hash};
 use radix_engine_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_engine_store_interface::interface::{
-    DbNodeKey, DbPartitionKey, DbPartitionNum, DbSortKey,
+    BatchPartitionDatabaseUpdate, DatabaseUpdate, DatabaseUpdates, DbNodeKey, DbPartitionKey,
+    DbPartitionNum, DbSortKey, DbSubstateKey, DbSubstateValue, NodeDatabaseUpdates,
+    PartitionDatabaseUpdates,
 };
+use sbor::prelude::indexmap::indexmap;
+use utils::prelude::{index_map_new, IndexMap};
 use utils::rust::collections::{hashmap, hashset, HashMap, HashSet};
 
 #[test]
 fn hash_of_next_version_differs_when_value_changed() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(&mut store, None, vec![change(1, 6, 2, Some(30))]);
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![change(1, 6, 2, Some(70))]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 = tester.put_substate_changes(vec![change(1, 6, 2, Some(30))]);
+    let hash_v2 = tester.put_substate_changes(vec![change(1, 6, 2, Some(70))]);
     assert_ne!(hash_v1, hash_v2);
 }
 
 #[test]
 fn hash_of_next_version_same_when_write_repeated() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(
-        &mut store,
-        None,
-        vec![change(4, 1, 6, Some(30)), change(3, 2, 9, Some(40))],
-    );
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![change(4, 1, 6, Some(30))]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 =
+        tester.put_substate_changes(vec![change(4, 1, 6, Some(30)), change(3, 2, 9, Some(40))]);
+    let hash_v2 = tester.put_substate_changes(vec![change(4, 1, 6, Some(30))]);
     assert_eq!(hash_v1, hash_v2);
 }
 
 #[test]
 fn hash_of_next_version_same_when_write_empty() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(
-        &mut store,
-        None,
-        vec![change(1, 6, 2, Some(30)), change(3, 7, 1, Some(40))],
-    );
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 =
+        tester.put_substate_changes(vec![change(1, 6, 2, Some(30)), change(3, 7, 1, Some(40))]);
+    let hash_v2 = tester.put_substate_changes(vec![]);
     assert_eq!(hash_v1, hash_v2);
 }
 
 #[test]
 fn hash_of_next_version_differs_when_entry_added() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(&mut store, None, vec![change(1, 6, 2, Some(30))]);
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![change(1, 6, 8, Some(30))]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 = tester.put_substate_changes(vec![change(1, 6, 2, Some(30))]);
+    let hash_v2 = tester.put_substate_changes(vec![change(1, 6, 8, Some(30))]);
     assert_ne!(hash_v1, hash_v2);
 }
 
 #[test]
 fn hash_of_next_version_differs_when_entry_removed() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(
-        &mut store,
-        None,
-        vec![change(1, 6, 2, Some(30)), change(4, 7, 3, Some(20))],
-    );
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![change(1, 6, 2, None)]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 =
+        tester.put_substate_changes(vec![change(1, 6, 2, Some(30)), change(4, 7, 3, Some(20))]);
+    let hash_v2 = tester.put_substate_changes(vec![change(1, 6, 2, None)]);
     assert_ne!(hash_v1, hash_v2);
 }
 
 #[test]
 fn hash_returns_to_same_when_previous_state_restored() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(
-        &mut store,
-        None,
-        vec![change(1, 6, 2, Some(30)), change(3, 7, 1, Some(40))],
-    );
-    put_at_next_version(
-        &mut store,
-        Some(1),
-        vec![
-            change(1, 6, 2, Some(90)),
-            change(3, 7, 1, None),
-            change(1, 6, 5, Some(10)),
-        ],
-    );
-    let hash_v3 = put_at_next_version(
-        &mut store,
-        Some(1),
-        vec![
-            change(1, 6, 2, Some(30)),
-            change(3, 7, 1, Some(40)),
-            change(1, 6, 5, None),
-        ],
-    );
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 =
+        tester.put_substate_changes(vec![change(1, 6, 2, Some(30)), change(3, 7, 1, Some(40))]);
+    tester.put_substate_changes(vec![
+        change(1, 6, 2, Some(90)),
+        change(3, 7, 1, None),
+        change(1, 6, 5, Some(10)),
+    ]);
+    let hash_v3 = tester.put_substate_changes(vec![
+        change(1, 6, 2, Some(30)),
+        change(3, 7, 1, Some(40)),
+        change(1, 6, 5, None),
+    ]);
     assert_eq!(hash_v1, hash_v3);
 }
 
 #[test]
 fn hash_computed_consistently_after_higher_tier_leafs_deleted() {
     // Compute a "reference" hash of state containing simply [2:3:4, 2:3:5].
-    let mut reference_store = TypedInMemoryTreeStore::new();
-    let reference_root = put_at_next_version(
-        &mut reference_store,
-        None,
-        vec![change(2, 3, 4, Some(234)), change(2, 3, 5, Some(235))],
-    );
+    let mut reference_tester = HashTreeTester::new_empty();
+    let reference_root = reference_tester
+        .put_substate_changes(vec![change(2, 3, 4, Some(234)), change(2, 3, 5, Some(235))]);
 
     // Compute a hash of the same state, at which we arrive after deleting some unrelated NodeId.
-    let mut store = TypedInMemoryTreeStore::new();
-    put_at_next_version(
-        &mut store,
-        None,
-        vec![
-            change(1, 6, 2, Some(162)),
-            change(1, 6, 3, Some(163)),
-            change(2, 3, 4, Some(234)),
-        ],
-    );
-    put_at_next_version(
-        &mut store,
-        Some(1),
-        vec![change(1, 6, 2, None), change(1, 6, 3, None)],
-    );
-    let root_after_deletes =
-        put_at_next_version(&mut store, Some(2), vec![change(2, 3, 5, Some(235))]);
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![
+        change(1, 6, 2, Some(162)),
+        change(1, 6, 3, Some(163)),
+        change(2, 3, 4, Some(234)),
+    ]);
+    tester.put_substate_changes(vec![change(1, 6, 2, None), change(1, 6, 3, None)]);
+    let root_after_deletes = tester.put_substate_changes(vec![change(2, 3, 5, Some(235))]);
 
     // We did [1:6:2, 1:6:3, 2:3:4] - [1:6:2, 1:6:3] + [2:3:5] = [2:3:4, 2:3:5] (i.e. same state).
     assert_eq!(root_after_deletes, reference_root);
@@ -130,23 +103,18 @@ fn hash_computed_consistently_after_higher_tier_leafs_deleted() {
 #[test]
 fn hash_computed_consistently_after_adding_higher_tier_sibling() {
     // Compute a "reference" hash of state containing simply [1:9:6, 2:3:4, 2:3:5].
-    let mut reference_store = TypedInMemoryTreeStore::new();
-    let reference_root = put_at_next_version(
-        &mut reference_store,
-        None,
-        vec![
-            change(1, 9, 6, Some(196)),
-            change(2, 3, 4, Some(234)),
-            change(2, 3, 5, Some(235)),
-        ],
-    );
+    let mut reference_tester = HashTreeTester::new_empty();
+    let reference_root = reference_tester.put_substate_changes(vec![
+        change(1, 9, 6, Some(196)),
+        change(2, 3, 4, Some(234)),
+        change(2, 3, 5, Some(235)),
+    ]);
 
     // Compute a hash of the same state, at which we arrive after adding some sibling NodeId.
-    let mut store = TypedInMemoryTreeStore::new();
-    put_at_next_version(&mut store, None, vec![change(2, 3, 4, Some(234))]);
-    put_at_next_version(&mut store, Some(1), vec![change(1, 9, 6, Some(196))]);
-    let root_after_adding_sibling =
-        put_at_next_version(&mut store, Some(2), vec![change(2, 3, 5, Some(235))]);
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![change(2, 3, 4, Some(234))]);
+    tester.put_substate_changes(vec![change(1, 9, 6, Some(196))]);
+    let root_after_adding_sibling = tester.put_substate_changes(vec![change(2, 3, 5, Some(235))]);
 
     // We did [2:3:4] + [1:9:6] + [2:3:5] = [1:9:6, 2:3:4, 2:3:5] (i.e. same state).
     assert_eq!(root_after_adding_sibling, reference_root);
@@ -154,46 +122,42 @@ fn hash_computed_consistently_after_adding_higher_tier_sibling() {
 
 #[test]
 fn hash_differs_when_states_only_differ_by_node_key() {
-    let mut store_1 = TypedInMemoryTreeStore::new();
-    let hash_1 = put_at_next_version(&mut store_1, None, vec![change(1, 6, 3, Some(30))]);
-    let mut store_2 = TypedInMemoryTreeStore::new();
-    let hash_2 = put_at_next_version(&mut store_2, None, vec![change(2, 6, 3, Some(30))]);
+    let mut tester_1 = HashTreeTester::new_empty();
+    let hash_1 = tester_1.put_substate_changes(vec![change(1, 6, 3, Some(30))]);
+    let mut tester_2 = HashTreeTester::new_empty();
+    let hash_2 = tester_2.put_substate_changes(vec![change(2, 6, 3, Some(30))]);
     assert_ne!(hash_1, hash_2);
 }
 
 #[test]
 fn hash_differs_when_states_only_differ_by_partition_num() {
-    let mut store_1 = TypedInMemoryTreeStore::new();
-    let hash_1 = put_at_next_version(&mut store_1, None, vec![change(1, 6, 3, Some(30))]);
-    let mut store_2 = TypedInMemoryTreeStore::new();
-    let hash_2 = put_at_next_version(&mut store_2, None, vec![change(1, 7, 3, Some(30))]);
+    let mut tester_1 = HashTreeTester::new_empty();
+    let hash_1 = tester_1.put_substate_changes(vec![change(1, 6, 3, Some(30))]);
+    let mut tester_2 = HashTreeTester::new_empty();
+    let hash_2 = tester_2.put_substate_changes(vec![change(1, 7, 3, Some(30))]);
     assert_ne!(hash_1, hash_2);
 }
 
 #[test]
 fn hash_differs_when_states_only_differ_by_sort_key() {
-    let mut store_1 = TypedInMemoryTreeStore::new();
-    let hash_1 = put_at_next_version(&mut store_1, None, vec![change(1, 6, 2, Some(30))]);
-    let mut store_2 = TypedInMemoryTreeStore::new();
-    let hash_2 = put_at_next_version(&mut store_2, None, vec![change(1, 6, 3, Some(30))]);
+    let mut tester_1 = HashTreeTester::new_empty();
+    let hash_1 = tester_1.put_substate_changes(vec![change(1, 6, 2, Some(30))]);
+    let mut tester_2 = HashTreeTester::new_empty();
+    let hash_2 = tester_2.put_substate_changes(vec![change(1, 6, 3, Some(30))]);
     assert_ne!(hash_1, hash_2);
 }
 
 #[test]
 fn hash_of_different_re_nodes_is_same_when_contained_entries_are_same() {
-    let mut store = TypedInMemoryTreeStore::new();
-    put_at_next_version(
-        &mut store,
-        None,
-        vec![
-            change(1, 6, 2, Some(30)),
-            change(1, 7, 9, Some(40)),
-            change(7, 6, 2, Some(30)),
-            change(7, 7, 9, Some(40)),
-        ],
-    );
-
-    let re_node_leaf_hashes = get_leafs_of_tier(&store, Tier::ReNode)
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![
+        change(1, 6, 2, Some(30)),
+        change(1, 7, 9, Some(40)),
+        change(7, 6, 2, Some(30)),
+        change(7, 7, 9, Some(40)),
+    ]);
+    let re_node_leaf_hashes = tester
+        .get_leafs_of_tier(Tier::ReNode)
         .into_values()
         .collect::<Vec<_>>();
     assert_eq!(re_node_leaf_hashes.len(), 2);
@@ -202,46 +166,18 @@ fn hash_of_different_re_nodes_is_same_when_contained_entries_are_same() {
 
 #[test]
 fn physical_nodes_of_tiered_jmt_have_expected_keys_and_contents() {
-    let mut store = TypedInMemoryTreeStore::new();
-
-    put_at_next_version(
-        &mut store,
-        None,
-        vec![
-            SubstateHashChange::new(
-                (db_partition_key(vec![1, 3, 3, 7], 99), DbSortKey(vec![253])),
-                Some(Hash([1; Hash::LENGTH])),
-            ),
-            SubstateHashChange::new(
-                (db_partition_key(vec![1, 3, 3, 7], 99), DbSortKey(vec![66])),
-                Some(Hash([2; Hash::LENGTH])),
-            ),
-            SubstateHashChange::new(
-                (
-                    db_partition_key(vec![123, 12, 1, 0], 88),
-                    DbSortKey(vec![6, 6, 6]),
-                ),
-                Some(Hash([3; Hash::LENGTH])),
-            ),
-            SubstateHashChange::new(
-                (
-                    db_partition_key(vec![123, 12, 1, 0], 88),
-                    DbSortKey(vec![6, 6, 7]),
-                ),
-                Some(Hash([4; Hash::LENGTH])),
-            ),
-            SubstateHashChange::new(
-                (
-                    db_partition_key(vec![123, 12, 1, 0], 66),
-                    DbSortKey(vec![1, 2, 3, 4]),
-                ),
-                Some(Hash([5; Hash::LENGTH])),
-            ),
-        ],
-    );
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![
+        change_exact(vec![1, 3, 3, 7], 99, vec![253], Some(vec![1])),
+        change_exact(vec![1, 3, 3, 7], 99, vec![66], Some(vec![2])),
+        change_exact(vec![123, 12, 1, 0], 88, vec![6, 6, 6], Some(vec![3])),
+        change_exact(vec![123, 12, 1, 0], 88, vec![6, 6, 7], Some(vec![4])),
+        change_exact(vec![123, 12, 1, 0], 66, vec![1, 2, 3], Some(vec![5])),
+    ]);
 
     // Assert on the keys of Node-tier leafs:
-    let node_tier_leaf_keys = get_leafs_of_tier(&store, Tier::ReNode)
+    let node_tier_leaf_keys = tester
+        .get_leafs_of_tier(Tier::ReNode)
         .into_keys()
         .collect::<HashSet<_>>();
     assert_eq!(
@@ -257,86 +193,161 @@ fn physical_nodes_of_tiered_jmt_have_expected_keys_and_contents() {
     );
 
     // Assert on the keys of Partition-tier leafs:
-    let partition_tier_leaf_keys = get_leafs_of_tier(&store, Tier::Partition)
+    let partition_tier_leaf_keys = tester
+        .get_leafs_of_tier(Tier::Partition)
         .into_keys()
         .collect::<HashSet<_>>();
     assert_eq!(
         partition_tier_leaf_keys,
         hashset!(
             LeafKey {
-                bytes: vec![1, 3, 3, 7, TIER_SEPARATOR, 99]
+                bytes: vec![1, 3, 3, 7, TIER_SEP, 99]
             },
             LeafKey {
-                bytes: vec![123, 12, 1, 0, TIER_SEPARATOR, 66]
+                bytes: vec![123, 12, 1, 0, TIER_SEP, 66]
             },
             LeafKey {
-                bytes: vec![123, 12, 1, 0, TIER_SEPARATOR, 88]
+                bytes: vec![123, 12, 1, 0, TIER_SEP, 88]
             },
         )
     );
 
     // Assert on the keys and hashes of the Substate-tier leaves:
-    let substate_tier_leaves = get_leafs_of_tier(&store, Tier::Substate);
+    let substate_tier_leaves = tester.get_leafs_of_tier(Tier::Substate);
     assert_eq!(
         substate_tier_leaves,
         hashmap!(
-            LeafKey { bytes: vec![1, 3, 3, 7, TIER_SEPARATOR, 99, TIER_SEPARATOR, 253] } => Hash([1; Hash::LENGTH]),
-            LeafKey { bytes: vec![1, 3, 3, 7, TIER_SEPARATOR, 99, TIER_SEPARATOR, 66] } => Hash([2; Hash::LENGTH]),
-            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEPARATOR, 88, TIER_SEPARATOR, 6, 6, 6] } => Hash([3; Hash::LENGTH]),
-            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEPARATOR, 88, TIER_SEPARATOR, 6, 6, 7] } => Hash([4; Hash::LENGTH]),
-            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEPARATOR, 66, TIER_SEPARATOR, 1, 2, 3, 4] } => Hash([5; Hash::LENGTH]),
+            LeafKey { bytes: vec![1, 3, 3, 7, TIER_SEP, 99, TIER_SEP, 253] } => hash([1]),
+            LeafKey { bytes: vec![1, 3, 3, 7, TIER_SEP, 99, TIER_SEP, 66] } => hash([2]),
+            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEP, 88, TIER_SEP, 6, 6, 6] } => hash([3]),
+            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEP, 88, TIER_SEP, 6, 6, 7] } => hash([4]),
+            LeafKey { bytes: vec![123, 12, 1, 0, TIER_SEP, 66, TIER_SEP, 1, 2, 3] } => hash([5]),
         )
     );
 }
 
 #[test]
 fn deletes_node_tier_leaf_when_all_its_entries_deleted() {
-    let mut store = TypedInMemoryTreeStore::new();
-    put_at_next_version(
-        &mut store,
-        None,
-        vec![
-            change(1, 6, 2, Some(30)),
-            change(1, 6, 9, Some(40)),
-            change(2, 7, 3, Some(30)),
-        ],
-    );
-    assert_eq!(get_leafs_of_tier(&store, Tier::ReNode).len(), 2);
-    put_at_next_version(
-        &mut store,
-        Some(1),
-        vec![change(1, 6, 2, None), change(1, 6, 9, None)],
-    );
-    assert_eq!(get_leafs_of_tier(&store, Tier::ReNode).len(), 1);
-    put_at_next_version(&mut store, Some(2), vec![change(2, 7, 3, None)]);
-    assert_eq!(get_leafs_of_tier(&store, Tier::ReNode).len(), 0);
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![
+        change(1, 6, 2, Some(30)),
+        change(1, 6, 9, Some(40)),
+        change(2, 7, 3, Some(30)),
+    ]);
+    assert_eq!(tester.get_leafs_of_tier(Tier::ReNode).len(), 2);
+    tester.put_substate_changes(vec![change(1, 6, 2, None), change(1, 6, 9, None)]);
+    assert_eq!(tester.get_leafs_of_tier(Tier::ReNode).len(), 1);
+    tester.put_substate_changes(vec![change(2, 7, 3, None)]);
+    assert_eq!(tester.get_leafs_of_tier(Tier::ReNode).len(), 0);
 }
 
 #[test]
 fn supports_empty_state() {
-    let mut store = TypedInMemoryTreeStore::new();
-    let hash_v1 = put_at_next_version(&mut store, None, vec![]);
+    let mut tester = HashTreeTester::new_empty();
+    let hash_v1 = tester.put_substate_changes(vec![]);
     assert_eq!(hash_v1, SPARSE_MERKLE_PLACEHOLDER_HASH);
-    let hash_v2 = put_at_next_version(&mut store, Some(1), vec![change(1, 6, 2, Some(30))]);
+    let hash_v2 = tester.put_substate_changes(vec![change(1, 6, 2, Some(30))]);
     assert_ne!(hash_v2, SPARSE_MERKLE_PLACEHOLDER_HASH);
-    let hash_v3 = put_at_next_version(&mut store, Some(2), vec![change(1, 6, 2, None)]);
+    let hash_v3 = tester.put_substate_changes(vec![change(1, 6, 2, None)]);
     assert_eq!(hash_v3, SPARSE_MERKLE_PLACEHOLDER_HASH);
 }
 
 #[test]
 fn records_stale_tree_node_keys() {
-    let mut store = TypedInMemoryTreeStore::new();
-    put_at_next_version(&mut store, None, vec![change(4, 1, 6, Some(30))]);
-    put_at_next_version(&mut store, Some(1), vec![change(3, 2, 9, Some(70))]);
-    put_at_next_version(&mut store, Some(2), vec![change(3, 2, 9, Some(80))]);
-    let stale_versions = store
-        .stale_key_buffer
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![change(4, 1, 6, Some(30))]);
+    tester.put_substate_changes(vec![change(3, 2, 9, Some(70))]);
+    tester.put_substate_changes(vec![change(3, 2, 9, Some(80))]);
+    let stale_versions = tester
+        .tree_store
+        .stale_part_buffer
         .iter()
-        .map(|key| key.version())
+        .map(|stale_part| {
+            let StaleTreePart::Node(key) = stale_part else {
+                panic!("expected only single node removals");
+            };
+            key.version()
+        })
         .unique()
         .sorted()
         .collect::<Vec<Version>>();
     assert_eq!(stale_versions, vec![1, 2]);
+}
+
+#[test]
+fn hash_computed_consistently_after_different_deletes() {
+    // Reference: simply put [2:1:3, 2:3:4]
+    let mut reference_tester = HashTreeTester::new_empty();
+    let reference_root = reference_tester
+        .put_substate_changes(vec![change(2, 1, 3, Some(213)), change(2, 3, 4, Some(234))]);
+
+    // Delete 2 individual substates to arrive at the same state:
+    let mut single_deletes_tester = HashTreeTester::new_empty();
+    single_deletes_tester.put_substate_changes(vec![
+        change(2, 1, 3, Some(213)),
+        change(2, 3, 4, Some(234)),
+        change(2, 3, 5, Some(235)),
+        change(2, 3, 6, Some(236)),
+    ]);
+    let single_deletes_root = single_deletes_tester
+        .put_substate_changes(vec![change(2, 3, 5, None), change(2, 3, 6, None)]);
+    assert_eq!(single_deletes_root, reference_root);
+
+    // Delete entire partition 2:3, and then add back 2:3:4 in next version:
+    let mut delete_and_put_tester = HashTreeTester::new_empty();
+    delete_and_put_tester.put_substate_changes(vec![
+        change(2, 1, 3, Some(213)),
+        change(2, 3, 4, Some(234)),
+        change(2, 3, 5, Some(235)),
+        change(2, 3, 6, Some(236)),
+    ]);
+    delete_and_put_tester.reset_partition(from_seed(2), 3, vec![]);
+    let delete_and_put_root =
+        delete_and_put_tester.put_substate_changes(vec![change(2, 3, 4, Some(234))]);
+    assert_eq!(delete_and_put_root, reference_root);
+
+    // Reset entire partition 2:3 to only contain 2:3:4:
+    let mut reset_tester = HashTreeTester::new_empty();
+    reset_tester.put_substate_changes(vec![
+        change(2, 1, 3, Some(213)),
+        change(2, 3, 4, Some(234)),
+        change(2, 3, 5, Some(235)),
+        change(2, 3, 6, Some(236)),
+    ]);
+    let reset_root = reset_tester.reset_partition(
+        from_seed(2),
+        3,
+        vec![(DbSortKey(from_seed(4)), from_seed(234))],
+    );
+    assert_eq!(reset_root, reference_root);
+}
+
+#[test]
+fn records_stale_subtree_root_key_when_partition_removed() {
+    let mut tester = HashTreeTester::new_empty();
+    tester.put_substate_changes(vec![
+        change(4, 7, 6, Some(36)),
+        change(4, 7, 7, Some(37)),
+        change(4, 7, 8, Some(38)),
+    ]);
+    tester.reset_partition(from_seed(4), 7, vec![]);
+    assert_eq!(
+        tester.tree_store.stale_part_buffer,
+        vec![
+            // The entire subtree starting at the root of substate-tier JMT of partition `4:7`:
+            StaleTreePart::Subtree(NodeKey::new(
+                1,
+                NibblePath::new_even([from_seed(4), vec![TIER_SEP, 7, TIER_SEP]].concat())
+            )),
+            // Regular single-node stale nodes up to the root, caused by hash update:
+            StaleTreePart::Node(NodeKey::new(
+                1,
+                NibblePath::new_even([from_seed(4), vec![TIER_SEP]].concat())
+            )),
+            StaleTreePart::Node(NodeKey::new(1, NibblePath::new_even(vec![]))),
+            // Importantly: individual 3x deletes of substate-tier nodes are not recorded
+        ]
+    );
 }
 
 #[test]
@@ -388,11 +399,17 @@ fn sbor_decodes_what_was_encoded() {
 
 #[test]
 fn serialized_keys_are_strictly_increasing() {
-    let mut store = SerializedInMemoryTreeStore::new();
-    put_at_next_version(&mut store, None, vec![change(3, 6, 4, Some(90))]);
-    let previous_keys = store.memory.keys().cloned().collect::<HashSet<_>>();
-    put_at_next_version(&mut store, Some(1), vec![change(1, 7, 2, Some(80))]);
-    let min_next_key = store
+    let mut tester = HashTreeTester::new(SerializedInMemoryTreeStore::new(), None);
+    tester.put_substate_changes(vec![change(3, 6, 4, Some(90))]);
+    let previous_keys = tester
+        .tree_store
+        .memory
+        .keys()
+        .cloned()
+        .collect::<HashSet<_>>();
+    tester.put_substate_changes(vec![change(1, 7, 2, Some(80))]);
+    let min_next_key = tester
+        .tree_store
         .memory
         .keys()
         .filter(|key| !previous_keys.contains(*key))
@@ -402,24 +419,44 @@ fn serialized_keys_are_strictly_increasing() {
     assert!(min_next_key > max_previous_key);
 }
 
+type SingleSubstateChange = (DbSubstateKey, DatabaseUpdate);
+
 fn change(
     node_key_seed: u8,
     partition_num: u8,
     sort_key_seed: u8,
-    value_hash_seed: Option<u8>,
-) -> SubstateHashChange {
-    SubstateHashChange::new(
-        (
-            db_partition_key(vec![node_key_seed; Hash::LENGTH], partition_num),
-            DbSortKey(vec![sort_key_seed; sort_key_seed as usize]),
-        ),
-        value_hash_seed.map(|value_seed| value_hash(value_seed)),
+    value_seed: Option<u8>,
+) -> SingleSubstateChange {
+    change_exact(
+        from_seed(node_key_seed),
+        partition_num,
+        from_seed(sort_key_seed),
+        value_seed.map(|value_seed| from_seed(value_seed)),
     )
 }
 
-fn value_hash(value_seed: u8) -> Hash {
-    let fake_kvs_value = scrypto_encode(&vec![value_seed; value_seed as usize]).unwrap();
-    hash(fake_kvs_value)
+pub fn change_exact(
+    node_key: Vec<u8>,
+    partition_num: u8,
+    sort_key: Vec<u8>,
+    value: Option<Vec<u8>>,
+) -> SingleSubstateChange {
+    (
+        (
+            DbPartitionKey {
+                node_key,
+                partition_num,
+            },
+            DbSortKey(sort_key),
+        ),
+        value
+            .map(|value| DatabaseUpdate::Set(value))
+            .unwrap_or(DatabaseUpdate::Delete),
+    )
+}
+
+fn from_seed(node_key_seed: u8) -> Vec<u8> {
+    vec![node_key_seed; node_key_seed as usize]
 }
 
 fn nibbles(hex_string: &str) -> NibblePath {
@@ -430,52 +467,143 @@ fn nibbles(hex_string: &str) -> NibblePath {
     )
 }
 
-fn leaf_key(node_key: &NodeKey, suffix_from_leaf: &NibblePath) -> LeafKey {
-    LeafKey::new(
-        NibblePath::from_iter(
-            node_key
-                .nibble_path()
-                .nibbles()
-                .chain(suffix_from_leaf.nibbles()),
-        )
-        .bytes(),
-    )
-}
-
-fn db_partition_key(node_key: DbNodeKey, partition_num: DbPartitionNum) -> DbPartitionKey {
-    DbPartitionKey {
-        node_key,
-        partition_num,
-    }
-}
-
-enum Tier {
+pub enum Tier {
     ReNode,
     Partition,
     Substate,
 }
 
-const TIER_SEPARATOR: u8 = b'_';
+const TIER_SEP: u8 = b'_';
 
-fn get_leafs_of_tier(store: &TypedInMemoryTreeStore, tier: Tier) -> HashMap<LeafKey, Hash> {
-    let separator_count = tier as usize;
-    store
-        .tree_nodes
-        .iter()
-        .filter(|(key, _)| {
-            key.nibble_path()
-                .bytes()
-                .iter()
-                .filter(|byte| **byte == TIER_SEPARATOR)
-                .count()
-                == separator_count
+pub struct HashTreeTester<S> {
+    pub tree_store: S,
+    pub current_version: Option<Version>,
+}
+
+impl<S: TreeStore> HashTreeTester<S> {
+    pub fn new(tree_store: S, current_version: Option<Version>) -> Self {
+        Self {
+            tree_store,
+            current_version,
+        }
+    }
+
+    pub fn put_substate_changes(
+        &mut self,
+        changes: impl IntoIterator<Item = SingleSubstateChange>,
+    ) -> Hash {
+        self.apply_database_updates(&DatabaseUpdates::from_delta_maps(
+            Self::index_to_delta_maps(changes),
+        ))
+    }
+
+    pub fn reset_partition(
+        &mut self,
+        node_key: DbNodeKey,
+        partition_num: DbPartitionNum,
+        values: impl IntoIterator<Item = (DbSortKey, DbSubstateValue)>,
+    ) -> Hash {
+        self.apply_database_updates(&DatabaseUpdates {
+            node_updates: indexmap!(
+                node_key => NodeDatabaseUpdates {
+                    partition_updates: indexmap!(
+                        partition_num => PartitionDatabaseUpdates::Batch(
+                            BatchPartitionDatabaseUpdate::Reset {
+                                new_substate_values: values.into_iter().collect()
+                            }
+                        )
+                    )
+                }
+            ),
         })
-        .filter(|(key, _)| !store.stale_key_buffer.contains(key))
-        .filter_map(|(key, node)| match node {
-            TreeNode::Leaf(leaf) => {
-                Some((leaf_key(key, &leaf.key_suffix), leaf.value_hash.clone()))
-            }
-            _ => None,
-        })
-        .collect()
+    }
+
+    fn apply_database_updates(&mut self, database_updates: &DatabaseUpdates) -> Hash {
+        let next_version = self.current_version.unwrap_or(0) + 1;
+        let current_version = self.current_version.replace(next_version);
+        put_at_next_version(&mut self.tree_store, current_version, database_updates)
+    }
+
+    fn index_to_delta_maps(
+        changes: impl IntoIterator<Item = SingleSubstateChange>,
+    ) -> IndexMap<DbNodeKey, IndexMap<DbPartitionNum, IndexMap<DbSortKey, DatabaseUpdate>>> {
+        let mut delta_maps = index_map_new::<
+            DbNodeKey,
+            IndexMap<DbPartitionNum, IndexMap<DbSortKey, DatabaseUpdate>>,
+        >();
+        for change in changes {
+            let (
+                (
+                    DbPartitionKey {
+                        node_key,
+                        partition_num,
+                    },
+                    sort_key,
+                ),
+                update,
+            ) = change;
+            delta_maps
+                .entry(node_key)
+                .or_default()
+                .entry(partition_num)
+                .or_default()
+                .insert(sort_key, update);
+        }
+        delta_maps
+    }
+}
+
+impl HashTreeTester<TypedInMemoryTreeStore> {
+    pub fn new_empty() -> Self {
+        Self::new(TypedInMemoryTreeStore::new(), None)
+    }
+
+    pub fn get_leafs_of_tier(&mut self, tier: Tier) -> HashMap<LeafKey, Hash> {
+        let stale_node_keys = self
+            .tree_store
+            .stale_part_buffer
+            .clone()
+            .into_iter()
+            .flat_map(|stale_part| match stale_part {
+                StaleTreePart::Node(key) => vec![key],
+                StaleTreePart::Subtree(key) => JellyfishMerkleTree::new(&mut self.tree_store)
+                    .get_all_nodes_referenced(key)
+                    .unwrap(),
+            })
+            .collect::<HashSet<_>>();
+        let expected_separator_count = tier as usize;
+        self.tree_store
+            .tree_nodes
+            .iter()
+            .filter(|(key, _)| {
+                let separator_count = key
+                    .nibble_path()
+                    .bytes()
+                    .iter()
+                    .filter(|byte| **byte == TIER_SEP)
+                    .count();
+                separator_count == expected_separator_count
+            })
+            .filter(|(key, _)| !stale_node_keys.contains(key))
+            .filter_map(|(key, node)| match node {
+                TreeNode::Leaf(leaf) => Some((
+                    Self::leaf_key(key, &leaf.key_suffix),
+                    leaf.value_hash.clone(),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn leaf_key(node_key: &NodeKey, suffix_from_leaf: &NibblePath) -> LeafKey {
+        LeafKey::new(
+            NibblePath::from_iter(
+                node_key
+                    .nibble_path()
+                    .nibbles()
+                    .chain(suffix_from_leaf.nibbles()),
+            )
+            .bytes(),
+        )
+    }
 }

--- a/radix-engine-stores/src/hash_tree/types.rs
+++ b/radix-engine-stores/src/hash_tree/types.rs
@@ -81,6 +81,7 @@
 
 use itertools::Itertools;
 use radix_engine_common::crypto::{hash, Hash};
+use radix_engine_common::Sbor;
 use sbor::rust::collections::hash_map::HashMap;
 use sbor::rust::ops::Range;
 use sbor::rust::string::String;
@@ -678,7 +679,7 @@ impl LeafKey {
 
 // SOURCE: https://github.com/aptos-labs/aptos-core/blob/1.0.4/storage/jellyfish-merkle/src/node_type/mod.rs#L48
 /// The unique key of each node.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Sbor)]
 pub struct NodeKey {
     // The version at which the node is created.
     version: Version,

--- a/radix-engine-stores/src/lib.rs
+++ b/radix-engine-stores/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate core;
 #[cfg(not(any(feature = "std", feature = "alloc")))]
 compile_error!("Either feature `std` or `alloc` must be enabled for this crate.");
 #[cfg(all(feature = "std", feature = "alloc"))]

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -18,7 +18,7 @@ use state_tree::*;
 const META_CF: &str = "meta";
 const SUBSTATES_CF: &str = "substates";
 const MERKLE_NODES_CF: &str = "merkle_nodes";
-const STALE_MERKLE_NODE_KEYS_CF: &str = "stale_merkle_node_keys";
+const STALE_MERKLE_TREE_PARTS_CF: &str = "stale_merkle_tree_parts";
 
 pub struct RocksDBWithMerkleTreeSubstateStore {
     db: DBWithThreadMode<SingleThreaded>,
@@ -49,7 +49,7 @@ impl RocksDBWithMerkleTreeSubstateStore {
                 META_CF,
                 SUBSTATES_CF,
                 MERKLE_NODES_CF,
-                STALE_MERKLE_NODE_KEYS_CF,
+                STALE_MERKLE_TREE_PARTS_CF,
             ]
             .into_iter()
             .map(|name| ColumnFamilyDescriptor::new(name, Options::default()))
@@ -118,19 +118,60 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         let mut batch = WriteBatch::default();
 
         // put regular substate changes
-        for (patrition_key, partition_updates) in database_updates {
-            for (sort_key, database_update) in partition_updates {
-                let key_bytes = encode_to_rocksdb_bytes(patrition_key, sort_key);
-                match database_update {
-                    DatabaseUpdate::Set(value_bytes) => {
-                        batch.put_cf(self.cf(SUBSTATES_CF), key_bytes, value_bytes)
-                    }
-                    DatabaseUpdate::Delete => batch.delete_cf(self.cf(SUBSTATES_CF), key_bytes),
+        for (node_key, node_updates) in &database_updates.node_updates {
+            for (partition_num, partition_updates) in &node_updates.partition_updates {
+                let partition_key = DbPartitionKey {
+                    node_key: node_key.clone(),
+                    partition_num: *partition_num,
                 };
+                match partition_updates {
+                    PartitionDatabaseUpdates::Delta { substate_updates } => {
+                        for (sort_key, update) in substate_updates {
+                            let key_bytes = encode_to_rocksdb_bytes(&partition_key, sort_key);
+                            match update {
+                                DatabaseUpdate::Set(value_bytes) => {
+                                    self.db
+                                        .put_cf(self.cf(SUBSTATES_CF), key_bytes, value_bytes)
+                                }
+                                DatabaseUpdate::Delete => {
+                                    self.db.delete_cf(self.cf(SUBSTATES_CF), key_bytes)
+                                }
+                            }
+                            .expect("IO error");
+                        }
+                    }
+                    PartitionDatabaseUpdates::Batch(batch) => {
+                        match batch {
+                            BatchPartitionDatabaseUpdate::Reset {
+                                new_substate_values,
+                            } => {
+                                // Note: a plain `delete_range()` is missing from rocksdb's API, and
+                                // (at the moment of writing) this is the only reason of having CF.
+                                self.db
+                                    .delete_range_cf(
+                                        self.cf(SUBSTATES_CF),
+                                        encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![])),
+                                        encode_to_rocksdb_bytes(
+                                            &partition_key.next(),
+                                            &DbSortKey(vec![]),
+                                        ),
+                                    )
+                                    .expect("IO error");
+                                for (sort_key, value_bytes) in new_substate_values {
+                                    let key_bytes =
+                                        encode_to_rocksdb_bytes(&partition_key, sort_key);
+                                    self.db
+                                        .put_cf(self.cf(SUBSTATES_CF), key_bytes, value_bytes)
+                                        .expect("IO error");
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 
-        // derive and put new JMT nodes (also record keys of stale nodes, for later amortized background GC [not implemented here!])
+        // derive and put new JMT nodes (also record references to stale parts, for later amortized background GC [not implemented here!])
         let state_hash_tree_update =
             compute_state_tree_update(self, parent_state_version, database_updates);
         for (key, node) in state_hash_tree_update.new_nodes {
@@ -140,15 +181,10 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
                 scrypto_encode(&node).unwrap(),
             );
         }
-        let encoded_node_keys = state_hash_tree_update
-            .stale_hash_tree_node_keys
-            .iter()
-            .map(encode_key)
-            .collect::<Vec<_>>();
         batch.put_cf(
-            self.cf(STALE_MERKLE_NODE_KEYS_CF),
+            self.cf(STALE_MERKLE_TREE_PARTS_CF),
             next_state_version.to_be_bytes(),
-            scrypto_encode(&encoded_node_keys).unwrap(),
+            scrypto_encode(&state_hash_tree_update.stale_tree_parts).unwrap(),
         );
 
         // update the metadata

--- a/radix-engine-tests/tests/system_db_checker.rs
+++ b/radix-engine-tests/tests/system_db_checker.rs
@@ -7,7 +7,7 @@ use radix_engine::vm::wasm::DefaultWasmEngine;
 use radix_engine::vm::*;
 use radix_engine_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
 use radix_engine_store_interface::interface::{
-    CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates, PartitionUpdates,
+    CommittableSubstateDatabase, DatabaseUpdate, DatabaseUpdates,
 };
 use radix_engine_stores::memory_db::InMemorySubstateDatabase;
 
@@ -21,20 +21,19 @@ fn system_database_checker_should_report_missing_owner_error_on_broken_db() {
     let mut bootstrapper =
         Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, true);
     bootstrapper.bootstrap_test_default().unwrap();
-    let remove_owner_update = {
-        let mut remove_owner_update = DatabaseUpdates::default();
-        let db_partition_key = SpreadPrefixKeyMapper::to_db_partition_key(
-            PACKAGE_PACKAGE.as_node_id(),
+    let (node_id, partition_num, sort_key, update) = (
+        SpreadPrefixKeyMapper::to_db_node_key(PACKAGE_PACKAGE.as_node_id()),
+        SpreadPrefixKeyMapper::to_db_partition_num(
             ROLE_ASSIGNMENT_BASE_PARTITION
                 .at_offset(ROLE_ASSIGNMENT_FIELDS_PARTITION_OFFSET)
                 .unwrap(),
-        );
-        let mut partition_updates = PartitionUpdates::default();
-        let db_key = SpreadPrefixKeyMapper::to_db_sort_key(&SubstateKey::Field(0u8));
-        partition_updates.insert(db_key, DatabaseUpdate::Delete);
-        remove_owner_update.insert(db_partition_key, partition_updates);
-        remove_owner_update
-    };
+        ),
+        SpreadPrefixKeyMapper::to_db_sort_key(&SubstateKey::Field(0u8)),
+        DatabaseUpdate::Delete,
+    );
+    let remove_owner_update = DatabaseUpdates::from_delta_maps(
+        indexmap!(node_id => indexmap!(partition_num => indexmap!(sort_key => update))),
+    );
     substate_db.commit(&remove_owner_update);
 
     // Act

--- a/radix-engine-tests/tests/transaction_tracker.rs
+++ b/radix-engine-tests/tests/transaction_tracker.rs
@@ -1,5 +1,5 @@
 use radix_engine::errors::RejectionReason;
-use radix_engine::track::{BatchPartitionUpdate, NodeStateUpdates, PartitionStateUpdates};
+use radix_engine::track::{BatchPartitionStateUpdate, NodeStateUpdates, PartitionStateUpdates};
 use radix_engine::transaction::{CostingParameters, ExecutionConfig};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::consensus_manager::EpochChangeCondition;
@@ -68,7 +68,7 @@ fn test_transaction_replay_protection() {
         })
         .filter_map(|partition_updates| match partition_updates {
             PartitionStateUpdates::Delta { .. } => None,
-            PartitionStateUpdates::Batch(BatchPartitionUpdate::Reset {
+            PartitionStateUpdates::Batch(BatchPartitionStateUpdate::Reset {
                 new_substate_values,
             }) => Some(new_substate_values),
         })

--- a/radix-engine/src/track/legacy_state_updates.rs
+++ b/radix-engine/src/track/legacy_state_updates.rs
@@ -1,4 +1,6 @@
-use crate::track::{BatchPartitionUpdate, NodeStateUpdates, PartitionStateUpdates, StateUpdates};
+use crate::track::{
+    BatchPartitionStateUpdate, NodeStateUpdates, PartitionStateUpdates, StateUpdates,
+};
 use radix_engine_common::types::{NodeId, PartitionNumber, SubstateKey};
 use radix_engine_interface::ScryptoSbor;
 use radix_engine_store_interface::interface::DatabaseUpdate;
@@ -54,7 +56,7 @@ impl From<StateUpdates> for LegacyStateUpdates {
                                 system_updates.insert(node_partition, by_substate);
                             }
                             PartitionStateUpdates::Batch(batch) => match batch {
-                                BatchPartitionUpdate::Reset {
+                                BatchPartitionStateUpdate::Reset {
                                     new_substate_values,
                                 } => {
                                     partition_deletions.insert(node_partition.clone());

--- a/radix-engine/src/transaction/system_structure.rs
+++ b/radix-engine/src/transaction/system_structure.rs
@@ -2,7 +2,7 @@ use crate::system::system_db_reader::*;
 use crate::system::system_type_checker::BlueprintTypeTarget;
 use crate::system::type_info::TypeInfoSubstate;
 use crate::track::{
-    BatchPartitionUpdate, NodeStateUpdates, PartitionStateUpdates, ReadOnly, StateUpdates,
+    BatchPartitionStateUpdate, NodeStateUpdates, PartitionStateUpdates, ReadOnly, StateUpdates,
     TrackedNode, TrackedSubstateValue,
 };
 use crate::types::*;
@@ -204,7 +204,7 @@ impl<'a, S: SubstateDatabase> SubstateSchemaMapper<'a, S> {
                             PartitionStateUpdates::Delta { by_substate } => {
                                 by_substate.keys().collect::<Vec<_>>()
                             }
-                            PartitionStateUpdates::Batch(BatchPartitionUpdate::Reset {
+                            PartitionStateUpdates::Batch(BatchPartitionStateUpdate::Reset {
                                 new_substate_values,
                             }) => new_substate_values.keys().collect::<Vec<_>>(),
                         };


### PR DESCRIPTION
Addresses https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@2bsEvpTYSt1HioteqmFu91DtjNfFVJXfM4N (and also https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@2bsEvpTYSt1HjAHLXdeLKnFMMdeki74XZoQ but ofc only limited to the test substate DBs used in this repo).

This change had to be accompanied by a refactor of `DatabaseUpdates` (which affected a lot of places, but again - a "convert from legacy format" util is provided and used).
Important design choice: I went for a struct which propagates the indexing from `StateUpdates`.