### PR TITLE
Clean up validator rewards distribution

### DIFF
--- a/radix-engine-tests/tests/consensus_manager.rs
+++ b/radix-engine-tests/tests/consensus_manager.rs
@@ -3249,3 +3249,64 @@ fn significant_protocol_updates_are_emitted_in_epoch_change_event() {
         Decimal::from(10)
     );
 }
+
+#[test]
+fn test_tips_and_fee_distribution_when_one_validator_has_zero_stake() {
+    let genesis_epoch = Epoch::of(5);
+    let initial_epoch = genesis_epoch.next().unwrap();
+    let initial_stake_amount1 = dec!("30000");
+    let initial_stake_amount2 = dec!("0");
+    let emission_xrd_per_epoch = dec!("0");
+    let validator1_key = Secp256k1PrivateKey::from_u64(5u64).unwrap().public_key();
+    let validator2_key = Secp256k1PrivateKey::from_u64(6u64).unwrap().public_key();
+    let staker_key = Secp256k1PrivateKey::from_u64(7u64).unwrap().public_key();
+    let staker_account = ComponentAddress::virtual_account_from_public_key(&staker_key);
+    let genesis = CustomGenesis::validators_and_single_staker(
+        vec![
+            (validator1_key, initial_stake_amount1),
+            (validator2_key, initial_stake_amount2),
+        ],
+        staker_account,
+        Decimal::ZERO,
+        genesis_epoch,
+        CustomGenesis::default_consensus_manager_config()
+            .with_total_emission_xrd_per_epoch(emission_xrd_per_epoch)
+            .with_epoch_change_condition(EpochChangeCondition {
+                min_round_count: 1,
+                max_round_count: 1, // deliberate, to go through rounds/epoch without gaps
+                target_duration_millis: 0,
+            }),
+    );
+    let mut test_runner = TestRunnerBuilder::new()
+        .with_custom_genesis(genesis)
+        .build();
+
+    // Do some transaction
+    let receipt1 = test_runner.execute_manifest_ignoring_fee(
+        ManifestBuilder::new().drop_auth_zone_proofs().build(),
+        vec![],
+    );
+    let result1 = receipt1.expect_commit_success();
+
+    // Advance epoch
+    let receipt2 = test_runner.advance_to_round(Round::of(1));
+    let result2 = receipt2.expect_commit_success();
+
+    // Assert
+    let events = test_runner.extract_events_of_type::<ValidatorRewardAppliedEvent>(result2);
+    assert_eq!(events.len(), 1); // only validator 1 receives rewards
+    assert_eq!(events[0].epoch, initial_epoch);
+    assert_close_to!(
+        events[0].amount,
+        result1
+            .fee_destination
+            .to_proposer
+            .checked_add(result1.fee_destination.to_validator_set)
+            .unwrap()
+    );
+    let vault_id = test_runner.get_component_vaults(CONSENSUS_MANAGER, XRD)[0];
+    assert_close_to!(
+        test_runner.inspect_vault_balance(vault_id).unwrap(),
+        dec!(0)
+    );
+}

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -1362,50 +1362,76 @@ impl ConsensusManagerBlueprint {
         //===========================
         // Distribute rewards (fees)
         //===========================
-        let total_individual_amount: Decimal = {
-            let mut sum = Decimal::ZERO;
+        let mut total_effective_stake = Decimal::ZERO;
+        let mut total_claimable_proposer_rewards = Decimal::ZERO;
 
-            for v in validator_rewards.proposer_rewards.values() {
-                sum = sum.checked_add(*v).ok_or(RuntimeError::ApplicationError(
-                    ApplicationError::ConsensusManagerError(
-                        ConsensusManagerError::UnexpectedDecimalComputationError,
-                    ),
-                ))?;
-            }
-            sum
-        };
-
-        let reward_per_staked_xrd = validator_rewards
-            .rewards_vault
-            .amount(api)?
-            .checked_sub(total_individual_amount)
-            .and_then(|amount| amount.checked_div(stake_sum_xrd))
-            .ok_or(RuntimeError::ApplicationError(
-                ApplicationError::ConsensusManagerError(
-                    ConsensusManagerError::UnexpectedDecimalComputationError,
-                ),
-            ))?;
-        for (index, validator_info) in validator_infos {
-            let from_self = validator_rewards
-                .proposer_rewards
-                .remove(&index)
-                .unwrap_or_default();
-            let reward_amount = validator_info
-                .effective_stake_xrd
-                .checked_mul(reward_per_staked_xrd)
-                .and_then(|from_pool| from_self.checked_add(from_pool))
+        // Note that `validator_infos` are for applicable validators (i.e. stake > 0) only
+        // Being an applicable validator doesn't necessarily mean the effective stake is positive, due to reliability rescaling.
+        for (index, validator_info) in &validator_infos {
+            total_effective_stake = total_effective_stake
+                .checked_add(validator_info.effective_stake_xrd)
                 .ok_or(RuntimeError::ApplicationError(
                     ApplicationError::ConsensusManagerError(
                         ConsensusManagerError::UnexpectedDecimalComputationError,
                     ),
                 ))?;
-            if reward_amount.is_zero() {
+            total_claimable_proposer_rewards = total_claimable_proposer_rewards
+                .checked_add(
+                    validator_rewards
+                        .proposer_rewards
+                        .get(&index)
+                        .cloned()
+                        .unwrap_or_default(),
+                )
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
+        }
+
+        let total_claimable_validator_set_rewards = validator_rewards
+            .rewards_vault
+            .amount(api)?
+            .checked_sub(total_claimable_proposer_rewards)
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?;
+        let reward_per_effective_stake = total_claimable_validator_set_rewards
+            .checked_div(total_effective_stake) // In theory, the effective stake can be zero
+            .ok_or(RuntimeError::ApplicationError(
+                ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                ),
+            ))?;
+
+        for (index, validator_info) in validator_infos {
+            let as_proposer = validator_rewards
+                .proposer_rewards
+                .remove(&index)
+                .unwrap_or_default();
+            let as_member_of_validator_set = validator_info
+                .effective_stake_xrd
+                .checked_mul(reward_per_effective_stake)
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?;
+            let total_rewards = as_proposer.checked_add(as_member_of_validator_set).ok_or(
+                RuntimeError::ApplicationError(ApplicationError::ConsensusManagerError(
+                    ConsensusManagerError::UnexpectedDecimalComputationError,
+                )),
+            )?;
+            if total_rewards.is_zero() {
                 continue;
             }
 
             // Note that dusted xrd (due to rounding) are kept in the vault and will
             // become retrievable next time.
-            let xrd_bucket = validator_rewards.rewards_vault.take(reward_amount, api)?;
+            let xrd_bucket = validator_rewards.rewards_vault.take(total_rewards, api)?;
 
             api.call_method(
                 validator_info.address.as_node_id(),
@@ -1413,6 +1439,10 @@ impl ConsensusManagerBlueprint {
                 scrypto_encode(&ValidatorApplyRewardInput { xrd_bucket, epoch }).unwrap(),
             )?;
         }
+
+        // For any reason, if a validator isn't included in the `validator_infos` but has accumulated
+        // proposer rewards, we reset the counter as the rewards has been distributed to other validators.
+        validator_rewards.proposer_rewards.clear();
 
         Ok(())
     }

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -1399,13 +1399,19 @@ impl ConsensusManagerBlueprint {
                     ConsensusManagerError::UnexpectedDecimalComputationError,
                 ),
             ))?;
-        let reward_per_effective_stake = total_claimable_validator_set_rewards
-            .checked_div(total_effective_stake) // In theory, the effective stake can be zero
-            .ok_or(RuntimeError::ApplicationError(
-                ApplicationError::ConsensusManagerError(
-                    ConsensusManagerError::UnexpectedDecimalComputationError,
-                ),
-            ))?;
+        let reward_per_effective_stake = if total_effective_stake.is_zero() {
+            // This is another extreme use case.
+            // Can the network even progress if total effective stake is zero?
+            Decimal::ZERO
+        } else {
+            total_claimable_validator_set_rewards
+                .checked_div(total_effective_stake)
+                .ok_or(RuntimeError::ApplicationError(
+                    ApplicationError::ConsensusManagerError(
+                        ConsensusManagerError::UnexpectedDecimalComputationError,
+                    ),
+                ))?
+        };
 
         for (index, validator_info) in validator_infos {
             let as_proposer = validator_rewards

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -1379,7 +1379,7 @@ impl ConsensusManagerBlueprint {
                 .checked_add(
                     validator_rewards
                         .proposer_rewards
-                        .get(&index)
+                        .get(index)
                         .cloned()
                         .unwrap_or_default(),
                 )


### PR DESCRIPTION
## Summary

- Use total effective stake, instead of total stake, when distributing "validator set rewards", so to hand them out ASAP.
- Reset the `proposer_rewards` at epoch end, for the extreme case where `zero` stake validator is in the validator set

