### PR TITLE
Resource tracker related update

### DIFF
--- a/radix-engine-profiling/resources-tracker-macro/src/lib.rs
+++ b/radix-engine-profiling/resources-tracker-macro/src/lib.rs
@@ -186,11 +186,11 @@ pub fn trace_resources(attr: TokenStream, input: TokenStream) -> TokenStream {
                         v.borrow_mut().start_counting(#fn_signature, qemu_call_args.as_slice());
                     });
                     let ret = #original_block;
-                    #arg_evaluate_after;
-                    #args_after_quote_array;
                     QEMU_PLUGIN.with(|v| {
                         v.borrow_mut().stop_counting(#fn_signature, qemu_call_args.as_slice());
                     });
+                    #arg_evaluate_after;
+                    #args_after_quote_array;
                     ret
                 }});
                 item.into_token_stream()

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -273,14 +273,14 @@ where
             })
     }
 
-    #[trace_resources(log=entity_type)]
+    #[trace_resources]
     fn kernel_allocate_node_id(&mut self, entity_type: EntityType) -> Result<NodeId, RuntimeError> {
         M::on_allocate_node_id(entity_type, self)?;
 
         self.id_allocator.allocate_node_id(entity_type)
     }
 
-    #[trace_resources(log=node_id.entity_type())]
+    #[trace_resources]
     fn kernel_create_node(
         &mut self,
         node_id: NodeId,
@@ -315,6 +315,7 @@ where
         Ok(())
     }
 
+    #[trace_resources]
     fn kernel_create_node_from(
         &mut self,
         node_id: NodeId,
@@ -385,7 +386,7 @@ where
         Ok(())
     }
 
-    #[trace_resources(log=node_id.entity_type())]
+    #[trace_resources]
     fn kernel_drop_node(&mut self, node_id: &NodeId) -> Result<DroppedNode, RuntimeError> {
         let mut read_only = as_read_only!(self);
         M::on_drop_node(&mut read_only, DropNodeEvent::Start(node_id))?;
@@ -669,7 +670,7 @@ where
             })
     }
 
-    #[trace_resources(log=node_id.entity_type())]
+    #[trace_resources]
     fn kernel_open_substate_with_default<F: FnOnce() -> IndexedScryptoValue>(
         &mut self,
         node_id: &NodeId,
@@ -815,7 +816,7 @@ where
         Ok(value)
     }
 
-    #[trace_resources(log=value.len())]
+    #[trace_resources]
     fn kernel_write_substate(
         &mut self,
         lock_handle: SubstateHandle,


### PR DESCRIPTION
## Summary
Added missing `trace_resources` to `kernel_create_node_from` function, cleaned up other `trace_resources` macro calls.
Updated Python conversion script (cleanup + handling of possible overflowed CPU instructions values due to calibration inaccuracy).
Optimised resource tracker CPU instructions reading place.