### PR TITLE
[ON HOLD] Metadata module refactoring

### DIFF
--- a/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
@@ -67,5 +67,9 @@ mod metadata_component {
         pub fn set_metadata_with_invalid_origin(global: Global<MetadataComponent>, key: String) {
             global.set_metadata(key, UncheckedOrigin::of("https:/abc"));
         }
+
+        pub fn get_metadata(global: Global<MetadataComponent>, key: String) -> Result<Option<String>, MetadataConversionError> {
+            global.get_metadata(key)
+        }
     }
 }

--- a/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
+++ b/radix-engine-tests/tests/blueprints/metadata_component/src/lib.rs
@@ -68,7 +68,10 @@ mod metadata_component {
             global.set_metadata(key, UncheckedOrigin::of("https:/abc"));
         }
 
-        pub fn get_metadata(global: Global<MetadataComponent>, key: String) -> Result<Option<String>, MetadataConversionError> {
+        pub fn get_metadata(
+            global: Global<MetadataComponent>,
+            key: String,
+        ) -> Result<Option<String>, MetadataConversionError> {
             global.get_metadata(key)
         }
     }

--- a/radix-engine/src/system/attached_modules/metadata/package.rs
+++ b/radix-engine/src/system/attached_modules/metadata/package.rs
@@ -278,7 +278,7 @@ impl MetadataNativePackage {
         ),
         MetadataError,
     > {
-        let mut init_kv_entries = index_map_new();
+        let mut init_kv_entries = index_map_with_capacity(data.data.len());
         for (key, entry) in data.data {
             if key.len() > MAX_METADATA_KEY_STRING_LEN {
                 return Err(MetadataError::KeyStringExceedsMaxLength {
@@ -401,6 +401,15 @@ impl MetadataNativePackage {
     where
         Y: ClientApi<RuntimeError>,
     {
+        if key.len() > MAX_METADATA_KEY_STRING_LEN {
+            return Err(RuntimeError::ApplicationError(
+                ApplicationError::MetadataError(MetadataError::KeyStringExceedsMaxLength {
+                    max: MAX_METADATA_KEY_STRING_LEN,
+                    actual: key.len(),
+                }),
+            ));
+        }
+
         let handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             MetadataCollection::EntryKeyValue.collection_index(),
@@ -417,6 +426,15 @@ impl MetadataNativePackage {
     where
         Y: ClientApi<RuntimeError>,
     {
+        if key.len() > MAX_METADATA_KEY_STRING_LEN {
+            return Err(RuntimeError::ApplicationError(
+                ApplicationError::MetadataError(MetadataError::KeyStringExceedsMaxLength {
+                    max: MAX_METADATA_KEY_STRING_LEN,
+                    actual: key.len(),
+                }),
+            ));
+        }
+
         let handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             MetadataCollection::EntryKeyValue.collection_index(),
@@ -434,6 +452,15 @@ impl MetadataNativePackage {
     where
         Y: ClientApi<RuntimeError>,
     {
+        if key.len() > MAX_METADATA_KEY_STRING_LEN {
+            return Err(RuntimeError::ApplicationError(
+                ApplicationError::MetadataError(MetadataError::KeyStringExceedsMaxLength {
+                    max: MAX_METADATA_KEY_STRING_LEN,
+                    actual: key.len(),
+                }),
+            ));
+        }
+
         let cur_value: Option<MetadataEntryEntryPayload> = api.actor_remove_key_value_entry_typed(
             ACTOR_STATE_SELF,
             0u8,


### PR DESCRIPTION
## Summary
Added verification of metadata key length in calls to functions: `get`, `lock` and `remove`, so the flow of the execution will be stopped in case of too long key and no internal calls to system and kernel layers will be invoked.

Improved memory handling when creating metadata with initial data.

## Testing
Added new test to validate key length check.

## Update Recommendations
Before this PR, querying with too long key will return `None` (as a metadata for such a key cannot be found in db), after this PR error: `MetadataError::KeyStringExceedsMaxLength` will be returned.