### PR TITLE
Filter logs based on level

### DIFF
--- a/examples/everything/Cargo.lock
+++ b/examples/everything/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "radix-engine-common",
+ "regex",
  "sbor",
  "scrypto-schema",
  "serde",

--- a/examples/everything/src/lib.rs
+++ b/examples/everything/src/lib.rs
@@ -135,6 +135,12 @@ mod everything {
         }
 
         pub fn protected_method(&self) {
+            error!("This");
+            warn!("is");
+            info!("a");
+            debug!("test");
+            trace!("message");
+
             FAUCET.lock_fee(dec!("1.0"));
         }
     }

--- a/examples/no-std/Cargo.lock
+++ b/examples/no-std/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "radix-engine-common",
+ "regex",
  "sbor",
  "scrypto-schema",
  "serde",

--- a/radix-engine-interface/src/types/level.rs
+++ b/radix-engine-interface/src/types/level.rs
@@ -1,12 +1,14 @@
 use crate::*;
+use core::str::FromStr;
 use sbor::rust::fmt;
 use sbor::rust::fmt::Debug;
 
 /// Represents the level of a log message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Sbor)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Sbor, Ord, PartialOrd, Default)]
 pub enum Level {
     Error,
     Warn,
+    #[default]
     Info,
     Debug,
     Trace,
@@ -20,6 +22,21 @@ impl fmt::Display for Level {
             Level::Info => write!(f, "INFO"),
             Level::Debug => write!(f, "DEBUG"),
             Level::Trace => write!(f, "TRACE"),
+        }
+    }
+}
+
+impl FromStr for Level {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ERROR" => Ok(Self::Error),
+            "WARN" => Ok(Self::Warn),
+            "INFO" => Ok(Self::Info),
+            "DEBUG" => Ok(Self::Debug),
+            "TRACE" => Ok(Self::Trace),
+            _ => Err(format!("Invalid level: {}", s)),
         }
     }
 }

--- a/radix-engine-interface/src/types/level.rs
+++ b/radix-engine-interface/src/types/level.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use core::str::FromStr;
-use sbor::rust::fmt;
-use sbor::rust::fmt::Debug;
+use sbor::rust::prelude::*;
 
 /// Represents the level of a log message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Sbor, Ord, PartialOrd, Default)]

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -83,7 +83,14 @@ impl Compile {
         let status = Command::new("cargo")
             .envs(env_vars)
             .current_dir(package_dir.as_ref())
-            .args(["build", "--target", "wasm32-unknown-unknown", "--release"])
+            .args([
+                "build", 
+                "--target",
+                "wasm32-unknown-unknown",
+                "--release",
+                "--features", 
+                "scrypto/log-error,scrypto/log-warn,scrypto/log-info,scrypto/log-debug,scrypto/log-trace"
+            ])
             .status()
             .unwrap_or_else(|error| {
                 panic!(

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -32,6 +32,12 @@ trace = ["scrypto-derive/trace"]
 # Disable schema gen in the output WASM.
 no-schema = ["scrypto-derive/no-schema"]
 
+log-error = []
+log-warn = []
+log-info = []
+log-debug = []
+log-trace = []
+
 [lib]
 doctest = false
 bench = false

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -9,7 +9,7 @@
 #[macro_export]
 macro_rules! error {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::emit_log($crate::types::Level::Error, ::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::error(::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -24,7 +24,7 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::emit_log($crate::types::Level::Warn, ::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::warn(::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -39,7 +39,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::emit_log($crate::types::Level::Info, ::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::info(::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -54,7 +54,7 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::emit_log($crate::types::Level::Debug, ::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::debug(::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -69,7 +69,7 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::emit_log($crate::types::Level::Trace, ::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::trace(::sbor::rust::format!($($args),+));
     }};
 }
 

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -6,11 +6,18 @@
 ///
 /// error!("Input number: {}", 100);
 /// ```
+#[cfg(feature = "log-error")]
 #[macro_export]
 macro_rules! error {
     ($($args: expr),+) => {{
         $crate::runtime::Logger::error(::sbor::rust::format!($($args),+));
     }};
+}
+
+#[cfg(not(feature = "log-error"))]
+#[macro_export]
+macro_rules! error {
+    ($($args: expr),+) => {{}};
 }
 
 /// Logs a `WARN` message.
@@ -21,11 +28,18 @@ macro_rules! error {
 ///
 /// warn!("Input number: {}", 100);
 /// ```
+#[cfg(feature = "log-warn")]
 #[macro_export]
 macro_rules! warn {
     ($($args: expr),+) => {{
         $crate::runtime::Logger::warn(::sbor::rust::format!($($args),+));
     }};
+}
+
+#[cfg(not(feature = "log-warn"))]
+#[macro_export]
+macro_rules! warn {
+    ($($args: expr),+) => {{}};
 }
 
 /// Logs an `INFO` message.
@@ -36,11 +50,18 @@ macro_rules! warn {
 ///
 /// info!("Input number: {}", 100);
 /// ```
+#[cfg(feature = "log-info")]
 #[macro_export]
 macro_rules! info {
     ($($args: expr),+) => {{
         $crate::runtime::Logger::info(::sbor::rust::format!($($args),+));
     }};
+}
+
+#[cfg(not(feature = "log-info"))]
+#[macro_export]
+macro_rules! info {
+    ($($args: expr),+) => {{}};
 }
 
 /// Logs a `DEBUG` message.
@@ -51,11 +72,18 @@ macro_rules! info {
 ///
 /// debug!("Input number: {}", 100);
 /// ```
+#[cfg(feature = "log-debug")]
 #[macro_export]
 macro_rules! debug {
     ($($args: expr),+) => {{
         $crate::runtime::Logger::debug(::sbor::rust::format!($($args),+));
     }};
+}
+
+#[cfg(not(feature = "log-debug"))]
+#[macro_export]
+macro_rules! debug {
+    ($($args: expr),+) => {{}};
 }
 
 /// Logs a `TRACE` message.
@@ -66,11 +94,18 @@ macro_rules! debug {
 ///
 /// trace!("Input number: {}", 100);
 /// ```
+#[cfg(feature = "log-trace")]
 #[macro_export]
 macro_rules! trace {
     ($($args: expr),+) => {{
         $crate::runtime::Logger::trace(::sbor::rust::format!($($args),+));
     }};
+}
+
+#[cfg(not(feature = "log-trace"))]
+#[macro_export]
+macro_rules! trace {
+    ($($args: expr),+) => {{}};
 }
 
 #[macro_export]

--- a/scrypto/src/runtime/logger.rs
+++ b/scrypto/src/runtime/logger.rs
@@ -6,7 +6,6 @@ use sbor::rust::string::String;
 #[derive(Debug)]
 pub struct Logger {}
 
-#[allow(unused_variables)]
 impl Logger {
     /// Emits a TRACE message.
     pub fn trace(message: String) {

--- a/scrypto/src/runtime/logger.rs
+++ b/scrypto/src/runtime/logger.rs
@@ -1,3 +1,5 @@
+use crate::engine::scrypto_env::ScryptoVmV1Api;
+use radix_engine_interface::types::Level;
 use sbor::rust::string::String;
 
 /// A utility for logging messages.
@@ -6,48 +8,28 @@ pub struct Logger {}
 
 #[allow(unused_variables)]
 impl Logger {
-    /// Emits a trace message.
+    /// Emits a TRACE message.
     pub fn trace(message: String) {
-        #[cfg(feature = "log-trace")]
-        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
-            radix_engine_interface::types::Level::Trace,
-            message,
-        );
+        ScryptoVmV1Api::sys_log(Level::Trace, message);
     }
 
-    /// Emits a debug message.
+    /// Emits a DEBUG message.
     pub fn debug(message: String) {
-        #[cfg(feature = "log-debug")]
-        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
-            radix_engine_interface::types::Level::Debug,
-            message,
-        );
+        ScryptoVmV1Api::sys_log(Level::Debug, message);
     }
 
-    /// Emits an info message.
+    /// Emits an INFO message.
     pub fn info(message: String) {
-        #[cfg(feature = "log-info")]
-        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
-            radix_engine_interface::types::Level::Info,
-            message,
-        );
+        ScryptoVmV1Api::sys_log(Level::Info, message);
     }
 
-    /// Emits a warn message.
+    /// Emits a WARN message.
     pub fn warn(message: String) {
-        #[cfg(feature = "log-warn")]
-        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
-            radix_engine_interface::types::Level::Warn,
-            message,
-        );
+        ScryptoVmV1Api::sys_log(Level::Warn, message);
     }
 
-    /// Emits an error message.
+    /// Emits an ERROR message.
     pub fn error(message: String) {
-        #[cfg(feature = "log-error")]
-        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
-            radix_engine_interface::types::Level::Error,
-            message,
-        );
+        ScryptoVmV1Api::sys_log(Level::Error, message);
     }
 }

--- a/scrypto/src/runtime/logger.rs
+++ b/scrypto/src/runtime/logger.rs
@@ -1,40 +1,53 @@
-use radix_engine_interface::types::Level;
 use sbor::rust::string::String;
-
-use crate::engine::scrypto_env::ScryptoVmV1Api;
 
 /// A utility for logging messages.
 #[derive(Debug)]
 pub struct Logger {}
 
+#[allow(unused_variables)]
 impl Logger {
-    /// Emits a log to console.
-    pub fn emit_log(level: Level, message: String) {
-        ScryptoVmV1Api::sys_log(level, message);
-    }
-
     /// Emits a trace message.
     pub fn trace(message: String) {
-        Self::emit_log(Level::Trace, message);
+        #[cfg(feature = "log-trace")]
+        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
+            radix_engine_interface::types::Level::Trace,
+            message,
+        );
     }
 
     /// Emits a debug message.
     pub fn debug(message: String) {
-        Self::emit_log(Level::Debug, message);
+        #[cfg(feature = "log-debug")]
+        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
+            radix_engine_interface::types::Level::Debug,
+            message,
+        );
     }
 
     /// Emits an info message.
     pub fn info(message: String) {
-        Self::emit_log(Level::Info, message);
+        #[cfg(feature = "log-info")]
+        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
+            radix_engine_interface::types::Level::Info,
+            message,
+        );
     }
 
     /// Emits a warn message.
     pub fn warn(message: String) {
-        Self::emit_log(Level::Warn, message);
+        #[cfg(feature = "log-warn")]
+        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
+            radix_engine_interface::types::Level::Warn,
+            message,
+        );
     }
 
     /// Emits an error message.
     pub fn error(message: String) {
-        Self::emit_log(Level::Error, message);
+        #[cfg(feature = "log-error")]
+        crate::engine::scrypto_env::ScryptoVmV1Api::sys_log(
+            radix_engine_interface::types::Level::Error,
+            message,
+        );
     }
 }

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -50,10 +50,10 @@ pub struct Publish {
     #[clap(long)]
     disable_wasm_opt: bool,
 
-    /// The min log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
+    /// The max log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
     /// The default is INFO.
     #[clap(long)]
-    min_log_level: Option<Level>,
+    log_level: Option<Level>,
 }
 
 impl Publish {
@@ -65,7 +65,7 @@ impl Publish {
                 false,
                 false,
                 self.disable_wasm_opt,
-                self.min_log_level.unwrap_or(Level::default()),
+                self.log_level.unwrap_or(Level::default()),
             )
             .map_err(Error::BuildError)?
         } else {

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -49,14 +49,24 @@ pub struct Publish {
     /// When passed, this argument disables wasm-opt from running on the built wasm.
     #[clap(long)]
     disable_wasm_opt: bool,
+
+    /// The min log level
+    #[clap(long)]
+    min_log_level: Option<Level>,
 }
 
 impl Publish {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         // Load wasm code
         let (code_path, definition_path) = if self.path.extension() != Some(OsStr::new("wasm")) {
-            build_package(&self.path, false, false, self.disable_wasm_opt)
-                .map_err(Error::BuildError)?
+            build_package(
+                &self.path,
+                false,
+                false,
+                self.disable_wasm_opt,
+                self.min_log_level.unwrap_or(Level::default()),
+            )
+            .map_err(Error::BuildError)?
         } else {
             let code_path = self.path.clone();
             let schema_path = code_path.with_extension("schema");

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -50,7 +50,8 @@ pub struct Publish {
     #[clap(long)]
     disable_wasm_opt: bool,
 
-    /// The min log level
+    /// The min log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
+    /// The default is INFO.
     #[clap(long)]
     min_log_level: Option<Level>,
 }

--- a/simulator/src/scrypto/cmd_build.rs
+++ b/simulator/src/scrypto/cmd_build.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
-use std::env::current_dir;
-use std::path::PathBuf;
-
 use crate::scrypto::*;
 use crate::utils::*;
+use clap::Parser;
+use radix_engine_interface::prelude::Level;
+use std::env::current_dir;
+use std::path::PathBuf;
 
 /// Build a Scrypto package
 #[derive(Parser, Debug)]
@@ -19,6 +19,10 @@ pub struct Build {
     /// When passed, this argument disables wasm-opt from running on the built wasm.
     #[clap(long)]
     disable_wasm_opt: bool,
+
+    /// The min log level
+    #[clap(long)]
+    min_log_level: Option<Level>,
 }
 
 impl Build {
@@ -28,6 +32,7 @@ impl Build {
             self.trace,
             false,
             self.disable_wasm_opt,
+            self.min_log_level.unwrap_or(Level::default()),
         )
         .map(|_| ())
         .map_err(Error::BuildError)

--- a/simulator/src/scrypto/cmd_build.rs
+++ b/simulator/src/scrypto/cmd_build.rs
@@ -20,7 +20,8 @@ pub struct Build {
     #[clap(long)]
     disable_wasm_opt: bool,
 
-    /// The min log level
+    /// The min log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
+    /// The default is INFO.
     #[clap(long)]
     min_log_level: Option<Level>,
 }

--- a/simulator/src/scrypto/cmd_build.rs
+++ b/simulator/src/scrypto/cmd_build.rs
@@ -20,10 +20,10 @@ pub struct Build {
     #[clap(long)]
     disable_wasm_opt: bool,
 
-    /// The min log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
+    /// The max log level, such as ERROR, WARN, INFO, DEBUG and TRACE.
     /// The default is INFO.
     #[clap(long)]
-    min_log_level: Option<Level>,
+    log_level: Option<Level>,
 }
 
 impl Build {
@@ -33,7 +33,7 @@ impl Build {
             self.trace,
             false,
             self.disable_wasm_opt,
-            self.min_log_level.unwrap_or(Level::default()),
+            self.log_level.unwrap_or(Level::default()),
         )
         .map(|_| ())
         .map_err(Error::BuildError)

--- a/simulator/src/utils/cargo.rs
+++ b/simulator/src/utils/cargo.rs
@@ -59,7 +59,7 @@ fn run_cargo_build(
     target_path: impl AsRef<OsStr>,
     trace: bool,
     no_schema: bool,
-    min_log_level: Level,
+    log_level: Level,
 ) -> Result<(), BuildError> {
     let mut features = String::new();
     if trace {
@@ -68,19 +68,19 @@ fn run_cargo_build(
     if no_schema {
         features.push_str(",scrypto/no-schema");
     }
-    if Level::Error <= min_log_level {
+    if Level::Error <= log_level {
         features.push_str(",scrypto/log-error");
     }
-    if Level::Warn <= min_log_level {
+    if Level::Warn <= log_level {
         features.push_str(",scrypto/log-warn");
     }
-    if Level::Info <= min_log_level {
+    if Level::Info <= log_level {
         features.push_str(",scrypto/log-info");
     }
-    if Level::Debug <= min_log_level {
+    if Level::Debug <= log_level {
         features.push_str(",scrypto/log-debug");
     }
-    if Level::Trace <= min_log_level {
+    if Level::Trace <= log_level {
         features.push_str(",scrypto/log-trace");
     }
 
@@ -141,7 +141,7 @@ pub fn build_package<P: AsRef<Path>>(
     trace: bool,
     force_local_target: bool,
     disable_wasm_opt: bool,
-    min_log_level: Level,
+    log_level: Level,
 ) -> Result<(PathBuf, PathBuf), BuildError> {
     let base_path = base_path.as_ref().to_owned();
 
@@ -168,7 +168,7 @@ pub fn build_package<P: AsRef<Path>>(
     out_path.push("release");
 
     // Build with SCHEMA
-    run_cargo_build(&manifest_path, &target_path, trace, false, min_log_level)?;
+    run_cargo_build(&manifest_path, &target_path, trace, false, log_level)?;
 
     // Find the binary paths
     let manifest = Manifest::from_path(&manifest_path)
@@ -199,7 +199,7 @@ pub fn build_package<P: AsRef<Path>>(
     .map_err(|err| BuildError::IOErrorAtPath(err, definition_path.clone()))?;
 
     // Build without SCHEMA
-    run_cargo_build(&manifest_path, &target_path, trace, true, min_log_level)?;
+    run_cargo_build(&manifest_path, &target_path, trace, true, log_level)?;
 
     // Optimizes the built wasm using Binaryen's wasm-opt tool. The code that follows is equivalent
     // to running the following commands in the CLI:

--- a/simulator/src/utils/cargo.rs
+++ b/simulator/src/utils/cargo.rs
@@ -61,31 +61,27 @@ fn run_cargo_build(
     no_schema: bool,
     min_log_level: Level,
 ) -> Result<(), BuildError> {
-    let mut features = Vec::<String>::new();
+    let mut features = String::new();
     if trace {
-        features.push("scrypto/trace".to_owned());
+        features.push_str(",scrypto/trace");
     }
     if no_schema {
-        features.push("scrypto/no-schema".to_owned());
+        features.push_str(",scrypto/no-schema");
     }
     if Level::Error <= min_log_level {
-        features.push("scrypto/log-error".to_owned());
+        features.push_str(",scrypto/log-error");
     }
     if Level::Warn <= min_log_level {
-        features.push("scrypto/log-warn".to_owned());
+        features.push_str(",scrypto/log-warn");
     }
     if Level::Info <= min_log_level {
-        features.push("scrypto/log-info".to_owned());
+        features.push_str(",scrypto/log-info");
     }
     if Level::Debug <= min_log_level {
-        features.push("scrypto/log-debug".to_owned());
+        features.push_str(",scrypto/log-debug");
     }
     if Level::Trace <= min_log_level {
-        features.push("scrypto/log-trace".to_owned());
-    }
-
-    if !features.is_empty() {
-        features.insert(0, "--features".to_owned());
+        features.push_str(",scrypto/log-trace");
     }
 
     let status = Command::new("cargo")
@@ -97,7 +93,11 @@ fn run_cargo_build(
         .arg(target_path.as_ref())
         .arg("--manifest-path")
         .arg(manifest_path.as_ref())
-        .args(features)
+        .args(if features.is_empty() {
+            vec![]
+        } else {
+            vec!["--features", &features[1..]]
+        })
         .status()
         .map_err(BuildError::IOError)?;
     if status.success() {

--- a/simulator/tests/scrypto.sh
+++ b/simulator/tests/scrypto.sh
@@ -21,15 +21,15 @@ $scrypto test --path $test_pkg -- test_hello --nocapture
 $scrypto test --path $test_pkg -- --nocapture
 
 # Logging
-$scrypto build --path ../examples/everything --min-log-level ERROR
+$scrypto build --path ../examples/everything --log-level ERROR
 size1=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
-$scrypto build --path ../examples/everything --min-log-level WARN
+$scrypto build --path ../examples/everything --log-level WARN
 size2=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
-$scrypto build --path ../examples/everything --min-log-level INFO
+$scrypto build --path ../examples/everything --log-level INFO
 size3=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
-$scrypto build --path ../examples/everything --min-log-level DEBUG
+$scrypto build --path ../examples/everything --log-level DEBUG
 size4=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
-$scrypto build --path ../examples/everything --min-log-level TRACE
+$scrypto build --path ../examples/everything --log-level TRACE
 size5=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
 
 if [ $size1 -lt $size2 ] && [ $size2 -lt $size3 ] && [ $size3 -lt $size4 ] && [ $size4 -lt $size5 ] ; then

--- a/simulator/tests/scrypto.sh
+++ b/simulator/tests/scrypto.sh
@@ -20,5 +20,25 @@ $scrypto test --path $test_pkg
 $scrypto test --path $test_pkg -- test_hello --nocapture
 $scrypto test --path $test_pkg -- --nocapture
 
+# Logging
+$scrypto build --path ../examples/everything --min-log-level ERROR
+size1=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
+$scrypto build --path ../examples/everything --min-log-level WARN
+size2=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
+$scrypto build --path ../examples/everything --min-log-level INFO
+size3=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
+$scrypto build --path ../examples/everything --min-log-level DEBUG
+size4=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
+$scrypto build --path ../examples/everything --min-log-level TRACE
+size5=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
+
+if (( $size1 -lt $size2 && $size2 -lt $size3 && $size3 -lt $size4 && $size4 -lt $size5 )) ; then
+  echo "Size check is okay"
+  exit 0
+else
+  echo "Invalid sizes: $size1, $size2, $size3, $size4, $size5"
+  exit 1
+fi
+
 # Clean up
 rm -fr $test_pkg

--- a/simulator/tests/scrypto.sh
+++ b/simulator/tests/scrypto.sh
@@ -32,7 +32,7 @@ size4=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/ever
 $scrypto build --path ../examples/everything --min-log-level TRACE
 size5=$(ls -la ../examples/everything/target/wasm32-unknown-unknown/release/everything.wasm | cut -d ' ' -f 5)
 
-if (( $size1 -lt $size2 && $size2 -lt $size3 && $size3 -lt $size4 && $size4 -lt $size5 )) ; then
+if [ $size1 -lt $size2 ] && [ $size2 -lt $size3 ] && [ $size3 -lt $size4 ] && [ $size4 -lt $size5 ] ; then
   echo "Size check is okay"
   exit 0
 else


### PR DESCRIPTION
## Summary

Add `--log-level` to `scrypto build`

Usage:
```
scrypto-build 
Build a Scrypto package

USAGE:
    scrypto build [OPTIONS]

OPTIONS:
        --disable-wasm-opt
            When passed, this argument disables wasm-opt from running on the built wasm

    -h, --help
            Print help information

        --log-level <MIN_LOG_LEVEL>
            The max log level, such as ERROR, WARN, INFO, DEBUG and TRACE. The default is INFO

        --path <PATH>
            The package directory

    -t, --trace
            Turn on tracing
```
