### PR TITLE
Make logging test more resistant to refactoring

### DIFF
--- a/radix-engine-tests/tests/logging.rs
+++ b/radix-engine-tests/tests/logging.rs
@@ -105,9 +105,9 @@ fn test_assert_length_5() {
         let logs = receipt.expect_commit(false).application_logs.clone();
         assert!(logs.is_empty());
         receipt.expect_specific_failure(|e| match e {
-            RuntimeError::ApplicationError(ApplicationError::PanicMessage(e)) => e.eq(
-                "assertion `left == right` failed\n  left: 2\n right: 5 @ logger/src/lib.rs:23:13",
-            ),
+            RuntimeError::ApplicationError(ApplicationError::PanicMessage(e)) => {
+                e.contains("logger/src/lib.rs:23:13")
+            }
             _ => false,
         })
     }

--- a/simulator/src/scrypto_bindgen/mod.rs
+++ b/simulator/src/scrypto_bindgen/mod.rs
@@ -117,7 +117,10 @@ where
     S: SubstateDatabase,
 {
     fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<VersionedScryptoSchema> {
-        self.1.get_schema(self.0.as_node_id(), schema_hash).ok().map(|x| x.as_ref().clone())
+        self.1
+            .get_schema(self.0.as_node_id(), schema_hash)
+            .ok()
+            .map(|x| x.as_ref().clone())
     }
 
     fn resolve_type_kind(


### PR DESCRIPTION
## Summary
A test is failing because of the update in the output of Rust panics. This PR fixes this issue and updates the test to make it more resistant to refactoring