### PR TITLE
Add `TimePrecision` to scrypto::prelude

### DIFF
--- a/radix-engine-tests/tests/blueprints/clock/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/clock/src/lib.rs
@@ -1,4 +1,3 @@
-use scrypto::blueprints::consensus_manager::*;
 use scrypto::prelude::*;
 
 #[blueprint]

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -27,6 +27,7 @@ pub use num_traits::{
 pub use radix_engine_interface::api::node_modules::auth::*;
 pub use radix_engine_interface::api::node_modules::metadata::*;
 pub use radix_engine_interface::api::node_modules::*;
+pub use radix_engine_interface::blueprints::consensus_manager::TimePrecision;
 pub use radix_engine_interface::blueprints::resource::*;
 pub use radix_engine_interface::crypto::*;
 pub use radix_engine_interface::math::*;


### PR DESCRIPTION
Add `TimePrecision` to `scrypto::prelude`


## Testing
Test updated

## Update Recommendations

### For dApp Developers
No longer need to import `TimePrecision` explicitly in scrypto code.

