### PR TITLE
Feature/test runner database check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,3 +429,31 @@ jobs:
     - name: Check fuzzed instructions coverage
       run: cargo nextest run test_check_fuzzed_instruction_coverage
       working-directory: fuzz-tests
+  
+  cargo-check:
+    name: Run cargo check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest-16-cores]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.70.0
+    - name: Cargo Check
+      run: cargo check --all
+  
+  cargo-check-post-run-db-check:
+    name: Run cargo check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest-16-cores]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.70.0
+    - name: Cargo Check
+      run: cargo check --all --features post_run_db_check

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -29,6 +29,7 @@ utils = { path = "../utils", default-features = false, features = ["radix_engine
 scrypto-unit = { path = "../scrypto-unit", default-features = false }
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 lazy_static = "1.4.0"
+serde_json = "1.0.107"
 
 [dev-dependencies]
 bincode = { version = "1.3.3" }

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -22,6 +22,7 @@ function usage() {
     echo "    decimal"
     echo "    parse_decimal"
     echo "    role_assignment"
+    echo "    system"
     echo "Available fuzzers"
     echo "    libfuzzer  - 'cargo fuzz' wrapper"
     echo "    afl        - 'cargo afl' wrapper"
@@ -108,7 +109,7 @@ function fuzzer_libfuzzer() {
     set -x
     cargo +nightly fuzz $cmd \
         --release \
-        --no-default-features --features std,libfuzzer-sys,post_run_db_check\
+        --no-default-features --features std,libfuzzer-sys\
         --fuzz-dir . \
         --no-cfg-fuzzing \
         --target-dir target-libfuzzer \
@@ -133,7 +134,7 @@ function fuzzer_afl() {
         set -x
         cargo afl build --release \
             --bin $target \
-            --no-default-features --features std,afl,post_run_db_check \
+            --no-default-features --features std,afl \
             --target-dir target-afl
     elif [ $cmd = "run" ] ; then
         mkdir -p afl/${target}/out
@@ -199,7 +200,7 @@ function generate_input() {
         return
     fi
 
-    if [ $target = "transaction" -o $target = "wasm_instrument" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" ] ; then
+    if [ $target = "transaction" -o $target = "wasm_instrument" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" ] ; then
         if [ ! -f target-afl/release/${target} ] ; then
             echo "target binary 'target-afl/release/${target}' not built. Call below command to build it"
             echo "$THIS_SCRIPT afl build"
@@ -216,7 +217,7 @@ function generate_input() {
         fi
 
 
-        if [ $target = "transaction" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" ] ; then
+        if [ $target = "transaction" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" ] ; then
             # Collect input data
 
             cargo nextest run test_${target}_generate_fuzz_input_data  --release

--- a/fuzz-tests/src/bin/attached_modules/role_assignment.rs
+++ b/fuzz-tests/src/bin/attached_modules/role_assignment.rs
@@ -162,7 +162,7 @@ fn check_invariants(
                 ModuleId::RoleAssignment,
                 RoleAssignmentField::Owner.field_index(),
             )
-            .expect("Failed to read Owner field of RoleAssignment module.");
+            .expect("Impossible case.");
 
         checker.on_field(
             blueprint_info.clone(),
@@ -180,12 +180,12 @@ fn check_invariants(
                 ModuleId::RoleAssignment,
                 RoleAssignmentCollection::AccessRuleKeyValue.collection_index(),
             )
-            .expect("Failed to read the collection information of the role assignment module");
+            .expect("Impossible case.");
 
         for (substate_key, substate_value) in iter {
             let SubstateKey::Map(map_key) = substate_key
             else {
-                panic!("Encountered a collection that doesn't have a MapKey!")
+                panic!("Impossible case.")
             };
 
             checker.on_collection_entry(


### PR DESCRIPTION
## Summary

This PR disables the `post_run_db_check` in the fuzz build scripts and refactors the `Drop` implementation to call a new method called `check_database` which contains all of the database checks. Fuzz tests that wish to check the database do not need to rely on this happening when the object is dropped, it needs to be explicitly called. 