### PR TITLE
Implement compile-time `dec!` and `pdec!` macros

### DIFF
--- a/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
+++ b/radix-engine-common/src/data/scrypto/custom_well_known_types.rs
@@ -582,6 +582,7 @@ pub fn resolve_scrypto_well_known_type(
 mod tests {
     use super::well_known_scrypto_custom_types::*;
     use super::*;
+    use crate::math::{Decimal, PreciseDecimal};
 
     #[test]
     fn test_custom_type_values_are_valid() {
@@ -590,8 +591,8 @@ mod tests {
         // But I've kept them in the list below for completeness, in order with the types above - as a comment.
 
         // MISC TYPES
-        test_equivalence(DECIMAL_TYPE, dec!(1));
-        test_equivalence(PRECISE_DECIMAL_TYPE, pdec!(1));
+        test_equivalence(DECIMAL_TYPE, Decimal::from(1));
+        test_equivalence(PRECISE_DECIMAL_TYPE, PreciseDecimal::from(1));
         test_equivalence(NON_FUNGIBLE_LOCAL_ID_TYPE, NonFungibleLocalId::integer(2));
         // NonFungibleGlobalId - tested in interface crate
         test_equivalence(INSTANT_TYPE, Instant::new(0));

--- a/radix-engine-common/src/lib.rs
+++ b/radix-engine-common/src/lib.rs
@@ -68,8 +68,7 @@ pub mod prelude {
     pub use super::time::*;
     pub use super::types::*;
     pub use crate::{
-        dec, define_wrapped_hash, i, manifest_args, pdec, scrypto_args,
-        to_manifest_value_and_unwrap,
+        define_wrapped_hash, i, manifest_args, scrypto_args, to_manifest_value_and_unwrap,
     };
 }
 

--- a/radix-engine-common/src/macros.rs
+++ b/radix-engine-common/src/macros.rs
@@ -32,32 +32,6 @@ macro_rules! dec {
     ($x:literal) => {
         $crate::math::Decimal::try_from($x).unwrap()
     };
-    ($base:literal, $shift:literal) => {
-        // Base can be any type that converts into a Decimal, and shift must support
-        // comparison and `-` unary operation, enforced by rustc.
-        {
-            let base = $crate::math::Decimal::try_from($base).unwrap();
-            if $shift >= 0 {
-                base.checked_mul(
-                    $crate::math::Decimal::try_from(
-                        $crate::math::I192::from(10u8)
-                            .pow(u32::try_from($shift).expect("Shift overflow")),
-                    )
-                    .expect("Shift overflow"),
-                )
-                .expect("Overflow")
-            } else {
-                base.checked_div(
-                    $crate::math::Decimal::try_from(
-                        $crate::math::I192::from(10u8)
-                            .pow(u32::try_from(-$shift).expect("Shift overflow")),
-                    )
-                    .expect("Shift overflow"),
-                )
-                .expect("Overflow")
-            }
-        }
-    };
 }
 
 /// Creates a safe integer from literals.
@@ -107,33 +81,6 @@ macro_rules! pdec {
     // If not then something is definitely wrong and panic is fine.
     ($x:literal) => {
         $crate::math::PreciseDecimal::try_from($x).unwrap()
-    };
-
-    ($base:literal, $shift:literal) => {
-        // Base can be any type that converts into a PreciseDecimal, and shift must support
-        // comparison and `-` unary operation, enforced by rustc.
-        {
-            let base = $crate::math::PreciseDecimal::try_from($base).unwrap();
-            if $shift >= 0 {
-                base.checked_mul(
-                    $crate::math::PreciseDecimal::try_from(
-                        $crate::math::I256::from(10u8)
-                            .pow(u32::try_from($shift).expect("Shift overflow")),
-                    )
-                    .expect("Shift overflow"),
-                )
-                .expect("Overflow")
-            } else {
-                base.checked_div(
-                    $crate::math::PreciseDecimal::try_from(
-                        $crate::math::I256::from(10u8)
-                            .pow(u32::try_from(-$shift).expect("Shift overflow")),
-                    )
-                    .expect("Shift overflow"),
-                )
-                .expect("Overflow")
-            }
-        }
     };
 }
 

--- a/radix-engine-common/src/macros.rs
+++ b/radix-engine-common/src/macros.rs
@@ -1,39 +1,3 @@
-/// Creates a `Decimal` from literals.
-///
-#[macro_export]
-macro_rules! dec {
-    (0) => {
-        $crate::math::Decimal::ZERO
-    };
-    ("0") => {
-        $crate::math::Decimal::ZERO
-    };
-    ("0.1") => {
-        $crate::math::Decimal::ONE_TENTH
-    };
-    ("1" | 1) => {
-        $crate::math::Decimal::ONE
-    };
-    (10) => {
-        $crate::math::Decimal::TEN
-    };
-    ("10") => {
-        $crate::math::Decimal::TEN
-    };
-    (100) => {
-        $crate::math::Decimal::ONE_HUNDRED
-    };
-    ("100") => {
-        $crate::math::Decimal::ONE_HUNDRED
-    };
-    // NOTE: Decimal arithmetic operation safe unwrap.
-    // In general, it is assumed that reasonable literals are provided.
-    // If not then something is definitely wrong and panic is fine.
-    ($x:literal) => {
-        $crate::math::Decimal::try_from($x).unwrap()
-    };
-}
-
 /// Creates a safe integer from literals.
 /// You must specify the type of the
 /// integer you want to create.
@@ -42,45 +6,6 @@ macro_rules! dec {
 macro_rules! i {
     ($x:expr) => {
         $x.try_into().expect("Parse Error")
-    };
-}
-
-/// Creates a `PreciseDecimal` from literals.
-///
-#[macro_export]
-macro_rules! pdec {
-    (0) => {
-        $crate::math::PreciseDecimal::ZERO
-    };
-    ("0") => {
-        $crate::math::PreciseDecimal::ZERO
-    };
-    ("0.1") => {
-        $crate::math::PreciseDecimal::ONE_TENTH
-    };
-    (1) => {
-        $crate::math::PreciseDecimal::ONE
-    };
-    ("1") => {
-        $crate::math::PreciseDecimal::ONE
-    };
-    (10) => {
-        $crate::math::PreciseDecimal::TEN
-    };
-    ("10") => {
-        $crate::math::PreciseDecimal::TEN
-    };
-    (100) => {
-        $crate::math::PreciseDecimal::ONE_HUNDRED
-    };
-    ("100") => {
-        $crate::math::PreciseDecimal::ONE_HUNDRED
-    };
-    // NOTE: PreciseDecimal arithmetic operation safe unwrap.
-    // In general, it is assumed that reasonable literals are provided.
-    // If not then something is definitely wrong and panic is fine.
-    ($x:literal) => {
-        $crate::math::PreciseDecimal::try_from($x).unwrap()
     };
 }
 

--- a/radix-engine-common/src/math/bnum_integer/convert.rs
+++ b/radix-engine-common/src/math/bnum_integer/convert.rs
@@ -705,7 +705,7 @@ impl_to_bytes! { U448, BUint::<7> }
 impl_to_bytes! { U512, BUint::<8> }
 impl_to_bytes! { U768, BUint::<12> }
 
-macro_rules! impl_from_u64_arr_signed {
+macro_rules! from_and_to_u64_arr_signed {
     ($($t:ident, $wrapped:ty),*) => {
         $(
             paste! {
@@ -715,13 +715,18 @@ macro_rules! impl_from_u64_arr_signed {
                         let u = BUint::<{$t::N}>::from_digits(digits);
                         Self(<$wrapped>::from_bits(u))
                     }
+
+                    pub const fn to_digits(&self) -> [u64; <$t>::N] {
+                        let u: BUint::<{$t::N}> = self.0.to_bits();
+                        *u.digits()
+                    }
                 }
             }
         )*
     };
 }
 
-macro_rules! from_u64_arr_unsigned {
+macro_rules! from_and_to_u64_arr_unsigned {
     ($($t:ident, $wrapped:ty),*) => {
         $(
             paste! {
@@ -730,24 +735,28 @@ macro_rules! from_u64_arr_unsigned {
                     pub const fn from_digits(digits: [u64; <$t>::N]) -> Self {
                         Self(<$wrapped>::from_digits(digits))
                     }
+
+                    pub const fn to_digits(&self) -> [u64; <$t>::N] {
+                        *self.0.digits()
+                    }
                 }
             }
         )*
     };
 }
 
-impl_from_u64_arr_signed! { I192, BInt::<3> }
-impl_from_u64_arr_signed! { I256, BInt::<4> }
-impl_from_u64_arr_signed! { I320, BInt::<5> }
-impl_from_u64_arr_signed! { I384, BInt::<6> }
-impl_from_u64_arr_signed! { I448, BInt::<7> }
-impl_from_u64_arr_signed! { I512, BInt::<8> }
-impl_from_u64_arr_signed! { I768, BInt::<12> }
+from_and_to_u64_arr_signed! { I192, BInt::<3> }
+from_and_to_u64_arr_signed! { I256, BInt::<4> }
+from_and_to_u64_arr_signed! { I320, BInt::<5> }
+from_and_to_u64_arr_signed! { I384, BInt::<6> }
+from_and_to_u64_arr_signed! { I448, BInt::<7> }
+from_and_to_u64_arr_signed! { I512, BInt::<8> }
+from_and_to_u64_arr_signed! { I768, BInt::<12> }
 
-from_u64_arr_unsigned! { U192, BUint::<3> }
-from_u64_arr_unsigned! { U256, BUint::<4> }
-from_u64_arr_unsigned! { U320, BUint::<5> }
-from_u64_arr_unsigned! { U384, BUint::<6> }
-from_u64_arr_unsigned! { U448, BUint::<7> }
-from_u64_arr_unsigned! { U512, BUint::<8> }
-from_u64_arr_unsigned! { U768, BUint::<12> }
+from_and_to_u64_arr_unsigned! { U192, BUint::<3> }
+from_and_to_u64_arr_unsigned! { U256, BUint::<4> }
+from_and_to_u64_arr_unsigned! { U320, BUint::<5> }
+from_and_to_u64_arr_unsigned! { U384, BUint::<6> }
+from_and_to_u64_arr_unsigned! { U448, BUint::<7> }
+from_and_to_u64_arr_unsigned! { U512, BUint::<8> }
+from_and_to_u64_arr_unsigned! { U768, BUint::<12> }

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -1206,30 +1206,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dec_rational_decimal() {
-        assert_eq!((dec!(11235, 0)).to_string(), "11235");
-        assert_eq!((dec!(11235, -2)).to_string(), "112.35");
-        assert_eq!((dec!(11235, 2)).to_string(), "1123500");
-
-        assert_eq!(
-            (dec!(112000000000000000001i128, -18)).to_string(),
-            "112.000000000000000001"
-        );
-
-        assert_eq!(
-            (dec!(112000000000000000001i128, -18)).to_string(),
-            "112.000000000000000001"
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "Shift overflow")]
-    fn test_shift_overflow_decimal() {
-        // u32::MAX + 1
-        dec!(1, 4_294_967_296i128); // use explicit type to defer error to runtime
-    }
-
-    #[test]
     fn test_floor_decimal() {
         assert_eq!(
             Decimal::MAX.checked_floor().unwrap(),

--- a/radix-engine-common/src/math/decimal.rs
+++ b/radix-engine-common/src/math/decimal.rs
@@ -865,8 +865,16 @@ try_from_integer!(I192, I256, I320, I448, I512, U192, U256, U320, U448, U512);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dec;
     use paste::paste;
+
+    macro_rules! test_dec {
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        // In general, it is assumed that reasonable literals are provided.
+        // If not then something is definitely wrong and panic is fine.
+        ($x:literal) => {
+            $crate::math::Decimal::try_from($x).unwrap()
+        };
+    }
 
     #[test]
     fn test_format_decimal() {
@@ -921,12 +929,12 @@ mod tests {
             Decimal::MIN,
         );
 
-        assert_eq!(dec!("0"), Decimal::ZERO);
-        assert_eq!(dec!("1"), Decimal::ONE);
-        assert_eq!(dec!("0.1"), Decimal::ONE_TENTH);
-        assert_eq!(dec!("10"), Decimal::TEN);
-        assert_eq!(dec!("100"), Decimal::ONE_HUNDRED);
-        assert_eq!(dec!("0.01"), Decimal::ONE_HUNDREDTH);
+        assert_eq!(test_dec!("0"), Decimal::ZERO);
+        assert_eq!(test_dec!("1"), Decimal::ONE);
+        assert_eq!(test_dec!("0.1"), Decimal::ONE_TENTH);
+        assert_eq!(test_dec!("10"), Decimal::TEN);
+        assert_eq!(test_dec!("100"), Decimal::ONE_HUNDRED);
+        assert_eq!(test_dec!("0.01"), Decimal::ONE_HUNDREDTH);
 
         assert_eq!("0", Decimal::ZERO.to_string());
         assert_eq!("1", Decimal::ONE.to_string());
@@ -970,20 +978,20 @@ mod tests {
         let b = Decimal::from_str("1000000000").unwrap();
         assert_eq!(a.checked_mul(b).unwrap().to_string(), "1000000000000000000");
         let a = Decimal::MAX;
-        let b = dec!(1);
+        let b = test_dec!(1);
         assert_eq!(a.checked_mul(b).unwrap(), Decimal::MAX);
     }
 
     #[test]
     fn test_mul_overflow_by_small_decimal() {
         assert!(Decimal::MAX
-            .checked_mul(dec!("1.000000000000000001"))
+            .checked_mul(test_dec!("1.000000000000000001"))
             .is_none());
     }
 
     #[test]
     fn test_mul_overflow_by_a_lot_decimal() {
-        assert!(Decimal::MAX.checked_mul(dec!("1.1")).is_none());
+        assert!(Decimal::MAX.checked_mul(test_dec!("1.1")).is_none());
     }
 
     #[test]
@@ -991,7 +999,7 @@ mod tests {
         assert!(Decimal::MAX
             .checked_neg()
             .unwrap()
-            .checked_mul(dec!("-1.000000000000000001"))
+            .checked_mul(test_dec!("-1.000000000000000001"))
             .is_none());
     }
 
@@ -1041,7 +1049,10 @@ mod tests {
             "0.714285714285714285"
         );
         assert_eq!(b.checked_div(a).unwrap().to_string(), "1.4");
-        assert_eq!(Decimal::MAX.checked_div(dec!(1)).unwrap(), Decimal::MAX);
+        assert_eq!(
+            Decimal::MAX.checked_div(test_dec!(1)).unwrap(),
+            Decimal::MAX
+        );
     }
 
     #[test]
@@ -1053,49 +1064,49 @@ mod tests {
 
     #[test]
     fn test_0_pow_0_decimal() {
-        let a = dec!("0");
+        let a = test_dec!("0");
         assert_eq!((a.checked_powi(0).unwrap()).to_string(), "1");
     }
 
     #[test]
     fn test_0_powi_1_decimal() {
-        let a = dec!("0");
+        let a = test_dec!("0");
         assert_eq!((a.checked_powi(1).unwrap()).to_string(), "0");
     }
 
     #[test]
     fn test_0_powi_10_decimal() {
-        let a = dec!("0");
+        let a = test_dec!("0");
         assert_eq!((a.checked_powi(10).unwrap()).to_string(), "0");
     }
 
     #[test]
     fn test_1_powi_0_decimal() {
-        let a = dec!(1);
+        let a = test_dec!(1);
         assert_eq!((a.checked_powi(0).unwrap()).to_string(), "1");
     }
 
     #[test]
     fn test_1_powi_1_decimal() {
-        let a = dec!(1);
+        let a = test_dec!(1);
         assert_eq!((a.checked_powi(1).unwrap()).to_string(), "1");
     }
 
     #[test]
     fn test_1_powi_10_decimal() {
-        let a = dec!(1);
+        let a = test_dec!(1);
         assert_eq!((a.checked_powi(10).unwrap()).to_string(), "1");
     }
 
     #[test]
     fn test_2_powi_0_decimal() {
-        let a = dec!("2");
+        let a = test_dec!("2");
         assert_eq!(a.checked_powi(0).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_2_powi_3724_decimal() {
-        let a = dec!("1.000234891009084238");
+        let a = test_dec!("1.000234891009084238");
         assert_eq!(
             a.checked_powi(3724).unwrap().to_string(),
             "2.397991232254669619"
@@ -1104,66 +1115,66 @@ mod tests {
 
     #[test]
     fn test_2_powi_2_decimal() {
-        let a = dec!("2");
+        let a = test_dec!("2");
         assert_eq!(a.checked_powi(2).unwrap().to_string(), "4");
     }
 
     #[test]
     fn test_2_powi_3_decimal() {
-        let a = dec!("2");
+        let a = test_dec!("2");
         assert_eq!(a.checked_powi(3).unwrap().to_string(), "8");
     }
 
     #[test]
     fn test_10_powi_3_decimal() {
-        let a = dec!("10");
+        let a = test_dec!("10");
         assert_eq!(a.checked_powi(3).unwrap().to_string(), "1000");
     }
 
     #[test]
     fn test_5_powi_2_decimal() {
-        let a = dec!("5");
+        let a = test_dec!("5");
         assert_eq!(a.checked_powi(2).unwrap().to_string(), "25");
     }
 
     #[test]
     fn test_5_powi_minus2_decimal() {
-        let a = dec!("5");
+        let a = test_dec!("5");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "0.04");
     }
 
     #[test]
     fn test_10_powi_minus3_decimal() {
-        let a = dec!("10");
+        let a = test_dec!("10");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "0.001");
     }
 
     #[test]
     fn test_minus10_powi_minus3_decimal() {
-        let a = dec!("-10");
+        let a = test_dec!("-10");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "-0.001");
     }
 
     #[test]
     fn test_minus10_powi_minus2_decimal() {
-        let a = dec!("-10");
+        let a = test_dec!("-10");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "0.01");
     }
 
     #[test]
     fn test_minus05_powi_minus2_decimal() {
-        let a = dec!("-0.5");
+        let a = test_dec!("-0.5");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "4");
     }
     #[test]
     fn test_minus05_powi_minus3_decimal() {
-        let a = dec!("-0.5");
+        let a = test_dec!("-0.5");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "-8");
     }
 
     #[test]
     fn test_10_powi_15_decimal() {
-        let a = dec!(10i128);
+        let a = test_dec!(10i128);
         assert_eq!(a.checked_powi(15).unwrap().to_string(), "1000000000000000");
     }
 
@@ -1182,67 +1193,67 @@ mod tests {
     #[test]
     fn test_dec_string_decimal_decimal() {
         assert_eq!(
-            dec!("1.123456789012345678").to_string(),
+            test_dec!("1.123456789012345678").to_string(),
             "1.123456789012345678"
         );
-        assert_eq!(dec!("-5.6").to_string(), "-5.6");
+        assert_eq!(test_dec!("-5.6").to_string(), "-5.6");
     }
 
     #[test]
     fn test_dec_string_decimal() {
-        assert_eq!(dec!(1).to_string(), "1");
-        assert_eq!(dec!("0").to_string(), "0");
+        assert_eq!(test_dec!(1).to_string(), "1");
+        assert_eq!(test_dec!("0").to_string(), "0");
     }
 
     #[test]
     fn test_dec_int_decimal() {
-        assert_eq!(dec!(1).to_string(), "1");
-        assert_eq!(dec!(5).to_string(), "5");
+        assert_eq!(test_dec!(1).to_string(), "1");
+        assert_eq!(test_dec!(5).to_string(), "5");
     }
 
     #[test]
     fn test_dec_bool_decimal() {
-        assert_eq!((dec!(false)).to_string(), "0");
+        assert_eq!((test_dec!(false)).to_string(), "0");
     }
 
     #[test]
     fn test_floor_decimal() {
         assert_eq!(
             Decimal::MAX.checked_floor().unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
-        assert_eq!(dec!("1.2").checked_floor().unwrap(), dec!("1"));
-        assert_eq!(dec!("1.0").checked_floor().unwrap(), dec!("1"));
-        assert_eq!(dec!("0.9").checked_floor().unwrap(), dec!("0"));
-        assert_eq!(dec!("0").checked_floor().unwrap(), dec!("0"));
-        assert_eq!(dec!("-0.1").checked_floor().unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1").checked_floor().unwrap(), dec!("-1"));
-        assert_eq!(dec!("-5.2").checked_floor().unwrap(), dec!("-6"));
+        assert_eq!(test_dec!("1.2").checked_floor().unwrap(), test_dec!("1"));
+        assert_eq!(test_dec!("1.0").checked_floor().unwrap(), test_dec!("1"));
+        assert_eq!(test_dec!("0.9").checked_floor().unwrap(), test_dec!("0"));
+        assert_eq!(test_dec!("0").checked_floor().unwrap(), test_dec!("0"));
+        assert_eq!(test_dec!("-0.1").checked_floor().unwrap(), test_dec!("-1"));
+        assert_eq!(test_dec!("-1").checked_floor().unwrap(), test_dec!("-1"));
+        assert_eq!(test_dec!("-5.2").checked_floor().unwrap(), test_dec!("-6"));
 
         assert_eq!(
-            dec!("-3138550867693340381917894711603833208050.177722232017256448") // Decimal::MIN+1
+            test_dec!("-3138550867693340381917894711603833208050.177722232017256448") // Decimal::MIN+1
                 .checked_floor()
                 .unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
         assert_eq!(
-            dec!("-3138550867693340381917894711603833208050.000000000000000001")
+            test_dec!("-3138550867693340381917894711603833208050.000000000000000001")
                 .checked_floor()
                 .unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
         assert_eq!(
-            dec!("-3138550867693340381917894711603833208051.000000000000000000")
+            test_dec!("-3138550867693340381917894711603833208051.000000000000000000")
                 .checked_floor()
                 .unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
 
         // below shall return None due to overflow
         assert!(Decimal::MIN.checked_floor().is_none());
 
         assert!(
-            dec!("-3138550867693340381917894711603833208051.000000000000000001")
+            test_dec!("-3138550867693340381917894711603833208051.000000000000000001")
                 .checked_floor()
                 .is_none()
         );
@@ -1250,9 +1261,9 @@ mod tests {
 
     #[test]
     fn test_abs_decimal() {
-        assert_eq!(dec!(-2).checked_abs().unwrap(), dec!(2));
-        assert_eq!(dec!(2).checked_abs().unwrap(), dec!(2));
-        assert_eq!(dec!(0).checked_abs().unwrap(), dec!(0));
+        assert_eq!(test_dec!(-2).checked_abs().unwrap(), test_dec!(2));
+        assert_eq!(test_dec!(2).checked_abs().unwrap(), test_dec!(2));
+        assert_eq!(test_dec!(0).checked_abs().unwrap(), test_dec!(0));
         assert_eq!(Decimal::MAX.checked_abs().unwrap(), Decimal::MAX);
 
         // below shall return None due to overflow
@@ -1261,34 +1272,37 @@ mod tests {
 
     #[test]
     fn test_ceiling_decimal() {
-        assert_eq!(dec!("1.2").checked_ceiling().unwrap(), dec!("2"));
-        assert_eq!(dec!("1.0").checked_ceiling().unwrap(), dec!("1"));
-        assert_eq!(dec!("0.9").checked_ceiling().unwrap(), dec!("1"));
-        assert_eq!(dec!("0").checked_ceiling().unwrap(), dec!("0"));
-        assert_eq!(dec!("-0.1").checked_ceiling().unwrap(), dec!("0"));
-        assert_eq!(dec!("-1").checked_ceiling().unwrap(), dec!("-1"));
-        assert_eq!(dec!("-5.2").checked_ceiling().unwrap(), dec!("-5"));
+        assert_eq!(test_dec!("1.2").checked_ceiling().unwrap(), test_dec!("2"));
+        assert_eq!(test_dec!("1.0").checked_ceiling().unwrap(), test_dec!("1"));
+        assert_eq!(test_dec!("0.9").checked_ceiling().unwrap(), test_dec!("1"));
+        assert_eq!(test_dec!("0").checked_ceiling().unwrap(), test_dec!("0"));
+        assert_eq!(test_dec!("-0.1").checked_ceiling().unwrap(), test_dec!("0"));
+        assert_eq!(test_dec!("-1").checked_ceiling().unwrap(), test_dec!("-1"));
+        assert_eq!(
+            test_dec!("-5.2").checked_ceiling().unwrap(),
+            test_dec!("-5")
+        );
         assert_eq!(
             Decimal::MIN.checked_ceiling().unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
         assert_eq!(
-            dec!("3138550867693340381917894711603833208050.177722232017256447") // Decimal::MAX-1
+            test_dec!("3138550867693340381917894711603833208050.177722232017256447") // Decimal::MAX-1
                 .checked_ceiling()
                 .unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
         assert_eq!(
-            dec!("3138550867693340381917894711603833208050.000000000000000000")
+            test_dec!("3138550867693340381917894711603833208050.000000000000000000")
                 .checked_ceiling()
                 .unwrap(),
-            dec!("3138550867693340381917894711603833208050")
+            test_dec!("3138550867693340381917894711603833208050")
         );
 
         // below shall return None due to overflow
         assert!(Decimal::MAX.checked_ceiling().is_none());
         assert!(
-            dec!("3138550867693340381917894711603833208051.000000000000000001")
+            test_dec!("3138550867693340381917894711603833208051.000000000000000001")
                 .checked_ceiling()
                 .is_none()
         );
@@ -1297,54 +1311,96 @@ mod tests {
     #[test]
     fn test_rounding_to_zero_decimal() {
         let mode = RoundingMode::ToZero;
-        assert_eq!(dec!("1.2").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("1.0").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("0.9").checked_round(0, mode).unwrap(), dec!("0"));
-        assert_eq!(dec!("0").checked_round(0, mode).unwrap(), dec!("0"));
-        assert_eq!(dec!("-0.1").checked_round(0, mode).unwrap(), dec!("0"));
-        assert_eq!(dec!("-1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-5.2").checked_round(0, mode).unwrap(), dec!("-5"));
+        assert_eq!(
+            test_dec!("1.2").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("1.0").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("0.9").checked_round(0, mode).unwrap(),
+            test_dec!("0")
+        );
+        assert_eq!(
+            test_dec!("0").checked_round(0, mode).unwrap(),
+            test_dec!("0")
+        );
+        assert_eq!(
+            test_dec!("-0.1").checked_round(0, mode).unwrap(),
+            test_dec!("0")
+        );
+        assert_eq!(
+            test_dec!("-1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-5.2").checked_round(0, mode).unwrap(),
+            test_dec!("-5")
+        );
         assert_eq!(
             Decimal::MAX.checked_round(0, mode).unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
         assert_eq!(
             Decimal::MIN.checked_round(0, mode).unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
     }
 
     #[test]
     fn test_rounding_away_from_zero_decimal() {
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(dec!("1.2").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.0").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("0.9").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("0").checked_round(0, mode).unwrap(), dec!("0"));
-        assert_eq!(dec!("-0.1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-5.2").checked_round(0, mode).unwrap(), dec!("-6"));
-
         assert_eq!(
-            dec!("-3138550867693340381917894711603833208050.9")
-                .checked_round(0, mode)
-                .unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("1.2").checked_round(0, mode).unwrap(),
+            test_dec!("2")
         );
         assert_eq!(
-            dec!("3138550867693340381917894711603833208050.9")
+            test_dec!("1.0").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("0.9").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("0").checked_round(0, mode).unwrap(),
+            test_dec!("0")
+        );
+        assert_eq!(
+            test_dec!("-0.1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-5.2").checked_round(0, mode).unwrap(),
+            test_dec!("-6")
+        );
+
+        assert_eq!(
+            test_dec!("-3138550867693340381917894711603833208050.9")
                 .checked_round(0, mode)
                 .unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
+        );
+        assert_eq!(
+            test_dec!("3138550867693340381917894711603833208050.9")
+                .checked_round(0, mode)
+                .unwrap(),
+            test_dec!("3138550867693340381917894711603833208051")
         );
 
         // below shall return None due to overflow
         assert!(Decimal::MIN.checked_round(0, mode).is_none());
-        assert!(dec!("-3138550867693340381917894711603833208051.1")
+        assert!(test_dec!("-3138550867693340381917894711603833208051.1")
             .checked_round(0, mode)
             .is_none());
         assert!(Decimal::MAX.checked_round(0, mode).is_none());
-        assert!(dec!("3138550867693340381917894711603833208051.1")
+        assert!(test_dec!("3138550867693340381917894711603833208051.1")
             .checked_round(0, mode)
             .is_none());
     }
@@ -1352,167 +1408,257 @@ mod tests {
     #[test]
     fn test_rounding_midpoint_toward_zero_decimal() {
         let mode = RoundingMode::ToNearestMidpointTowardZero;
-        assert_eq!(dec!("5.5").checked_round(0, mode).unwrap(), dec!("5"));
-        assert_eq!(dec!("2.5").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.6").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.1").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("1.0").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("-1.0").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.6").checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(dec!("-2.5").checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(dec!("-5.5").checked_round(0, mode).unwrap(), dec!("-5"));
+        assert_eq!(
+            test_dec!("5.5").checked_round(0, mode).unwrap(),
+            test_dec!("5")
+        );
+        assert_eq!(
+            test_dec!("2.5").checked_round(0, mode).unwrap(),
+            test_dec!("2")
+        );
+        assert_eq!(
+            test_dec!("1.6").checked_round(0, mode).unwrap(),
+            test_dec!("2")
+        );
+        assert_eq!(
+            test_dec!("1.1").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("1.0").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("-1.0").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.6").checked_round(0, mode).unwrap(),
+            test_dec!("-2")
+        );
+        assert_eq!(
+            test_dec!("-2.5").checked_round(0, mode).unwrap(),
+            test_dec!("-2")
+        );
+        assert_eq!(
+            test_dec!("-5.5").checked_round(0, mode).unwrap(),
+            test_dec!("-5")
+        );
         assert_eq!(
             Decimal::MAX.checked_round(0, mode).unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
         assert_eq!(
             Decimal::MIN.checked_round(0, mode).unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
     }
 
     #[test]
     fn test_rounding_midpoint_away_from_zero_decimal() {
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(dec!("5.5").checked_round(0, mode).unwrap(), dec!("6"));
-        assert_eq!(dec!("2.5").checked_round(0, mode).unwrap(), dec!("3"));
-        assert_eq!(dec!("1.6").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.1").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("1.0").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("-1.0").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.6").checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(dec!("-2.5").checked_round(0, mode).unwrap(), dec!("-3"));
-        assert_eq!(dec!("-5.5").checked_round(0, mode).unwrap(), dec!("-6"));
+        assert_eq!(
+            test_dec!("5.5").checked_round(0, mode).unwrap(),
+            test_dec!("6")
+        );
+        assert_eq!(
+            test_dec!("2.5").checked_round(0, mode).unwrap(),
+            test_dec!("3")
+        );
+        assert_eq!(
+            test_dec!("1.6").checked_round(0, mode).unwrap(),
+            test_dec!("2")
+        );
+        assert_eq!(
+            test_dec!("1.1").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("1.0").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("-1.0").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.6").checked_round(0, mode).unwrap(),
+            test_dec!("-2")
+        );
+        assert_eq!(
+            test_dec!("-2.5").checked_round(0, mode).unwrap(),
+            test_dec!("-3")
+        );
+        assert_eq!(
+            test_dec!("-5.5").checked_round(0, mode).unwrap(),
+            test_dec!("-6")
+        );
         assert_eq!(
             Decimal::MAX.checked_round(0, mode).unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
         assert_eq!(
             Decimal::MIN.checked_round(0, mode).unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
     }
 
     #[test]
     fn test_rounding_midpoint_nearest_even_zero_decimal() {
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(dec!("5.5").checked_round(0, mode).unwrap(), dec!("6"));
-        assert_eq!(dec!("2.5").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.6").checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(dec!("1.1").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("1.0").checked_round(0, mode).unwrap(), dec!("1"));
-        assert_eq!(dec!("-1.0").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.1").checked_round(0, mode).unwrap(), dec!("-1"));
-        assert_eq!(dec!("-1.6").checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(dec!("-2.5").checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(dec!("-5.5").checked_round(0, mode).unwrap(), dec!("-6"));
+        assert_eq!(
+            test_dec!("5.5").checked_round(0, mode).unwrap(),
+            test_dec!("6")
+        );
+        assert_eq!(
+            test_dec!("2.5").checked_round(0, mode).unwrap(),
+            test_dec!("2")
+        );
+        assert_eq!(
+            test_dec!("1.6").checked_round(0, mode).unwrap(),
+            test_dec!("2")
+        );
+        assert_eq!(
+            test_dec!("1.1").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("1.0").checked_round(0, mode).unwrap(),
+            test_dec!("1")
+        );
+        assert_eq!(
+            test_dec!("-1.0").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.1").checked_round(0, mode).unwrap(),
+            test_dec!("-1")
+        );
+        assert_eq!(
+            test_dec!("-1.6").checked_round(0, mode).unwrap(),
+            test_dec!("-2")
+        );
+        assert_eq!(
+            test_dec!("-2.5").checked_round(0, mode).unwrap(),
+            test_dec!("-2")
+        );
+        assert_eq!(
+            test_dec!("-5.5").checked_round(0, mode).unwrap(),
+            test_dec!("-6")
+        );
 
         assert_eq!(
             Decimal::MAX.checked_round(0, mode).unwrap(),
-            dec!("3138550867693340381917894711603833208051")
+            test_dec!("3138550867693340381917894711603833208051")
         );
         assert_eq!(
             Decimal::MIN.checked_round(0, mode).unwrap(),
-            dec!("-3138550867693340381917894711603833208051")
+            test_dec!("-3138550867693340381917894711603833208051")
         );
     }
 
     #[test]
     fn test_various_decimal_places_decimal() {
-        let num = dec!("2.4595");
+        let num = test_dec!("2.4595");
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.46"));
 
         assert_eq!(
-            dec!("3138550867693340381917894711603833208050.177722232017256447")
+            test_dec!("3138550867693340381917894711603833208050.177722232017256447")
                 .checked_round(1, mode)
                 .unwrap(),
-            dec!("3138550867693340381917894711603833208050.2")
+            test_dec!("3138550867693340381917894711603833208050.2")
         );
         assert_eq!(
-            dec!("-3138550867693340381917894711603833208050.177722232017256448")
+            test_dec!("-3138550867693340381917894711603833208050.177722232017256448")
                 .checked_round(1, mode)
                 .unwrap(),
-            dec!("-3138550867693340381917894711603833208050.2")
+            test_dec!("-3138550867693340381917894711603833208050.2")
         );
 
         let mode = RoundingMode::ToZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.459"));
         let mode = RoundingMode::ToPositiveInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.46"));
         let mode = RoundingMode::ToNegativeInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.459"));
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.46"));
         let mode = RoundingMode::ToNearestMidpointTowardZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.459"));
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("2.46"));
 
-        let num = dec!("-2.4595");
+        let num = test_dec!("-2.4595");
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.46"));
         let mode = RoundingMode::ToZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.459"));
         let mode = RoundingMode::ToPositiveInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.459"));
         let mode = RoundingMode::ToNegativeInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.46"));
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.46"));
         let mode = RoundingMode::ToNearestMidpointTowardZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.459"));
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(num.checked_round(0, mode).unwrap(), dec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), dec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), dec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), dec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_dec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_dec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_dec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_dec!("-2.46"));
     }
 
     #[test]
     fn test_encode_decimal_value_decimal() {
-        let dec = dec!("0");
+        let dec = test_dec!("0");
         let bytes = scrypto_encode(&dec).unwrap();
         assert_eq!(bytes, {
             let mut a = [0; 26];
@@ -1524,10 +1670,10 @@ mod tests {
 
     #[test]
     fn test_decode_decimal_value_decimal() {
-        let dec = dec!("1.23456789");
+        let dec = test_dec!("1.23456789");
         let bytes = scrypto_encode(&dec).unwrap();
         let decoded: Decimal = scrypto_decode(&bytes).unwrap();
-        assert_eq!(decoded, dec!("1.23456789"));
+        assert_eq!(decoded, test_dec!("1.23456789"));
     }
 
     #[test]
@@ -1666,44 +1812,44 @@ mod tests {
 
     #[test]
     fn test_sqrt() {
-        let sqrt_of_42 = dec!(42).checked_sqrt();
-        let sqrt_of_0 = dec!(0).checked_sqrt();
-        let sqrt_of_negative = dec!("-1").checked_sqrt();
+        let sqrt_of_42 = test_dec!(42).checked_sqrt();
+        let sqrt_of_0 = test_dec!(0).checked_sqrt();
+        let sqrt_of_negative = test_dec!("-1").checked_sqrt();
         let sqrt_max = Decimal::MAX.checked_sqrt();
-        assert_eq!(sqrt_of_42.unwrap(), dec!("6.48074069840786023"));
-        assert_eq!(sqrt_of_0.unwrap(), dec!(0));
+        assert_eq!(sqrt_of_42.unwrap(), test_dec!("6.48074069840786023"));
+        assert_eq!(sqrt_of_0.unwrap(), test_dec!(0));
         assert_eq!(sqrt_of_negative, None);
         assert_eq!(
             sqrt_max.unwrap(),
-            dec!("56022770974786139918.731938227458171762")
+            test_dec!("56022770974786139918.731938227458171762")
         );
     }
 
     #[test]
     fn test_cbrt() {
-        let cbrt_of_42 = dec!(42).checked_cbrt().unwrap();
-        let cbrt_of_0 = dec!(0).checked_cbrt().unwrap();
-        let cbrt_of_negative_42 = dec!("-42").checked_cbrt().unwrap();
+        let cbrt_of_42 = test_dec!(42).checked_cbrt().unwrap();
+        let cbrt_of_0 = test_dec!(0).checked_cbrt().unwrap();
+        let cbrt_of_negative_42 = test_dec!("-42").checked_cbrt().unwrap();
         let cbrt_max = Decimal::MAX.checked_cbrt().unwrap();
-        assert_eq!(cbrt_of_42, dec!("3.476026644886449786"));
-        assert_eq!(cbrt_of_0, dec!("0"));
-        assert_eq!(cbrt_of_negative_42, dec!("-3.476026644886449786"));
-        assert_eq!(cbrt_max, dec!("14641190473997.345813510937532903"));
+        assert_eq!(cbrt_of_42, test_dec!("3.476026644886449786"));
+        assert_eq!(cbrt_of_0, test_dec!("0"));
+        assert_eq!(cbrt_of_negative_42, test_dec!("-3.476026644886449786"));
+        assert_eq!(cbrt_max, test_dec!("14641190473997.345813510937532903"));
     }
 
     #[test]
     fn test_nth_root() {
-        let root_4_42 = dec!(42).checked_nth_root(4);
-        let root_5_42 = dec!(42).checked_nth_root(5);
-        let root_42_42 = dec!(42).checked_nth_root(42);
-        let root_neg_4_42 = dec!("-42").checked_nth_root(4);
-        let root_neg_5_42 = dec!("-42").checked_nth_root(5);
-        let root_0 = dec!(42).checked_nth_root(0);
-        assert_eq!(root_4_42.unwrap(), dec!("2.545729895021830518"));
-        assert_eq!(root_5_42.unwrap(), dec!("2.111785764966753912"));
-        assert_eq!(root_42_42.unwrap(), dec!("1.093072057934823618"));
+        let root_4_42 = test_dec!(42).checked_nth_root(4);
+        let root_5_42 = test_dec!(42).checked_nth_root(5);
+        let root_42_42 = test_dec!(42).checked_nth_root(42);
+        let root_neg_4_42 = test_dec!("-42").checked_nth_root(4);
+        let root_neg_5_42 = test_dec!("-42").checked_nth_root(5);
+        let root_0 = test_dec!(42).checked_nth_root(0);
+        assert_eq!(root_4_42.unwrap(), test_dec!("2.545729895021830518"));
+        assert_eq!(root_5_42.unwrap(), test_dec!("2.111785764966753912"));
+        assert_eq!(root_42_42.unwrap(), test_dec!("1.093072057934823618"));
         assert_eq!(root_neg_4_42, None);
-        assert_eq!(root_neg_5_42.unwrap(), dec!("-2.111785764966753912"));
+        assert_eq!(root_neg_5_42.unwrap(), test_dec!("-2.111785764966753912"));
         assert_eq!(root_0, None);
     }
 
@@ -1737,7 +1883,7 @@ mod tests {
     #[test]
     fn test_neg_decimal() {
         let d = Decimal::ONE;
-        assert_eq!(-d, dec!("-1"));
+        assert_eq!(-d, test_dec!("-1"));
         let d = Decimal::MAX;
         assert_eq!(-d, Decimal(I192::MIN + I192::ONE));
     }
@@ -1758,14 +1904,14 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_arith_decimal_$type>]() {
-                    let d1 = dec!("2");
+                    let d1 = test_dec!("2");
                     let u1 = $type::try_from(4).unwrap();
-                    assert_eq!(d1.checked_add(u1).unwrap(), dec!("6"));
-                    assert_eq!(d1.checked_sub(u1).unwrap(), dec!("-2"));
-                    assert_eq!(d1.checked_mul(u1).unwrap(), dec!("8"));
-                    assert_eq!(d1.checked_div(u1).unwrap(), dec!("0.5"));
+                    assert_eq!(d1.checked_add(u1).unwrap(), test_dec!("6"));
+                    assert_eq!(d1.checked_sub(u1).unwrap(), test_dec!("-2"));
+                    assert_eq!(d1.checked_mul(u1).unwrap(), test_dec!("8"));
+                    assert_eq!(d1.checked_div(u1).unwrap(), test_dec!("0.5"));
 
-                    let d1 = dec!("2");
+                    let d1 = test_dec!("2");
                     let u1 = $type::MAX;
                     let d2 = Decimal::from($type::MAX);
                     assert_eq!(d1.checked_add(u1).unwrap(), d1.checked_add(d2).unwrap());
@@ -1775,7 +1921,7 @@ mod tests {
 
                     let d1 = Decimal::from($type::MIN);
                     let u1 = 2 as $type;
-                    let d2 = dec!("2");
+                    let d2 = test_dec!("2");
                     assert_eq!(d1.checked_add(u1).unwrap(), d1.checked_add(d2).unwrap());
                     assert_eq!(d1.checked_sub(u1).unwrap(), d1.checked_sub(d2).unwrap());
                     assert_eq!(d1.checked_mul(u1).unwrap(), d1.checked_mul(d2).unwrap());
@@ -1802,16 +1948,16 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_arith_decimal_$type:lower>]() {
-                    let d1 = dec!("2");
+                    let d1 = test_dec!("2");
                     let u1 = $type::try_from(4).unwrap();
                     let u2 = $type::try_from(2).unwrap();
-                    let d2 = dec!("4");
+                    let d2 = test_dec!("4");
                     assert_eq!(d1.checked_add(u1).unwrap(), u2.checked_add(d2).unwrap());
                     assert_eq!(d1.checked_sub(u1).unwrap(), u2.checked_sub(d2).unwrap());
                     assert_eq!(d1.checked_mul(u1).unwrap(), u2.checked_mul(d2).unwrap());
                     assert_eq!(d1.checked_div(u1).unwrap(), u2.checked_div(d2).unwrap());
 
-                    let d1 = dec!("2");
+                    let d1 = test_dec!("2");
                     let u1 = $type::MAX;
                     assert!(d1.checked_add(u1).is_none());
                     assert!(d1.checked_sub(u1).is_none());
@@ -1821,9 +1967,9 @@ mod tests {
                     let d1 = Decimal::MAX;
                     let u1 = $type::try_from(2).unwrap();
                     assert_eq!(d1.checked_add(u1), None);
-                    assert_eq!(d1.checked_sub(u1).unwrap(), Decimal::MAX - dec!("2"));
+                    assert_eq!(d1.checked_sub(u1).unwrap(), Decimal::MAX - test_dec!("2"));
                     assert_eq!(d1.checked_mul(u1), None);
-                    assert_eq!(d1.checked_div(u1).unwrap(), Decimal::MAX / dec!("2"));
+                    assert_eq!(d1.checked_div(u1).unwrap(), Decimal::MAX / test_dec!("2"));
 
                 }
             }
@@ -1841,37 +1987,37 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_math_operands_decimal_$type:lower>]() {
-                    let d1 = dec!("2");
+                    let d1 = test_dec!("2");
                     let u1 = $type::try_from(4).unwrap();
-                    assert_eq!(d1 + u1, dec!("6"));
-                    assert_eq!(d1 - u1, dec!("-2"));
-                    assert_eq!(d1 * u1, dec!("8"));
-                    assert_eq!(d1 / u1, dec!("0.5"));
+                    assert_eq!(d1 + u1, test_dec!("6"));
+                    assert_eq!(d1 - u1, test_dec!("-2"));
+                    assert_eq!(d1 * u1, test_dec!("8"));
+                    assert_eq!(d1 / u1, test_dec!("0.5"));
 
                     let u1 = $type::try_from(2).unwrap();
-                    let d1 = dec!("4");
-                    assert_eq!(u1 + d1, dec!("6"));
-                    assert_eq!(u1 - d1, dec!("-2"));
-                    assert_eq!(u1 * d1, dec!("8"));
-                    assert_eq!(u1 / d1, dec!("0.5"));
+                    let d1 = test_dec!("4");
+                    assert_eq!(u1 + d1, test_dec!("6"));
+                    assert_eq!(u1 - d1, test_dec!("-2"));
+                    assert_eq!(u1 * d1, test_dec!("8"));
+                    assert_eq!(u1 / d1, test_dec!("0.5"));
 
                     let u1 = $type::try_from(4).unwrap();
 
-                    let mut d1 = dec!("2");
+                    let mut d1 = test_dec!("2");
                     d1 += u1;
-                    assert_eq!(d1, dec!("6"));
+                    assert_eq!(d1, test_dec!("6"));
 
-                    let mut d1 = dec!("2");
+                    let mut d1 = test_dec!("2");
                     d1 -= u1;
-                    assert_eq!(d1, dec!("-2"));
+                    assert_eq!(d1, test_dec!("-2"));
 
-                    let mut d1 = dec!("2");
+                    let mut d1 = test_dec!("2");
                     d1 *= u1;
-                    assert_eq!(d1, dec!("8"));
+                    assert_eq!(d1, test_dec!("8"));
 
-                    let mut d1 = dec!("2");
+                    let mut d1 = test_dec!("2");
                     d1 /= u1;
-                    assert_eq!(d1, dec!("0.5"));
+                    assert_eq!(d1, test_dec!("0.5"));
                 }
 
                 #[test]
@@ -2002,11 +2148,11 @@ mod tests {
                 #[test]
                 fn [<test_decimal_from_primitive_$type>]() {
                     let v = $type::try_from(1).unwrap();
-                    assert_eq!(Decimal::from(v), dec!(1));
+                    assert_eq!(Decimal::from(v), test_dec!(1));
 
                     if $type::MIN != 0 {
                         let v = $type::try_from(-1).unwrap();
-                        assert_eq!(Decimal::from(v), dec!(-1));
+                        assert_eq!(Decimal::from(v), test_dec!(-1));
                     }
 
                     let v = $type::MAX;
@@ -2036,12 +2182,12 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_decimal_to_primitive_$type>]() {
-                    let d = dec!(1);
+                    let d = test_dec!(1);
                     let v = $type::try_from(1).unwrap();
                     assert_eq!($type::try_from(d).unwrap(), v);
 
                     if $type::MIN != 0 {
-                        let d = dec!(-1);
+                        let d = test_dec!(-1);
                         let v = $type::try_from(-1).unwrap();
                         assert_eq!($type::try_from(d).unwrap(), v);
                     }
@@ -2068,7 +2214,7 @@ mod tests {
                     let err = $type::try_from(d).unwrap_err();
                     assert_eq!(err, ParseDecimalError::Overflow);
 
-                    let d = dec!("1.1");
+                    let d = test_dec!("1.1");
                     let err = $type::try_from(d).unwrap_err();
                     assert_eq!(err, ParseDecimalError::InvalidDigit);
                 }

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -1294,25 +1294,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dec_rational_precise_decimal() {
-        assert_eq!((pdec!(11235, 0)).to_string(), "11235");
-        assert_eq!((pdec!(11235, -2)).to_string(), "112.35");
-        assert_eq!((pdec!(11235, 2)).to_string(), "1123500");
-
-        //        assert_eq!(
-        //            pdec!("1120000000000000000000000000000000000000000000000000000000000000001", -64).to_string(),
-        //            "112.0000000000000000000000000000000000000000000000000000000000000001"
-        //        );
-    }
-
-    #[test]
-    #[should_panic(expected = "Shift overflow")]
-    fn test_shift_overflow_precise_decimal() {
-        // u32::MAX + 1
-        pdec!(1, 4_294_967_296i128); // use explicit type to defer error to runtime
-    }
-
-    #[test]
     fn test_floor_precise_decimal() {
         assert_eq!(
             PreciseDecimal::MAX.checked_floor().unwrap(),

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -920,10 +920,26 @@ try_from_integer!(U192, U256, U320, U384, U448, U512);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dec;
     use crate::math::precise_decimal::RoundingMode;
-    use crate::pdec;
     use paste::paste;
+
+    macro_rules! test_dec {
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        // In general, it is assumed that reasonable literals are provided.
+        // If not then something is definitely wrong and panic is fine.
+        ($x:literal) => {
+            $crate::math::Decimal::try_from($x).unwrap()
+        };
+    }
+
+    macro_rules! test_pdec {
+        // NOTE: Decimal arithmetic operation safe unwrap.
+        // In general, it is assumed that reasonable literals are provided.
+        // If not then something is definitely wrong and panic is fine.
+        ($x:literal) => {
+            $crate::math::PreciseDecimal::try_from($x).unwrap()
+        };
+    }
 
     #[test]
     fn test_format_precise_decimal() {
@@ -996,12 +1012,12 @@ mod tests {
             PreciseDecimal::MIN,
         );
 
-        assert_eq!(pdec!("0"), PreciseDecimal::ZERO);
-        assert_eq!(pdec!("1"), PreciseDecimal::ONE);
-        assert_eq!(pdec!("0.1"), PreciseDecimal::ONE_TENTH);
-        assert_eq!(pdec!("10"), PreciseDecimal::TEN);
-        assert_eq!(pdec!("100"), PreciseDecimal::ONE_HUNDRED);
-        assert_eq!(pdec!("0.01"), PreciseDecimal::ONE_HUNDREDTH);
+        assert_eq!(test_pdec!("0"), PreciseDecimal::ZERO);
+        assert_eq!(test_pdec!("1"), PreciseDecimal::ONE);
+        assert_eq!(test_pdec!("0.1"), PreciseDecimal::ONE_TENTH);
+        assert_eq!(test_pdec!("10"), PreciseDecimal::TEN);
+        assert_eq!(test_pdec!("100"), PreciseDecimal::ONE_HUNDRED);
+        assert_eq!(test_pdec!("0.01"), PreciseDecimal::ONE_HUNDREDTH);
 
         assert_eq!("0", PreciseDecimal::ZERO.to_string());
         assert_eq!("1", PreciseDecimal::ONE.to_string());
@@ -1049,24 +1065,26 @@ mod tests {
         let b = PreciseDecimal::from_str("1000000000").unwrap();
         assert_eq!(a.checked_mul(b).unwrap().to_string(), "1000000000000000000");
 
-        let a = PreciseDecimal::MAX.checked_div(pdec!(2)).unwrap();
+        let a = PreciseDecimal::MAX.checked_div(test_pdec!(2)).unwrap();
         let b = PreciseDecimal::from(2);
         assert_eq!(
             a.checked_mul(b).unwrap(),
-            pdec!("57896044618658097711785492504343953926634.992332820282019728792003956564819966")
+            test_pdec!(
+                "57896044618658097711785492504343953926634.992332820282019728792003956564819966"
+            )
         );
     }
 
     #[test]
     fn test_mul_overflow_by_small_precise_decimal() {
         assert!(PreciseDecimal::MAX
-            .checked_mul(pdec!("1.000000000000000000000000000000000001"))
+            .checked_mul(test_pdec!("1.000000000000000000000000000000000001"))
             .is_none());
     }
 
     #[test]
     fn test_mul_overflow_by_a_lot_precise_decimal() {
-        assert!(PreciseDecimal::MAX.checked_mul(pdec!("1.1")).is_none());
+        assert!(PreciseDecimal::MAX.checked_mul(test_pdec!("1.1")).is_none());
     }
 
     #[test]
@@ -1074,7 +1092,7 @@ mod tests {
         assert!(PreciseDecimal::MAX
             .checked_neg()
             .unwrap()
-            .checked_mul(pdec!("-1.000000000000000000000000000000000001"))
+            .checked_mul(test_pdec!("-1.000000000000000000000000000000000001"))
             .is_none());
     }
 
@@ -1128,7 +1146,9 @@ mod tests {
         let b = PreciseDecimal::from(2);
         assert_eq!(
             a.checked_div(b).unwrap(),
-            pdec!("28948022309329048855892746252171976963317.496166410141009864396001978282409983")
+            test_pdec!(
+                "28948022309329048855892746252171976963317.496166410141009864396001978282409983"
+            )
         );
     }
 
@@ -1141,49 +1161,49 @@ mod tests {
 
     #[test]
     fn test_0_pow_0_precise_decimal() {
-        let a = pdec!("0");
+        let a = test_pdec!("0");
         assert_eq!(a.checked_powi(0).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_0_powi_1_precise_decimal() {
-        let a = pdec!("0");
+        let a = test_pdec!("0");
         assert_eq!(a.checked_powi(1).unwrap().to_string(), "0");
     }
 
     #[test]
     fn test_0_powi_10_precise_decimal() {
-        let a = pdec!("0");
+        let a = test_pdec!("0");
         assert_eq!(a.checked_powi(10).unwrap().to_string(), "0");
     }
 
     #[test]
     fn test_1_powi_0_precise_decimal() {
-        let a = pdec!(1);
+        let a = test_pdec!(1);
         assert_eq!(a.checked_powi(0).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_1_powi_1_precise_decimal() {
-        let a = pdec!(1);
+        let a = test_pdec!(1);
         assert_eq!(a.checked_powi(1).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_1_powi_10_precise_decimal() {
-        let a = pdec!(1);
+        let a = test_pdec!(1);
         assert_eq!(a.checked_powi(10).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_2_powi_0_precise_decimal() {
-        let a = pdec!("2");
+        let a = test_pdec!("2");
         assert_eq!(a.checked_powi(0).unwrap().to_string(), "1");
     }
 
     #[test]
     fn test_2_powi_3724_precise_decimal() {
-        let a = pdec!("1.000234891009084238");
+        let a = test_pdec!("1.000234891009084238");
         assert_eq!(
             a.checked_powi(3724).unwrap().to_string(),
             "2.3979912322546748642222795591580985"
@@ -1192,66 +1212,66 @@ mod tests {
 
     #[test]
     fn test_2_powi_2_precise_decimal() {
-        let a = pdec!("2");
+        let a = test_pdec!("2");
         assert_eq!(a.checked_powi(2).unwrap().to_string(), "4");
     }
 
     #[test]
     fn test_2_powi_3_precise_decimal() {
-        let a = pdec!("2");
+        let a = test_pdec!("2");
         assert_eq!(a.checked_powi(3).unwrap().to_string(), "8");
     }
 
     #[test]
     fn test_10_powi_3_precise_decimal() {
-        let a = pdec!("10");
+        let a = test_pdec!("10");
         assert_eq!(a.checked_powi(3).unwrap().to_string(), "1000");
     }
 
     #[test]
     fn test_5_powi_2_precise_decimal() {
-        let a = pdec!("5");
+        let a = test_pdec!("5");
         assert_eq!(a.checked_powi(2).unwrap().to_string(), "25");
     }
 
     #[test]
     fn test_5_powi_minus2_precise_decimal() {
-        let a = pdec!("5");
+        let a = test_pdec!("5");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "0.04");
     }
 
     #[test]
     fn test_10_powi_minus3_precise_decimal() {
-        let a = pdec!("10");
+        let a = test_pdec!("10");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "0.001");
     }
 
     #[test]
     fn test_minus10_powi_minus3_precise_decimal() {
-        let a = pdec!("-10");
+        let a = test_pdec!("-10");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "-0.001");
     }
 
     #[test]
     fn test_minus10_powi_minus2_precise_decimal() {
-        let a = pdec!("-10");
+        let a = test_pdec!("-10");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "0.01");
     }
 
     #[test]
     fn test_minus05_powi_minus2_precise_decimal() {
-        let a = pdec!("-0.5");
+        let a = test_pdec!("-0.5");
         assert_eq!(a.checked_powi(-2).unwrap().to_string(), "4");
     }
     #[test]
     fn test_minus05_powi_minus3_precise_decimal() {
-        let a = pdec!("-0.5");
+        let a = test_pdec!("-0.5");
         assert_eq!(a.checked_powi(-3).unwrap().to_string(), "-8");
     }
 
     #[test]
     fn test_10_powi_15_precise_decimal() {
-        let a = pdec!(10i128);
+        let a = test_pdec!(10i128);
         assert_eq!(a.checked_powi(15).unwrap().to_string(), "1000000000000000");
     }
 
@@ -1270,72 +1290,78 @@ mod tests {
     #[test]
     fn test_dec_string_decimal_precise_decimal() {
         assert_eq!(
-            pdec!("1.123456789012345678").to_string(),
+            test_pdec!("1.123456789012345678").to_string(),
             "1.123456789012345678"
         );
-        assert_eq!(pdec!("-5.6").to_string(), "-5.6");
+        assert_eq!(test_pdec!("-5.6").to_string(), "-5.6");
     }
 
     #[test]
     fn test_dec_string_precise_decimal() {
-        assert_eq!(pdec!(1).to_string(), "1");
-        assert_eq!(pdec!("0").to_string(), "0");
+        assert_eq!(test_pdec!(1).to_string(), "1");
+        assert_eq!(test_pdec!("0").to_string(), "0");
     }
 
     #[test]
     fn test_dec_int_precise_decimal() {
-        assert_eq!(pdec!(1).to_string(), "1");
-        assert_eq!(pdec!(5).to_string(), "5");
+        assert_eq!(test_pdec!(1).to_string(), "1");
+        assert_eq!(test_pdec!(5).to_string(), "5");
     }
 
     #[test]
     fn test_dec_bool_precise_decimal() {
-        assert_eq!((pdec!(false)).to_string(), "0");
+        assert_eq!((test_pdec!(false)).to_string(), "0");
     }
 
     #[test]
     fn test_floor_precise_decimal() {
         assert_eq!(
             PreciseDecimal::MAX.checked_floor().unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!("57896044618658097711785492504343953926634")
         );
-        assert_eq!(pdec!("1.2").checked_floor().unwrap(), pdec!("1"));
-        assert_eq!(pdec!("1.0").checked_floor().unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0.9").checked_floor().unwrap(), pdec!("0"));
-        assert_eq!(pdec!("0").checked_floor().unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-0.1").checked_floor().unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1").checked_floor().unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-5.2").checked_floor().unwrap(), pdec!("-6"));
+        assert_eq!(test_pdec!("1.2").checked_floor().unwrap(), test_pdec!("1"));
+        assert_eq!(test_pdec!("1.0").checked_floor().unwrap(), test_pdec!("1"));
+        assert_eq!(test_pdec!("0.9").checked_floor().unwrap(), test_pdec!("0"));
+        assert_eq!(test_pdec!("0").checked_floor().unwrap(), test_pdec!("0"));
+        assert_eq!(
+            test_pdec!("-0.1").checked_floor().unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(test_pdec!("-1").checked_floor().unwrap(), test_pdec!("-1"));
+        assert_eq!(
+            test_pdec!("-5.2").checked_floor().unwrap(),
+            test_pdec!("-6")
+        );
 
         assert_eq!(
-            pdec!(
+            test_pdec!(
                 "-57896044618658097711785492504343953926633.992332820282019728792003956564819968"
             ) // PreciseDecimal::MIN+1
             .checked_floor()
             .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
         assert_eq!(
-            pdec!(
+            test_pdec!(
                 "-57896044618658097711785492504343953926633.000000000000000000000000000000000001"
             )
             .checked_floor()
             .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
         assert_eq!(
-            pdec!(
+            test_pdec!(
                 "-57896044618658097711785492504343953926634.000000000000000000000000000000000000"
             )
             .checked_floor()
             .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
 
         // below shall return None due to overflow
         assert!(PreciseDecimal::MIN.checked_floor().is_none());
 
-        assert!(pdec!(
+        assert!(test_pdec!(
             "-57896044618658097711785492504343953926634.000000000000000000000000000000000001"
         )
         .checked_floor()
@@ -1344,9 +1370,9 @@ mod tests {
 
     #[test]
     fn test_abs_precise_decimal() {
-        assert_eq!(pdec!(-2).checked_abs().unwrap(), pdec!(2));
-        assert_eq!(pdec!(2).checked_abs().unwrap(), pdec!(2));
-        assert_eq!(pdec!(0).checked_abs().unwrap(), pdec!(0));
+        assert_eq!(test_pdec!(-2).checked_abs().unwrap(), test_pdec!(2));
+        assert_eq!(test_pdec!(2).checked_abs().unwrap(), test_pdec!(2));
+        assert_eq!(test_pdec!(0).checked_abs().unwrap(), test_pdec!(0));
         assert_eq!(
             PreciseDecimal::MAX.checked_abs().unwrap(),
             PreciseDecimal::MAX
@@ -1358,33 +1384,55 @@ mod tests {
 
     #[test]
     fn test_ceiling_precise_decimal() {
-        assert_eq!(pdec!("1.2").checked_ceiling().unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.0").checked_ceiling().unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0.9").checked_ceiling().unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0").checked_ceiling().unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-0.1").checked_ceiling().unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-1").checked_ceiling().unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-5.2").checked_ceiling().unwrap(), pdec!("-5"));
+        assert_eq!(
+            test_pdec!("1.2").checked_ceiling().unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_ceiling().unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("0.9").checked_ceiling().unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(test_pdec!("0").checked_ceiling().unwrap(), test_pdec!("0"));
+        assert_eq!(
+            test_pdec!("-0.1").checked_ceiling().unwrap(),
+            test_pdec!("0")
+        );
+        assert_eq!(
+            test_pdec!("-1").checked_ceiling().unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-5.2").checked_ceiling().unwrap(),
+            test_pdec!("-5")
+        );
         assert_eq!(
             PreciseDecimal::MIN.checked_ceiling().unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926633.992332820282019728792003956564819967") // PreciseDecimal::MAX-1
-                .checked_ceiling()
-                .unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!(
+                "57896044618658097711785492504343953926633.992332820282019728792003956564819967"
+            ) // PreciseDecimal::MAX-1
+            .checked_ceiling()
+            .unwrap(),
+            test_pdec!("57896044618658097711785492504343953926634")
         );
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926633.000000000000000000000000000000000000")
-                .checked_ceiling()
-                .unwrap(),
-            pdec!("57896044618658097711785492504343953926633")
+            test_pdec!(
+                "57896044618658097711785492504343953926633.000000000000000000000000000000000000"
+            )
+            .checked_ceiling()
+            .unwrap(),
+            test_pdec!("57896044618658097711785492504343953926633")
         );
 
         // below shall return None due to overflow
         assert!(PreciseDecimal::MAX.checked_ceiling().is_none());
-        assert!(pdec!(
+        assert!(test_pdec!(
             "57896044618658097711785492504343953926634.000000000000000000000000000000000001"
         )
         .checked_ceiling()
@@ -1394,41 +1442,83 @@ mod tests {
     #[test]
     fn test_rounding_to_zero_precise_decimal() {
         let mode = RoundingMode::ToZero;
-        assert_eq!(pdec!("1.2").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("1.0").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0.9").checked_round(0, mode).unwrap(), pdec!("0"));
-        assert_eq!(pdec!("0").checked_round(0, mode).unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-0.1").checked_round(0, mode).unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-5.2").checked_round(0, mode).unwrap(), pdec!("-5"));
+        assert_eq!(
+            test_pdec!("1.2").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("0.9").checked_round(0, mode).unwrap(),
+            test_pdec!("0")
+        );
+        assert_eq!(
+            test_pdec!("0").checked_round(0, mode).unwrap(),
+            test_pdec!("0")
+        );
+        assert_eq!(
+            test_pdec!("-0.1").checked_round(0, mode).unwrap(),
+            test_pdec!("0")
+        );
+        assert_eq!(
+            test_pdec!("-1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-5.2").checked_round(0, mode).unwrap(),
+            test_pdec!("-5")
+        );
         assert_eq!(
             PreciseDecimal::MAX.checked_round(0, mode).unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!("57896044618658097711785492504343953926634")
         );
         assert_eq!(
             PreciseDecimal::MIN.checked_round(0, mode).unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
     }
 
     #[test]
     fn test_rounding_away_from_zero_precise_decimal() {
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(pdec!("1.2").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.0").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0.9").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("0").checked_round(0, mode).unwrap(), pdec!("0"));
-        assert_eq!(pdec!("-0.1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-5.2").checked_round(0, mode).unwrap(), pdec!("-6"));
+        assert_eq!(
+            test_pdec!("1.2").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("0.9").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("0").checked_round(0, mode).unwrap(),
+            test_pdec!("0")
+        );
+        assert_eq!(
+            test_pdec!("-0.1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-5.2").checked_round(0, mode).unwrap(),
+            test_pdec!("-6")
+        );
 
         // below shall return None due to overflow
         assert!(PreciseDecimal::MIN.checked_round(0, mode).is_none());
-        assert!(pdec!("-57896044618658097711785492504343953926634.1")
+        assert!(test_pdec!("-57896044618658097711785492504343953926634.1")
             .checked_round(0, mode)
             .is_none());
         assert!(PreciseDecimal::MAX.checked_round(0, mode).is_none());
-        assert!(pdec!("57896044618658097711785492504343953926634.1")
+        assert!(test_pdec!("57896044618658097711785492504343953926634.1")
             .checked_round(0, mode)
             .is_none());
     }
@@ -1437,36 +1527,66 @@ mod tests {
     fn test_rounding_midpoint_toward_zero_precise_decimal() {
         let mode = RoundingMode::ToNearestMidpointTowardZero;
         //3.5 -> 3`, `-3.5 -> -3
-        assert_eq!(pdec!("5.5").checked_round(0, mode).unwrap(), pdec!("5"));
-        assert_eq!(pdec!("2.5").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.6").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.1").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("1.0").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("-1.0").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.6").checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(pdec!("-2.5").checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(pdec!("-5.5").checked_round(0, mode).unwrap(), pdec!("-5"));
-
         assert_eq!(
-            pdec!("-57896044618658097711785492504343953926634.5")
-                .checked_round(0, mode)
-                .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("5")
         );
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926634.5")
+            test_pdec!("2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("-1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("-2")
+        );
+        assert_eq!(
+            test_pdec!("-2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-2")
+        );
+        assert_eq!(
+            test_pdec!("-5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-5")
+        );
+
+        assert_eq!(
+            test_pdec!("-57896044618658097711785492504343953926634.5")
                 .checked_round(0, mode)
                 .unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
+        );
+        assert_eq!(
+            test_pdec!("57896044618658097711785492504343953926634.5")
+                .checked_round(0, mode)
+                .unwrap(),
+            test_pdec!("57896044618658097711785492504343953926634")
         );
 
         assert!(PreciseDecimal::MIN.checked_round(0, mode).is_none());
-        assert!(pdec!("-57896044618658097711785492504343953926634.6")
+        assert!(test_pdec!("-57896044618658097711785492504343953926634.6")
             .checked_round(0, mode)
             .is_none());
         assert!(PreciseDecimal::MAX.checked_round(0, mode).is_none());
-        assert!(pdec!("57896044618658097711785492504343953926634.6")
+        assert!(test_pdec!("57896044618658097711785492504343953926634.6")
             .checked_round(0, mode)
             .is_none());
     }
@@ -1474,36 +1594,66 @@ mod tests {
     #[test]
     fn test_rounding_midpoint_away_from_zero_precise_decimal() {
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(pdec!("5.5").checked_round(0, mode).unwrap(), pdec!("6"));
-        assert_eq!(pdec!("2.5").checked_round(0, mode).unwrap(), pdec!("3"));
-        assert_eq!(pdec!("1.6").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.1").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("1.0").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("-1.0").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.6").checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(pdec!("-2.5").checked_round(0, mode).unwrap(), pdec!("-3"));
-        assert_eq!(pdec!("-5.5").checked_round(0, mode).unwrap(), pdec!("-6"));
-
         assert_eq!(
-            pdec!("-57896044618658097711785492504343953926634.4")
-                .checked_round(0, mode)
-                .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("6")
         );
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926634.4")
+            test_pdec!("2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("3")
+        );
+        assert_eq!(
+            test_pdec!("1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("-1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("-2")
+        );
+        assert_eq!(
+            test_pdec!("-2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-3")
+        );
+        assert_eq!(
+            test_pdec!("-5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-6")
+        );
+
+        assert_eq!(
+            test_pdec!("-57896044618658097711785492504343953926634.4")
                 .checked_round(0, mode)
                 .unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
+        );
+        assert_eq!(
+            test_pdec!("57896044618658097711785492504343953926634.4")
+                .checked_round(0, mode)
+                .unwrap(),
+            test_pdec!("57896044618658097711785492504343953926634")
         );
 
         assert!(PreciseDecimal::MIN.checked_round(0, mode).is_none());
-        assert!(pdec!("-57896044618658097711785492504343953926634.5")
+        assert!(test_pdec!("-57896044618658097711785492504343953926634.5")
             .checked_round(0, mode)
             .is_none());
         assert!(PreciseDecimal::MAX.checked_round(0, mode).is_none());
-        assert!(pdec!("57896044618658097711785492504343953926634.5")
+        assert!(test_pdec!("57896044618658097711785492504343953926634.5")
             .checked_round(0, mode)
             .is_none());
     }
@@ -1511,135 +1661,167 @@ mod tests {
     #[test]
     fn test_rounding_midpoint_nearest_even_precise_decimal() {
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(pdec!("5.5").checked_round(0, mode).unwrap(), pdec!("6"));
-        assert_eq!(pdec!("2.5").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.6").checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(pdec!("1.1").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("1.0").checked_round(0, mode).unwrap(), pdec!("1"));
-        assert_eq!(pdec!("-1.0").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.1").checked_round(0, mode).unwrap(), pdec!("-1"));
-        assert_eq!(pdec!("-1.6").checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(pdec!("-2.5").checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(pdec!("-5.5").checked_round(0, mode).unwrap(), pdec!("-6"));
+        assert_eq!(
+            test_pdec!("5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("6")
+        );
+        assert_eq!(
+            test_pdec!("2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("2")
+        );
+        assert_eq!(
+            test_pdec!("1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("1")
+        );
+        assert_eq!(
+            test_pdec!("-1.0").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.1").checked_round(0, mode).unwrap(),
+            test_pdec!("-1")
+        );
+        assert_eq!(
+            test_pdec!("-1.6").checked_round(0, mode).unwrap(),
+            test_pdec!("-2")
+        );
+        assert_eq!(
+            test_pdec!("-2.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-2")
+        );
+        assert_eq!(
+            test_pdec!("-5.5").checked_round(0, mode).unwrap(),
+            test_pdec!("-6")
+        );
 
         assert_eq!(
-            pdec!("-57896044618658097711785492504343953926634.5")
+            test_pdec!("-57896044618658097711785492504343953926634.5")
                 .checked_round(0, mode)
                 .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634")
+            test_pdec!("-57896044618658097711785492504343953926634")
         );
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926634.5")
+            test_pdec!("57896044618658097711785492504343953926634.5")
                 .checked_round(0, mode)
                 .unwrap(),
-            pdec!("57896044618658097711785492504343953926634")
+            test_pdec!("57896044618658097711785492504343953926634")
         );
         assert!(PreciseDecimal::MIN.checked_round(0, mode).is_none());
-        assert!(pdec!("-57896044618658097711785492504343953926634.6")
+        assert!(test_pdec!("-57896044618658097711785492504343953926634.6")
             .checked_round(0, mode)
             .is_none());
         assert!(PreciseDecimal::MAX.checked_round(0, mode).is_none());
-        assert!(pdec!("57896044618658097711785492504343953926634.6")
+        assert!(test_pdec!("57896044618658097711785492504343953926634.6")
             .checked_round(0, mode)
             .is_none());
     }
 
     #[test]
     fn test_various_decimal_places_precise_decimal() {
-        let num = pdec!("2.4595");
+        let num = test_pdec!("2.4595");
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.46"));
 
         assert_eq!(
-            pdec!("57896044618658097711785492504343953926633.992332820282019728792003956564819967")
-                .checked_round(1, mode)
-                .unwrap(),
-            pdec!("57896044618658097711785492504343953926634.0")
+            test_pdec!(
+                "57896044618658097711785492504343953926633.992332820282019728792003956564819967"
+            )
+            .checked_round(1, mode)
+            .unwrap(),
+            test_pdec!("57896044618658097711785492504343953926634.0")
         );
         assert_eq!(
-            pdec!(
+            test_pdec!(
                 "-57896044618658097711785492504343953926633.992332820282019728792003956564819967"
             )
             .checked_round(1, mode)
             .unwrap(),
-            pdec!("-57896044618658097711785492504343953926634.0")
+            test_pdec!("-57896044618658097711785492504343953926634.0")
         );
 
         let mode = RoundingMode::ToZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.459"));
         let mode = RoundingMode::ToPositiveInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.46"));
         let mode = RoundingMode::ToNegativeInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.459"));
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.46"));
         let mode = RoundingMode::ToNearestMidpointTowardZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.459"));
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("2.46"));
 
-        let num = pdec!("-2.4595");
+        let num = test_pdec!("-2.4595");
         let mode = RoundingMode::AwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.46"));
         let mode = RoundingMode::ToZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.459"));
         let mode = RoundingMode::ToPositiveInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.4"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.45"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.4"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.45"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.459"));
         let mode = RoundingMode::ToNegativeInfinity;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-3"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-3"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.46"));
         let mode = RoundingMode::ToNearestMidpointAwayFromZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.46"));
         let mode = RoundingMode::ToNearestMidpointTowardZero;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.459"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.459"));
         let mode = RoundingMode::ToNearestMidpointToEven;
-        assert_eq!(num.checked_round(0, mode).unwrap(), pdec!("-2"));
-        assert_eq!(num.checked_round(1, mode).unwrap(), pdec!("-2.5"));
-        assert_eq!(num.checked_round(2, mode).unwrap(), pdec!("-2.46"));
-        assert_eq!(num.checked_round(3, mode).unwrap(), pdec!("-2.46"));
+        assert_eq!(num.checked_round(0, mode).unwrap(), test_pdec!("-2"));
+        assert_eq!(num.checked_round(1, mode).unwrap(), test_pdec!("-2.5"));
+        assert_eq!(num.checked_round(2, mode).unwrap(), test_pdec!("-2.46"));
+        assert_eq!(num.checked_round(3, mode).unwrap(), test_pdec!("-2.46"));
     }
 
     #[test]
     fn test_encode_decimal_value_precise_decimal() {
-        let pdec = pdec!("0");
+        let pdec = test_pdec!("0");
         let bytes = scrypto_encode(&pdec).unwrap();
         assert_eq!(bytes, {
             let mut a = [0; 34];
@@ -1651,10 +1833,10 @@ mod tests {
 
     #[test]
     fn test_decode_decimal_value_precise_decimal() {
-        let pdec = pdec!("1.23456789");
+        let pdec = test_pdec!("1.23456789");
         let bytes = scrypto_encode(&pdec).unwrap();
         let decoded: PreciseDecimal = scrypto_decode(&bytes).unwrap();
-        assert_eq!(decoded, pdec!("1.23456789"));
+        assert_eq!(decoded, test_pdec!("1.23456789"));
     }
 
     #[test]
@@ -1675,7 +1857,7 @@ mod tests {
             $(
                 #[test]
                 fn [<test_from_into_decimal_precise_decimal_ $suffix>]() {
-                    let dec = dec!($from);
+                    let dec = test_dec!($from);
                     let pdec = PreciseDecimal::from(dec);
                     assert_eq!(pdec.to_string(), $expected);
 
@@ -1771,18 +1953,18 @@ mod tests {
     fn test_truncate_precise_decimal_towards_zero() {
         for (pdec, dec) in [
             (
-                pdec!("12345678.123456789012345678901234567890123456"),
-                dec!("12345678.123456789012345678"),
+                test_pdec!("12345678.123456789012345678901234567890123456"),
+                test_dec!("12345678.123456789012345678"),
             ),
-            (pdec!(1), dec!(1)),
-            (pdec!("123.5"), dec!("123.5")),
+            (test_pdec!(1), test_dec!(1)),
+            (test_pdec!("123.5"), test_dec!("123.5")),
             (
-                pdec!("-12345678.123456789012345678901234567890123456"),
-                dec!("-12345678.123456789012345678"),
+                test_pdec!("-12345678.123456789012345678901234567890123456"),
+                test_dec!("-12345678.123456789012345678"),
             ),
             (
-                pdec!("-12345678.123456789012345678101234567890123456"),
-                dec!("-12345678.123456789012345678"),
+                test_pdec!("-12345678.123456789012345678101234567890123456"),
+                test_dec!("-12345678.123456789012345678"),
             ),
         ] {
             assert_eq!(pdec.checked_truncate(RoundingMode::ToZero).unwrap(), dec);
@@ -1793,18 +1975,18 @@ mod tests {
     fn test_truncate_precise_decimal_away_from_zero() {
         for (pdec, dec) in [
             (
-                pdec!("12345678.123456789012345678901234567890123456"),
-                dec!("12345678.123456789012345679"),
+                test_pdec!("12345678.123456789012345678901234567890123456"),
+                test_dec!("12345678.123456789012345679"),
             ),
-            (pdec!(1), dec!(1)),
-            (pdec!("123.5"), dec!("123.5")),
+            (test_pdec!(1), test_dec!(1)),
+            (test_pdec!("123.5"), test_dec!("123.5")),
             (
-                pdec!("-12345678.123456789012345678901234567890123456"),
-                dec!("-12345678.123456789012345679"),
+                test_pdec!("-12345678.123456789012345678901234567890123456"),
+                test_dec!("-12345678.123456789012345679"),
             ),
             (
-                pdec!("-12345678.123456789012345678101234567890123456"),
-                dec!("-12345678.123456789012345679"),
+                test_pdec!("-12345678.123456789012345678101234567890123456"),
+                test_dec!("-12345678.123456789012345679"),
             ),
         ] {
             assert_eq!(
@@ -1816,54 +1998,57 @@ mod tests {
 
     #[test]
     fn test_sqrt() {
-        let sqrt_of_42 = pdec!(42).checked_sqrt();
-        let sqrt_of_0 = pdec!(0).checked_sqrt();
-        let sqrt_of_negative = pdec!("-1").checked_sqrt();
+        let sqrt_of_42 = test_pdec!(42).checked_sqrt();
+        let sqrt_of_0 = test_pdec!(0).checked_sqrt();
+        let sqrt_of_negative = test_pdec!("-1").checked_sqrt();
         assert_eq!(
             sqrt_of_42.unwrap(),
-            pdec!("6.480740698407860230965967436087996657")
+            test_pdec!("6.480740698407860230965967436087996657")
         );
-        assert_eq!(sqrt_of_0.unwrap(), pdec!(0));
+        assert_eq!(sqrt_of_0.unwrap(), test_pdec!(0));
         assert_eq!(sqrt_of_negative, None);
     }
 
     #[test]
     fn test_cbrt() {
-        let cbrt_of_42 = pdec!(42).checked_cbrt().unwrap();
-        let cbrt_of_0 = pdec!(0).checked_cbrt().unwrap();
-        let cbrt_of_negative_42 = pdec!("-42").checked_cbrt().unwrap();
-        assert_eq!(cbrt_of_42, pdec!("3.476026644886449786739865219004537434"));
-        assert_eq!(cbrt_of_0, pdec!("0"));
+        let cbrt_of_42 = test_pdec!(42).checked_cbrt().unwrap();
+        let cbrt_of_0 = test_pdec!(0).checked_cbrt().unwrap();
+        let cbrt_of_negative_42 = test_pdec!("-42").checked_cbrt().unwrap();
+        assert_eq!(
+            cbrt_of_42,
+            test_pdec!("3.476026644886449786739865219004537434")
+        );
+        assert_eq!(cbrt_of_0, test_pdec!("0"));
         assert_eq!(
             cbrt_of_negative_42,
-            pdec!("-3.476026644886449786739865219004537434")
+            test_pdec!("-3.476026644886449786739865219004537434")
         );
     }
 
     #[test]
     fn test_nth_root() {
-        let root_4_42 = pdec!(42).checked_nth_root(4);
-        let root_5_42 = pdec!(42).checked_nth_root(5);
-        let root_42_42 = pdec!(42).checked_nth_root(42);
-        let root_neg_4_42 = pdec!("-42").checked_nth_root(4);
-        let root_neg_5_42 = pdec!("-42").checked_nth_root(5);
-        let root_0 = pdec!(42).checked_nth_root(0);
+        let root_4_42 = test_pdec!(42).checked_nth_root(4);
+        let root_5_42 = test_pdec!(42).checked_nth_root(5);
+        let root_42_42 = test_pdec!(42).checked_nth_root(42);
+        let root_neg_4_42 = test_pdec!("-42").checked_nth_root(4);
+        let root_neg_5_42 = test_pdec!("-42").checked_nth_root(5);
+        let root_0 = test_pdec!(42).checked_nth_root(0);
         assert_eq!(
             root_4_42.unwrap(),
-            pdec!("2.545729895021830518269788960576288685")
+            test_pdec!("2.545729895021830518269788960576288685")
         );
         assert_eq!(
             root_5_42.unwrap(),
-            pdec!("2.111785764966753912732567330550233486")
+            test_pdec!("2.111785764966753912732567330550233486")
         );
         assert_eq!(
             root_42_42.unwrap(),
-            pdec!("1.093072057934823618682784731855625786")
+            test_pdec!("1.093072057934823618682784731855625786")
         );
         assert_eq!(root_neg_4_42, None);
         assert_eq!(
             root_neg_5_42.unwrap(),
-            pdec!("-2.111785764966753912732567330550233486")
+            test_pdec!("-2.111785764966753912732567330550233486")
         );
         assert_eq!(root_0, None);
     }
@@ -1898,7 +2083,7 @@ mod tests {
     #[test]
     fn test_neg_precise_decimal() {
         let d = PreciseDecimal::ONE;
-        assert_eq!(-d, pdec!("-1"));
+        assert_eq!(-d, test_pdec!("-1"));
         let d = PreciseDecimal::MAX;
         assert_eq!(-d, PreciseDecimal(I256::MIN + I256::ONE));
     }
@@ -1937,18 +2122,18 @@ mod tests {
         assert_eq!(p1.checked_add(d1).unwrap(), d2.checked_add(p2).unwrap());
         assert_eq!(p1.checked_sub(d1).unwrap(), d2.checked_sub(p2).unwrap());
 
-        let p1 = pdec!("0.000001");
-        let d1 = dec!("0.001");
-        let d2 = dec!("0.000001");
-        let p2 = pdec!("0.001");
+        let p1 = test_pdec!("0.000001");
+        let d1 = test_dec!("0.001");
+        let d2 = test_dec!("0.000001");
+        let p2 = test_pdec!("0.001");
         assert_eq!(p1.checked_mul(d1).unwrap(), d2.checked_mul(p2).unwrap());
         assert_eq!(p1.checked_div(d1).unwrap(), d2.checked_div(p2).unwrap());
         assert_eq!(p1.checked_add(d1).unwrap(), d2.checked_add(p2).unwrap());
         assert_eq!(p1.checked_sub(d1).unwrap(), d2.checked_sub(p2).unwrap());
 
-        let p1 = pdec!("0.000000000000000001");
+        let p1 = test_pdec!("0.000000000000000001");
         let d1 = Decimal::MIN;
-        let d2 = dec!("0.000000000000000001");
+        let d2 = test_dec!("0.000000000000000001");
         let p2 = PreciseDecimal::from(Decimal::MIN);
         assert_eq!(p1.checked_mul(d1).unwrap(), d2.checked_mul(p2).unwrap());
         assert_eq!(p1.checked_div(d1).unwrap(), d2.checked_div(p2).unwrap());
@@ -1975,14 +2160,14 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_arith_precise_decimal_$type>]() {
-                    let p1 = pdec!("2");
+                    let p1 = test_pdec!("2");
                     let u1 = 4 as $type;
-                    assert_eq!(p1.checked_add(u1).unwrap(), pdec!("6"));
-                    assert_eq!(p1.checked_sub(u1).unwrap(), pdec!("-2"));
-                    assert_eq!(p1.checked_mul(u1).unwrap(), pdec!("8"));
-                    assert_eq!(p1.checked_div(u1).unwrap(), pdec!("0.5"));
+                    assert_eq!(p1.checked_add(u1).unwrap(), test_pdec!("6"));
+                    assert_eq!(p1.checked_sub(u1).unwrap(), test_pdec!("-2"));
+                    assert_eq!(p1.checked_mul(u1).unwrap(), test_pdec!("8"));
+                    assert_eq!(p1.checked_div(u1).unwrap(), test_pdec!("0.5"));
 
-                    let p1 = pdec!("2");
+                    let p1 = test_pdec!("2");
                     let u1 = $type::MAX;
                     let p2 = PreciseDecimal::from($type::MAX);
                     assert_eq!(p1.checked_add(u1).unwrap(), p1.checked_add(p2).unwrap());
@@ -1992,7 +2177,7 @@ mod tests {
 
                     let p1 = PreciseDecimal::from($type::MIN);
                     let u1 = 2 as $type;
-                    let p2 = pdec!("2");
+                    let p2 = test_pdec!("2");
                     assert_eq!(p1.checked_add(u1).unwrap(), p1.checked_add(p2).unwrap());
                     assert_eq!(p1.checked_sub(u1).unwrap(), p1.checked_sub(p2).unwrap());
                     assert_eq!(p1.checked_mul(u1).unwrap(), p1.checked_mul(p2).unwrap());
@@ -2019,16 +2204,16 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_arith_precise_decimal_$type:lower>]() {
-                    let d1 = pdec!("2");
+                    let d1 = test_pdec!("2");
                     let u1 = $type::try_from(4).unwrap();
                     let u2 = $type::try_from(2).unwrap();
-                    let d2 = pdec!("4");
+                    let d2 = test_pdec!("4");
                     assert_eq!(d1.checked_add(u1).unwrap(), u2.checked_add(d2).unwrap());
                     assert_eq!(d1.checked_sub(u1).unwrap(), u2.checked_sub(d2).unwrap());
                     assert_eq!(d1.checked_mul(u1).unwrap(), u2.checked_mul(d2).unwrap());
                     assert_eq!(d1.checked_div(u1).unwrap(), u2.checked_div(d2).unwrap());
 
-                    let d1 = pdec!("2");
+                    let d1 = test_pdec!("2");
                     let u1 = $type::MAX;
                     assert!(d1.checked_add(u1).is_none());
                     assert!(d1.checked_sub(u1).is_none());
@@ -2038,9 +2223,9 @@ mod tests {
                     let d1 = PreciseDecimal::MAX;
                     let u1 = $type::try_from(2).unwrap();
                     assert_eq!(d1.checked_add(u1), None);
-                    assert_eq!(d1.checked_sub(u1).unwrap(), PreciseDecimal::MAX - dec!("2"));
+                    assert_eq!(d1.checked_sub(u1).unwrap(), PreciseDecimal::MAX - test_dec!("2"));
                     assert_eq!(d1.checked_mul(u1), None);
-                    assert_eq!(d1.checked_div(u1).unwrap(), PreciseDecimal::MAX / dec!("2"));
+                    assert_eq!(d1.checked_div(u1).unwrap(), PreciseDecimal::MAX / test_dec!("2"));
                 }
             }
         };
@@ -2061,37 +2246,37 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_math_operands_precise_decimal_$type:lower>]() {
-                    let d1 = pdec!("2");
+                    let d1 = test_pdec!("2");
                     let u1 = $type::try_from(4).unwrap();
-                    assert_eq!(d1 + u1, pdec!("6"));
-                    assert_eq!(d1 - u1, pdec!("-2"));
-                    assert_eq!(d1 * u1, pdec!("8"));
-                    assert_eq!(d1 / u1, pdec!("0.5"));
+                    assert_eq!(d1 + u1, test_pdec!("6"));
+                    assert_eq!(d1 - u1, test_pdec!("-2"));
+                    assert_eq!(d1 * u1, test_pdec!("8"));
+                    assert_eq!(d1 / u1, test_pdec!("0.5"));
 
                     let u1 = $type::try_from(2).unwrap();
-                    let d1 = pdec!("4");
-                    assert_eq!(u1 + d1, pdec!("6"));
-                    assert_eq!(u1 - d1, pdec!("-2"));
-                    assert_eq!(u1 * d1, pdec!("8"));
-                    assert_eq!(u1 / d1, pdec!("0.5"));
+                    let d1 = test_pdec!("4");
+                    assert_eq!(u1 + d1, test_pdec!("6"));
+                    assert_eq!(u1 - d1, test_pdec!("-2"));
+                    assert_eq!(u1 * d1, test_pdec!("8"));
+                    assert_eq!(u1 / d1, test_pdec!("0.5"));
 
                     let u1 = $type::try_from(4).unwrap();
 
-                    let mut d1 = pdec!("2");
+                    let mut d1 = test_pdec!("2");
                     d1 += u1;
-                    assert_eq!(d1, pdec!("6"));
+                    assert_eq!(d1, test_pdec!("6"));
 
-                    let mut d1 = pdec!("2");
+                    let mut d1 = test_pdec!("2");
                     d1 -= u1;
-                    assert_eq!(d1, pdec!("-2"));
+                    assert_eq!(d1, test_pdec!("-2"));
 
-                    let mut d1 = pdec!("2");
+                    let mut d1 = test_pdec!("2");
                     d1 *= u1;
-                    assert_eq!(d1, pdec!("8"));
+                    assert_eq!(d1, test_pdec!("8"));
 
-                    let mut d1 = pdec!("2");
+                    let mut d1 = test_pdec!("2");
                     d1 /= u1;
-                    assert_eq!(d1, pdec!("0.5"));
+                    assert_eq!(d1, test_pdec!("0.5"));
                 }
 
                 #[test]
@@ -2222,11 +2407,11 @@ mod tests {
                 #[test]
                 fn [<test_precise_decimal_from_primitive_$type>]() {
                     let v = $type::try_from(1).unwrap();
-                    assert_eq!(PreciseDecimal::from(v), pdec!(1));
+                    assert_eq!(PreciseDecimal::from(v), test_pdec!(1));
 
                     if $type::MIN != 0 {
                         let v = $type::try_from(-1).unwrap();
-                        assert_eq!(PreciseDecimal::from(v), pdec!(-1));
+                        assert_eq!(PreciseDecimal::from(v), test_pdec!(-1));
                     }
 
                     let v = $type::MAX;
@@ -2256,12 +2441,12 @@ mod tests {
             paste! {
                 #[test]
                 fn [<test_precise_decimal_to_primitive_$type>]() {
-                    let d = pdec!(1);
+                    let d = test_pdec!(1);
                     let v = $type::try_from(1).unwrap();
                     assert_eq!($type::try_from(d).unwrap(), v);
 
                     if $type::MIN != 0 {
-                        let d = pdec!(-1);
+                        let d = test_pdec!(-1);
                         let v = $type::try_from(-1).unwrap();
                         assert_eq!($type::try_from(d).unwrap(), v);
                     }
@@ -2288,7 +2473,7 @@ mod tests {
                     let err = $type::try_from(d).unwrap_err();
                     assert_eq!(err, ParsePreciseDecimalError::Overflow);
 
-                    let d = pdec!("1.1");
+                    let d = test_pdec!("1.1");
                     let err = $type::try_from(d).unwrap_err();
                     assert_eq!(err, ParsePreciseDecimalError::InvalidDigit);
                 }

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 sbor = { path = "../sbor", default-features = false }
 radix-engine-derive = { path = "../radix-engine-derive", default-features = false }
 radix-engine-common = { path = "../radix-engine-common", default-features = false }
+radix-engine-macros = { path = "../radix-engine-macros", default-features = false }
 scrypto-schema = { path = "../scrypto-schema", default-features = false }
 utils = { path = "../utils", default-features = false }
-radix-engine-macros = { path = "../radix-engine-macros" }
 
 hex = { version = "0.4.3", default-features = false }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
@@ -24,8 +24,8 @@ regex = { version = "=1.9.3", default-features = false }
 [features]
 # You should enable either `std` or `alloc`
 default = ["std"]
-std = ["hex/std", "serde_json/std", "sbor/std", "scrypto-schema/std", "radix-engine-derive/std", "radix-engine-common/std", "strum/std", "utils/std"]
-alloc = ["hex/alloc", "serde_json/alloc", "sbor/alloc", "scrypto-schema/alloc", "radix-engine-derive/alloc", "radix-engine-common/alloc", "utils/alloc"]
+std = ["hex/std", "serde_json/std", "sbor/std", "scrypto-schema/std", "radix-engine-derive/std", "radix-engine-common/std", "radix-engine-macros/std", "strum/std", "utils/std"]
+alloc = ["hex/alloc", "serde_json/alloc", "sbor/alloc", "scrypto-schema/alloc", "radix-engine-derive/alloc", "radix-engine-common/alloc", "radix-engine-macros/alloc", "utils/alloc"]
 
 # Turn on this feature to enable tracing.
 trace = ["radix-engine-derive/trace"]

--- a/radix-engine-interface/Cargo.toml
+++ b/radix-engine-interface/Cargo.toml
@@ -9,6 +9,7 @@ radix-engine-derive = { path = "../radix-engine-derive", default-features = fals
 radix-engine-common = { path = "../radix-engine-common", default-features = false }
 scrypto-schema = { path = "../scrypto-schema", default-features = false }
 utils = { path = "../utils", default-features = false }
+radix-engine-macros = { path = "../radix-engine-macros" }
 
 hex = { version = "0.4.3", default-features = false }
 strum = { version = "0.24", default-features = false, features = ["derive"] }

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -57,9 +57,10 @@ pub mod prelude {
     pub use crate::traits::*;
     pub use crate::types::*;
     pub use crate::{
-        access_and_or, access_rule_node, burn_roles, deposit_roles, freeze_roles, internal_roles,
-        metadata, metadata_init, metadata_init_set_entry, metadata_roles, mint_roles,
-        non_fungible_data_update_roles, recall_roles, role_entry, roles2, rule, withdraw_roles,
+        access_and_or, access_rule_node, burn_roles, dec, deposit_roles, freeze_roles,
+        internal_roles, metadata, metadata_init, metadata_init_set_entry, metadata_roles,
+        mint_roles, non_fungible_data_update_roles, pdec, recall_roles, role_entry, roles2, rule,
+        withdraw_roles,
     };
 }
 

--- a/radix-engine-interface/src/macros.rs
+++ b/radix-engine-interface/src/macros.rs
@@ -115,26 +115,6 @@ macro_rules! roles2 {
     })
 }
 
-/// Creates a `Decimal` from literals.
-///
-#[macro_export]
-macro_rules! dec {
-    // NOTE: Decimal arithmetic operation safe unwrap.
-    // In general, it is assumed that reasonable literals are provided.
-    // If not then something is definitely wrong and panic is fine.
-    ($x:literal) => {
-        radix_engine_common::math::Decimal::try_from($x).unwrap()
-    };
-}
-
-/// Creates a `PreciseDecimal` from literals.
-///
-#[macro_export]
-macro_rules! pdec {
-    // NOTE: PreciseDecimal arithmetic operation safe unwrap.
-    // In general, it is assumed that reasonable literals are provided.
-    // If not then something is definitely wrong and panic is fine.
-    ($x:literal) => {
-        radix_engine_common::math::PreciseDecimal::try_from($x).unwrap()
-    };
-}
+extern crate radix_engine_macros;
+pub use radix_engine_macros::dec;
+pub use radix_engine_macros::pdec;

--- a/radix-engine-interface/src/macros.rs
+++ b/radix-engine-interface/src/macros.rs
@@ -114,3 +114,78 @@ macro_rules! roles2 {
         roles
     })
 }
+
+/// Creates a `Decimal` from literals.
+///
+#[macro_export]
+macro_rules! dec {
+    (0) => {
+        radix_engine_common::math::Decimal::ZERO
+    };
+    ("0") => {
+        radix_engine_common::math::Decimal::ZERO
+    };
+    ("0.1") => {
+        radix_engine_common::math::Decimal::ONE_TENTH
+    };
+    ("1" | 1) => {
+        radix_engine_common::math::Decimal::ONE
+    };
+    (10) => {
+        radix_engine_common::math::Decimal::TEN
+    };
+    ("10") => {
+        radix_engine_common::math::Decimal::TEN
+    };
+    (100) => {
+        radix_engine_common::math::Decimal::ONE_HUNDRED
+    };
+    ("100") => {
+        radix_engine_common::math::Decimal::ONE_HUNDRED
+    };
+    // NOTE: Decimal arithmetic operation safe unwrap.
+    // In general, it is assumed that reasonable literals are provided.
+    // If not then something is definitely wrong and panic is fine.
+    ($x:literal) => {
+        radix_engine_common::math::Decimal::try_from($x).unwrap()
+    };
+}
+
+/// Creates a `PreciseDecimal` from literals.
+///
+#[macro_export]
+macro_rules! pdec {
+    (0) => {
+        radix_engine_common::math::PreciseDecimal::ZERO
+    };
+    ("0") => {
+        radix_engine_common::math::PreciseDecimal::ZERO
+    };
+    ("0.1") => {
+        radix_engine_common::math::PreciseDecimal::ONE_TENTH
+    };
+    (1) => {
+        radix_engine_common::math::PreciseDecimal::ONE
+    };
+    ("1") => {
+        radix_engine_common::math::PreciseDecimal::ONE
+    };
+    (10) => {
+        radix_engine_common::math::PreciseDecimal::TEN
+    };
+    ("10") => {
+        radix_engine_common::math::PreciseDecimal::TEN
+    };
+    (100) => {
+        radix_engine_common::math::PreciseDecimal::ONE_HUNDRED
+    };
+    ("100") => {
+        radix_engine_common::math::PreciseDecimal::ONE_HUNDRED
+    };
+    // NOTE: PreciseDecimal arithmetic operation safe unwrap.
+    // In general, it is assumed that reasonable literals are provided.
+    // If not then something is definitely wrong and panic is fine.
+    ($x:literal) => {
+        radix_engine_common::math::PreciseDecimal::try_from($x).unwrap()
+    };
+}

--- a/radix-engine-interface/src/macros.rs
+++ b/radix-engine-interface/src/macros.rs
@@ -119,30 +119,6 @@ macro_rules! roles2 {
 ///
 #[macro_export]
 macro_rules! dec {
-    (0) => {
-        radix_engine_common::math::Decimal::ZERO
-    };
-    ("0") => {
-        radix_engine_common::math::Decimal::ZERO
-    };
-    ("0.1") => {
-        radix_engine_common::math::Decimal::ONE_TENTH
-    };
-    ("1" | 1) => {
-        radix_engine_common::math::Decimal::ONE
-    };
-    (10) => {
-        radix_engine_common::math::Decimal::TEN
-    };
-    ("10") => {
-        radix_engine_common::math::Decimal::TEN
-    };
-    (100) => {
-        radix_engine_common::math::Decimal::ONE_HUNDRED
-    };
-    ("100") => {
-        radix_engine_common::math::Decimal::ONE_HUNDRED
-    };
     // NOTE: Decimal arithmetic operation safe unwrap.
     // In general, it is assumed that reasonable literals are provided.
     // If not then something is definitely wrong and panic is fine.
@@ -155,33 +131,6 @@ macro_rules! dec {
 ///
 #[macro_export]
 macro_rules! pdec {
-    (0) => {
-        radix_engine_common::math::PreciseDecimal::ZERO
-    };
-    ("0") => {
-        radix_engine_common::math::PreciseDecimal::ZERO
-    };
-    ("0.1") => {
-        radix_engine_common::math::PreciseDecimal::ONE_TENTH
-    };
-    (1) => {
-        radix_engine_common::math::PreciseDecimal::ONE
-    };
-    ("1") => {
-        radix_engine_common::math::PreciseDecimal::ONE
-    };
-    (10) => {
-        radix_engine_common::math::PreciseDecimal::TEN
-    };
-    ("10") => {
-        radix_engine_common::math::PreciseDecimal::TEN
-    };
-    (100) => {
-        radix_engine_common::math::PreciseDecimal::ONE_HUNDRED
-    };
-    ("100") => {
-        radix_engine_common::math::PreciseDecimal::ONE_HUNDRED
-    };
     // NOTE: PreciseDecimal arithmetic operation safe unwrap.
     // In general, it is assumed that reasonable literals are provided.
     // If not then something is definitely wrong and panic is fine.

--- a/radix-engine-macros/Cargo.toml
+++ b/radix-engine-macros/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = { git = "https://github.com/dtolnay/syn.git", tag = "1.0.93", features = ["full", "extra-traits"] }
+paste = { version = "1.0.13" }
 radix-engine-common= { path = "../radix-engine-common", default-features = false }
 
 [lib]

--- a/radix-engine-macros/Cargo.toml
+++ b/radix-engine-macros/Cargo.toml
@@ -7,9 +7,14 @@ edition = "2021"
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = { git = "https://github.com/dtolnay/syn.git", tag = "1.0.93", features = ["full", "extra-traits"] }
-radix-engine-common = { path = "../radix-engine-common" }
+radix-engine-common= { path = "../radix-engine-common", default-features = false }
 
 [lib]
 doctest = false
 proc-macro = true
 bench = false
+
+[features]
+default = ["std"]
+std = ["radix-engine-common/std"]
+alloc = ["radix-engine-common/alloc"]

--- a/radix-engine-macros/Cargo.toml
+++ b/radix-engine-macros/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = { git = "https://github.com/dtolnay/syn.git", tag = "1.0.93", features = ["full", "extra-traits"] }
+radix-engine-common = { path = "../radix-engine-common" }
 
 [lib]
 doctest = false

--- a/radix-engine-macros/src/decimal.rs
+++ b/radix-engine-macros/src/decimal.rs
@@ -1,0 +1,83 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Expr};
+
+extern crate radix_engine_common;
+
+fn get_decimal_from_expr(expr: &Expr) -> radix_engine_common::math::Decimal {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Str(lit_str) => {
+                radix_engine_common::math::Decimal::try_from(lit_str.value()).unwrap()
+            }
+            syn::Lit::Int(lit_int) => {
+                radix_engine_common::math::Decimal::try_from(lit_int.base10_digits()).unwrap()
+            }
+            syn::Lit::Bool(lit_bool) => radix_engine_common::math::Decimal::from(lit_bool.value),
+            _ => panic!("Unsupported literal type!"),
+        },
+        Expr::Group(group) => get_decimal_from_expr(&group.expr),
+        Expr::Unary(unary) => match unary.op {
+            syn::UnOp::Neg(_) => -get_decimal_from_expr(unary.expr.as_ref()),
+            _ => panic!("Unsupported unary expression!"),
+        },
+        _ => panic!("Unsupported expression!"),
+    }
+}
+
+fn get_precise_decimal_from_expr(expr: &Expr) -> radix_engine_common::math::PreciseDecimal {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Str(lit_str) => {
+                radix_engine_common::math::PreciseDecimal::try_from(lit_str.value()).unwrap()
+            }
+            syn::Lit::Int(lit_int) => {
+                radix_engine_common::math::PreciseDecimal::try_from(lit_int.base10_digits())
+                    .unwrap()
+            }
+            syn::Lit::Bool(lit_bool) => {
+                radix_engine_common::math::PreciseDecimal::from(lit_bool.value)
+            }
+            _ => panic!("Unsupported literal type!"),
+        },
+        Expr::Group(group) => get_precise_decimal_from_expr(&group.expr),
+        Expr::Unary(unary) => match unary.op {
+            syn::UnOp::Neg(_) => -get_precise_decimal_from_expr(unary.expr.as_ref()),
+            _ => panic!("Unsupported unary expression!"),
+        },
+        _ => panic!("Unsupported expression!"),
+    }
+}
+
+pub fn to_decimal(input: TokenStream) -> TokenStream {
+    // Parse the input into an Expression
+    let expr = parse_macro_input!(input as Expr);
+
+    let decimal = get_decimal_from_expr(&expr);
+    let int = decimal.0;
+    let arr = int.to_digits();
+    let i0 = arr[0];
+    let i1 = arr[1];
+    let i2 = arr[2];
+
+    TokenStream::from(quote! {
+        radix_engine_common::math::Decimal(radix_engine_common::math::I192::from_digits([#i0, #i1, #i2]))
+    })
+}
+
+pub fn to_precise_decimal(input: TokenStream) -> TokenStream {
+    // Parse the input into an Expression
+    let expr = parse_macro_input!(input as Expr);
+
+    let decimal = get_precise_decimal_from_expr(&expr);
+    let int = decimal.0;
+    let arr = int.to_digits();
+    let i0 = arr[0];
+    let i1 = arr[1];
+    let i2 = arr[2];
+    let i3 = arr[2];
+
+    TokenStream::from(quote! {
+        radix_engine_common::math::PreciseDecimal(radix_engine_common::math::I256::from_digits([#i0, #i1, #i2, #i3]))
+    })
+}

--- a/radix-engine-macros/src/decimal.rs
+++ b/radix-engine-macros/src/decimal.rs
@@ -1,75 +1,106 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Expr};
+use radix_engine_common::prelude::CheckedNeg;
+use syn::{parse, spanned::Spanned, Error, Expr, Lit, Result, UnOp};
 
 extern crate radix_engine_common;
+use radix_engine_common::math::{Decimal, PreciseDecimal};
 
-fn get_decimal_from_expr(expr: &Expr) -> radix_engine_common::math::Decimal {
+fn get_decimal_from_expr(expr: &Expr) -> Result<Decimal> {
     match expr {
         Expr::Lit(lit) => match &lit.lit {
-            syn::Lit::Str(lit_str) => {
-                radix_engine_common::math::Decimal::try_from(lit_str.value()).unwrap()
-            }
-            syn::Lit::Int(lit_int) => {
-                radix_engine_common::math::Decimal::try_from(lit_int.base10_digits()).unwrap()
-            }
-            syn::Lit::Bool(lit_bool) => radix_engine_common::math::Decimal::from(lit_bool.value),
-            _ => panic!("Unsupported literal type!"),
+            Lit::Str(lit_str) => Decimal::try_from(lit_str.value())
+                .map_err(|err| Error::new(lit_str.span(), format!("Parsing failed due to {:?}", err.to_string()))),
+            Lit::Int(lit_int) => Decimal::try_from(lit_int.base10_digits())
+                .map_err(|err| Error::new(lit_int.span(),format!("Parsing failed due to {:?}", err.to_string()))),
+            Lit::Bool(lit_bool) => Ok(Decimal::from(lit_bool.value)),
+            other_lit => Err(Error::new(
+                other_lit.span(),
+                "Not supported literal. This macro only supports string, integer and bool literal expressions.",
+            )),
         },
         Expr::Group(group) => get_decimal_from_expr(&group.expr),
         Expr::Unary(unary) => match unary.op {
-            syn::UnOp::Neg(_) => -get_decimal_from_expr(unary.expr.as_ref()),
-            _ => panic!("Unsupported unary expression!"),
+            UnOp::Neg(unary_neg) => {
+                let res = get_decimal_from_expr(unary.expr.as_ref());
+                match res {
+                    Ok(val) => {
+                        let val = val.checked_neg().ok_or(Error::new(unary_neg.span, "Parsing failed due to Overflow"))?;
+                        Ok(val)
+                    },
+                    Err(err) => Err(syn::Error::new(unary_neg.span, err.to_string())),
+                }
+            }
+            other_unary => Err(Error::new(
+                other_unary.span(),
+                "Not supported unary operator. This macro only supports '-' unary operator.",
+            )),
         },
-        _ => panic!("Unsupported expression!"),
+        other_expr => Err(Error::new(
+            other_expr.span(),
+            "Not supported expression. This macro only supports string, integer and bool literal expressions.",
+        )),
     }
 }
 
-fn get_precise_decimal_from_expr(expr: &Expr) -> radix_engine_common::math::PreciseDecimal {
+fn get_precise_decimal_from_expr(expr: &Expr) -> Result<PreciseDecimal> {
     match expr {
         Expr::Lit(lit) => match &lit.lit {
-            syn::Lit::Str(lit_str) => {
-                radix_engine_common::math::PreciseDecimal::try_from(lit_str.value()).unwrap()
-            }
-            syn::Lit::Int(lit_int) => {
-                radix_engine_common::math::PreciseDecimal::try_from(lit_int.base10_digits())
-                    .unwrap()
-            }
-            syn::Lit::Bool(lit_bool) => {
-                radix_engine_common::math::PreciseDecimal::from(lit_bool.value)
-            }
-            _ => panic!("Unsupported literal type!"),
+            Lit::Str(lit_str) => PreciseDecimal::try_from(lit_str.value())
+                .map_err(|err| Error::new(lit_str.span(), format!("Parsing failed due to {:?}", err.to_string()))),
+            Lit::Int(lit_int) => PreciseDecimal::try_from(lit_int.base10_digits())
+                .map_err(|err| Error::new(lit_int.span(), format!("Parsing failed due to {:?}", err.to_string()))),
+            Lit::Bool(lit_bool) => Ok(PreciseDecimal::from(lit_bool.value)),
+            other_lit => Err(Error::new(
+                other_lit.span(),
+                "Not supported literal. This macro only supports string, integer and bool literal expressions.",
+            )),
         },
         Expr::Group(group) => get_precise_decimal_from_expr(&group.expr),
         Expr::Unary(unary) => match unary.op {
-            syn::UnOp::Neg(_) => -get_precise_decimal_from_expr(unary.expr.as_ref()),
-            _ => panic!("Unsupported unary expression!"),
+            UnOp::Neg(unary_neg) => {
+                let res = get_precise_decimal_from_expr(unary.expr.as_ref());
+                match res {
+                    Ok(val) => {
+                        let val = val.checked_neg().ok_or(Error::new(unary_neg.span, "Parsing failed due to Overflow"))?;
+                        Ok(val)
+                    },
+                    Err(err) => Err(syn::Error::new(unary_neg.span, err.to_string())),
+                }
+            }
+            other_unary => Err(Error::new(
+                other_unary.span(),
+                "Not supported unary operator. This macro only supports '-' unary operator.",
+            )),
         },
-        _ => panic!("Unsupported expression!"),
+        other_expr => Err(Error::new(
+            other_expr.span(),
+            "Not supported expression. This macro only supports string, integer and bool literal expressions.",
+        )),
     }
 }
 
-pub fn to_decimal(input: TokenStream) -> TokenStream {
+pub fn to_decimal(input: TokenStream) -> Result<TokenStream> {
     // Parse the input into an Expression
-    let expr = parse_macro_input!(input as Expr);
+    let expr = parse::<Expr>(input)?;
 
-    let decimal = get_decimal_from_expr(&expr);
+    let decimal = get_decimal_from_expr(&expr)?;
     let int = decimal.0;
     let arr = int.to_digits();
     let i0 = arr[0];
     let i1 = arr[1];
     let i2 = arr[2];
 
-    TokenStream::from(quote! {
+    Ok(TokenStream::from(quote! {
         radix_engine_common::math::Decimal(radix_engine_common::math::I192::from_digits([#i0, #i1, #i2]))
-    })
+    }))
 }
 
-pub fn to_precise_decimal(input: TokenStream) -> TokenStream {
+pub fn to_precise_decimal(input: TokenStream) -> Result<TokenStream> {
     // Parse the input into an Expression
-    let expr = parse_macro_input!(input as Expr);
+    let expr = parse::<Expr>(input)?;
 
-    let decimal = get_precise_decimal_from_expr(&expr);
+    let decimal = get_precise_decimal_from_expr(&expr)?;
     let int = decimal.0;
     let arr = int.to_digits();
     let i0 = arr[0];
@@ -77,7 +108,7 @@ pub fn to_precise_decimal(input: TokenStream) -> TokenStream {
     let i2 = arr[2];
     let i3 = arr[3];
 
-    TokenStream::from(quote! {
+    Ok(TokenStream::from(quote! {
         radix_engine_common::math::PreciseDecimal(radix_engine_common::math::I256::from_digits([#i0, #i1, #i2, #i3]))
-    })
+    }))
 }

--- a/radix-engine-macros/src/decimal.rs
+++ b/radix-engine-macros/src/decimal.rs
@@ -23,7 +23,6 @@ macro_rules! get_decimal {
                             "Not supported literal. This macro only supports string, integer and bool literal expressions.",
                         )),
                     },
-                    Expr::Group(group) => [< get_ $type:snake:lower _from_expr >](&group.expr),
                     Expr::Unary(unary) => match unary.op {
                         UnOp::Neg(unary_neg) => {
                             let res = [< get_ $type:snake:lower _from_expr >](unary.expr.as_ref());

--- a/radix-engine-macros/src/decimal.rs
+++ b/radix-engine-macros/src/decimal.rs
@@ -75,7 +75,7 @@ pub fn to_precise_decimal(input: TokenStream) -> TokenStream {
     let i0 = arr[0];
     let i1 = arr[1];
     let i2 = arr[2];
-    let i3 = arr[2];
+    let i3 = arr[3];
 
     TokenStream::from(quote! {
         radix_engine_common::math::PreciseDecimal(radix_engine_common::math::I256::from_digits([#i0, #i1, #i2, #i3]))

--- a/radix-engine-macros/src/decimal.rs
+++ b/radix-engine-macros/src/decimal.rs
@@ -14,9 +14,9 @@ macro_rules! get_decimal {
                 match expr {
                     Expr::Lit(lit) => match &lit.lit {
                         Lit::Str(lit_str) => $type::try_from(lit_str.value())
-                            .map_err(|err| Error::new(lit_str.span(), format!("Parsing failed due to {:?}", err.to_string()))),
+                            .map_err(|err| Error::new(lit_str.span(), format!("Parsing failed due to {:?}", err))),
                         Lit::Int(lit_int) => $type::try_from(lit_int.base10_digits())
-                            .map_err(|err| Error::new(lit_int.span(), format!("Parsing failed due to {:?}", err.to_string()))),
+                            .map_err(|err| Error::new(lit_int.span(), format!("Parsing failed due to {:?}", err))),
                         Lit::Bool(lit_bool) => Ok($type::from(lit_bool.value)),
                         other_lit => Err(Error::new(
                             other_lit.span(),
@@ -31,7 +31,7 @@ macro_rules! get_decimal {
                                     let val = val.checked_neg().ok_or(Error::new(unary_neg.span, "Parsing failed due to Overflow"))?;
                                     Ok(val)
                                 },
-                                Err(err) => Err(syn::Error::new(unary_neg.span, err.to_string())),
+                                Err(err) => Err(Error::new(unary_neg.span, err)),
                             }
                         }
                         other_unary => Err(Error::new(

--- a/radix-engine-macros/src/lib.rs
+++ b/radix-engine-macros/src/lib.rs
@@ -34,7 +34,7 @@ pub fn ignore(_: TokenStream, input: TokenStream) -> TokenStream {
 // If not then something is definitely wrong and panic is fine.
 #[proc_macro]
 pub fn dec(input: TokenStream) -> TokenStream {
-    to_decimal(input)
+    to_decimal(input).unwrap_or_else(|err| err.to_compile_error().into())
 }
 
 /// Creates a `PreciseDecimal` from literals.
@@ -50,5 +50,5 @@ pub fn dec(input: TokenStream) -> TokenStream {
 // If not then something is definitely wrong and panic is fine.
 #[proc_macro]
 pub fn pdec(input: TokenStream) -> TokenStream {
-    to_precise_decimal(input)
+    to_precise_decimal(input).unwrap_or_else(|err| err.to_compile_error().into())
 }

--- a/radix-engine-macros/src/unwind.rs
+++ b/radix-engine-macros/src/unwind.rs
@@ -1,0 +1,42 @@
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::*;
+
+pub fn handle_catch_unwind(metadata: TokenStream2, input: TokenStream2) -> Result<TokenStream2> {
+    let rtn_transformer = parse2::<Path>(metadata)?;
+
+    if let Ok(mut item_fn) = parse2::<ItemFn>(input.clone()) {
+        process_function(&mut item_fn.attrs, &mut item_fn.block, &rtn_transformer);
+        Ok(quote! { #item_fn })
+    } else if let Ok(mut item_impl) = parse2::<ItemImpl>(input) {
+        for item in item_impl.items.iter_mut() {
+            if let ImplItem::Method(method) = item {
+                process_function(&mut method.attrs, &mut method.block, &rtn_transformer)
+            }
+        }
+        Ok(quote! { #item_impl })
+    } else {
+        Err(Error::new(
+            Span::call_site(),
+            "Only functions and impls are supported by `catch_unwind`.",
+        ))
+    }
+}
+
+fn process_function(attrs: &mut Vec<Attribute>, block: &mut Block, rtn_transformer: &Path) {
+    if let Some((index, _)) = attrs.iter().enumerate().find(|(_, attribute)| {
+        (&(*attribute).clone())
+            .into_token_stream()
+            .to_string()
+            .contains("catch_unwind_ignore")
+    }) {
+        attrs.remove(index);
+        return;
+    }
+
+    let transformed_block: Block = parse_quote! { {
+        #rtn_transformer(::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(crate::utils::fn_once(|| #block))))
+    } };
+    *block = transformed_block;
+}
+

--- a/radix-engine-macros/src/unwind.rs
+++ b/radix-engine-macros/src/unwind.rs
@@ -39,4 +39,3 @@ fn process_function(attrs: &mut Vec<Attribute>, block: &mut Block, rtn_transform
     } };
     *block = transformed_block;
 }
-

--- a/radix-engine-tests/tests/decimal.rs
+++ b/radix-engine-tests/tests/decimal.rs
@@ -23,6 +23,21 @@ fn test_dec_macro() {
 
     const X4: Decimal = dec!(-1_000_000_i64);
     assert_eq!(X4, Decimal::try_from(-1_000_000_i64).unwrap());
+
+    static X5: Decimal = dec!(1);
+    assert_eq!(X5, Decimal::ONE);
+
+    static X6: Decimal = dec!(10);
+    assert_eq!(X6, Decimal::TEN);
+
+    static X7: Decimal = dec!(100);
+    assert_eq!(X7, Decimal::ONE_HUNDRED);
+
+    static X8: Decimal = dec!("0.1");
+    assert_eq!(X8, Decimal::ONE_TENTH);
+
+    static X9: Decimal = dec!("0.01");
+    assert_eq!(X9, Decimal::ONE_HUNDREDTH);
 }
 
 #[test]
@@ -49,4 +64,19 @@ fn test_pdec_macro() {
 
     const X4: PreciseDecimal = pdec!(-1_000_000_i64);
     assert_eq!(X4, PreciseDecimal::try_from(-1_000_000_i64).unwrap());
+
+    static X5: PreciseDecimal = pdec!(1);
+    assert_eq!(X5, PreciseDecimal::ONE);
+
+    static X6: PreciseDecimal = pdec!(10);
+    assert_eq!(X6, PreciseDecimal::TEN);
+
+    static X7: PreciseDecimal = pdec!(100);
+    assert_eq!(X7, PreciseDecimal::ONE_HUNDRED);
+
+    static X8: PreciseDecimal = pdec!("0.1");
+    assert_eq!(X8, PreciseDecimal::ONE_TENTH);
+
+    static X9: PreciseDecimal = pdec!("0.01");
+    assert_eq!(X9, PreciseDecimal::ONE_HUNDREDTH);
 }

--- a/radix-engine-tests/tests/decimal.rs
+++ b/radix-engine-tests/tests/decimal.rs
@@ -1,0 +1,52 @@
+use radix_engine_common::math::*;
+use radix_engine_interface::{dec, pdec};
+
+#[test]
+fn test_dec_macro() {
+    let x1 = dec!("1.1");
+    assert_eq!(x1, Decimal::try_from("1.1").unwrap());
+
+    let x2 = dec!("3138550867693340381917894711603833208051.177722232017256447");
+    assert_eq!(x2, Decimal::MAX);
+
+    let x3 = dec!("-3138550867693340381917894711603833208051.177722232017256448");
+    assert_eq!(x3, Decimal::MIN);
+
+    const X1: Decimal = dec!("111111.10");
+    assert_eq!(X1, Decimal::try_from("111111.10").unwrap());
+
+    const X2: Decimal = dec!(-111);
+    assert_eq!(X2, Decimal::try_from(-111).unwrap());
+
+    const X3: Decimal = dec!(129u128);
+    assert_eq!(X3, Decimal::try_from(129u128).unwrap());
+
+    const X4: Decimal = dec!(-1_000_000_i64);
+    assert_eq!(X4, Decimal::try_from(-1_000_000_i64).unwrap());
+}
+
+#[test]
+fn test_pdec_macro() {
+    let x1 = pdec!("1.1");
+    assert_eq!(x1, PreciseDecimal::try_from("1.1").unwrap());
+
+    let x2 =
+        pdec!("57896044618658097711785492504343953926634.992332820282019728792003956564819967");
+    assert_eq!(x2, PreciseDecimal::MAX);
+
+    let x3 =
+        pdec!("-57896044618658097711785492504343953926634.992332820282019728792003956564819968");
+    assert_eq!(x3, PreciseDecimal::MIN);
+
+    const X1: PreciseDecimal = pdec!("111111.10");
+    assert_eq!(X1, PreciseDecimal::try_from("111111.10").unwrap());
+
+    const X2: PreciseDecimal = pdec!(-111);
+    assert_eq!(X2, PreciseDecimal::try_from(-111).unwrap());
+
+    const X3: PreciseDecimal = pdec!(129u128);
+    assert_eq!(X3, PreciseDecimal::try_from(129u128).unwrap());
+
+    const X4: PreciseDecimal = pdec!(-1_000_000_i64);
+    assert_eq!(X4, PreciseDecimal::try_from(-1_000_000_i64).unwrap());
+}

--- a/radix-engine-tests/tests/error_injection.rs
+++ b/radix-engine-tests/tests/error_injection.rs
@@ -1,5 +1,5 @@
 use radix_engine::vm::NoExtension;
-use radix_engine_common::dec;
+use radix_engine_interface::dec;
 use radix_engine_interface::prelude::{FromPublicKey, NonFungibleGlobalId};
 use scrypto_unit::{InjectSystemCostingError, TestRunnerBuilder};
 use transaction::builder::ManifestBuilder;

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -22,7 +22,7 @@ perfcnt = { version = "0.8.0", optional = true }
 radix-engine-profiling = { path = "../radix-engine-profiling", optional = true, features = ["resource_tracker"] }
 resources-tracker-macro = { path = "../radix-engine-profiling/resources-tracker-macro" }
 paste = { version = "1.0.13" }
-radix-engine-macros = { path = "../radix-engine-macros" }
+radix-engine-macros = { path = "../radix-engine-macros", default-features = false }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
 
 # WASM validation
@@ -59,8 +59,8 @@ harness = false
 [features]
 # You should enable either `std` or `alloc`
 default = ["std", "moka"]
-std = ["sbor/std", "native-sdk/std", "wasmi/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "utils/std", "serde_json?/std", "wasm-instrument/std" ]
-alloc = ["sbor/alloc", "native-sdk/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "utils/alloc", "lru?/hashbrown", "serde_json?/alloc"]
+std = ["sbor/std", "native-sdk/std", "wasmi/std", "transaction/std", "radix-engine-interface/std", "radix-engine-store-interface/std", "radix-engine-macros/std", "utils/std", "serde_json?/std", "wasm-instrument/std" ]
+alloc = ["sbor/alloc", "native-sdk/alloc", "transaction/alloc", "radix-engine-interface/alloc", "radix-engine-store-interface/alloc", "radix-engine-macros/alloc", "utils/alloc", "lru?/hashbrown", "serde_json?/alloc"]
 
 # Enables heap memory and CPU cycles resource tracing - available only for Linux OS on x86 arch.
 # Requires CAP_PERFMON capability for the process (sudo setcap cap_perfmon=eip <exec_file>).

--- a/scrypto-derive-tests/tests/math.rs
+++ b/scrypto-derive-tests/tests/math.rs
@@ -11,9 +11,9 @@ mod test_decimal {
                 .unwrap()
                 .checked_sub(
                     dec!("3.5")
-                        .checked_mul(dec!(5, 6))
+                        .checked_mul(dec!(5_000_000))
                         .unwrap()
-                        .checked_div(dec!("7", -8))
+                        .checked_div(dec!("0.00000007"))
                         .unwrap(),
                 )
                 .unwrap()
@@ -24,9 +24,9 @@ mod test_decimal {
                 .unwrap()
                 .checked_sub(
                     pdec!("3.5")
-                        .checked_mul(pdec!(5, 6))
+                        .checked_mul(pdec!(5_000_000))
                         .unwrap()
-                        .checked_div(pdec!("7", -8))
+                        .checked_div(pdec!("0.00000007"))
                         .unwrap(),
                 )
                 .unwrap()


### PR DESCRIPTION
## Summary
Macros `dec!()` and `pdec!()` are capable to define a compile-time constant.

Additional changes:
- Remove `dec!()`and `pdec!()` macro variants with shifting
 
## Testing
Respective tests have been implemented 

## Update Recommendations

### For dApp Developers
It is possible to declare any `Decimal`/`PreciseDecimal` as a compile-time constant.
```
  const a: Decimal = dec!(222);
  const b: Decimal = dec!("0.000001");
``` 
The same applies for `PreciseDecimal`


