### PR TITLE
Decimal various optimizations

### DIFF
--- a/radix-engine-common/src/macros.rs
+++ b/radix-engine-common/src/macros.rs
@@ -2,6 +2,30 @@
 ///
 #[macro_export]
 macro_rules! dec {
+    (0) => {
+        $crate::math::Decimal::ZERO
+    };
+    ("0") => {
+        $crate::math::Decimal::ZERO
+    };
+    ("0.1") => {
+        $crate::math::Decimal::ONE_TENTH
+    };
+    ("1" | 1) => {
+        $crate::math::Decimal::ONE
+    };
+    (10) => {
+        $crate::math::Decimal::TEN
+    };
+    ("10") => {
+        $crate::math::Decimal::TEN
+    };
+    (100) => {
+        $crate::math::Decimal::ONE_HUNDRED
+    };
+    ("100") => {
+        $crate::math::Decimal::ONE_HUNDRED
+    };
     // NOTE: Decimal arithmetic operation safe unwrap.
     // In general, it is assumed that reasonable literals are provided.
     // If not then something is definitely wrong and panic is fine.
@@ -51,6 +75,33 @@ macro_rules! i {
 ///
 #[macro_export]
 macro_rules! pdec {
+    (0) => {
+        $crate::math::PreciseDecimal::ZERO
+    };
+    ("0") => {
+        $crate::math::PreciseDecimal::ZERO
+    };
+    ("0.1") => {
+        $crate::math::PreciseDecimal::ONE_TENTH
+    };
+    (1) => {
+        $crate::math::PreciseDecimal::ONE
+    };
+    ("1") => {
+        $crate::math::PreciseDecimal::ONE
+    };
+    (10) => {
+        $crate::math::PreciseDecimal::TEN
+    };
+    ("10") => {
+        $crate::math::PreciseDecimal::TEN
+    };
+    (100) => {
+        $crate::math::PreciseDecimal::ONE_HUNDRED
+    };
+    ("100") => {
+        $crate::math::PreciseDecimal::ONE_HUNDRED
+    };
     // NOTE: PreciseDecimal arithmetic operation safe unwrap.
     // In general, it is assumed that reasonable literals are provided.
     // If not then something is definitely wrong and panic is fine.

--- a/radix-engine-common/src/math/bnum_integer/bits.rs
+++ b/radix-engine-common/src/math/bnum_integer/bits.rs
@@ -61,37 +61,6 @@ macro_rules! impl_bits {
                         self.0.leading_zeros()
                     }
 
-                    /// Shifts the bits to the left by a specified amount, `n`,
-                    /// wrapping the truncated bits to the end of the resulting
-                    /// integer.
-                    ///
-                    /// Please note this isn't the same operation as the `<<` shifting
-                    /// operator! This method can not overflow as opposed to '<<'.
-                    ///
-                    /// Please note that this example is shared between integer types.
-                    /// Which explains why `I128` is used here.
-                    ///
-                    #[inline]
-                    #[must_use = "this returns the result of the operation, \
-                          without modifying the original"]
-                    pub fn rotate_left(self, other: Self) -> Self {
-                        Self(self.0.rotate_left(u32::try_from(other).unwrap()))
-                    }
-
-                    /// Shifts the bits to the right by a specified amount, `n`,
-                    /// wrapping the truncated bits to the beginning of the resulting
-                    /// integer.
-                    ///
-                    /// Please note this isn't the same operation as the `>>` shifting
-                    /// operator! This method can not overflow as opposed to '>>'.
-                    ///
-                    #[inline]
-                    #[must_use = "this returns the result of the operation, \
-                          without modifying the original"]
-                    pub fn rotate_right(self, other: Self) -> Self {
-                        Self(self.0.rotate_right(u32::try_from(other).unwrap()))
-                    }
-
                     /// Converts an integer from big endian to the target's endianness.
                     ///
                     /// On big endian this is a no-op. On little endian the bytes are

--- a/radix-engine-common/src/math/bnum_integer/convert.rs
+++ b/radix-engine-common/src/math/bnum_integer/convert.rs
@@ -1,13 +1,6 @@
 use super::*;
 use bnum::cast::CastFrom;
 
-/// Trait for short hand notation for try_from().unwrap()
-/// As opposed to `try_from(x).unwrap()` this will panic if the conversion fails.
-pub trait By<T> {
-    type Output;
-    fn by(val: T) -> Self::Output;
-}
-
 macro_rules! impl_from_primitive {
     ($t:ident, $wrapped:ty, ($($type:ident),*)) => {
         paste! {
@@ -73,12 +66,6 @@ macro_rules! impl_from_builtin{
                     fn from(val: $o) -> Self {
                         Self::[<from_$o>](val).unwrap()
 
-                    }
-                }
-                impl By<$o> for $t {
-                    type Output = $t;
-                    fn by(val: $o) -> Self::Output {
-                        Self::Output::try_from(val).unwrap()
                     }
                 }
             )*

--- a/radix-engine-common/src/math/bnum_integer/convert.rs
+++ b/radix-engine-common/src/math/bnum_integer/convert.rs
@@ -683,10 +683,6 @@ macro_rules! impl_to_bytes {
                         }
                         bytes
                     }
-
-                    pub fn to_vec(&self) -> Vec<u8> {
-                        self.to_le_bytes().to_vec()
-                    }
                 }
             )*
         }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -307,9 +307,9 @@ impl TryFrom<String> for Decimal {
 impl From<bool> for Decimal {
     fn from(val: bool) -> Self {
         if val {
-            Self::from(1u8)
+            Self::ONE
         } else {
-            Self::from(0u8)
+            Self::ZERO
         }
     }
 }
@@ -718,7 +718,7 @@ impl FromStr for Decimal {
     type Err = ParseDecimalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tens = I192::from(10);
+        let tens = I192::TEN;
         let v: Vec<&str> = s.split('.').collect();
 
         let mut int = match I192::from_str(v[0]) {

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -921,10 +921,19 @@ mod tests {
             Decimal::MIN,
         );
 
+        assert_eq!(dec!("0"), Decimal::ZERO);
+        assert_eq!(dec!("1"), Decimal::ONE);
         assert_eq!(dec!("0.1"), Decimal::ONE_TENTH);
         assert_eq!(dec!("10"), Decimal::TEN);
         assert_eq!(dec!("100"), Decimal::ONE_HUNDRED);
         assert_eq!(dec!("0.01"), Decimal::ONE_HUNDREDTH);
+
+        assert_eq!("0", Decimal::ZERO.to_string());
+        assert_eq!("1", Decimal::ONE.to_string());
+        assert_eq!("0.1", Decimal::ONE_TENTH.to_string());
+        assert_eq!("10", Decimal::TEN.to_string());
+        assert_eq!("100", Decimal::ONE_HUNDRED.to_string());
+        assert_eq!("0.01", Decimal::ONE_HUNDREDTH.to_string());
     }
 
     #[test]

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -2011,6 +2011,41 @@ mod tests {
     test_math_operands_decimal!(U448);
     test_math_operands_decimal!(U512);
 
+    macro_rules! test_from_primitive_type {
+        ($type:ident) => {
+            paste! {
+                #[test]
+                fn [<test_decimal_from_primitive_$type>]() {
+                    let v = $type::try_from(1).unwrap();
+                    assert_eq!(Decimal::from(v), dec!(1));
+
+                    if $type::MIN != 0 {
+                        let v = $type::try_from(-1).unwrap();
+                        assert_eq!(Decimal::from(v), dec!(-1));
+                    }
+
+                    let v = $type::MAX;
+                    assert_eq!(Decimal::from(v), Decimal::from_str(&v.to_string()).unwrap());
+
+                    let v = $type::MIN;
+                    assert_eq!(Decimal::from(v), Decimal::from_str(&v.to_string()).unwrap());
+                }
+            }
+        };
+    }
+    test_from_primitive_type!(u8);
+    test_from_primitive_type!(u16);
+    test_from_primitive_type!(u32);
+    test_from_primitive_type!(u64);
+    test_from_primitive_type!(u128);
+    test_from_primitive_type!(usize);
+    test_from_primitive_type!(i8);
+    test_from_primitive_type!(i16);
+    test_from_primitive_type!(i32);
+    test_from_primitive_type!(i64);
+    test_from_primitive_type!(i128);
+    test_from_primitive_type!(isize);
+
     macro_rules! test_to_primitive_type {
         ($type:ident) => {
             paste! {

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -64,10 +64,11 @@ impl Decimal {
 
     pub const ZERO: Self = Self(I192::ZERO);
 
+    pub const ONE_HUNDREDTH: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE - 2), 0, 0]));
+    pub const ONE_TENTH: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE - 1), 0, 0]));
     pub const ONE: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE), 0, 0]));
     pub const TEN: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE + 1), 0, 0]));
     pub const ONE_HUNDRED: Self = Self(I192::from_digits([7766279631452241920, 0x5, 0]));
-    pub const ONE_HUNDREDTH: Self = Self(I192::from_digits([10_u64.pow(Decimal::SCALE - 2), 0, 0]));
 
     /// Returns `Decimal` of 0.
     pub const fn zero() -> Self {
@@ -897,6 +898,7 @@ mod tests {
             Decimal::MIN,
         );
 
+        assert_eq!(dec!("0.1"), Decimal::ONE_TENTH);
         assert_eq!(dec!("10"), Decimal::TEN);
         assert_eq!(dec!("100"), Decimal::ONE_HUNDRED);
         assert_eq!(dec!("0.01"), Decimal::ONE_HUNDREDTH);

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -2226,6 +2226,41 @@ mod tests {
     test_math_operands_decimal!(U448);
     test_math_operands_decimal!(U512);
 
+    macro_rules! test_from_primitive_type {
+        ($type:ident) => {
+            paste! {
+                #[test]
+                fn [<test_precise_decimal_from_primitive_$type>]() {
+                    let v = $type::try_from(1).unwrap();
+                    assert_eq!(PreciseDecimal::from(v), pdec!(1));
+
+                    if $type::MIN != 0 {
+                        let v = $type::try_from(-1).unwrap();
+                        assert_eq!(PreciseDecimal::from(v), pdec!(-1));
+                    }
+
+                    let v = $type::MAX;
+                    assert_eq!(PreciseDecimal::from(v), PreciseDecimal::from_str(&v.to_string()).unwrap());
+
+                    let v = $type::MIN;
+                    assert_eq!(PreciseDecimal::from(v), PreciseDecimal::from_str(&v.to_string()).unwrap());
+                }
+            }
+        };
+    }
+    test_from_primitive_type!(u8);
+    test_from_primitive_type!(u16);
+    test_from_primitive_type!(u32);
+    test_from_primitive_type!(u64);
+    test_from_primitive_type!(u128);
+    test_from_primitive_type!(usize);
+    test_from_primitive_type!(i8);
+    test_from_primitive_type!(i16);
+    test_from_primitive_type!(i32);
+    test_from_primitive_type!(i64);
+    test_from_primitive_type!(i128);
+    test_from_primitive_type!(isize);
+
     macro_rules! test_to_primitive_type {
         ($type:ident) => {
             paste! {

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -331,9 +331,9 @@ impl TryFrom<String> for PreciseDecimal {
 impl From<bool> for PreciseDecimal {
     fn from(val: bool) -> Self {
         if val {
-            Self::from(1u8)
+            Self::ONE
         } else {
-            Self::from(0u8)
+            Self::ZERO
         }
     }
 }
@@ -750,7 +750,7 @@ impl FromStr for PreciseDecimal {
     type Err = ParsePreciseDecimalError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tens = I256::from(10);
+        let tens = I256::TEN;
         let v: Vec<&str> = s.split('.').collect();
 
         let mut int = match I256::from_str(v[0]) {
@@ -841,7 +841,7 @@ impl fmt::Display for ParsePreciseDecimalError {
 
 impl From<Decimal> for PreciseDecimal {
     fn from(val: Decimal) -> Self {
-        Self(I256::try_from(val.0).unwrap() * I256::from(10i8).pow(Self::SCALE - Decimal::SCALE))
+        Self(I256::try_from(val.0).unwrap() * I256::TEN.pow(Self::SCALE - Decimal::SCALE))
     }
 }
 

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -996,10 +996,19 @@ mod tests {
             PreciseDecimal::MIN,
         );
 
+        assert_eq!(pdec!("0"), PreciseDecimal::ZERO);
+        assert_eq!(pdec!("1"), PreciseDecimal::ONE);
         assert_eq!(pdec!("0.1"), PreciseDecimal::ONE_TENTH);
         assert_eq!(pdec!("10"), PreciseDecimal::TEN);
         assert_eq!(pdec!("100"), PreciseDecimal::ONE_HUNDRED);
         assert_eq!(pdec!("0.01"), PreciseDecimal::ONE_HUNDREDTH);
+
+        assert_eq!("0", PreciseDecimal::ZERO.to_string());
+        assert_eq!("1", PreciseDecimal::ONE.to_string());
+        assert_eq!("0.1", PreciseDecimal::ONE_TENTH.to_string());
+        assert_eq!("10", PreciseDecimal::TEN.to_string());
+        assert_eq!("100", PreciseDecimal::ONE_HUNDRED.to_string());
+        assert_eq!("0.01", PreciseDecimal::ONE_HUNDREDTH.to_string());
     }
 
     #[test]

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -65,6 +65,18 @@ impl PreciseDecimal {
 
     pub const ZERO: Self = Self(I256::ZERO);
 
+    pub const ONE_HUNDREDTH: Self = Self(I256::from_digits([
+        4003012203950112768,
+        542101086242752,
+        0,
+        0,
+    ]));
+    pub const ONE_TENTH: Self = Self(I256::from_digits([
+        3136633892082024448,
+        5421010862427522,
+        0,
+        0,
+    ]));
     pub const ONE: Self = Self(I256::from_digits([
         12919594847110692864,
         54210108624275221,
@@ -80,12 +92,6 @@ impl PreciseDecimal {
     pub const ONE_HUNDRED: Self = Self(I256::from_digits([
         687399551400673280,
         5421010862427522170,
-        0,
-        0,
-    ]));
-    pub const ONE_HUNDREDTH: Self = Self(I256::from_digits([
-        4003012203950112768,
-        542101086242752,
         0,
         0,
     ]));
@@ -968,6 +974,7 @@ mod tests {
             PreciseDecimal::MIN,
         );
 
+        assert_eq!(pdec!("0.1"), PreciseDecimal::ONE_TENTH);
         assert_eq!(pdec!("10"), PreciseDecimal::TEN);
         assert_eq!(pdec!("100"), PreciseDecimal::ONE_HUNDRED);
         assert_eq!(pdec!("0.01"), PreciseDecimal::ONE_HUNDREDTH);

--- a/radix-engine-interface/src/blueprints/resource/mod.rs
+++ b/radix-engine-interface/src/blueprints/resource/mod.rs
@@ -42,14 +42,7 @@ pub fn check_fungible_amount(amount: &Decimal, divisibility: u8) -> bool {
 
 pub fn check_non_fungible_amount(amount: &Decimal) -> Result<u32, ()> {
     // Integers between [0..u32::MAX]
-    if amount >= &Decimal::from(u32::MIN)
-        && amount <= &Decimal::from(u32::MAX)
-        && amount.0 % I192::from(10i128.pow(18)) == I192::from(0)
-    {
-        Ok(u32::from_str(&amount.to_string()).unwrap())
-    } else {
-        Err(())
-    }
+    u32::try_from(amount).map_err(|_| ())
 }
 
 #[macro_export]


### PR DESCRIPTION
## Summary
- Various decimal optimizations 
- refactor `truncate()` to `checked_truncate()` with rounding mode as parameter

## Details
Optimizations list:
- Add ONE_TENTH constant
- Let `dec!` and `pdec!` macros use decimal constants for elementary values
- Remove `to_vec()` from Integer types
- Remove rotate methods from Integer types 
- Remove By trait from Integer types
- Add conversion to primitive integer types for `Decimal` and `PreciseDecimal`


## Testing
- Add missing tests for conversion from primitive types
- Add tests for conversion to primitive types

## Update Recommendations

### For dApp Developers
Refactor scrypto sources to  `checked_truncate()` 

