### PR TITLE
avoid publishing to public registry

### DIFF
--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -32,11 +32,10 @@ jobs:
       dockerfile: "Dockerfile"
       platforms: "linux/amd64"
       provenance: "false"
-      scan_image: false
+      scan_image: true
       snyk_target_ref: ${{ github.ref_name }}
       enable_dockerhub: false
       push_image: false
-      post_script: "./update-assets.sh --reuse-image --image-tag ${{ needs.tags.outputs.tag }}"
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -3,6 +3,7 @@ name: Build scrypto-builder image
 on:
   push:
     branches:
+      - chore/avoid-builder-push
       - develop
       - main
       - release\/*
@@ -20,7 +21,7 @@ jobs:
         run: echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   build-amd:
     needs: tags
-    uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
+    uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@chore/conditionaly-push
     with:
       runs_on: ubuntu-latest-16-cores
       image_registry: "docker.io"
@@ -34,6 +35,7 @@ jobs:
       scan_image: false
       snyk_target_ref: ${{ github.ref_name }}
       enable_dockerhub: false
+      push_image: false
       post_script: "./update-assets.sh --reuse-image --image-tag ${{ needs.tags.outputs.tag }}"
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -3,7 +3,6 @@ name: Build scrypto-builder image
 on:
   push:
     branches:
-      - chore/avoid-builder-push
       - develop
       - main
       - release\/*
@@ -21,7 +20,7 @@ jobs:
         run: echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   build-amd:
     needs: tags
-    uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@chore/conditionaly-push
+    uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
       runs_on: ubuntu-latest-16-cores
       image_registry: "docker.io"

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -26,7 +26,7 @@ jobs:
       runs_on: ubuntu-latest-16-cores
       image_registry: "docker.io"
       image_organization: "radixdlt"
-      image_name: "scrypto-builder"
+      image_name: "private-scrypto-builder"
       tag: ${{ needs.tags.outputs.tag }}
       context: "."
       dockerfile: "Dockerfile"
@@ -35,7 +35,6 @@ jobs:
       scan_image: true
       snyk_target_ref: ${{ github.ref_name }}
       enable_dockerhub: false
-      push_image: false
     secrets:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
this makes sure that the image built in CI is only published to the private repo where people can't pull from
