### PR TITLE
Test/royalty module

### DIFF
--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -46,7 +46,7 @@ alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", 
 
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work
-radix_engine_fuzzing = ["arbitrary", "bnum/arbitrary"]
+radix_engine_fuzzing = ["arbitrary", "bnum/arbitrary", "sbor/radix_engine_fuzzing", "utils/radix_engine_fuzzing"]
 
 resource_tracker=[]
 full_math_benches = [ "dep:rug", "dep:ethnum"]

--- a/radix-engine-common/src/types/royalty_amount.rs
+++ b/radix-engine-common/src/types/royalty_amount.rs
@@ -4,7 +4,7 @@ use arbitrary::Arbitrary;
 
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Eq, ManifestSbor, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
+    Debug, Clone, Copy, PartialEq, Eq, ManifestSbor, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
 )]
 pub enum RoyaltyAmount {
     Free,
@@ -32,5 +32,12 @@ impl RoyaltyAmount {
 
     pub fn is_non_zero(&self) -> bool {
         !self.is_zero()
+    }
+
+    pub fn is_negative(&self) -> bool {
+        match self {
+            Self::Free => false,
+            Self::Usd(amount) | Self::Xrd(amount) => amount.is_negative(),
+        }
     }
 }

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -31,7 +31,7 @@ trace = ["radix-engine-derive/trace"]
 
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work
-radix_engine_fuzzing = ["arbitrary"]
+radix_engine_fuzzing = ["arbitrary", "sbor/radix_engine_fuzzing", "radix-engine-common/radix_engine_fuzzing", "utils/radix_engine_fuzzing"]
 
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]

--- a/radix-engine-interface/src/api/node_modules/royalty/substates.rs
+++ b/radix-engine-interface/src/api/node_modules/royalty/substates.rs
@@ -6,11 +6,3 @@ use sbor::rust::prelude::*;
 pub struct ComponentRoyaltySubstate {
     pub royalty_vault: Vault,
 }
-
-impl Clone for ComponentRoyaltySubstate {
-    fn clone(&self) -> Self {
-        Self {
-            royalty_vault: Vault(self.royalty_vault.0.clone()),
-        }
-    }
-}

--- a/radix-engine-tests/tests/blueprints/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/Cargo.toml
@@ -59,7 +59,8 @@ members = [
     "events_invalid",
     "logger",
     "validator",
-    "wasm_non_mvp"
+    "wasm_non_mvp",
+    "royalty-edge-cases"
 ]
 
 [profile.release]

--- a/radix-engine-tests/tests/blueprints/royalty-edge-cases/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/royalty-edge-cases/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "royalty-edge-cases"
+version = "0.13.0"
+edition = "2021"
+
+[dependencies]
+sbor = { path = "../../../../sbor" }
+scrypto = { path = "../../../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../../../radix-engine" }
+
+[lib]
+doctest = false
+crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/royalty-edge-cases/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/royalty-edge-cases/src/lib.rs
@@ -5,6 +5,7 @@ mod royalty_edge_cases {
     enable_package_royalties! {
         // We manipulate the value of this manually in tests by modifying the [`PackageDefinition`]
         instantiate => Free;
+        instantiate_with_missing_method_royalty => Free;
         func => Free;
         method => Free;
     }
@@ -22,6 +23,59 @@ mod royalty_edge_cases {
                     }
                 })
                 .globalize()
+        }
+
+        pub fn instantiate_with_missing_method_royalty() -> Global<RoyaltyEdgeCases> {
+            let this = Self {}.instantiate();
+
+            let mut modules = index_map_new();
+            let mut roles = index_map_new();
+
+            // Main
+            {
+                roles.insert(ModuleId::Main, Default::default());
+            }
+
+            // Metadata
+            {
+                let metadata_config = ModuleConfig::<MetadataInit>::default();
+                let metadata = Metadata::new_with_data(metadata_config.init);
+                modules.insert(AttachedModuleId::Metadata, *metadata.handle().as_node_id());
+                roles.insert(ModuleId::Metadata, metadata_config.roles);
+            };
+
+            // Royalties
+            let royalty_config: Option<ModuleConfig<ComponentRoyaltyConfig>> = {
+                Some(ModuleConfig {
+                    init: ComponentRoyaltyConfig {
+                        royalty_amounts: indexmap! {}, /* Intentionally no royalty for `method`. */
+                    },
+                    roles: RoleAssignmentInit::new(),
+                })
+            };
+            if let Some(royalty_config) = royalty_config {
+                roles.insert(ModuleId::Royalty, royalty_config.roles);
+                let royalty = Royalty::new(royalty_config.init);
+                modules.insert(AttachedModuleId::Royalty, *royalty.handle().as_node_id());
+            }
+
+            // Role Assignment
+            {
+                let role_assignment = RoleAssignment::new(OwnerRole::None, roles);
+                modules.insert(
+                    AttachedModuleId::RoleAssignment,
+                    *role_assignment.handle().as_node_id(),
+                );
+            }
+
+            let address =
+                ScryptoVmV1Api::object_globalize(*this.handle().as_node_id(), modules, None);
+
+            Global(
+                <royalty_edge_cases::RoyaltyEdgeCases as scrypto::component::HasStub>::Stub::new(
+                    ObjectStubHandle::Global(address),
+                ),
+            )
         }
 
         pub fn func() {}

--- a/radix-engine-tests/tests/blueprints/royalty-edge-cases/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/royalty-edge-cases/src/lib.rs
@@ -1,0 +1,30 @@
+use scrypto::prelude::*;
+
+#[blueprint]
+mod royalty_edge_cases {
+    enable_package_royalties! {
+        // We manipulate the value of this manually in tests by modifying the [`PackageDefinition`]
+        instantiate => Free;
+        func => Free;
+        method => Free;
+    }
+
+    struct RoyaltyEdgeCases;
+
+    impl RoyaltyEdgeCases {
+        pub fn instantiate(royalty_amount: RoyaltyAmount) -> Global<RoyaltyEdgeCases> {
+            Self {}
+                .instantiate()
+                .prepare_to_globalize(OwnerRole::Updatable(AccessRule::AllowAll))
+                .enable_component_royalties(component_royalties! {
+                    init {
+                        method => royalty_amount, updatable;
+                    }
+                })
+                .globalize()
+        }
+
+        pub fn func() {}
+        pub fn method(&self) {}
+    }
+}

--- a/radix-engine-tests/tests/package_loader.rs
+++ b/radix-engine-tests/tests/package_loader.rs
@@ -2,7 +2,6 @@
 mod package_loader {
     use radix_engine_common::prelude::*;
     use radix_engine_queries::typed_substate_layout::*;
-    use sbor::prelude::*;
 
     const PACKAGES_BINARY: &[u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/compiled_packages.bin"));

--- a/radix-engine-tests/tests/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/royalty_edge_cases.rs
@@ -1,0 +1,334 @@
+mod package_loader;
+
+use package_loader::PackageLoader;
+use radix_engine::errors::*;
+use radix_engine::transaction::*;
+use radix_engine_queries::typed_substate_layout::*;
+use scrypto_unit::*;
+use transaction::prelude::*;
+
+#[test]
+fn test_component_royalty_edge_cases_at_instantiation() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let package_address =
+        test_runner.publish_package_simple(PackageLoader::get("royalty-edge-cases"));
+
+    for (royalty_amount, error_checking_fn, _) in test_cases().into_iter() {
+        // Act
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .call_function(
+                package_address,
+                "RoyaltyEdgeCases",
+                "instantiate",
+                manifest_args!(royalty_amount),
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        // Assert
+        match error_checking_fn {
+            Some(func) => {
+                receipt.expect_specific_failure(func);
+            }
+            None => {
+                receipt.expect_commit_success();
+            }
+        };
+    }
+}
+
+#[test]
+fn test_package_royalty_edge_cases_at_publishing() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+
+    for (royalty_amount, _, error_checking_fn) in test_cases().into_iter() {
+        update_package_royalties(&mut definition, royalty_amount);
+
+        // Act
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .publish_package_advanced(
+                None,
+                code.clone(),
+                definition.clone(),
+                MetadataInit::default(),
+                OwnerRole::None,
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        // Assert
+        match error_checking_fn {
+            Some(func) => {
+                receipt.expect_specific_failure(func);
+            }
+            None => {
+                receipt.expect_commit_success();
+            }
+        };
+    }
+}
+
+#[test]
+fn test_component_royalty_edge_cases_at_interactions() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let package_address =
+        test_runner.publish_package_simple(PackageLoader::get("royalty-edge-cases"));
+
+    for (royalty_amount, error_checking_fn, _) in test_cases().into_iter() {
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .call_function(
+                package_address,
+                "RoyaltyEdgeCases",
+                "instantiate",
+                manifest_args!(royalty_amount),
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        let commit_result = match error_checking_fn {
+            Some(func) => {
+                receipt.expect_specific_failure(func);
+                return; /* If component instantiation failed, that's correct behavior, exit early */
+            }
+            None => {
+                receipt.expect_commit_success();
+                receipt.expect_commit_success()
+            }
+        };
+        let component_address = *commit_result.new_component_addresses().first().unwrap();
+
+        // Act
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .call_method(component_address, "method", manifest_args!())
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        // Assert
+        assert_eq!(
+            receipt.fee_summary.total_royalty_cost_in_xrd,
+            royalty_amount_to_xrd(&royalty_amount)
+        )
+    }
+}
+
+#[test]
+fn test_package_royalty_edge_cases_at_interactions() {
+    // Arrange
+    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+
+    for (royalty_amount, _, error_checking_fn) in test_cases().into_iter() {
+        update_package_royalties(&mut definition, royalty_amount);
+
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .publish_package_advanced(
+                None,
+                code.clone(),
+                definition.clone(),
+                MetadataInit::default(),
+                OwnerRole::None,
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        let commit_result = match error_checking_fn {
+            Some(func) => {
+                receipt.expect_specific_failure(func);
+                return; /* If component instantiation failed, that's correct behavior, exit early */
+            }
+            None => {
+                receipt.expect_commit_success();
+                receipt.expect_commit_success()
+            }
+        };
+        let package_address = *commit_result.new_package_addresses().first().unwrap();
+
+        // Act
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .call_function(
+                package_address,
+                "RoyaltyEdgeCases",
+                "func",
+                manifest_args!(),
+            )
+            .build();
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+        // Assert
+        assert_eq!(
+            receipt.fee_summary.total_royalty_cost_in_xrd,
+            royalty_amount_to_xrd(&royalty_amount)
+        )
+    }
+}
+
+fn royalty_amount_to_xrd(royalty_amount: &RoyaltyAmount) -> Decimal {
+    match royalty_amount {
+        RoyaltyAmount::Free => Decimal::zero(),
+        RoyaltyAmount::Xrd(amount) => *amount,
+        RoyaltyAmount::Usd(amount) => *amount / CostingParameters::default().usd_price,
+    }
+}
+
+fn test_cases() -> Vec<(
+    RoyaltyAmount,
+    Option<fn(&RuntimeError) -> bool>,
+    Option<fn(&RuntimeError) -> bool>,
+)> {
+    let network_definition = NetworkDefinition::simulator();
+    let ExecutionConfig {
+        max_per_function_royalty_in_xrd,
+        ..
+    } = ExecutionConfig::for_notarized_transaction(network_definition);
+    let CostingParameters { usd_price, .. } = CostingParameters::default();
+
+    let max_per_function_royalty_in_usd = max_per_function_royalty_in_xrd / usd_price;
+    let very_small_decimal = dec!("0.000000000000000001");
+
+    vec![
+        /* Negative royalty amounts are not permitted */
+        (
+            RoyaltyAmount::Xrd(Decimal::MIN),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        (
+            RoyaltyAmount::Usd(Decimal::MIN),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        (
+            RoyaltyAmount::Xrd(dec!("-1")),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        (
+            RoyaltyAmount::Usd(dec!("-1")),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        (
+            RoyaltyAmount::Xrd(-very_small_decimal),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        (
+            RoyaltyAmount::Usd(-very_small_decimal),
+            Some(is_component_royalty_error_royalty_amount_is_negative),
+            Some(is_package_royalty_error_royalty_amount_is_negative),
+        ),
+        /* Zero is permitted */
+        (RoyaltyAmount::Free, None, None),
+        (RoyaltyAmount::Xrd(Decimal::ZERO), None, None),
+        (RoyaltyAmount::Usd(Decimal::ZERO), None, None),
+        /* Positive Less than Max is permitted */
+        (RoyaltyAmount::Xrd(very_small_decimal), None, None),
+        (RoyaltyAmount::Usd(very_small_decimal), None, None),
+        (RoyaltyAmount::Xrd(dec!("1")), None, None),
+        (RoyaltyAmount::Usd(dec!("1")), None, None),
+        (
+            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd - very_small_decimal),
+            None,
+            None,
+        ),
+        (
+            RoyaltyAmount::Usd(max_per_function_royalty_in_usd - very_small_decimal),
+            None,
+            None,
+        ),
+        /* Maximum of XRD and USD is permitted */
+        (
+            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd),
+            None,
+            None,
+        ),
+        (
+            RoyaltyAmount::Usd(max_per_function_royalty_in_usd),
+            None,
+            None,
+        ),
+        /* Anything above maximum is not permitted */
+        (
+            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd + very_small_decimal),
+            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+        ),
+        (
+            RoyaltyAmount::Usd(max_per_function_royalty_in_usd + very_small_decimal),
+            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+        ),
+        (
+            RoyaltyAmount::Xrd(Decimal::MAX),
+            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+        ),
+        (
+            RoyaltyAmount::Usd(Decimal::MAX),
+            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+        ),
+    ]
+}
+
+fn is_component_royalty_error_royalty_amount_is_negative(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::ComponentRoyaltyError(
+            ComponentRoyaltyError::RoyaltyAmountIsNegative(..)
+        ))
+    )
+}
+
+fn is_component_royalty_error_royalty_amount_is_greater_than_allowed(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::ComponentRoyaltyError(
+            ComponentRoyaltyError::RoyaltyAmountIsGreaterThanAllowed { .. },
+        ),)
+    )
+}
+
+fn is_package_royalty_error_royalty_amount_is_negative(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::PackageError(
+            PackageError::RoyaltyAmountIsNegative(..)
+        ))
+    )
+}
+
+fn is_package_royalty_error_royalty_amount_is_greater_than_allowed(error: &RuntimeError) -> bool {
+    matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::PackageError(
+            PackageError::RoyaltyAmountIsGreaterThanAllowed { .. },
+        ),)
+    )
+}
+
+fn update_package_royalties(
+    package_definition: &mut PackageDefinition,
+    royalty_amount: RoyaltyAmount,
+) {
+    for blueprint_definition in package_definition.blueprints.values_mut() {
+        let function_royalties = blueprint_definition
+            .schema
+            .functions
+            .functions
+            .keys()
+            .map(|key| (key.clone(), royalty_amount))
+            .collect::<IndexMap<_, _>>();
+        blueprint_definition.royalty_config = PackageRoyaltyConfig::Enabled(function_royalties)
+    }
+}

--- a/radix-engine-tests/tests/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/royalty_edge_cases.rs
@@ -7,176 +7,451 @@ use radix_engine_queries::typed_substate_layout::*;
 use scrypto_unit::*;
 use transaction::prelude::*;
 
-#[test]
-fn test_component_royalty_edge_cases_at_instantiation() {
-    // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address =
-        test_runner.publish_package_simple(PackageLoader::get("royalty-edge-cases"));
+const DECIMAL_MIN: Decimal = Decimal::MIN;
+const DECIMAL_MAX: Decimal = Decimal::MAX;
 
-    for (royalty_amount, error_checking_fn, _) in test_cases().into_iter() {
-        // Act
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .call_function(
-                package_address,
-                "RoyaltyEdgeCases",
-                "instantiate",
-                manifest_args!(royalty_amount),
-            )
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+const DECIMAL_ZERO: Decimal = Decimal::ZERO;
+const DECIMAL_VERY_SMALL: Decimal = Decimal(I192::ONE);
 
-        // Assert
-        match error_checking_fn {
-            Some(func) => {
-                receipt.expect_specific_failure(func);
-            }
-            None => {
-                receipt.expect_commit_success();
-            }
-        };
-    }
+const DECIMAL_ONE: Decimal = Decimal::ONE;
+
+lazy_static::lazy_static! {
+    static ref CODE_AND_DEF: (Vec<u8>, PackageDefinition) = PackageLoader::get("royalty-edge-cases");
 }
 
-#[test]
-fn test_package_royalty_edge_cases_at_publishing() {
-    // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+component_instantiation_tests! {
+    instantiation_of_component_with_decimal_min_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(DECIMAL_MIN),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-    for (royalty_amount, _, error_checking_fn) in test_cases().into_iter() {
-        update_package_royalties(&mut definition, royalty_amount);
+    instantiation_of_component_with_decimal_min_usd_royalties_fails(
+        RoyaltyAmount::Usd(DECIMAL_MIN),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Act
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .publish_package_advanced(
-                None,
-                code.clone(),
-                definition.clone(),
-                MetadataInit::default(),
-                OwnerRole::None,
-            )
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    instantiation_of_component_with_negative_one_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(-DECIMAL_ONE),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Assert
-        match error_checking_fn {
-            Some(func) => {
-                receipt.expect_specific_failure(func);
-            }
-            None => {
-                receipt.expect_commit_success();
-            }
-        };
-    }
+    instantiation_of_component_with_negative_one_usd_royalties_fails(
+        RoyaltyAmount::Usd(-DECIMAL_ONE),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
+
+    instantiation_of_component_with_very_small_decimal_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(-DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
+
+    instantiation_of_component_with_very_small_decimal_usd_royalties_fails(
+        RoyaltyAmount::Usd(-DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
+
+    instantiation_of_component_with_zero_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_ZERO),
+        None
+    );
+
+    instantiation_of_component_with_zero_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_ZERO),
+        None
+    );
+
+    instantiation_of_component_with_free_royalties_succeeds(
+        RoyaltyAmount::Free,
+        None
+    );
+
+    instantiation_of_component_with_very_small_positive_amount_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    instantiation_of_component_with_very_small_positive_amount_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    instantiation_of_component_with_one_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_ONE),
+        None
+    );
+
+    instantiation_of_component_with_one_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_ONE),
+        None
+    );
+
+    instantiation_of_component_with_slightly_less_than_maximum_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    instantiation_of_component_with_slightly_less_than_maximum_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    instantiation_of_component_with_maximum_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd()),
+        None,
+    );
+
+    instantiation_of_component_with_maximum_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd()),
+        None,
+    );
+
+    instantiation_of_component_with_slightly_more_than_maximum_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() + DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    instantiation_of_component_with_slightly_more_than_maximum_usd_royalties_fails(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() + DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    instantiation_of_component_with_decimal_max_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(DECIMAL_MAX),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    instantiation_of_component_with_decimal_max_usd_royalties_fails(
+        RoyaltyAmount::Usd(DECIMAL_MAX),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
 }
 
-#[test]
-fn test_component_royalty_edge_cases_at_interactions() {
-    // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address =
-        test_runner.publish_package_simple(PackageLoader::get("royalty-edge-cases"));
+component_interaction_tests! {
+    interactions_with_component_with_decimal_min_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_MIN),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-    for (royalty_amount, error_checking_fn, _) in test_cases().into_iter() {
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .call_function(
-                package_address,
-                "RoyaltyEdgeCases",
-                "instantiate",
-                manifest_args!(royalty_amount),
-            )
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    interactions_with_component_with_decimal_min_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_MIN),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-        let commit_result = match error_checking_fn {
-            Some(func) => {
-                receipt.expect_specific_failure(func);
-                return; /* If component instantiation failed, that's correct behavior, exit early */
-            }
-            None => {
-                receipt.expect_commit_success();
-                receipt.expect_commit_success()
-            }
-        };
-        let component_address = *commit_result.new_component_addresses().first().unwrap();
+    interactions_with_component_with_negative_one_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(-DECIMAL_ONE),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Act
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .call_method(component_address, "method", manifest_args!())
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    interactions_with_component_with_negative_one_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(-DECIMAL_ONE),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Assert
-        assert_eq!(
-            receipt.fee_summary.total_royalty_cost_in_xrd,
-            royalty_amount_to_xrd(&royalty_amount)
-        )
-    }
+    interactions_with_component_with_very_small_decimal_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(-DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_component_with_very_small_decimal_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(-DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_component_with_zero_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_ZERO),
+        None
+    );
+
+    interactions_with_component_with_zero_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_ZERO),
+        None
+    );
+
+    interactions_with_component_with_free_royalties_proceeds_as_expected(
+        RoyaltyAmount::Free,
+        None
+    );
+
+    interactions_with_component_with_very_small_positive_amount_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    interactions_with_component_with_very_small_positive_amount_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    interactions_with_component_with_one_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_ONE),
+        None
+    );
+
+    interactions_with_component_with_one_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_ONE),
+        None
+    );
+
+    interactions_with_component_with_slightly_less_than_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    interactions_with_component_with_slightly_less_than_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    interactions_with_component_with_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd()),
+        None,
+    );
+
+    interactions_with_component_with_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd()),
+        None,
+    );
+
+    interactions_with_component_with_slightly_more_than_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() + DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_component_with_slightly_more_than_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() + DECIMAL_VERY_SMALL),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_component_with_decimal_max_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_MAX),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_component_with_decimal_max_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_MAX),
+        Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
 }
 
-#[test]
-fn test_package_royalty_edge_cases_at_interactions() {
-    // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+package_publishing_tests! {
+    publishing_of_package_with_decimal_min_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(DECIMAL_MIN),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
 
-    for (royalty_amount, _, error_checking_fn) in test_cases().into_iter() {
-        update_package_royalties(&mut definition, royalty_amount);
+    publishing_of_package_with_decimal_min_usd_royalties_fails(
+        RoyaltyAmount::Usd(DECIMAL_MIN),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
 
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .publish_package_advanced(
-                None,
-                code.clone(),
-                definition.clone(),
-                MetadataInit::default(),
-                OwnerRole::None,
-            )
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    publishing_of_package_with_negative_one_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(-DECIMAL_ONE),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
 
-        let commit_result = match error_checking_fn {
-            Some(func) => {
-                receipt.expect_specific_failure(func);
-                return; /* If component instantiation failed, that's correct behavior, exit early */
-            }
-            None => {
-                receipt.expect_commit_success();
-                receipt.expect_commit_success()
-            }
-        };
-        let package_address = *commit_result.new_package_addresses().first().unwrap();
+    publishing_of_package_with_negative_one_usd_royalties_fails(
+        RoyaltyAmount::Usd(-DECIMAL_ONE),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Act
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .call_function(
-                package_address,
-                "RoyaltyEdgeCases",
-                "func",
-                manifest_args!(),
-            )
-            .build();
-        let receipt = test_runner.execute_manifest(manifest, vec![]);
+    publishing_of_package_with_very_small_decimal_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(-DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
 
-        // Assert
-        assert_eq!(
-            receipt.fee_summary.total_royalty_cost_in_xrd,
-            royalty_amount_to_xrd(&royalty_amount)
-        )
-    }
+    publishing_of_package_with_very_small_decimal_usd_royalties_fails(
+        RoyaltyAmount::Usd(-DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    publishing_of_package_with_zero_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_ZERO),
+        None
+    );
+
+    publishing_of_package_with_zero_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_ZERO),
+        None
+    );
+
+    publishing_of_package_with_free_royalties_succeeds(
+        RoyaltyAmount::Free,
+        None
+    );
+
+    publishing_of_package_with_very_small_positive_amount_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    publishing_of_package_with_very_small_positive_amount_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    publishing_of_package_with_one_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(DECIMAL_ONE),
+        None
+    );
+
+    publishing_of_package_with_one_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(DECIMAL_ONE),
+        None
+    );
+
+    publishing_of_package_with_slightly_less_than_maximum_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    publishing_of_package_with_slightly_less_than_maximum_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    publishing_of_package_with_maximum_xrd_royalties_succeeds(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd()),
+        None,
+    );
+
+    publishing_of_package_with_maximum_usd_royalties_succeeds(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd()),
+        None,
+    );
+
+    publishing_of_package_with_slightly_more_than_maximum_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() + DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    publishing_of_package_with_slightly_more_than_maximum_usd_royalties_fails(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() + DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    publishing_of_package_with_decimal_max_xrd_royalties_fails(
+        RoyaltyAmount::Xrd(DECIMAL_MAX),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    publishing_of_package_with_decimal_max_usd_royalties_fails(
+        RoyaltyAmount::Usd(DECIMAL_MAX),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+}
+
+package_interactions_tests! {
+    interactions_with_package_with_decimal_min_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_MIN),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_decimal_min_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_MIN),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_negative_one_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(-DECIMAL_ONE),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_negative_one_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(-DECIMAL_ONE),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_very_small_decimal_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(-DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_very_small_decimal_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(-DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_negative),
+    );
+
+    interactions_with_package_with_zero_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_ZERO),
+        None
+    );
+
+    interactions_with_package_with_zero_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_ZERO),
+        None
+    );
+
+    interactions_with_package_with_free_royalties_proceeds_as_expected(
+        RoyaltyAmount::Free,
+        None
+    );
+
+    interactions_with_package_with_very_small_positive_amount_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    interactions_with_package_with_very_small_positive_amount_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_VERY_SMALL),
+        None
+    );
+
+    interactions_with_package_with_one_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_ONE),
+        None
+    );
+
+    interactions_with_package_with_one_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_ONE),
+        None
+    );
+
+    interactions_with_package_with_slightly_less_than_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    interactions_with_package_with_slightly_less_than_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() - DECIMAL_VERY_SMALL),
+        None,
+    );
+
+    interactions_with_package_with_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd()),
+        None,
+    );
+
+    interactions_with_package_with_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd()),
+        None,
+    );
+
+    interactions_with_package_with_slightly_more_than_maximum_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd() + DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_package_with_slightly_more_than_maximum_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(max_per_function_royalty_in_usd() + DECIMAL_VERY_SMALL),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_package_with_decimal_max_xrd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Xrd(DECIMAL_MAX),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
+
+    interactions_with_package_with_decimal_max_usd_royalties_proceeds_as_expected(
+        RoyaltyAmount::Usd(DECIMAL_MAX),
+        Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
+    );
 }
 
 #[test]
 fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+    let (code, mut definition) = CODE_AND_DEF.clone();
 
     for blueprint_definition in definition.blueprints.values_mut() {
         blueprint_definition.royalty_config = PackageRoyaltyConfig::Enabled(Default::default())
@@ -210,7 +485,7 @@ fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
 fn component_and_package_royalties_are_both_applied() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
+    let (code, mut definition) = CODE_AND_DEF.clone();
     let royalty_amount = RoyaltyAmount::Xrd(10.into());
     update_package_royalties(&mut definition, royalty_amount);
 
@@ -255,8 +530,7 @@ fn component_and_package_royalties_are_both_applied() {
 fn test_component_with_missing_method_royalty() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().without_trace().build();
-    let package_address =
-        test_runner.publish_package_simple(PackageLoader::get("royalty-edge-cases"));
+    let package_address = test_runner.publish_package_simple(CODE_AND_DEF.clone());
 
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
@@ -290,109 +564,8 @@ fn royalty_amount_to_xrd(royalty_amount: &RoyaltyAmount) -> Decimal {
     match royalty_amount {
         RoyaltyAmount::Free => Decimal::zero(),
         RoyaltyAmount::Xrd(amount) => *amount,
-        RoyaltyAmount::Usd(amount) => *amount / CostingParameters::default().usd_price,
+        RoyaltyAmount::Usd(amount) => *amount * CostingParameters::default().usd_price,
     }
-}
-
-fn test_cases() -> Vec<(
-    RoyaltyAmount,
-    Option<fn(&RuntimeError) -> bool>,
-    Option<fn(&RuntimeError) -> bool>,
-)> {
-    let network_definition = NetworkDefinition::simulator();
-    let ExecutionConfig {
-        max_per_function_royalty_in_xrd,
-        ..
-    } = ExecutionConfig::for_notarized_transaction(network_definition);
-    let CostingParameters { usd_price, .. } = CostingParameters::default();
-
-    let max_per_function_royalty_in_usd = max_per_function_royalty_in_xrd / usd_price;
-    let very_small_decimal = dec!("0.000000000000000001");
-
-    vec![
-        /* Negative royalty amounts are not permitted */
-        (
-            RoyaltyAmount::Xrd(Decimal::MIN),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        (
-            RoyaltyAmount::Usd(Decimal::MIN),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        (
-            RoyaltyAmount::Xrd(dec!("-1")),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        (
-            RoyaltyAmount::Usd(dec!("-1")),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        (
-            RoyaltyAmount::Xrd(-very_small_decimal),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        (
-            RoyaltyAmount::Usd(-very_small_decimal),
-            Some(is_component_royalty_error_royalty_amount_is_negative),
-            Some(is_package_royalty_error_royalty_amount_is_negative),
-        ),
-        /* Zero is permitted */
-        (RoyaltyAmount::Free, None, None),
-        (RoyaltyAmount::Xrd(Decimal::ZERO), None, None),
-        (RoyaltyAmount::Usd(Decimal::ZERO), None, None),
-        /* Positive Less than Max is permitted */
-        (RoyaltyAmount::Xrd(very_small_decimal), None, None),
-        (RoyaltyAmount::Usd(very_small_decimal), None, None),
-        (RoyaltyAmount::Xrd(dec!("1")), None, None),
-        (RoyaltyAmount::Usd(dec!("1")), None, None),
-        (
-            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd - very_small_decimal),
-            None,
-            None,
-        ),
-        (
-            RoyaltyAmount::Usd(max_per_function_royalty_in_usd - very_small_decimal),
-            None,
-            None,
-        ),
-        /* Maximum of XRD and USD is permitted */
-        (
-            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd),
-            None,
-            None,
-        ),
-        (
-            RoyaltyAmount::Usd(max_per_function_royalty_in_usd),
-            None,
-            None,
-        ),
-        /* Anything above maximum is not permitted */
-        (
-            RoyaltyAmount::Xrd(max_per_function_royalty_in_xrd + very_small_decimal),
-            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
-            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
-        ),
-        (
-            RoyaltyAmount::Usd(max_per_function_royalty_in_usd + very_small_decimal),
-            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
-            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
-        ),
-        (
-            RoyaltyAmount::Xrd(Decimal::MAX),
-            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
-            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
-        ),
-        (
-            RoyaltyAmount::Usd(Decimal::MAX),
-            Some(is_component_royalty_error_royalty_amount_is_greater_than_allowed),
-            Some(is_package_royalty_error_royalty_amount_is_greater_than_allowed),
-        ),
-    ]
 }
 
 fn is_component_royalty_error_royalty_amount_is_negative(error: &RuntimeError) -> bool {
@@ -446,3 +619,243 @@ fn update_package_royalties(
         blueprint_definition.royalty_config = PackageRoyaltyConfig::Enabled(function_royalties)
     }
 }
+
+fn max_per_function_royalty_in_xrd() -> Decimal {
+    let network_definition = NetworkDefinition::simulator();
+    let ExecutionConfig {
+        max_per_function_royalty_in_xrd,
+        ..
+    } = ExecutionConfig::for_notarized_transaction(network_definition);
+    max_per_function_royalty_in_xrd
+}
+
+fn max_per_function_royalty_in_usd() -> Decimal {
+    let max_per_function_royalty_in_xrd = max_per_function_royalty_in_xrd();
+    let CostingParameters { usd_price, .. } = CostingParameters::default();
+    max_per_function_royalty_in_xrd / usd_price
+}
+
+macro_rules! component_instantiation_tests {
+    (
+        $(
+            $name: ident (
+                $royalty_amount: expr,
+                $error_checking_fn: expr $(,)?
+            );
+        )*
+    ) => {
+        $(
+            #[test]
+            fn $name() {
+                // Arrange
+                let royalty_amount: RoyaltyAmount = $royalty_amount;
+                let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
+
+                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let package_address =
+                    test_runner.publish_package_simple(CODE_AND_DEF.clone());
+
+                // Act
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .call_function(
+                        package_address,
+                        "RoyaltyEdgeCases",
+                        "instantiate",
+                        manifest_args!(royalty_amount),
+                    )
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                // Assert
+                match error_checking_fn {
+                    Some(func) => {
+                        receipt.expect_specific_failure(func);
+                    }
+                    None => {
+                        receipt.expect_commit_success();
+                    }
+                };
+            }
+        )*
+    };
+}
+
+macro_rules! component_interaction_tests {
+    (
+        $(
+            $name: ident (
+                $royalty_amount: expr,
+                $error_checking_fn: expr $(,)?
+            );
+        )*
+    ) => {
+        $(
+            #[test]
+            fn $name() {
+                // Arrange
+                let royalty_amount: RoyaltyAmount = $royalty_amount;
+                let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
+
+                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let package_address =
+                    test_runner.publish_package_simple(CODE_AND_DEF.clone());
+
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .call_function(
+                        package_address,
+                        "RoyaltyEdgeCases",
+                        "instantiate",
+                        manifest_args!(royalty_amount),
+                    )
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                let commit_result = match error_checking_fn {
+                    Some(func) => {
+                        receipt.expect_specific_failure(func);
+                        return; /* If component instantiation failed, that's correct behavior, exit early */
+                    }
+                    None => {
+                        receipt.expect_commit_success();
+                        receipt.expect_commit_success()
+                    }
+                };
+                let component_address = *commit_result.new_component_addresses().first().unwrap();
+
+                // Act
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .call_method(component_address, "method", manifest_args!())
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                // Assert
+                assert_eq!(
+                    receipt.fee_summary.total_royalty_cost_in_xrd,
+                    royalty_amount_to_xrd(&royalty_amount)
+                )
+            }
+        )*
+    };
+}
+
+macro_rules! package_publishing_tests {
+    (
+        $(
+            $name: ident (
+                $royalty_amount: expr,
+                $error_checking_fn: expr $(,)?
+            );
+        )*
+    ) => {
+        $(
+            #[test]
+            fn $name() {
+                // Arrange
+                let royalty_amount: RoyaltyAmount = $royalty_amount;
+                let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
+
+                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let (code, mut definition) = CODE_AND_DEF.clone();
+
+                update_package_royalties(&mut definition, royalty_amount);
+
+                // Act
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .publish_package_advanced(
+                        None,
+                        code.clone(),
+                        definition.clone(),
+                        MetadataInit::default(),
+                        OwnerRole::None,
+                    )
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                // Assert
+                match error_checking_fn {
+                    Some(func) => {
+                        receipt.expect_specific_failure(func);
+                    }
+                    None => {
+                        receipt.expect_commit_success();
+                    }
+                };
+            }
+        )*
+    };
+}
+
+macro_rules! package_interactions_tests {
+    (
+        $(
+            $name: ident (
+                $royalty_amount: expr,
+                $error_checking_fn: expr $(,)?
+            );
+        )*
+    ) => {
+        $(
+            #[test]
+            fn $name() {
+                // Arrange
+                let royalty_amount: RoyaltyAmount = $royalty_amount;
+                let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
+
+                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let (code, mut definition) = CODE_AND_DEF.clone();
+
+                update_package_royalties(&mut definition, royalty_amount);
+
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .publish_package_advanced(
+                        None,
+                        code.clone(),
+                        definition.clone(),
+                        MetadataInit::default(),
+                        OwnerRole::None,
+                    )
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                let commit_result = match error_checking_fn {
+                    Some(func) => {
+                        receipt.expect_specific_failure(func);
+                        return; /* If component instantiation failed, that's correct behavior, exit early */
+                    }
+                    None => {
+                        receipt.expect_commit_success();
+                        receipt.expect_commit_success()
+                    }
+                };
+                let package_address = *commit_result.new_package_addresses().first().unwrap();
+
+                // Act
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
+                    .call_function(
+                        package_address,
+                        "RoyaltyEdgeCases",
+                        "func",
+                        manifest_args!(),
+                    )
+                    .build();
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
+
+                // Assert
+                assert_eq!(
+                    receipt.fee_summary.total_royalty_cost_in_xrd,
+                    royalty_amount_to_xrd(&royalty_amount)
+                )
+            }
+        )*
+    };
+}
+use component_instantiation_tests;
+use component_interaction_tests;
+use package_interactions_tests;
+use package_publishing_tests;

--- a/radix-engine-tests/tests/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/royalty_edge_cases.rs
@@ -179,7 +179,7 @@ fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
     let (code, mut definition) = PackageLoader::get("royalty-edge-cases");
 
     for blueprint_definition in definition.blueprints.values_mut() {
-        blueprint_definition.royalty_config = PackageRoyaltyConfig::Enabled(IndexMap::new())
+        blueprint_definition.royalty_config = PackageRoyaltyConfig::Enabled(Default::default())
     }
 
     // Act

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -81,7 +81,13 @@ db_checker = []
 
 # This flag is set by fuzz-tests framework and it disables cache in wasm_instrumenter/wasmi/wasmer
 # to prevent non-determinism when fuzzing
-radix_engine_fuzzing = []
+radix_engine_fuzzing = [
+    "radix-engine-common/radix_engine_fuzzing",
+    "radix-engine-interface/radix_engine_fuzzing",
+    "sbor/radix_engine_fuzzing",
+    "transaction/radix_engine_fuzzing",
+    "utils/radix_engine_fuzzing",
+]
 
 # This flag enables code parts used only for testing. Using "test" config option is not enough in cases,
 # when external crate is used for tests (eg. radix-engine-tests)

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -4,7 +4,9 @@ use crate::internal_prelude::*;
 use crate::kernel::kernel_api::{KernelApi, KernelSubstateApi};
 use crate::system::node_init::type_info_partition;
 use crate::system::node_modules::metadata::MetadataNativePackage;
-use crate::system::system_modules::costing::{apply_royalty_cost, RoyaltyRecipient};
+use crate::system::system_modules::costing::{
+    apply_royalty_cost, CostingError, FeeReserveError, RoyaltyRecipient,
+};
 use crate::system::type_info::TypeInfoSubstate;
 use crate::track::interface::NodeSubstates;
 use crate::types::*;
@@ -1427,6 +1429,15 @@ impl PackageRoyaltyNativeBlueprint {
             })
             .unwrap_or(RoyaltyAmount::Free);
 
+        // This should always be false and this code path should never be visited. This is because
+        // we check for negative royalties at the instantiation time of the royalty module.
+        if royalty_charge.is_negative() {
+            return Err(RuntimeError::SystemModuleError(
+                SystemModuleError::CostingError(CostingError::FeeReserveError(
+                    FeeReserveError::RoyaltyAmountIsNegative(royalty_charge),
+                )),
+            ));
+        }
         if royalty_charge.is_non_zero() {
             let handle = api.kernel_open_substate(
                 receiver,

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -124,6 +124,7 @@ pub enum PackageError {
     InvalidMetadataKey(String),
 
     RoyaltiesNotEnabled,
+    RoyaltyAmountIsNegative(RoyaltyAmount),
 }
 
 fn validate_package_schema(

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -471,7 +471,9 @@ impl ComponentRoyaltyBlueprint {
                 &SubstateKey::Map(scrypto_encode(ident).unwrap()),
                 LockFlags::read_only(),
                 Some(|| {
-                    let kv_entry = KeyValueEntrySubstate::<()>::default();
+                    let kv_entry =
+                        KeyValueEntrySubstate::<ComponentRoyaltyMethodAmountEntryPayload>::default(
+                        );
                     IndexedScryptoValue::from_typed(&kv_entry)
                 }),
                 SystemLockData::default(),

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -488,8 +488,8 @@ impl ComponentRoyaltyBlueprint {
                 .unwrap_or(RoyaltyAmount::Free)
         };
 
-        // This should always be false and this code path should never be visited. This is becase we
-        // check for negative royalties at the instantiation time of the royalty module.
+        // This should always be false and this code path should never be visited. This is because 
+        // we check for negative royalties at the instantiation time of the royalty module.
         if royalty_charge.is_negative() {
             return Err(RuntimeError::SystemModuleError(
                 SystemModuleError::CostingError(CostingError::FeeReserveError(

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -246,7 +246,7 @@ impl RoyaltyUtil {
         )?;
 
         for royalty_amount in royalty_amounts {
-            // Disallow negative royalties - 0 is acceptable.
+            // Disallow negative royalties, 0 is acceptable.
             if royalty_amount.is_negative() {
                 if is_component {
                     return Err(RuntimeError::ApplicationError(

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -488,7 +488,7 @@ impl ComponentRoyaltyBlueprint {
                 .unwrap_or(RoyaltyAmount::Free)
         };
 
-        // This should always be false and this code path should never be visited. This is because 
+        // This should always be false and this code path should never be visited. This is because
         // we check for negative royalties at the instantiation time of the royalty module.
         if royalty_charge.is_negative() {
             return Err(RuntimeError::SystemModuleError(

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -213,7 +213,6 @@ impl RoyaltyNativePackage {
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]
 pub enum ComponentRoyaltyError {
-    ComponentRoyaltyIsDisabled,
     RoyaltyAmountIsGreaterThanAllowed {
         max: RoyaltyAmount,
         actual: RoyaltyAmount,

--- a/radix-engine/src/system/node_modules/royalty/package.rs
+++ b/radix-engine/src/system/node_modules/royalty/package.rs
@@ -1,5 +1,7 @@
 use crate::errors::*;
-use crate::system::system_modules::costing::{apply_royalty_cost, RoyaltyRecipient};
+use crate::system::system_modules::costing::{
+    apply_royalty_cost, CostingError, FeeReserveError, RoyaltyRecipient,
+};
 use crate::types::*;
 use native_sdk::resource::NativeVault;
 use radix_engine_interface::api::field_api::LockFlags;
@@ -218,6 +220,7 @@ pub enum ComponentRoyaltyError {
         actual: RoyaltyAmount,
     },
     UnexpectedDecimalComputationError,
+    RoyaltyAmountIsNegative(RoyaltyAmount),
 }
 
 pub struct RoyaltyUtil;
@@ -243,6 +246,23 @@ impl RoyaltyUtil {
         )?;
 
         for royalty_amount in royalty_amounts {
+            // Disallow negative royalties - 0 is acceptable.
+            if royalty_amount.is_negative() {
+                if is_component {
+                    return Err(RuntimeError::ApplicationError(
+                        ApplicationError::ComponentRoyaltyError(
+                            ComponentRoyaltyError::RoyaltyAmountIsNegative(*royalty_amount),
+                        ),
+                    ));
+                } else {
+                    return Err(RuntimeError::ApplicationError(
+                        ApplicationError::PackageError(PackageError::RoyaltyAmountIsNegative(
+                            *royalty_amount,
+                        )),
+                    ));
+                }
+            }
+
             match royalty_amount {
                 RoyaltyAmount::Free => {}
                 RoyaltyAmount::Xrd(xrd_amount) => {
@@ -466,6 +486,15 @@ impl ComponentRoyaltyBlueprint {
                 .unwrap_or(RoyaltyAmount::Free)
         };
 
+        // This should always be false and this code path should never be visited. This is becase we
+        // check for negative royalties at the instantiation time of the royalty module.
+        if royalty_charge.is_negative() {
+            return Err(RuntimeError::SystemModuleError(
+                SystemModuleError::CostingError(CostingError::FeeReserveError(
+                    FeeReserveError::RoyaltyAmountIsNegative(royalty_charge),
+                )),
+            ));
+        }
         if royalty_charge.is_non_zero() {
             let vault_id = component_royalty.royalty_vault.0;
             let component_address = ComponentAddress::new_or_panic(receiver.0);

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -26,6 +26,7 @@ pub enum FeeReserveError {
         xrd_owed: Decimal,
     },
     Abort(AbortReason),
+    RoyaltyAmountIsNegative(RoyaltyAmount),
 }
 
 #[derive(Copy, Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, ScryptoSbor)]
@@ -507,6 +508,9 @@ impl ExecutionFeeReserve for SystemLoanFeeReserve {
     ) -> Result<(), FeeReserveError> {
         if royalty_amount.is_zero() {
             return Ok(());
+        }
+        if royalty_amount.is_negative() {
+            return Err(FeeReserveError::RoyaltyAmountIsNegative(royalty_amount));
         }
 
         self.consume_royalty_internal(royalty_amount, recipient)?;

--- a/sbor/Cargo.toml
+++ b/sbor/Cargo.toml
@@ -30,7 +30,7 @@ trace = ["sbor-derive/trace"]
 
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work
-radix_engine_fuzzing = ["arbitrary"]
+radix_engine_fuzzing = ["arbitrary", "utils/radix_engine_fuzzing"]
 
 [lib]
 doctest = false

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -31,7 +31,12 @@ serde = ["serde/derive"]
 dump_manifest_to_file = []
 
 # This flag is set by fuzz-tests framework
-radix_engine_fuzzing = []
+radix_engine_fuzzing = [
+    "sbor/radix_engine_fuzzing",
+    "utils/radix_engine_fuzzing",
+    "radix-engine-interface/radix_engine_fuzzing",
+    "radix-engine-common/radix_engine_fuzzing",
+]
 
 [lib]
 doctest = false

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -19,7 +19,7 @@ alloc = ["hashbrown"]
 serde = ["serde/derive", "indexmap/serde"]
 # This flag is set by fuzz-tests framework and it enables StubHasher (instead of RandomHasher) for
 # Map and Set structs to prevent non-determinism when fuzzing.
-radix_engine_fuzzing= ["indexmap/arbitrary"]
+radix_engine_fuzzing = ["indexmap/arbitrary"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
## Summary

Additional testing for the Royalty module and package royalties. This PR also adds checks to the royalty module and costing module to check for negative amounts which it didn't have before. Luckily, we were saved by the fact that transmutating a negative `Decimal` to a `u128` results in an overflow (which we caught). 

## Testing

* Added tests around the various edge cases of the `RoyaltyAmount`. Specifically: `Decimal::MIN`, -1, 0, 1, max XRD and USD, and `Decimal::MAX` for both components and packages. 
* Added tests that component and package royalties work together as expected. 
* Added tests for the exhaustiveness of the specification of royalties in the package definition.

## Note:

This PR will **LOWER** the code coverage of the royalty module even though all of the possible paths that we can go through have been tested. The lines in code coverage that remain untested are: comments (yeah idk why the tool counts those?), errors that we know are impossible to get to, errors that are too small to test (e.g., the `invocation` method of the package erroring out for an incorrect method name). If you want to quickly check the code coverage of this module before approving the PR then here is a gist of it: https://gist.github.com/0xOmarA/a0a060e15d815d593143f99b4c0ad0a1