### PR TITLE
QEMU workflow update

### DIFF
--- a/.github/workflows/cpu_instructions.yml
+++ b/.github/workflows/cpu_instructions.yml
@@ -24,6 +24,7 @@ jobs:
              cargo test --release --no-run --features resource_tracker
              rm -f ../target/release/deps/transaction_multi_threaded-*
              rm -f ../target/release/deps/*.d
+             rm -f ../target/release/deps/*.o
              rm -f ../target/release/deps/*.rlib
              rm -f ../target/release/deps/*.rmeta
       - name: Preapare files for cache
@@ -47,30 +48,6 @@ jobs:
           path: ./target/release/deps_2
           key: ${{ runner.os }}-build-cache-2-radix-engine-tests-${{ github.run_id }}
 
-  build-monkey-tests:          
-    name: Build monkey tests
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Setup dependencies
-        run: rustup target add wasm32-unknown-unknown 
-      - name: Build tests
-        run: |
-             cd monkey-tests
-             cargo test --release --no-run --features resource_tracker
-             rm -f ./target/release/deps/*.d
-             rm -f ./target/release/deps/*.rlib
-             rm -f ./target/release/deps/*.rmeta
-             mv ../target/release/deps ../target/release/deps_3
-      - name: Cache build results
-        uses: actions/cache/save@v3
-        with:
-          path: ./target/release/deps_3
-          key: ${{ runner.os }}-build-cache-3-radix-engine-tests-${{ github.run_id }}
-
   build-other-tests:          
     name: Build other tests
     runs-on: ubuntu-22.04
@@ -83,12 +60,27 @@ jobs:
         run: rustup target add wasm32-unknown-unknown 
       - name: Build tests
         run: |
-             cargo test --release --no-run --features resource_tracker --workspace --exclude radix-engine-tests --exclude monkey-tests
+             cargo test --release --no-run --features resource_tracker --workspace --exclude radix-engine-tests
              rm -f ./target/release/deps/*.d
+             rm -f ./target/release/deps/*.o
              rm -f ./target/release/deps/*.rlib
              rm -f ./target/release/deps/*.rmeta
-             mv ./target/release/deps ./target/release/deps_4
-      - name: Cache build results
+      - name: Preapare files for cache
+        run: |
+             cd target/release
+             mkdir deps_3
+             cd deps
+             count=`ls fuzz* | wc -l`
+             half=`echo $(($count / 2))`
+             ls fuzz* | head -n$half | xargs mv -t ../deps_3
+             cd ..
+             mv deps deps_4
+      - name: Cache build results 1
+        uses: actions/cache/save@v3
+        with:
+          path: ./target/release/deps_3
+          key: ${{ runner.os }}-build-cache-3-radix-engine-tests-${{ github.run_id }}
+      - name: Cache build results 2
         uses: actions/cache/save@v3
         with:
           path: ./target/release/deps_4
@@ -134,7 +126,7 @@ jobs:
   qemu-costing-evaluation-run:
     name: QEMU costing - CPU instructions
     runs-on: ubuntu-22.04
-    needs: [build-radix-engine-tests, build-monkey-tests, build-other-tests, qemu-build]
+    needs: [build-radix-engine-tests, build-other-tests, qemu-build]
     strategy:
       matrix:
         bin-cache: [1, 2, 3, 4]

--- a/.github/workflows/cpu_instructions.yml
+++ b/.github/workflows/cpu_instructions.yml
@@ -134,7 +134,7 @@ jobs:
   qemu-costing-evaluation-run:
     name: QEMU costing - CPU instructions
     runs-on: ubuntu-22.04
-    needs: [build-radix-engine-tests, build-other-tests, qemu-build]
+    needs: [build-radix-engine-tests, build-monkey-tests, build-other-tests, qemu-build]
     strategy:
       matrix:
         bin-cache: [1, 2, 3, 4]

--- a/.github/workflows/cpu_instructions.yml
+++ b/.github/workflows/cpu_instructions.yml
@@ -64,7 +64,7 @@ jobs:
              rm -f ./target/release/deps/*.d
              rm -f ./target/release/deps/*.rlib
              rm -f ./target/release/deps/*.rmeta
-             mv ./target/release/deps ./target/release/deps_3
+             mv ../target/release/deps ../target/release/deps_3
       - name: Cache build results
         uses: actions/cache/save@v3
         with:

--- a/.github/workflows/cpu_instructions.yml
+++ b/.github/workflows/cpu_instructions.yml
@@ -46,7 +46,31 @@ jobs:
         with:
           path: ./target/release/deps_2
           key: ${{ runner.os }}-build-cache-2-radix-engine-tests-${{ github.run_id }}
-          
+
+  build-monkey-tests:          
+    name: Build monkey tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Setup dependencies
+        run: rustup target add wasm32-unknown-unknown 
+      - name: Build tests
+        run: |
+             cd monkey-tests
+             cargo test --release --no-run --features resource_tracker
+             rm -f ./target/release/deps/*.d
+             rm -f ./target/release/deps/*.rlib
+             rm -f ./target/release/deps/*.rmeta
+             mv ./target/release/deps ./target/release/deps_3
+      - name: Cache build results
+        uses: actions/cache/save@v3
+        with:
+          path: ./target/release/deps_3
+          key: ${{ runner.os }}-build-cache-3-radix-engine-tests-${{ github.run_id }}
+
   build-other-tests:          
     name: Build other tests
     runs-on: ubuntu-22.04
@@ -59,16 +83,16 @@ jobs:
         run: rustup target add wasm32-unknown-unknown 
       - name: Build tests
         run: |
-             cargo test --release --no-run --features resource_tracker --workspace --exclude radix-engine-tests
+             cargo test --release --no-run --features resource_tracker --workspace --exclude radix-engine-tests --exclude monkey-tests
              rm -f ./target/release/deps/*.d
              rm -f ./target/release/deps/*.rlib
              rm -f ./target/release/deps/*.rmeta
-             mv ./target/release/deps ./target/release/deps_3
+             mv ./target/release/deps ./target/release/deps_4
       - name: Cache build results
         uses: actions/cache/save@v3
         with:
-          path: ./target/release/deps_3
-          key: ${{ runner.os }}-build-cache-3-radix-engine-tests-${{ github.run_id }}
+          path: ./target/release/deps_4
+          key: ${{ runner.os }}-build-cache-4-radix-engine-tests-${{ github.run_id }}
 
   qemu-build:
     name: QEMU build
@@ -113,7 +137,7 @@ jobs:
     needs: [build-radix-engine-tests, build-other-tests, qemu-build]
     strategy:
       matrix:
-        bin-cache: [1, 2, 3]
+        bin-cache: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -180,6 +204,12 @@ jobs:
         with:
           path: /tmp/scrypto-resources-usage
           key: ${{ runner.os }}-build-cache-3-radix-engine-tests-${{ github.run_id }}-qemu-results
+          fail-on-cache-miss: true
+      - name: Read cache QEMU run 4 results
+        uses: actions/cache/restore@v3
+        with:
+          path: /tmp/scrypto-resources-usage
+          key: ${{ runner.os }}-build-cache-4-radix-engine-tests-${{ github.run_id }}-qemu-results
           fail-on-cache-miss: true
       - name: Upload xml files
         uses: actions/upload-artifact@v3

--- a/monkey-tests/Cargo.toml
+++ b/monkey-tests/Cargo.toml
@@ -38,6 +38,7 @@ std = ["sbor/std", "transaction/std", "transaction-scenarios/std", "radix-engine
 alloc = ["sbor/alloc", "transaction/alloc", "transaction-scenarios/alloc", "radix-engine/alloc", "radix-engine/lru", "radix-engine-interface/alloc", "radix-engine-stores/alloc", "radix-engine-store-interface/alloc", "radix-engine-queries/alloc", "utils/alloc", "scrypto/alloc", "scrypto-unit/alloc"]
 rocksdb = ["scrypto-unit/rocksdb"]
 post_run_db_check = ["scrypto-unit/post_run_db_check"]
+resource_tracker = ["dep:radix-engine-profiling", "resources-tracker-macro/resource_tracker", "radix-engine/resource_tracker", "radix-engine-common/resource_tracker", "scrypto-unit/resource_tracker"]
 
 [lib]
 doctest = false

--- a/radix-engine-profiling/resources-tracker-macro/scripts/convert.py
+++ b/radix-engine-profiling/resources-tracker-macro/scripts/convert.py
@@ -216,23 +216,8 @@ f.close()
 
 # Write results output table
 f = open("/tmp/_out_table.txt", "w")
-min_ins = sys.maxsize
-if len(output_tab) > 0 and len(output_tab[0]) > 2 and output_tab[0][2] > 0:
-    min_ins = output_tab[0][2]
-for row in output_tab:
-    if row[2] < min_ins and row[2] > 0:
-        min_ins = row[2]
-mul_div = 16
-for row in output_tab:
-    coeff = round(mul_div * row[2] / min_ins)
-    row.append(coeff)
-    row.append( row[2] - coeff * min_ins / mul_div )
-output_tab.insert(0,["No.", "API function with params", "instructions", "calculation", "function cost (F)", "error"])
+output_tab.insert(0,["No.", "API function with params", "instructions", "calculation"])
 f.write(tabulate(output_tab, headers="firstrow"))
-coef = "\nCost function coeff: " + str(min_ins) + "\n"
-f.write(coef)
-fcn = "Cost calculation = ( F *" + str(min_ins) + ") /" + str(mul_div) + "\n"
-f.write(fcn)
 f.close()
 
 # Write results output table as csv file


### PR DESCRIPTION
## Summary
Updated QEMU github workflow.

## Details
All tests from `monkey-tests` takes 5~6 hours of QEMU execution, which is very close to github job time limit (6h). Because of that these tests has been divided into two separate jobs (automatic extraction of half of these tests to separate job).
Also updated `convert.pl` script to remove not needed data output.
Successful action run: https://github.com/radixdlt/radixdlt-scrypto/actions/runs/6377443462