### PR TITLE
Fuzz: Royalty module state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,7 @@
         "transactiontracker",
         "txid",
         "undeposited",
+        "unpreparable",
         "unregistration",
         "Unstake",
         "unstaked",

--- a/fuzz-tests/Cargo.toml
+++ b/fuzz-tests/Cargo.toml
@@ -63,6 +63,12 @@ path = "src/bin/attached_modules/role_assignment.rs"
 #test = false
 doc = false
 
+[[bin]]
+name = "royalty_state"
+path = "src/bin/attached_modules/royalty_state.rs"
+#test = false
+doc = false
+
 [features]
 # You should enable either `std` or `alloc`
 default = ["std", "fuzzer"]

--- a/fuzz-tests/fuzz.sh
+++ b/fuzz-tests/fuzz.sh
@@ -23,6 +23,7 @@ function usage() {
     echo "    parse_decimal"
     echo "    role_assignment"
     echo "    system"
+    echo "    royalty_state"
     echo "Available fuzzers"
     echo "    libfuzzer  - 'cargo fuzz' wrapper"
     echo "    afl        - 'cargo afl' wrapper"
@@ -200,7 +201,7 @@ function generate_input() {
         return
     fi
 
-    if [ $target = "transaction" -o $target = "wasm_instrument" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" ] ; then
+    if [ $target = "transaction" -o $target = "wasm_instrument" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" -o $target = "royalty_state" ] ; then
         if [ ! -f target-afl/release/${target} ] ; then
             echo "target binary 'target-afl/release/${target}' not built. Call below command to build it"
             echo "$THIS_SCRIPT afl build"
@@ -217,7 +218,7 @@ function generate_input() {
         fi
 
 
-        if [ $target = "transaction" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" ] ; then
+        if [ $target = "transaction" -o $target = "decimal" -o $target = "parse_decimal" -o $target = "role_assignment" -o $target = "system" -o $target = "royalty_state" ] ; then
             # Collect input data
 
             cargo nextest run test_${target}_generate_fuzz_input_data  --release

--- a/fuzz-tests/src/bin/attached_modules/royalty_state.rs
+++ b/fuzz-tests/src/bin/attached_modules/royalty_state.rs
@@ -1,0 +1,572 @@
+//! This module contains the fuzz test for joint fuzzing of the state and behavior of component and
+//! package royalties. The following are the invariants tested for:
+//!
+//! 1. None of the transactions involving royalties end a native-vm panic, this is not the intended
+//! behavior.
+//! 2. The royalty amount of packages and components can not be negative and can not exceed the max
+//! for the given currency.
+
+use fuzz_tests::fuzz_template;
+
+use radix_engine::blueprints::package::*;
+use radix_engine::errors::*;
+use radix_engine::system::attached_modules::royalty::*;
+use radix_engine::system::checkers::*;
+use radix_engine::system::system_db_reader::SystemDatabaseReader;
+use radix_engine::transaction::*;
+use radix_engine_stores::memory_db::*;
+use transaction::prelude::*;
+
+use arbitrary::Arbitrary;
+use radix_engine_interface::prelude::node_modules::royalty::*;
+
+fuzz_template!(|input: RoyaltyFuzzerInput| { fuzz_func(input) });
+
+fn fuzz_func(input: RoyaltyFuzzerInput) {
+    let mut test_runner = package::test_runner();
+
+    // Generate the package definition, change the royalty configuration and then attempt to publish
+    // it.
+    let package_address = {
+        let package_royalties = input.0.royalty_config.package_royalty_config();
+        let mut package_definition = package::RoyaltyFuzzBlueprint::definition();
+        package_definition
+            .blueprints
+            .get_mut(package::BLUEPRINT_IDENT)
+            .unwrap()
+            .royalty_config = package_royalties;
+
+        let receipt = test_runner.execute_system_transaction(
+            assert_can_be_prepared!(
+                return,
+                ManifestBuilder::new()
+                    .call_function(
+                        PACKAGE_PACKAGE,
+                        PACKAGE_BLUEPRINT,
+                        PACKAGE_PUBLISH_NATIVE_IDENT,
+                        &PackagePublishNativeManifestInput {
+                            definition: package_definition,
+                            native_package_code_id: package::PACKAGE_CODE_ID,
+                            metadata: Default::default(),
+                            package_address: None
+                        }
+                    )
+                    .build()
+            )
+            .instructions,
+            Default::default(),
+        );
+        let receipt = assert_no_native_vm_panic_in_receipt(receipt);
+
+        match receipt.result {
+            TransactionResult::Commit(CommitResult {
+                outcome: TransactionOutcome::Success(..),
+                ref state_update_summary,
+                ..
+            }) => *state_update_summary.new_packages.first().unwrap(),
+            TransactionResult::Commit(CommitResult {
+                outcome: TransactionOutcome::Failure(..),
+                ..
+            })
+            | TransactionResult::Abort(..)
+            | TransactionResult::Reject(..) => return,
+        }
+    };
+
+    // Instantiate a new royalty test component and get the component address.
+    let component_address = {
+        let receipt = test_runner.execute_manifest(
+            assert_can_be_prepared!(
+                return,
+                TransactionManifestV1 {
+                    instructions: vec![
+                        InstructionV1::CallMethod {
+                            address: DynamicGlobalAddress::Static(FAUCET.into()),
+                            method_name: "lock_fee".to_owned(),
+                            args: manifest_args!(dec!("100")).into(),
+                        },
+                        InstructionV1::CallFunction {
+                            package_address: DynamicPackageAddress::Static(package_address),
+                            blueprint_name: package::BLUEPRINT_IDENT.to_owned(),
+                            function_name: package::ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT
+                                .to_owned(),
+                            args: manifest_decode_with_depth_limit(
+                                &manifest_encode_with_depth_limit(
+                                    &package::RoyaltyFuzzBlueprintInstantiateInput {
+                                        creation_invocation: input.1.creation_invocation,
+                                        pre_attachment_invocations: input
+                                            .1
+                                            .pre_attachment_invocations,
+                                    },
+                                    usize::MAX,
+                                )
+                                .unwrap(),
+                                usize::MAX,
+                            )
+                            .unwrap(),
+                        },
+                    ],
+                    blobs: Default::default(),
+                }
+            ),
+            vec![],
+        );
+        let receipt = assert_no_native_vm_panic_in_receipt(receipt);
+        match receipt.result {
+            TransactionResult::Commit(CommitResult {
+                outcome: TransactionOutcome::Success(..),
+                ref state_update_summary,
+                ..
+            }) => *state_update_summary.new_components.first().unwrap(),
+            TransactionResult::Commit(CommitResult {
+                outcome: TransactionOutcome::Failure(..),
+                ..
+            })
+            | TransactionResult::Abort(..)
+            | TransactionResult::Reject(..) => return,
+        }
+    };
+
+    // Perform the method invocations to the royalty module. Each invocation is its own transaction.
+    // This is because we would like for a failed invocation not to stop other ones from happening.
+    let mut receipts = Vec::new();
+    for invocation in input.1.post_attachment_invocations.into_iter() {
+        let manifest = assert_can_be_prepared!(
+            continue,
+            TransactionManifestV1 {
+                instructions: vec![
+                    InstructionV1::CallMethod {
+                        address: DynamicGlobalAddress::Static(FAUCET.into()),
+                        method_name: "lock_fee".to_owned(),
+                        args: manifest_args!(dec!("100")).into(),
+                    },
+                    InstructionV1::CallMethod {
+                        address: DynamicGlobalAddress::Static(component_address.into()),
+                        method_name: invocation.method_ident().to_owned(),
+                        args: invocation.manifest_value(),
+                    },
+                ],
+                blobs: Default::default(),
+            }
+        );
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
+        receipts.push(receipt);
+    }
+
+    check_invariants(
+        package_address,
+        component_address,
+        &receipts,
+        test_runner.substate_db(),
+    )
+}
+
+fn check_invariants(
+    package_address: PackageAddress,
+    component_address: ComponentAddress,
+    receipts: &[TransactionReceipt],
+    substate_database: &InMemorySubstateDatabase,
+) {
+    let reader = SystemDatabaseReader::new(substate_database);
+    let mut component_royalties_checker = ComponentRoyaltyDatabaseChecker::default();
+    let mut package_royalties_checker =
+        PackageRoyaltyDatabaseChecker::new(|blueprint_id, func_name| {
+            reader
+                .get_blueprint_definition(blueprint_id)
+                .map(|bp_def| bp_def.interface.functions.contains_key(func_name))
+                .unwrap_or(false)
+        });
+
+    // Component royalties validation
+    for (key, value) in reader
+        .collection_iter(
+            component_address.as_node_id(),
+            ModuleId::Royalty,
+            ComponentRoyaltyCollection::MethodAmountKeyValue.collection_index(),
+        )
+        .expect("Impossible case.")
+    {
+        let SubstateKey::Map(key) = key
+            else {
+                panic!("Impossible case.")
+            };
+        component_royalties_checker.on_collection_entry(
+            reader
+                .get_blueprint_type_target(component_address.as_node_id(), ModuleId::Main)
+                .unwrap()
+                .blueprint_info,
+            component_address.into(),
+            ModuleId::Royalty,
+            ComponentRoyaltyCollection::MethodAmountKeyValue.collection_index(),
+            &key,
+            &value,
+        )
+    }
+
+    // Package royalties validation
+    for (key, value) in reader
+        .collection_iter(
+            package_address.as_node_id(),
+            ModuleId::Royalty,
+            PackageCollection::BlueprintVersionRoyaltyConfigKeyValue.collection_index(),
+        )
+        .expect("Impossible case.")
+    {
+        let SubstateKey::Map(key) = key
+            else {
+                panic!("Impossible case.")
+            };
+        package_royalties_checker.on_collection_entry(
+            reader
+                .get_blueprint_type_target(package_address.as_node_id(), ModuleId::Main)
+                .unwrap()
+                .blueprint_info,
+            package_address.into(),
+            ModuleId::Royalty,
+            PackageCollection::BlueprintVersionRoyaltyConfigKeyValue.collection_index(),
+            &key,
+            &value,
+        )
+    }
+
+    let component_royalties_results = component_royalties_checker.on_finish();
+    let package_royalties_results = package_royalties_checker.on_finish();
+
+    if !component_royalties_results.is_empty() || !package_royalties_results.is_empty() {
+        panic!("Encountered invalid state in the component or package royalties: {component_royalties_results:#?}, {package_royalties_results:#?}");
+    }
+
+    // Verify that none of the transactions panicked.
+    {
+        for (i, receipt) in receipts.iter().enumerate() {
+            if let Some(error) = get_error_from_receipt(receipt) {
+                if matches!(
+                    error,
+                    RuntimeError::VmError(VmError::Native(
+                        radix_engine::errors::NativeRuntimeError::Trap { .. }
+                    ))
+                ) {
+                    panic!("An panic was encountered in the transaction. Receipt index: {i}. Error: {error:?}")
+                }
+            }
+        }
+    }
+}
+
+fn assert_no_native_vm_panic_in_receipt(receipt: TransactionReceipt) -> TransactionReceipt {
+    if let Some(error) = get_error_from_receipt(&receipt) {
+        if matches!(
+            error,
+            RuntimeError::VmError(VmError::Native(
+                radix_engine::errors::NativeRuntimeError::Trap { .. }
+            ))
+        ) {
+            panic!("An panic was encountered in the transaction. Error: {error:?}")
+        }
+    }
+    receipt
+}
+
+fn get_error_from_receipt(receipt: &TransactionReceipt) -> Option<&RuntimeError> {
+    match receipt.result {
+        TransactionResult::Commit(CommitResult {
+            outcome: TransactionOutcome::Failure(ref error),
+            ..
+        })
+        | TransactionResult::Reject(RejectResult {
+            reason: RejectionReason::ErrorBeforeLoanAndDeferredCostsRepaid(ref error),
+        }) => Some(error),
+        TransactionResult::Commit(CommitResult {
+            outcome: TransactionOutcome::Success(..),
+            ..
+        })
+        | TransactionResult::Abort(..)
+        | TransactionResult::Reject(RejectResult { .. }) => None,
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, ScryptoSbor, serde::Serialize, serde::Deserialize)]
+struct RoyaltyFuzzerInput(RoyaltyFuzzerPackageInput, RoyaltyFuzzerComponentInput);
+
+#[derive(Arbitrary, Clone, Debug, ScryptoSbor, serde::Serialize, serde::Deserialize)]
+struct RoyaltyFuzzerPackageInput {
+    /// The configuration to use for package royalties, this may either be valid function names or
+    /// completely random.
+    royalty_config: RoyaltyFuzzerPackageRoyaltyConfig,
+}
+
+#[derive(Arbitrary, Clone, Debug, ScryptoSbor, serde::Serialize, serde::Deserialize)]
+struct RoyaltyFuzzerComponentInput {
+    /// The invocation made for the creation of the royalty module.
+    creation_invocation: ComponentRoyaltyCreateInput,
+    /// The method invocations to make to the royalty module before it has been attached to
+    /// the component.
+    pre_attachment_invocations: Vec<ComponentRoyaltyMethodInvocation>,
+    /// The method invocations to make to the royalty module after it has been attached to
+    /// the component.
+    post_attachment_invocations: Vec<ComponentRoyaltyMethodInvocation>,
+}
+
+#[derive(Arbitrary, Clone, Debug, ScryptoSbor, serde::Serialize, serde::Deserialize)]
+pub enum RoyaltyFuzzerPackageRoyaltyConfig {
+    ValidFunctionNames {
+        /// The royalty amount of the `instantiate` function.
+        instantiate_fn: RoyaltyAmount,
+    },
+    CompletelyRandom(PackageRoyaltyConfig),
+}
+
+impl RoyaltyFuzzerPackageRoyaltyConfig {
+    pub fn package_royalty_config(self) -> PackageRoyaltyConfig {
+        match self {
+            Self::ValidFunctionNames { instantiate_fn } => {
+                PackageRoyaltyConfig::Enabled(indexmap! {
+                    package::ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT.to_owned() => instantiate_fn
+                })
+            }
+            Self::CompletelyRandom(random) => random,
+        }
+    }
+}
+
+#[derive(
+    Arbitrary, Clone, Debug, ScryptoSbor, ManifestSbor, serde::Serialize, serde::Deserialize,
+)]
+pub enum ComponentRoyaltyMethodInvocation {
+    Set(ComponentRoyaltySetInput),
+    Lock(ComponentRoyaltyLockInput),
+    Claim(ComponentClaimRoyaltiesInput),
+}
+
+impl ComponentRoyaltyMethodInvocation {
+    pub const fn method_ident(&self) -> &'static str {
+        match self {
+            Self::Set(..) => COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
+            Self::Lock(..) => COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT,
+            Self::Claim(..) => COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT,
+        }
+    }
+
+    /// Convert the arguments to a [`ManifestValue`]. This method does not adhere to the SBOR depth
+    /// limits.
+    pub fn manifest_value(&self) -> ManifestValue {
+        let encoded = match self {
+            Self::Set(value) => manifest_encode_with_depth_limit(&value, usize::MAX).unwrap(),
+            Self::Lock(value) => manifest_encode_with_depth_limit(&value, usize::MAX).unwrap(),
+            Self::Claim(value) => manifest_encode_with_depth_limit(&value, usize::MAX).unwrap(),
+        };
+        manifest_decode_with_depth_limit(&encoded, usize::MAX).unwrap()
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, ScryptoSbor, serde::Serialize, serde::Deserialize)]
+pub enum PackageRoyaltyMethodInvocation {
+    Claim(PackageClaimRoyaltiesInput),
+}
+
+impl PackageRoyaltyMethodInvocation {
+    pub const fn method_ident(&self) -> &'static str {
+        match self {
+            Self::Claim(..) => COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT,
+        }
+    }
+
+    /// Convert the arguments to a [`ManifestValue`]. This method does not adhere to the SBOR depth
+    /// limits.
+    pub fn manifest_value(&self) -> ManifestValue {
+        let encoded = match self {
+            Self::Claim(value) => manifest_encode_with_depth_limit(&value, usize::MAX).unwrap(),
+        };
+        manifest_decode_with_depth_limit(&encoded, usize::MAX).unwrap()
+    }
+}
+
+// A module of the package used in this test.
+mod package {
+    use super::*;
+
+    use native_sdk::modules::metadata::*;
+    use native_sdk::modules::royalty::*;
+
+    use radix_engine::errors::RuntimeError;
+    use radix_engine::vm::*;
+    use radix_engine_interface::prelude::AttachedModuleId;
+    use radix_engine_interface::prelude::Bucket;
+    use radix_engine_interface::prelude::ClientApi;
+    use radix_engine_stores::memory_db::InMemorySubstateDatabase;
+    use scrypto_unit::*;
+
+    pub const BLUEPRINT_IDENT: &str = "RoyaltyFuzzBlueprint";
+    pub const PACKAGE_CODE_ID: u64 = 1024;
+
+    #[derive(Clone)]
+    pub struct TestInvoke;
+    impl VmInvoke for TestInvoke {
+        fn invoke<Y>(
+            &mut self,
+            export_name: &str,
+            input: &IndexedScryptoValue,
+            api: &mut Y,
+        ) -> Result<IndexedScryptoValue, RuntimeError>
+        where
+            Y: ClientApi<RuntimeError>,
+        {
+            match export_name {
+                ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT => {
+                    let RoyaltyFuzzBlueprintInstantiateInput {
+                        creation_invocation,
+                        pre_attachment_invocations,
+                    } = input
+                        .as_typed::<RoyaltyFuzzBlueprintInstantiateInput>()
+                        .expect("Failed to decode");
+                    RoyaltyFuzzBlueprint::instantiate(
+                        creation_invocation,
+                        pre_attachment_invocations,
+                        api,
+                    )
+                    .map(|value| IndexedScryptoValue::from_typed(&value))
+                }
+                _ => {
+                    panic!("Invalid method, how did we even get here?")
+                }
+            }
+        }
+    }
+
+    pub struct RoyaltyFuzzBlueprint;
+
+    impl RoyaltyFuzzBlueprint {
+        pub fn definition() -> PackageDefinition {
+            PackageDefinition::new_functions_only_test_definition(
+                BLUEPRINT_IDENT,
+                vec![(
+                    ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT,
+                    ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT,
+                    false,
+                )],
+            )
+        }
+
+        fn instantiate<Y>(
+            ComponentRoyaltyCreateInput { royalty_config }: ComponentRoyaltyCreateInput,
+            pre_attachment_invocations: Vec<ComponentRoyaltyMethodInvocation>,
+            api: &mut Y,
+        ) -> Result<RoyaltyFuzzBlueprintInstantiateOutput, RuntimeError>
+        where
+            Y: ClientApi<RuntimeError>,
+        {
+            let mut royalty = ComponentRoyalty(ComponentRoyalty::create(royalty_config, api)?);
+            let metadata = Metadata::create(api)?;
+            let node_id = api.new_simple_object(BLUEPRINT_IDENT, Default::default())?;
+
+            /* Perform all of the method invocations */
+            let mut buckets = vec![];
+            for invocation in pre_attachment_invocations {
+                match invocation {
+                    ComponentRoyaltyMethodInvocation::Set(ComponentRoyaltySetInput {
+                        method,
+                        amount,
+                    }) => royalty.set_royalty(&method, amount, api)?,
+                    ComponentRoyaltyMethodInvocation::Lock(ComponentRoyaltyLockInput {
+                        method,
+                    }) => royalty.lock_royalty(&method, api)?,
+                    ComponentRoyaltyMethodInvocation::Claim(ComponentClaimRoyaltiesInput {}) => {
+                        buckets.push(royalty.claim_royalty(api)?)
+                    }
+                }
+            }
+
+            let modules = indexmap! {
+                AttachedModuleId::Royalty => royalty.0.0,
+                AttachedModuleId::Metadata => metadata.0,
+            };
+
+            api.globalize(node_id, modules, None)?;
+
+            Ok(buckets)
+        }
+    }
+
+    pub const ROYALTY_FUZZ_BLUEPRINT_INSTANTIATE_IDENT: &str = "instantiate";
+    #[derive(
+        Arbitrary, Clone, Debug, ManifestSbor, ScryptoSbor, serde::Serialize, serde::Deserialize,
+    )]
+    pub struct RoyaltyFuzzBlueprintInstantiateInput {
+        pub creation_invocation: ComponentRoyaltyCreateInput,
+        pub pre_attachment_invocations: Vec<ComponentRoyaltyMethodInvocation>,
+    }
+    pub type RoyaltyFuzzBlueprintInstantiateOutput = Vec<Bucket>;
+
+    /// Creates a new test-runner with this package published to it and ready for use.
+    pub fn test_runner() -> TestRunner<OverridePackageCode<TestInvoke>, InMemorySubstateDatabase> {
+        TestRunnerBuilder::new()
+            .with_custom_extension(OverridePackageCode::new(PACKAGE_CODE_ID, TestInvoke))
+            .without_trace()
+            .build_from_snapshot(TEST_RUNNER_SNAPSHOT.clone())
+    }
+
+    lazy_static::lazy_static! {
+        static ref TEST_RUNNER_SNAPSHOT: TestRunnerSnapshot = {
+            let test_runner = TestRunnerBuilder::new()
+                .with_custom_extension(OverridePackageCode::new(PACKAGE_CODE_ID, TestInvoke))
+                .without_trace()
+                .build();
+            test_runner.create_snapshot()
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arbitrary::*;
+    use rand::{RngCore, SeedableRng};
+    use rand_chacha::*;
+
+    use crate::*;
+
+    #[test]
+    fn test_royalty_state_generate_fuzz_input_data() {
+        for (index, input) in gen_random(7).into_iter().enumerate() {
+            std::fs::write(
+                format!("royalty_state_{:03?}.raw", index),
+                bincode::serialize(&input).unwrap(),
+            )
+            .unwrap();
+        }
+    }
+
+    fn gen_random(n: usize) -> Vec<RoyaltyFuzzerInput> {
+        let mut vec = Vec::new();
+
+        while vec.len() < n {
+            let mut rng = ChaCha8Rng::from_entropy();
+            let mut bytes = [0u8; 1024 * 10];
+            rng.fill_bytes(&mut bytes);
+            let mut unstructured = Unstructured::new(&bytes);
+            let input = RoyaltyFuzzerInput::arbitrary(&mut unstructured).unwrap();
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                fuzz_func(input.clone());
+            }));
+            if result.is_ok() {
+                vec.push(input)
+            }
+        }
+
+        dbg!(vec)
+    }
+}
+
+macro_rules! assert_can_be_prepared {
+    ($else: expr, $manifest: expr) => {{
+        let manifest = $manifest;
+        if ::transaction::prelude::TestTransaction::new_from_nonce(manifest.clone(), 0)
+            .prepare()
+            .is_ok()
+        {
+            manifest
+        } else {
+            $else;
+        }
+    }};
+}
+use assert_can_be_prepared;

--- a/fuzz-tests/src/utils/fuzz_utils.rs
+++ b/fuzz-tests/src/utils/fuzz_utils.rs
@@ -1,0 +1,172 @@
+//! This module contains a set of utility functions used by some of the fuzz tests. Additionally,
+//! there is a set of macros that are useful.
+
+use radix_engine::errors::*;
+use radix_engine::transaction::*;
+use radix_engine_interface::blueprints::transaction_processor::*;
+
+use transaction::prelude::*;
+
+/// Checks if the manifest is preparable or not through [`manifest_can_be_prepared`]. If it is not
+/// then a `break` is inserted. Otherwise, the manifest is returned. This is useful for cases when
+/// we wish to break out of a loop if an unpreparable manifest is encountered.
+#[macro_export]
+macro_rules! break_if_manifest_is_unpreparable {
+    ($manifest: expr) => {
+        ::fuzz_tests::arbitrary_action_if_manifest_is_unpreparable!($manifest, break)
+    };
+}
+
+/// Checks if the manifest is preparable or not through [`manifest_can_be_prepared`]. If it is not
+/// then a `return` is inserted. Otherwise, the manifest is returned. This is useful in cases when
+/// we wish to early return if an unpreparable manifest is encountered.
+#[macro_export]
+macro_rules! return_if_manifest_is_unpreparable {
+    ($manifest: expr) => {
+        ::fuzz_tests::arbitrary_action_if_manifest_is_unpreparable!($manifest, return)
+    };
+}
+
+/// Checks if the manifest is preparable or not through [`manifest_can_be_prepared`]. If it is not
+/// then a `continue` is inserted. Otherwise, the manifest is returned. This is useful for cases
+/// when we wish to continue to the next iteration if an unpreparable manifest is encountered.
+#[macro_export]
+macro_rules! continue_if_manifest_is_unpreparable {
+    ($manifest: expr) => {
+        ::fuzz_tests::arbitrary_action_if_manifest_is_unpreparable!($manifest, continue)
+    };
+}
+
+/// Checks if the manifest is preparable or not through [`manifest_can_be_prepared`]. If it is not
+/// then whatever passed `$action` is performed.
+#[macro_export]
+macro_rules! arbitrary_action_if_manifest_is_unpreparable {
+    (
+        $manifest: expr,
+        $action: block $(,)?
+    ) => {{
+        let manifest = $manifest;
+        if !::fuzz_tests::utils::manifest_can_be_prepared(manifest.clone()) {
+            $action
+        } else {
+            manifest
+        }
+    }};
+    (
+        $manifest: expr,
+        $stmt: stmt $(,)?
+    ) => {
+        ::fuzz_tests::arbitrary_action_if_manifest_is_unpreparable!($manifest, { $stmt })
+    };
+}
+
+/// Checks if the manifest can be prepared. A manifest that can't be prepared is one which exceeds
+/// the maximum depth limit allowed in the Manifest SBOR codec.
+pub fn manifest_can_be_prepared(manifest: TransactionManifestV1) -> bool {
+    TestTransaction::new_from_nonce(manifest, 0xFF)
+        .prepare()
+        .is_ok()
+}
+
+/* Receipt handling */
+
+/// Panics if the passed receipt contains a [`NativeRuntimeError::Trap`] in the receipt result. This
+/// function takes an additional optional argument of the `index` to allow this function to be give
+/// better panic messages when checking more than
+pub fn panic_if_native_vm_trap<'r, R: Into<OneOrMore<'r, TransactionReceipt>>>(receipt: R) {
+    let receipt = receipt.into();
+    match receipt {
+        OneOrMore::One(receipt) => {
+            if receipt_contains_native_vm_trap(receipt) {
+                panic!("Receipt contained a native-vm trap. Receipt: {receipt:?}")
+            }
+        }
+        OneOrMore::More(receipts) => receipts.iter().enumerate().for_each(|(index, receipt)| {
+            if receipt_contains_native_vm_trap(receipt) {
+                panic!("Receipt at index {index} contained a native-vm trap. Receipt: {receipt:?}")
+            }
+        }),
+    }
+}
+
+/// Returns [`true`] if the receipt has a [`NativeRuntimeError::Trap`].
+pub fn receipt_contains_native_vm_trap(receipt: &TransactionReceipt) -> bool {
+    matches!(
+        get_receipt_error(receipt),
+        Some(RuntimeError::VmError(VmError::Native(
+            radix_engine::errors::NativeRuntimeError::Trap { .. }
+        )))
+    )
+}
+
+/// Returns the [`RuntimeError`] in the transaction if one is reported. A [`None`] is returned if no
+/// [`RuntimeError`] is encountered in the receipt.
+pub fn get_receipt_error(receipt: &TransactionReceipt) -> Option<&RuntimeError> {
+    match receipt.result {
+        TransactionResult::Commit(CommitResult {
+            outcome: TransactionOutcome::Failure(ref error),
+            ..
+        })
+        | TransactionResult::Reject(RejectResult {
+            reason: RejectionReason::ErrorBeforeLoanAndDeferredCostsRepaid(ref error),
+        }) => Some(error),
+        TransactionResult::Commit(CommitResult {
+            outcome: TransactionOutcome::Success(..),
+            ..
+        })
+        | TransactionResult::Abort(..)
+        | TransactionResult::Reject(RejectResult { .. }) => None,
+    }
+}
+
+/// Executes the passed function is the receipt was committed successfully returning a [`Some`]
+/// variant with the returns of the callback function, otherwise [`None`] is returned.
+pub fn map_if_commit_success<F, O>(receipt: &TransactionReceipt, callback: F) -> Option<O>
+where
+    F: Fn(&TransactionReceipt, &CommitResult, &[InstructionOutput]) -> O,
+{
+    match receipt.result {
+        TransactionResult::Commit(
+            ref commit_result @ CommitResult {
+                outcome: TransactionOutcome::Success(ref outcome),
+                ..
+            },
+        ) => Some(callback(receipt, commit_result, outcome)),
+        TransactionResult::Commit(CommitResult {
+            outcome: TransactionOutcome::Failure(..),
+            ..
+        })
+        | TransactionResult::Abort(..)
+        | TransactionResult::Reject(..) => None,
+    }
+}
+
+/// Converts any typed value that implements [`ManifestEncode`] to a [`ManifestValue`] without
+/// respecting the maximum depth limit.
+pub fn to_manifest_value_ignoring_depth<T>(value: &T) -> ManifestValue
+where
+    T: ManifestEncode,
+{
+    const DEPTH_LIMIT: usize = usize::MAX;
+    manifest_encode_with_depth_limit(value, DEPTH_LIMIT)
+        .ok()
+        .and_then(|encoded| manifest_decode_with_depth_limit(&encoded, DEPTH_LIMIT).ok())
+        .expect("Impossible case!")
+}
+
+pub enum OneOrMore<'t, T> {
+    One(&'t T),
+    More(&'t [T]),
+}
+
+impl<'t, T> From<&'t T> for OneOrMore<'t, T> {
+    fn from(value: &'t T) -> Self {
+        Self::One(value)
+    }
+}
+
+impl<'t, T> From<&'t [T]> for OneOrMore<'t, T> {
+    fn from(value: &'t [T]) -> Self {
+        Self::More(value)
+    }
+}

--- a/fuzz-tests/src/utils/mod.rs
+++ b/fuzz-tests/src/utils/mod.rs
@@ -5,3 +5,7 @@ pub mod simple_fuzzer;
 
 #[macro_use]
 pub mod fuzz_template;
+
+mod fuzz_utils;
+
+pub use fuzz_utils::*;

--- a/native-sdk/src/modules/royalty/royalty.rs
+++ b/native-sdk/src/modules/royalty/royalty.rs
@@ -1,14 +1,13 @@
-use radix_engine_interface::api::node_modules::royalty::{
-    ComponentRoyaltyCreateInput, COMPONENT_ROYALTY_BLUEPRINT, COMPONENT_ROYALTY_CREATE_IDENT,
-};
-use radix_engine_interface::api::ClientApi;
-use radix_engine_interface::constants::ROYALTY_MODULE_PACKAGE;
+use radix_engine_common::types::*;
+use radix_engine_interface::api::*;
+use radix_engine_interface::constants::*;
 use radix_engine_interface::data::scrypto::model::Own;
 use radix_engine_interface::data::scrypto::*;
-use radix_engine_interface::types::ComponentRoyaltyConfig;
+use radix_engine_interface::prelude::node_modules::royalty::*;
+use radix_engine_interface::types::*;
 use sbor::rust::prelude::*;
 
-pub struct ComponentRoyalty;
+pub struct ComponentRoyalty(pub Own);
 
 impl ComponentRoyalty {
     pub fn create<Y, E: Debug + ScryptoDecode>(
@@ -24,8 +23,66 @@ impl ComponentRoyalty {
             COMPONENT_ROYALTY_CREATE_IDENT,
             scrypto_encode(&ComponentRoyaltyCreateInput { royalty_config }).unwrap(),
         )?;
-        let componentroyatly: Own = scrypto_decode(&rtn).unwrap();
+        let component_royalty: Own = scrypto_decode(&rtn).unwrap();
 
-        Ok(componentroyatly)
+        Ok(component_royalty)
+    }
+
+    pub fn set_royalty<Y, E: Debug + ScryptoDecode>(
+        &mut self,
+        method_name: &str,
+        amount: RoyaltyAmount,
+        api: &mut Y,
+    ) -> Result<ComponentRoyaltySetOutput, E>
+    where
+        Y: ClientApi<E>,
+    {
+        let rtn = api.call_method(
+            self.0.as_node_id(),
+            COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
+            scrypto_encode(&ComponentRoyaltySetInput {
+                method: method_name.to_owned(),
+                amount,
+            })
+            .unwrap(),
+        )?;
+        let rtn = scrypto_decode::<ComponentRoyaltySetOutput>(&rtn).unwrap();
+        Ok(rtn)
+    }
+
+    pub fn lock_royalty<Y, E: Debug + ScryptoDecode>(
+        &mut self,
+        method_name: &str,
+        api: &mut Y,
+    ) -> Result<ComponentRoyaltyLockOutput, E>
+    where
+        Y: ClientApi<E>,
+    {
+        let rtn = api.call_method(
+            self.0.as_node_id(),
+            COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT,
+            scrypto_encode(&ComponentRoyaltyLockInput {
+                method: method_name.to_owned(),
+            })
+            .unwrap(),
+        )?;
+        let rtn = scrypto_decode::<ComponentRoyaltyLockOutput>(&rtn).unwrap();
+        Ok(rtn)
+    }
+
+    pub fn claim_royalty<Y, E: Debug + ScryptoDecode>(
+        &mut self,
+        api: &mut Y,
+    ) -> Result<ComponentClaimRoyaltiesOutput, E>
+    where
+        Y: ClientApi<E>,
+    {
+        let rtn = api.call_method(
+            self.0.as_node_id(),
+            COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT,
+            scrypto_encode(&ComponentClaimRoyaltiesInput {}).unwrap(),
+        )?;
+        let rtn = scrypto_decode::<ComponentClaimRoyaltiesOutput>(&rtn).unwrap();
+        Ok(rtn)
     }
 }

--- a/radix-engine-common/src/types/royalty_amount.rs
+++ b/radix-engine-common/src/types/royalty_amount.rs
@@ -2,7 +2,10 @@ use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
 
-#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, ManifestSbor, ScryptoCategorize, ScryptoEncode, ScryptoDecode,
 )]

--- a/radix-engine-interface/src/api/node_modules/royalty/invocations.rs
+++ b/radix-engine-interface/src/api/node_modules/royalty/invocations.rs
@@ -18,6 +18,10 @@ pub const COMPONENT_ROYALTY_BLUEPRINT: &str = "ComponentRoyalty";
 
 pub const COMPONENT_ROYALTY_CREATE_IDENT: &str = "create";
 
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
@@ -29,6 +33,10 @@ pub type ComponentRoyaltyCreateOutput = Own;
 
 pub const COMPONENT_ROYALTY_SET_ROYALTY_IDENT: &str = "set_royalty";
 
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
@@ -41,6 +49,10 @@ pub type ComponentRoyaltySetOutput = ();
 
 pub const COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT: &str = "lock_royalty";
 
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]
@@ -52,6 +64,10 @@ pub type ComponentRoyaltyLockOutput = ();
 
 pub const COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT: &str = "claim_royalties";
 
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]

--- a/radix-engine-interface/src/blueprints/package/invocations.rs
+++ b/radix-engine-interface/src/blueprints/package/invocations.rs
@@ -76,6 +76,10 @@ pub type PackagePublishNativeOutput = PackageAddress;
 
 pub const PACKAGE_CLAIM_ROYALTIES_IDENT: &str = "PackageRoyalty_claim_royalties";
 
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(arbitrary::Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(
     Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestCategorize, ManifestEncode, ManifestDecode,
 )]

--- a/radix-engine-interface/src/types/royalty_config.rs
+++ b/radix-engine-interface/src/types/royalty_config.rs
@@ -6,14 +6,20 @@ use sbor::rust::prelude::*;
 use crate::*;
 
 /// Royalty rules
-#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(Debug, Clone, Default, PartialEq, Eq, ScryptoSbor, ManifestSbor)]
 pub struct ComponentRoyaltyConfig {
     pub royalty_amounts: IndexMap<String, (RoyaltyAmount, bool)>,
 }
 
 /// Royalty rules
-#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, ManifestSbor)]
 pub enum PackageRoyalty {
     Disabled,
@@ -21,7 +27,10 @@ pub enum PackageRoyalty {
 }
 
 /// Royalty rules
-#[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
+#[cfg_attr(
+    feature = "radix_engine_fuzzing",
+    derive(Arbitrary, serde::Serialize, serde::Deserialize)
+)]
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor, ManifestSbor)]
 pub enum PackageRoyaltyConfig {
     Disabled,

--- a/radix-engine/src/system/checkers/component_royalty_db_checker.rs
+++ b/radix-engine/src/system/checkers/component_royalty_db_checker.rs
@@ -1,0 +1,115 @@
+use super::*;
+use crate::system::attached_modules::royalty::*;
+
+use radix_engine_interface::prelude::*;
+
+/// Checks the state invariants of the component royalty module. Currently, the only invariant that
+/// this checks is that the royalty amount is within the allowed limits. This does not check
+/// anything about the accumulator vault as most of the things to check for are already handled by
+/// the resource checker.
+#[derive(Clone, Default, Debug)]
+pub struct ComponentRoyaltyDatabaseChecker(Vec<LocatedError<ComponentRoyaltyDatabaseCheckerError>>);
+
+impl ApplicationChecker for ComponentRoyaltyDatabaseChecker {
+    type ApplicationCheckerResults = Vec<LocatedError<ComponentRoyaltyDatabaseCheckerError>>;
+
+    fn on_collection_entry(
+        &mut self,
+        info: BlueprintInfo,
+        node_id: NodeId,
+        module_id: ModuleId,
+        collection_index: CollectionIndex,
+        key: &Vec<u8>,
+        value: &Vec<u8>,
+    ) {
+        // Ignore if the module id is not the royalty module.
+        if module_id == ModuleId::Royalty {
+            return;
+        }
+
+        let location = ErrorLocation::CollectionEntry {
+            info,
+            node_id,
+            module_id,
+            collection_index,
+            key: key.clone(),
+            value: value.clone(),
+        };
+
+        let collection_index =
+            ComponentRoyaltyCollection::from_repr(collection_index).expect("Impossible case!");
+        match collection_index {
+            ComponentRoyaltyCollection::MethodAmountKeyValue => {
+                let _key = scrypto_decode::<ComponentRoyaltyMethodAmountKeyPayload>(&key)
+                    .expect("Impossible Case.");
+                let value = scrypto_decode::<ComponentRoyaltyMethodAmountEntryPayload>(&value)
+                    .expect("Impossible Case.");
+
+                self.check_royalty_amount(value, location);
+            }
+        }
+    }
+
+    fn on_finish(&self) -> Self::ApplicationCheckerResults {
+        self.0.clone()
+    }
+}
+
+impl ComponentRoyaltyDatabaseChecker {
+    pub fn check_royalty_amount(
+        &mut self,
+        royalty_amount: ComponentRoyaltyMethodAmountEntryPayload,
+        location: ErrorLocation,
+    ) {
+        let royalty_amount = royalty_amount.into_latest();
+        let max_royalty_in_xrd = Decimal::from_str(MAX_PER_FUNCTION_ROYALTY_IN_XRD).unwrap();
+        let max_royalty_in_usd = max_royalty_in_xrd / Decimal::from_str(USD_PRICE_IN_XRD).unwrap();
+
+        match royalty_amount {
+            RoyaltyAmount::Free => {}
+            RoyaltyAmount::Xrd(amount) => {
+                if amount.is_negative() {
+                    self.0.push(LocatedError::new(
+                        location,
+                        ComponentRoyaltyDatabaseCheckerError::NegativeRoyaltyAmount(royalty_amount),
+                    ))
+                } else if amount > max_royalty_in_xrd {
+                    self.0.push(LocatedError::new(
+                        location,
+                        ComponentRoyaltyDatabaseCheckerError::RoyaltyAmountExceedsMaximum {
+                            amount: royalty_amount,
+                            maximum: amount,
+                        },
+                    ))
+                }
+            }
+            RoyaltyAmount::Usd(amount) => {
+                if amount.is_negative() {
+                    self.0.push(LocatedError::new(
+                        location,
+                        ComponentRoyaltyDatabaseCheckerError::NegativeRoyaltyAmount(royalty_amount),
+                    ))
+                } else if amount > max_royalty_in_usd {
+                    self.0.push(LocatedError::new(
+                        location,
+                        ComponentRoyaltyDatabaseCheckerError::RoyaltyAmountExceedsMaximum {
+                            amount: royalty_amount,
+                            maximum: amount,
+                        },
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ComponentRoyaltyDatabaseCheckerError {
+    /// Negative royalty amounts are not permitted.
+    NegativeRoyaltyAmount(RoyaltyAmount),
+    /// Royalty amounts exceeding maximums are not permitted.
+    RoyaltyAmountExceedsMaximum {
+        amount: RoyaltyAmount,
+        maximum: Decimal,
+    },
+}

--- a/radix-engine/src/system/checkers/error.rs
+++ b/radix-engine/src/system/checkers/error.rs
@@ -1,0 +1,35 @@
+use radix_engine_interface::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct LocatedError<T> {
+    /// The location where the error was encountered. This is the full path a field or a collection
+    /// as well as the value.
+    pub location: ErrorLocation,
+    /// The encountered error.
+    pub error: T,
+}
+
+impl<T> LocatedError<T> {
+    pub fn new(location: ErrorLocation, error: T) -> Self {
+        Self { location, error }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ErrorLocation {
+    Field {
+        info: BlueprintInfo,
+        node_id: NodeId,
+        module_id: ModuleId,
+        field_index: FieldIndex,
+        value: Vec<u8>,
+    },
+    CollectionEntry {
+        info: BlueprintInfo,
+        node_id: NodeId,
+        module_id: ModuleId,
+        collection_index: CollectionIndex,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    },
+}

--- a/radix-engine/src/system/checkers/mod.rs
+++ b/radix-engine/src/system/checkers/mod.rs
@@ -1,4 +1,7 @@
+pub mod component_royalty_db_checker;
+pub mod error;
 pub mod kernel_db_checker;
+pub mod package_royalty_db_checker;
 pub mod resource_db_checker;
 pub mod resource_event_checker;
 pub mod resource_reconciler;
@@ -6,7 +9,10 @@ pub mod role_assignment_db_checker;
 pub mod system_db_checker;
 pub mod system_event_checker;
 
+pub use component_royalty_db_checker::*;
+pub use error::*;
 pub use kernel_db_checker::*;
+pub use package_royalty_db_checker::*;
 pub use resource_db_checker::*;
 pub use resource_event_checker::*;
 pub use resource_reconciler::*;

--- a/radix-engine/src/system/checkers/package_royalty_db_checker.rs
+++ b/radix-engine/src/system/checkers/package_royalty_db_checker.rs
@@ -1,0 +1,182 @@
+use super::*;
+use crate::blueprints::package::*;
+
+use radix_engine_interface::prelude::*;
+
+/// Checks the following invariants of the substates of the package royalties:
+/// 1. That the royalties are within their allowable limits.
+/// 2. No package royalties may be defined for methods that do not exist in the package schema.
+///
+/// This does not check anything about the accumulator vault as most of the things to check for are
+/// already handled by the resource checker.
+#[derive(Clone, Debug)]
+pub struct PackageRoyaltyDatabaseChecker<F>
+where
+    F: Fn(&BlueprintId, &str) -> bool,
+{
+    /// A callback function used to check if a function or method exist in the package definition or
+    /// not. This callback will be called for each function seen in the package royalties to verify
+    /// their existence in the package definition.
+    function_existence_callback: F,
+
+    /// The errors collected as the checker goes through the database.   
+    errors: Vec<LocatedError<PackageRoyaltyDatabaseCheckerError>>,
+}
+
+impl<F> ApplicationChecker for PackageRoyaltyDatabaseChecker<F>
+where
+    F: Fn(&BlueprintId, &str) -> bool,
+{
+    type ApplicationCheckerResults = Vec<LocatedError<PackageRoyaltyDatabaseCheckerError>>;
+
+    fn on_collection_entry(
+        &mut self,
+        info: BlueprintInfo,
+        node_id: NodeId,
+        module_id: ModuleId,
+        collection_index: CollectionIndex,
+        key: &Vec<u8>,
+        value: &Vec<u8>,
+    ) {
+        // Ignore if the module id is not the royalty module.
+        if module_id == ModuleId::Royalty {
+            return;
+        }
+
+        let location = ErrorLocation::CollectionEntry {
+            info,
+            node_id,
+            module_id,
+            collection_index,
+            key: key.clone(),
+            value: value.clone(),
+        };
+
+        let collection_index =
+            PackageCollection::from_repr(collection_index).expect("Impossible case!");
+        match collection_index {
+            PackageCollection::BlueprintVersionRoyaltyConfigKeyValue => {
+                let _key = scrypto_decode::<PackageBlueprintVersionRoyaltyConfigKeyPayload>(&key)
+                    .expect("Impossible Case.");
+                let value =
+                    scrypto_decode::<PackageBlueprintVersionRoyaltyConfigEntryPayload>(&value)
+                        .expect("Impossible Case.");
+                self.check_package_royalty_config(value, location);
+            }
+            /* Nothing else to check in the package substates. */
+            _ => return,
+        }
+    }
+
+    fn on_finish(&self) -> Self::ApplicationCheckerResults {
+        self.errors.clone()
+    }
+}
+
+impl PackageRoyaltyDatabaseChecker<fn(&BlueprintId, &str) -> bool> {
+    pub fn new_without_function_existence_check() -> Self {
+        /* All functions exist regardless of the input */
+        Self::new(|_, _| true)
+    }
+}
+
+impl<F> PackageRoyaltyDatabaseChecker<F>
+where
+    F: Fn(&BlueprintId, &str) -> bool,
+{
+    pub fn new(function_existence_callback: F) -> Self {
+        Self {
+            function_existence_callback,
+            errors: Default::default(),
+        }
+    }
+
+    pub fn check_package_royalty_config(
+        &mut self,
+        config: PackageBlueprintVersionRoyaltyConfigEntryPayload,
+        location: ErrorLocation,
+    ) {
+        let royalty_config = config.into_latest();
+
+        match royalty_config {
+            PackageRoyaltyConfig::Disabled => {}
+            PackageRoyaltyConfig::Enabled(royalty_config) => {
+                royalty_config.values().for_each(|royalty_amount| {
+                    self.check_royalty_amount(*royalty_amount, location.clone())
+                })
+            }
+        }
+    }
+
+    pub fn check_for_function_existence(
+        &mut self,
+        blueprint_id: &BlueprintId,
+        function_name: &str,
+        location: ErrorLocation,
+    ) {
+        let func = &self.function_existence_callback;
+        if !func(blueprint_id, function_name) {
+            self.errors.push(LocatedError::new(
+                location,
+                PackageRoyaltyDatabaseCheckerError::FunctionDoesNotExistForPackage(
+                    function_name.to_owned(),
+                ),
+            ))
+        }
+    }
+
+    pub fn check_royalty_amount(&mut self, royalty_amount: RoyaltyAmount, location: ErrorLocation) {
+        let max_royalty_in_xrd = Decimal::from_str(MAX_PER_FUNCTION_ROYALTY_IN_XRD).unwrap();
+        let max_royalty_in_usd = max_royalty_in_xrd / Decimal::from_str(USD_PRICE_IN_XRD).unwrap();
+
+        match royalty_amount {
+            RoyaltyAmount::Free => {}
+            RoyaltyAmount::Xrd(amount) => {
+                if amount.is_negative() {
+                    self.errors.push(LocatedError::new(
+                        location,
+                        PackageRoyaltyDatabaseCheckerError::NegativeRoyaltyAmount(royalty_amount),
+                    ))
+                } else if amount > max_royalty_in_xrd {
+                    self.errors.push(LocatedError::new(
+                        location,
+                        PackageRoyaltyDatabaseCheckerError::RoyaltyAmountExceedsMaximum {
+                            amount: royalty_amount,
+                            maximum: amount,
+                        },
+                    ))
+                }
+            }
+            RoyaltyAmount::Usd(amount) => {
+                if amount.is_negative() {
+                    self.errors.push(LocatedError::new(
+                        location,
+                        PackageRoyaltyDatabaseCheckerError::NegativeRoyaltyAmount(royalty_amount),
+                    ))
+                } else if amount > max_royalty_in_usd {
+                    self.errors.push(LocatedError::new(
+                        location,
+                        PackageRoyaltyDatabaseCheckerError::RoyaltyAmountExceedsMaximum {
+                            amount: royalty_amount,
+                            maximum: amount,
+                        },
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PackageRoyaltyDatabaseCheckerError {
+    /// Negative royalty amounts are not permitted.
+    NegativeRoyaltyAmount(RoyaltyAmount),
+    /// Royalty amounts exceeding maximums are not permitted.
+    RoyaltyAmountExceedsMaximum {
+        amount: RoyaltyAmount,
+        maximum: Decimal,
+    },
+    /// Encountered royalties defined for a function or method that does not exist in the package
+    /// schema.
+    FunctionDoesNotExistForPackage(String),
+}

--- a/radix-engine/src/system/checkers/role_assignment_db_checker.rs
+++ b/radix-engine/src/system/checkers/role_assignment_db_checker.rs
@@ -18,11 +18,11 @@ pub struct RoleAssignmentDatabaseChecker {
     node_id: Option<NodeId>,
 
     /// A vector of all of the errors encountered when going through the RoleAssignment substates.
-    errors: Vec<LocatedRoleAssignmentDatabaseCheckerError>,
+    errors: Vec<LocatedError<RoleAssignmentDatabaseCheckerError>>,
 }
 
 impl ApplicationChecker for RoleAssignmentDatabaseChecker {
-    type ApplicationCheckerResults = Vec<LocatedRoleAssignmentDatabaseCheckerError>;
+    type ApplicationCheckerResults = Vec<LocatedError<RoleAssignmentDatabaseCheckerError>>;
 
     fn on_field(
         &mut self,
@@ -35,7 +35,7 @@ impl ApplicationChecker for RoleAssignmentDatabaseChecker {
         // The method responsible for the addition of errors to the checker state. This method will
         // add the location information.
         let mut add_error = |error| {
-            self.errors.push(LocatedRoleAssignmentDatabaseCheckerError {
+            self.errors.push(LocatedError {
                 location: ErrorLocation::Field {
                     info: info.clone(),
                     node_id,
@@ -80,7 +80,7 @@ impl ApplicationChecker for RoleAssignmentDatabaseChecker {
         // The method responsible for the addition of errors to the checker state. This method will
         // add the location information.
         let mut add_error = |error| {
-            self.errors.push(LocatedRoleAssignmentDatabaseCheckerError {
+            self.errors.push(LocatedError {
                 location: ErrorLocation::CollectionEntry {
                     info: info.clone(),
                     node_id,
@@ -170,8 +170,7 @@ impl RoleAssignmentDatabaseChecker {
         location: ErrorLocation,
         error: RoleAssignmentDatabaseCheckerError,
     ) {
-        self.errors
-            .push(LocatedRoleAssignmentDatabaseCheckerError { location, error })
+        self.errors.push(LocatedError { location, error })
     }
 
     fn check_access_rule_limits<F>(access_rule: AccessRule, add_error: &mut F)
@@ -255,15 +254,6 @@ impl RoleAssignmentDatabaseChecker {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct LocatedRoleAssignmentDatabaseCheckerError {
-    /// The location where the error was encountered. This is the full path a field or a collection
-    /// as well as the value.
-    pub location: ErrorLocation,
-    /// The encountered error.
-    pub error: RoleAssignmentDatabaseCheckerError,
-}
-
 /// An enum of all of the errors that we may encounter when doing a database check. These errors are
 /// collected and then returned at the end of database check.
 #[derive(Debug, Clone)]
@@ -291,24 +281,5 @@ pub enum RoleAssignmentDatabaseCheckerError {
     RoleKeyWasCreatedAfterInitialization {
         initial_role_keys: Vec<ModuleRoleKey>,
         role_key: ModuleRoleKey,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub enum ErrorLocation {
-    Field {
-        info: BlueprintInfo,
-        node_id: NodeId,
-        module_id: ModuleId,
-        field_index: FieldIndex,
-        value: Vec<u8>,
-    },
-    CollectionEntry {
-        info: BlueprintInfo,
-        node_id: NodeId,
-        module_id: ModuleId,
-        collection_index: CollectionIndex,
-        key: Vec<u8>,
-        value: Vec<u8>,
     },
 }

--- a/radix-engine/src/system/checkers/system_db_checker.rs
+++ b/radix-engine/src/system/checkers/system_db_checker.rs
@@ -132,7 +132,7 @@ pub enum SystemDatabaseCheckError {
     PartitionError(NodeInfo, SystemPartitionCheckError),
 }
 
-pub trait ApplicationChecker: Default {
+pub trait ApplicationChecker {
     type ApplicationCheckerResults: Debug + Default;
     fn on_field(
         &mut self,
@@ -176,7 +176,10 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
     }
 }
 
-impl<A: ApplicationChecker> Default for SystemDatabaseChecker<A> {
+impl<A: ApplicationChecker> Default for SystemDatabaseChecker<A>
+where
+    A: Default,
+{
     fn default() -> Self {
         Self {
             application_checker: A::default(),

--- a/radix-engine/src/system/checkers/system_db_checker.rs
+++ b/radix-engine/src/system/checkers/system_db_checker.rs
@@ -872,22 +872,34 @@ macro_rules! define_composite_checker {
     (
         $ident: ident,
         [
-            $($ty: ident),* $(,)?
+            $($ty: ident $(< $( $generic_ident: ident: $generic_type: ty ),* $(,)? >)?),* $(,)?
         ] $(,)?
     ) => {
         paste::paste! {
-            #[derive(Default, Debug)]
-            pub struct $ident {
+            #[derive(Debug)]
+            pub struct $ident<
+            $(
+                $($($generic_ident: $generic_type),*)?
+            )*
+            > {
                 $(
-                    pub [< $ty: snake >]: $ty,
+                    pub [< $ty: snake >]: $ty $(< $($generic_ident),* >)?,
                 )*
             }
 
             const _: () = {
-                impl $ident {
+                impl<
+                $(
+                    $($($generic_ident: $generic_type),*)?
+                )*
+                > $ident<
+                $(
+                    $($($generic_ident),*)?
+                )*
+                > {
                     pub fn new(
                         $(
-                            [< $ty: snake >]: $ty,
+                            [< $ty: snake >]: $ty $(< $($generic_ident),* >)?,
                         )*
                     ) -> Self {
                         Self {
@@ -898,10 +910,17 @@ macro_rules! define_composite_checker {
                     }
                 }
 
-                impl $crate::system::checkers::ApplicationChecker for $ident {
+                impl<
+                $(
+                    $($($generic_ident: $generic_type),*)?
+                )* > $crate::system::checkers::ApplicationChecker for $ident<
+                $(
+                    $($($generic_ident),*)?
+                )*
+                > {
                     type ApplicationCheckerResults = (
                         $(
-                            < $ty as $crate::system::checkers::ApplicationChecker >::ApplicationCheckerResults,
+                            < $ty $(::< $($generic_ident),* >)? as $crate::system::checkers::ApplicationChecker >::ApplicationCheckerResults,
                         )*
                     );
 

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -2482,12 +2482,28 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             CompositeApplicationDatabaseChecker,
             [
                 ResourceDatabaseChecker,
-                RoleAssignmentDatabaseChecker
+                RoleAssignmentDatabaseChecker,
+                PackageRoyaltyDatabaseChecker<F: Fn(&BlueprintId, &str) -> bool>,
+                ComponentRoyaltyDatabaseChecker,
             ]
         }
-        let db_results = self
-            .check_db::<CompositeApplicationDatabaseChecker>()
-            .expect("Database should be consistent after running test");
+        let db_results = {
+            let reader = SystemDatabaseReader::new(&self.database);
+            let mut checker = SystemDatabaseChecker::new(CompositeApplicationDatabaseChecker::new(
+                Default::default(),
+                Default::default(),
+                PackageRoyaltyDatabaseChecker::new(|blueprint_id, func_name| {
+                    reader
+                        .get_blueprint_definition(blueprint_id)
+                        .map(|bp_def| bp_def.interface.functions.contains_key(func_name))
+                        .unwrap_or(false)
+                }),
+                Default::default(),
+            ));
+            checker
+                .check_db(&self.database)
+                .expect("Database should be consistent after running test")
+        };
         println!("{:#?}", db_results);
 
         if !db_results.1 .1.is_empty() {

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -2454,7 +2454,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             .collect::<Vec<_>>()
     }
 
-    pub fn check_db<A: ApplicationChecker>(
+    pub fn check_db<A: ApplicationChecker + Default>(
         &self,
     ) -> Result<
         (SystemDatabaseCheckerResults, A::ApplicationCheckerResults),


### PR DESCRIPTION
## Summary

Added fuzz tests for the component royalty module and the package royalty state. This test checks for the following:

* If the royalty amount could be set to anything negative or above the maximum.
* If royalties could be defined for any function that doesn't exist on the package.
* If the royalty transactions result in a native-vm panic.

This fuzzer invokes the royalty module pre and post attachment for added checks.

The next steps would be to add fuzz tests for the accounting of royalties and to ensure that the final royalties shown in transactions withstand random inputs.