### PR TITLE
Some improvements to fuzzing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -27,6 +27,7 @@ on:
         description: 'Fuzz input data generation mode'
         required: true
         options:
+          - empty
           - minimize
           - unique
           - raw

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -19,6 +19,8 @@ function usage() {
     echo "Available targets:"
     echo "    transaction"
     echo "    wasm_instrument"
+    echo "    decimal"
+    echo "    parse_decimal"
     echo "Available fuzzers"
     echo "    libfuzzer  - 'cargo fuzz' wrapper"
     echo "    afl        - 'cargo afl' wrapper"
@@ -42,6 +44,7 @@ function usage() {
     echo "Available commands"
     echo "    generate-input - generate fuzzing input data"
     echo "  Subcommands:"
+    echo "        empty       - Empty input"
     echo "        raw         - Do not process generated data"
     echo "        unique      - Make the input data unique"
     echo "        minimize    - Minimize the input data"
@@ -186,6 +189,14 @@ function generate_input() {
     local cmin_dir=fuzz_input/${target}_cmin
     local raw_dir=fuzz_input/${target}_raw
     local final_dir=fuzz_input/${target}
+
+    if [ $mode = "empty" ] ; then
+        echo "creating empty input $final_dir"
+        mkdir -p $final_dir
+        # Cannot be empty, let's use newline (0xA).
+        echo "" > ${final_dir}/empty
+        return
+    fi
 
     if [ $target = "transaction" -o $target = "wasm_instrument" -o $target = "decimal" -o $target = "parse_decimal" ] ; then
         if [ ! -f target-afl/release/${target} ] ; then

--- a/fuzz-tests/src/bin/decimal.rs
+++ b/fuzz-tests/src/bin/decimal.rs
@@ -1,20 +1,13 @@
 #![cfg_attr(feature = "libfuzzer-sys", no_main)]
-
 use arbitrary::Arbitrary;
-#[cfg(feature = "libfuzzer-sys")]
-use libfuzzer_sys::fuzz_target;
-
-#[cfg(feature = "afl")]
-use afl::fuzz;
-
-#[cfg(feature = "simple-fuzzer")]
-use fuzz_tests::fuzz;
-
+use fuzz_tests::fuzz_template;
 use radix_engine_common::math::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Arbitrary, Serialize, Deserialize)]
 struct OneDecimal(Decimal, Decimal, i64, u32, i32, RoundingMode);
+
+fuzz_template!(|decimal: OneDecimal| { fuzz_decimal(decimal) });
 
 fn fuzz_decimal(decimal: OneDecimal) {
     let _ = decimal.0.checked_sqrt();
@@ -55,26 +48,6 @@ fn fuzz_decimal(decimal: OneDecimal) {
     let _ = decimal.0.checked_powi(decimal.2);
     let _ = decimal.0.checked_nth_root(decimal.3);
      */
-}
-
-// Fuzzer entry points
-#[cfg(feature = "libfuzzer-sys")]
-fuzz_target!(|decimal: OneDecimal| {
-    fuzz_decimal(decimal);
-});
-
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|decimal: OneDecimal| {
-        fuzz_decimal(decimal);
-    });
-}
-
-#[cfg(feature = "simple-fuzzer")]
-fn main() {
-    fuzz!(|decimal: OneDecimal| {
-        fuzz_decimal(decimal);
-    });
 }
 
 #[test]

--- a/fuzz-tests/src/bin/parse_decimal.rs
+++ b/fuzz-tests/src/bin/parse_decimal.rs
@@ -1,35 +1,10 @@
 #![cfg_attr(feature = "libfuzzer-sys", no_main)]
-
-#[cfg(feature = "libfuzzer-sys")]
-use libfuzzer_sys::fuzz_target;
-
-#[cfg(feature = "afl")]
-use afl::fuzz;
-
-#[cfg(feature = "simple-fuzzer")]
-use fuzz_tests::fuzz;
-
+use fuzz_tests::fuzz_template;
 use radix_engine_common::math::Decimal;
 
-// Fuzzer entry points
-#[cfg(feature = "libfuzzer-sys")]
-fuzz_target!(|data: String| {
+fuzz_template!(|data: String| {
     let _ = Decimal::try_from(data);
 });
-
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data: String| {
-        let _ = Decimal::try_from(data);
-    });
-}
-
-#[cfg(feature = "simple-fuzzer")]
-fn main() {
-    fuzz!(|data: String| {
-        let _ = Decimal::try_from(data);
-    });
-}
 
 #[test]
 fn test_parse_decimal_generate_fuzz_input_data() {

--- a/fuzz-tests/src/bin/wasm_instrument.rs
+++ b/fuzz-tests/src/bin/wasm_instrument.rs
@@ -1,15 +1,10 @@
 #![cfg_attr(feature = "libfuzzer-sys", no_main)]
-
-#[cfg(feature = "libfuzzer-sys")]
-use libfuzzer_sys::fuzz_target;
-
-#[cfg(feature = "afl")]
-use afl::fuzz;
-
-#[cfg(feature = "simple-fuzzer")]
-use fuzz_tests::fuzz;
-
+use fuzz_tests::fuzz_template;
 use radix_engine::vm::wasm::{PrepareError, WasmModule, WasmValidatorConfigV1};
+
+fuzz_template!(|data: &[u8]| {
+    let _ = fuzz_wasm(data);
+});
 
 fn fuzz_wasm(data: &[u8]) -> Result<WasmModule, PrepareError> {
     let instrumenter_config = WasmValidatorConfigV1::new();
@@ -17,24 +12,4 @@ fn fuzz_wasm(data: &[u8]) -> Result<WasmModule, PrepareError> {
     WasmModule::init(data)?
         .inject_instruction_metering(&instrumenter_config)?
         .inject_stack_metering(instrumenter_config.max_stack_size())
-}
-
-// Fuzzer entry points
-#[cfg(feature = "libfuzzer-sys")]
-fuzz_target!(|data: &[u8]| {
-    let _ = fuzz_wasm(data);
-});
-
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data: &[u8]| {
-        let _ = fuzz_wasm(data);
-    });
-}
-
-#[cfg(feature = "simple-fuzzer")]
-fn main() {
-    fuzz!(|data: &[u8]| {
-        let _ = fuzz_wasm(data);
-    });
 }

--- a/fuzz-tests/src/utils/fuzz_template.rs
+++ b/fuzz-tests/src/utils/fuzz_template.rs
@@ -1,0 +1,36 @@
+// Helper macro to reduce the boilerplate code needed to implement
+// fuzz tests for our fuzzers: afl, libfuzzer, simple-fuzzer.
+// For more complicated tests this macro is noth enough and the tests
+// must be coded manually (see src/bin/transaction.rs).
+//
+// NOTE!
+// Following piece of code has to be put anyway in implemented fuzz target
+// in the first line:
+// #![cfg_attr(feature = "libfuzzer-sys", no_main)]
+#[macro_export]
+macro_rules! fuzz_template {
+    (|$buf:ident: $dty: ty| $body:block) => {
+        #[cfg(feature = "libfuzzer-sys")]
+        use libfuzzer_sys::fuzz_target;
+
+        #[cfg(feature = "afl")]
+        use afl::fuzz;
+
+        #[cfg(feature = "simple-fuzzer")]
+        use fuzz_tests::fuzz;
+
+        // Fuzzer entry points
+        #[cfg(feature = "libfuzzer-sys")]
+        libfuzzer_sys::fuzz_target!(|$buf: $dty| { $body });
+
+        #[cfg(feature = "afl")]
+        fn main() {
+            afl::fuzz!(|$buf: $dty| { $body });
+        }
+
+        #[cfg(feature = "simple-fuzzer")]
+        fn main() {
+            fuzz_tests::fuzz!(|$buf: $dty| { $body });
+        }
+    };
+}

--- a/fuzz-tests/src/utils/mod.rs
+++ b/fuzz-tests/src/utils/mod.rs
@@ -2,3 +2,6 @@
 // Import fuzzing macros (exported by simple_fuzzer module) to the crate's root
 #[macro_use]
 pub mod simple_fuzzer;
+
+#[macro_use]
+pub mod fuzz_template;


### PR DESCRIPTION
## Summary
- Add `fuzz_template!()` macro to setup all fuzz tests: `libfuzzer`, `afl`, `simple-fuzzer` at once.
- option to create empty input for given fuzzing target
eg. `./fuzz.sh generate-input decimal empty`
