### PR TITLE
Tests for event replacements

### DIFF
--- a/radix-engine-tests/tests/blueprints/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/Cargo.toml
@@ -61,7 +61,8 @@ members = [
     "validator",
     "wasm_non_mvp",
     "royalty-edge-cases",
-    "system_wasm_buffers"
+    "system_wasm_buffers",
+    "event-replacement"
 ]
 
 [profile.release]

--- a/radix-engine-tests/tests/blueprints/event-replacement/Cargo.toml
+++ b/radix-engine-tests/tests/blueprints/event-replacement/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "event-replacement"
+version = "0.13.0"
+edition = "2021"
+
+[dependencies]
+sbor = { path = "../../../../sbor" }
+scrypto = { path = "../../../../scrypto" }
+
+[dev-dependencies]
+radix-engine = { path = "../../../../radix-engine" }
+
+[lib]
+doctest = false
+crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/tests/blueprints/event-replacement/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/event-replacement/src/lib.rs
@@ -1,0 +1,75 @@
+use scrypto::prelude::*;
+
+#[blueprint]
+mod event_replacement {
+    struct EventReplacement;
+
+    impl EventReplacement {
+        pub fn instantiate() -> Global<EventReplacement> {
+            let this = Self {}.instantiate();
+
+            let mut modules = index_map_new();
+            let mut roles = index_map_new();
+
+            // Main
+            {
+                roles.insert(ModuleId::Main, Default::default());
+            }
+
+            // Metadata
+            {
+                let metadata_config = ModuleConfig::<MetadataInit>::default();
+                let metadata = Metadata::new_with_data(metadata_config.init);
+                modules.insert(AttachedModuleId::Metadata, *metadata.handle().as_node_id());
+                roles.insert(ModuleId::Metadata, metadata_config.roles);
+
+                /*
+                Event replacements are required when a module emits an event before becoming
+                attached. So, in here, we're updating the metadata so that the metadata module emits
+                an event prior to attachment. We want to ensure that the final events in the receipt
+                show that this event has been emitted by the component's metadata module.
+                */
+
+                metadata.set("Hello", "World".to_owned());
+            };
+
+            // Royalties
+            let royalty_config: Option<ModuleConfig<ComponentRoyaltyConfig>> = {
+                Some(ModuleConfig {
+                    init: ComponentRoyaltyConfig {
+                        royalty_amounts: indexmap! {
+                            "instantiate".to_owned() => (RoyaltyAmount::Free, true)
+                        },
+                    },
+                    roles: RoleAssignmentInit::new(),
+                })
+            };
+            if let Some(royalty_config) = royalty_config {
+                roles.insert(ModuleId::Royalty, royalty_config.roles);
+                let royalty = Royalty::new(royalty_config.init);
+                modules.insert(AttachedModuleId::Royalty, *royalty.handle().as_node_id());
+            }
+
+            // Role Assignment
+            {
+                let role_assignment = RoleAssignment::new(OwnerRole::None, roles);
+                modules.insert(
+                    AttachedModuleId::RoleAssignment,
+                    *role_assignment.handle().as_node_id(),
+                );
+            }
+
+            let address =
+                ScryptoVmV1Api::object_globalize(*this.handle().as_node_id(), modules, None);
+
+            Global(
+                <event_replacement::EventReplacement as scrypto::component::HasStub>::Stub::new(
+                    ObjectStubHandle::Global(address),
+                ),
+            )
+        }
+
+        pub fn func() {}
+        pub fn method(&self) {}
+    }
+}

--- a/radix-engine/src/system/node_modules/metadata/events.rs
+++ b/radix-engine/src/system/node_modules/metadata/events.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 
-#[derive(ScryptoSbor, ScryptoEvent, Debug)]
+#[derive(ScryptoSbor, ScryptoEvent, Debug, PartialEq, Eq)]
 pub struct SetMetadataEvent {
     pub key: String,
     pub value: MetadataValue,


### PR DESCRIPTION
## Summary

Add tests for event replacements. A quick into into event replacements and why they take place. Any event that is emitted by a node module prior to it being attached need to have replacements done to their event type identifiers to reflect that. As an example, if the metadata module A was created, emitted an event, and then was attached to component B, then the event emitted by module A should be changed to say that it was emitted by the metadata module of component B.