### PR TITLE
Misc: clean up code

### DIFF
--- a/monkey-tests/tests/fuzz_kernel.rs
+++ b/monkey-tests/tests/fuzz_kernel.rs
@@ -542,10 +542,12 @@ fn kernel_fuzz<F: FnMut(&mut KernelFuzzer) -> Vec<KernelFuzzAction>>(
         let database_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
         substate_db.commit(&database_updates);
         let mut checker = KernelDatabaseChecker::new();
-        checker.check_db(&substate_db).expect(&format!(
-            "Database is not consistent at seed: {:?} actions: {:?}",
-            seed, actions
-        ));
+        checker.check_db(&substate_db).unwrap_or_else(|_| {
+            panic!(
+                "Database is not consistent at seed: {:?} actions: {:?}",
+                seed, actions
+            )
+        });
     }
 
     Ok(())

--- a/radix-engine-common/benches/schema.rs
+++ b/radix-engine-common/benches/schema.rs
@@ -27,7 +27,7 @@ pub struct SimpleStruct {
 pub fn get_simple_dataset(repeat: usize) -> SimpleStruct {
     let mut data = SimpleStruct {
         number: 12345678901234567890,
-        string: "dummy".repeat(repeat).to_owned(),
+        string: "dummy".repeat(repeat),
         bytes: vec![123u8; repeat],
         vector: vec![12345u16; repeat],
         enumeration: vec![

--- a/radix-engine-common/src/data/scrypto/model/non_fungible_local_id.rs
+++ b/radix-engine-common/src/data/scrypto/model/non_fungible_local_id.rs
@@ -532,10 +532,10 @@ impl FromStr for NonFungibleLocalId {
     type Err = ParseNonFungibleLocalIdError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let local_id = if s.starts_with("<") && s.ends_with(">") {
-            Self::string(s[1..s.len() - 1].to_string())
+        let local_id = if s.starts_with('<') && s.ends_with('>') {
+            Self::string(&s[1..s.len() - 1])
                 .map_err(ParseNonFungibleLocalIdError::ContentValidationError)?
-        } else if s.starts_with("#") && s.ends_with("#") {
+        } else if s.starts_with('#') && s.ends_with('#') {
             let digits = &s[1..s.len() - 1];
             if !is_canonically_formatted_integer(digits) {
                 return Err(ParseNonFungibleLocalIdError::InvalidInteger);
@@ -544,13 +544,13 @@ impl FromStr for NonFungibleLocalId {
                 u64::from_str_radix(&s[1..s.len() - 1], 10)
                     .map_err(|_| ParseNonFungibleLocalIdError::InvalidInteger)?,
             )
-        } else if s.starts_with("[") && s.ends_with("]") {
+        } else if s.starts_with('[') && s.ends_with(']') {
             NonFungibleLocalId::bytes(
                 hex::decode(&s[1..s.len() - 1])
                     .map_err(|_| ParseNonFungibleLocalIdError::InvalidBytes)?,
             )
             .map_err(ParseNonFungibleLocalIdError::ContentValidationError)?
-        } else if s.starts_with("{") && s.ends_with("}") {
+        } else if s.starts_with('{') && s.ends_with('}') {
             let chars: Vec<char> = s[1..s.len() - 1].chars().collect();
             if chars.len() == 32 * 2 + 3 && chars[16] == '-' && chars[33] == '-' && chars[50] == '-'
             {
@@ -627,7 +627,7 @@ mod tests {
         let validation_result =
             NonFungibleLocalId::string(string_of_length(1 + NON_FUNGIBLE_LOCAL_ID_MAX_LENGTH));
         assert_eq!(validation_result, Err(ContentValidationError::TooLong));
-        let validation_result = NonFungibleLocalId::string("".to_string());
+        let validation_result = NonFungibleLocalId::string("");
         assert_eq!(validation_result, Err(ContentValidationError::Empty));
 
         let validation_result =
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn test_non_fungible_string_validation() {
         let valid_id_string = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWZYZ_0123456789";
-        let validation_result = NonFungibleLocalId::string(valid_id_string.to_owned());
+        let validation_result = NonFungibleLocalId::string(valid_id_string);
         assert!(matches!(validation_result, Ok(_)));
 
         test_invalid_char('.');

--- a/radix-engine-common/src/math/bnum_integer.rs
+++ b/radix-engine-common/src/math/bnum_integer.rs
@@ -48,7 +48,7 @@ macro_rules! types {
                 #[doc = "`" $t "` will have the same methods and traits as"]
                 /// the built-in counterpart.
                 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary, Serialize, Deserialize))]
-                #[derive(Clone , Copy , Eq , Hash)]
+                #[derive(Clone , Copy)]
                 #[repr(transparent)]
                 pub struct $t(pub $wrap);
 
@@ -113,9 +113,20 @@ macro_rules! types {
                     }
                 }
 
+                // The following three trait implementations must be aligned.
+
                 impl PartialEq for $t {
                     fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
+                        self.0.eq(&other.0)
+                    }
+                }
+
+                impl Eq for $t {
+                }
+
+                impl sbor::rust::hash::Hash for $t {
+                    fn hash<H>(&self, state: &mut H) where H: sbor::rust::hash::Hasher {
+                        self.0.hash(state)
                     }
                 }
             )*

--- a/radix-engine-common/src/math/precise_decimal.rs
+++ b/radix-engine-common/src/math/precise_decimal.rs
@@ -878,7 +878,7 @@ impl fmt::Display for PreciseDecimal {
 
 impl fmt::Debug for PreciseDecimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self)
     }
 }
 

--- a/radix-engine-common/src/time/utc_date_time.rs
+++ b/radix-engine-common/src/time/utc_date_time.rs
@@ -130,7 +130,7 @@ impl UtcDateTime {
         minute: u8,
         second: u8,
     ) -> Result<Self, DateTimeError> {
-        if year <= 0 {
+        if year == 0 {
             return Err(DateTimeError::InvalidYear);
         }
 

--- a/radix-engine-derive/src/manifest_sbor.rs
+++ b/radix-engine-derive/src/manifest_sbor.rs
@@ -23,10 +23,8 @@ pub fn handle_manifest_sbor(input: TokenStream) -> Result<TokenStream> {
         input.clone(),
         context_custom_value_kind.clone(),
     )?;
-    let decode = sbor_derive_common::decode::handle_decode(
-        input.clone(),
-        context_custom_value_kind.clone(),
-    )?;
+    let decode =
+        sbor_derive_common::decode::handle_decode(input, context_custom_value_kind.clone())?;
 
     let output = quote! {
         #categorize

--- a/radix-engine-interface/src/api/node_modules/metadata/models/mod.rs
+++ b/radix-engine-interface/src/api/node_modules/metadata/models/mod.rs
@@ -478,9 +478,7 @@ mod tests {
             POOL_PACKAGE,
         )]);
         encode_decode(&[
-            NonFungibleLocalId::String(
-                StringNonFungibleLocalId::new("Hello_world".to_owned()).unwrap(),
-            ),
+            NonFungibleLocalId::String(StringNonFungibleLocalId::new("Hello_world").unwrap()),
             NonFungibleLocalId::Integer(IntegerNonFungibleLocalId::new(42)),
             NonFungibleLocalId::Bytes(BytesNonFungibleLocalId::new(vec![1u8]).unwrap()),
             NonFungibleLocalId::RUID(RUIDNonFungibleLocalId::new([1; 32])),
@@ -488,8 +486,8 @@ mod tests {
         encode_decode(&[Instant {
             seconds_since_unix_epoch: 1687446137,
         }]);
-        encode_decode(&[UncheckedUrl::of("https://www.radixdlt.com".to_owned())]);
-        encode_decode(&[UncheckedOrigin::of("https://www.radixdlt.com".to_owned())]);
+        encode_decode(&[UncheckedUrl::of("https://www.radixdlt.com")]);
+        encode_decode(&[UncheckedOrigin::of("https://www.radixdlt.com")]);
         encode_decode(&[
             PublicKeyHash::Ed25519(Ed25519PublicKey([0; Ed25519PublicKey::LENGTH]).get_hash()),
             PublicKeyHash::Secp256k1(

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -26,17 +26,6 @@ pub struct AccessControllerCreateInput {
     pub address_reservation: Option<GlobalAddressReservation>,
 }
 
-impl Clone for AccessControllerCreateInput {
-    fn clone(&self) -> Self {
-        Self {
-            controlled_asset: Bucket(self.controlled_asset.0),
-            rule_set: self.rule_set.clone(),
-            timed_recovery_delay_in_minutes: self.timed_recovery_delay_in_minutes.clone(),
-            address_reservation: self.address_reservation.clone(),
-        }
-    }
-}
-
 pub type AccessControllerCreateGlobalOutput = Global<AccessControllerObjectTypeInfo>;
 
 //================================

--- a/radix-engine-interface/src/blueprints/resource/auth_zone.rs
+++ b/radix-engine-interface/src/blueprints/resource/auth_zone.rs
@@ -2,14 +2,11 @@ use crate::blueprints::resource::*;
 use crate::data::scrypto::model::*;
 use crate::math::Decimal;
 use crate::*;
-use radix_engine_common::data::scrypto::*;
 use radix_engine_common::types::*;
-use radix_engine_interface::constants::RESOURCE_PACKAGE;
 use sbor::rust::collections::IndexSet;
 use sbor::rust::fmt::Debug;
 use sbor::rust::prelude::*;
 use sbor::rust::vec::Vec;
-use sbor::*;
 
 pub const AUTH_ZONE_BLUEPRINT: &str = "AuthZone";
 
@@ -25,14 +22,6 @@ pub const AUTH_ZONE_PUSH_IDENT: &str = "push";
 #[derive(Debug, Eq, PartialEq, ScryptoSbor)]
 pub struct AuthZonePushInput {
     pub proof: Proof,
-}
-
-impl Clone for AuthZonePushInput {
-    fn clone(&self) -> Self {
-        Self {
-            proof: Proof(self.proof.0),
-        }
-    }
 }
 
 pub type AuthZonePushOutput = ();
@@ -103,26 +92,5 @@ pub struct AuthZoneAssertAccessRuleInput {
 
 pub type AuthZoneAssertAccessRuleOutput = ();
 
-#[derive(Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-#[sbor(transparent)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AuthZoneRef(pub NodeId);
-
-impl Describe<ScryptoCustomTypeKind> for AuthZoneRef {
-    const TYPE_ID: RustTypeId =
-        RustTypeId::Novel(const_sha1::sha1("OwnedAuthZone".as_bytes()).as_bytes());
-
-    fn type_data() -> TypeData<ScryptoCustomTypeKind, RustTypeId> {
-        TypeData {
-            kind: TypeKind::Custom(ScryptoCustomTypeKind::Own),
-            metadata: TypeMetadata::no_child_names("OwnedAuthZone"),
-            validation: TypeValidation::Custom(ScryptoCustomTypeValidation::Own(
-                OwnValidation::IsTypedObject(
-                    Some(RESOURCE_PACKAGE),
-                    AUTH_ZONE_BLUEPRINT.to_string(),
-                ),
-            )),
-        }
-    }
-
-    fn add_all_dependencies(_aggregator: &mut TypeAggregator<ScryptoCustomTypeKind>) {}
-}

--- a/radix-engine-interface/src/blueprints/resource/bucket.rs
+++ b/radix-engine-interface/src/blueprints/resource/bucket.rs
@@ -38,14 +38,6 @@ pub struct BucketPutInput {
 
 pub type BucketPutOutput = ();
 
-impl Clone for BucketPutInput {
-    fn clone(&self) -> Self {
-        Self {
-            bucket: Bucket(self.bucket.0),
-        }
-    }
-}
-
 pub const BUCKET_GET_AMOUNT_IDENT: &str = "get_amount";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]

--- a/radix-engine-interface/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -47,7 +47,7 @@ impl FungibleResourceRoles {
                 withdrawer_updater => rule!(deny_all);
             },
             deposit_roles: deposit_roles! {
-                depositor => access_rule.clone();
+                depositor => access_rule;
                 depositor_updater => rule!(deny_all);
             },
         }

--- a/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -61,7 +61,7 @@ impl NonFungibleResourceRoles {
                 withdrawer_updater => rule!(deny_all);
             },
             deposit_roles: deposit_roles! {
-                depositor => access_rule.clone();
+                depositor => access_rule;
                 depositor_updater => rule!(deny_all);
             },
         }

--- a/radix-engine-interface/src/blueprints/resource/vault.rs
+++ b/radix-engine-interface/src/blueprints/resource/vault.rs
@@ -18,14 +18,6 @@ pub struct VaultPutInput {
 
 pub type VaultPutOutput = ();
 
-impl Clone for VaultPutInput {
-    fn clone(&self) -> Self {
-        Self {
-            bucket: Bucket(self.bucket.0),
-        }
-    }
-}
-
 pub const VAULT_TAKE_IDENT: &str = "take";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]

--- a/radix-engine-interface/src/blueprints/resource/worktop.rs
+++ b/radix-engine-interface/src/blueprints/resource/worktop.rs
@@ -49,14 +49,6 @@ pub struct WorktopPutInput {
 
 pub type WorktopPutOutput = ();
 
-impl Clone for WorktopPutInput {
-    fn clone(&self) -> Self {
-        Self {
-            bucket: Bucket(self.bucket.0),
-        }
-    }
-}
-
 pub const WORKTOP_TAKE_IDENT: &str = "Worktop_take";
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor)]

--- a/radix-engine-interface/src/types/interface_well_known_types.rs
+++ b/radix-engine-interface/src/types/interface_well_known_types.rs
@@ -19,7 +19,7 @@ mod tests {
 
         // ROLE ASSIGNMENT
         let resource_or_non_fungible_1 = ResourceOrNonFungible::Resource(XRD);
-        let resource_or_non_fungible_2 = ResourceOrNonFungible::NonFungible(nf_global_id.clone());
+        let resource_or_non_fungible_2 = ResourceOrNonFungible::NonFungible(nf_global_id);
         let resource_or_non_fungible_list = vec![
             resource_or_non_fungible_1.clone(),
             resource_or_non_fungible_2.clone(),

--- a/radix-engine-tests/benches/transfer.rs
+++ b/radix-engine-tests/benches/transfer.rs
@@ -50,7 +50,7 @@ fn bench_transfer(c: &mut Criterion) {
                 vm.clone(),
                 &CostingParameters::default(),
                 &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
-                &TestTransaction::new_from_nonce(manifest.clone(), 1)
+                &TestTransaction::new_from_nonce(manifest, 1)
                     .prepare()
                     .unwrap()
                     .get_executable(btreeset![NonFungibleGlobalId::from_public_key(&public_key)]),

--- a/radix-engine-tests/tests/account_authorized_depositors.rs
+++ b/radix-engine-tests/tests/account_authorized_depositors.rs
@@ -75,9 +75,7 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
-                    AccountAddAuthorizedDepositorInput {
-                        badge: badge.clone(),
-                    },
+                    AccountAddAuthorizedDepositorInput { badge: badge },
                 )
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk1)],
@@ -324,9 +322,7 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
-                    AccountAddAuthorizedDepositorInput {
-                        badge: badge.clone(),
-                    },
+                    AccountAddAuthorizedDepositorInput { badge: badge },
                 )
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk1)],
@@ -485,9 +481,7 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
-                    AccountAddAuthorizedDepositorInput {
-                        badge: badge.clone(),
-                    },
+                    AccountAddAuthorizedDepositorInput { badge: badge },
                 )
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk1)],
@@ -646,9 +640,7 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
                 .call_method(
                     account1,
                     ACCOUNT_ADD_AUTHORIZED_DEPOSITOR,
-                    AccountAddAuthorizedDepositorInput {
-                        badge: badge.clone(),
-                    },
+                    AccountAddAuthorizedDepositorInput { badge: badge },
                 )
                 .build(),
             vec![NonFungibleGlobalId::from_public_key(&pk1)],

--- a/radix-engine-tests/tests/balance_changes.rs
+++ b/radix-engine-tests/tests/balance_changes.rs
@@ -34,7 +34,7 @@ fn test_balance_changes_when_success() {
             .build(),
         vec![
             NonFungibleGlobalId::from_public_key(&public_key),
-            owner_badge_addr.clone(),
+            owner_badge_addr,
         ],
     );
     let component_address = receipt.expect_commit(true).new_component_addresses()[0];
@@ -119,7 +119,7 @@ fn test_balance_changes_when_failure() {
             .build(),
         vec![
             NonFungibleGlobalId::from_public_key(&public_key),
-            owner_badge_addr.clone(),
+            owner_badge_addr,
         ],
     );
     let component_address = receipt.expect_commit(true).new_component_addresses()[0];

--- a/radix-engine-tests/tests/events.rs
+++ b/radix-engine-tests/tests/events.rs
@@ -531,9 +531,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier)
                 && is_decoded_equal(
-                    &non_fungible_vault::DepositEvent::new(
-                        indexset!(non_fungible_local_id.clone())
-                    ),
+                    &non_fungible_vault::DepositEvent::new(indexset!(non_fungible_local_id)),
                     event_data
                 ) =>
                 true,
@@ -797,9 +795,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
             )) if test_runner
                 .is_event_name_equal::<BurnNonFungibleResourceEvent>(event_identifier)
                 && is_decoded_equal(
-                    &BurnNonFungibleResourceEvent {
-                        ids: indexset!(id.clone())
-                    },
+                    &BurnNonFungibleResourceEvent { ids: indexset!(id) },
                     event_data
                 ) =>
                 true,
@@ -952,7 +948,7 @@ fn vault_take_non_fungibles_by_amount_emits_correct_event() {
             )) if test_runner
                 .is_event_name_equal::<non_fungible_vault::DepositEvent>(event_identifier)
                 && is_decoded_equal(
-                    &non_fungible_vault::DepositEvent::new(indexset!(id.clone(), id2.clone())),
+                    &non_fungible_vault::DepositEvent::new(indexset!(id, id2)),
                     event_data
                 ) =>
                 true,
@@ -2509,7 +2505,7 @@ fn account_configuration_emits_expected_events() {
             )
             .unwrap(),
             account::RemoveAuthorizedDepositorEvent {
-                authorized_depositor_badge: authorized_depositor_badge.clone()
+                authorized_depositor_badge: authorized_depositor_badge
             }
         )
     }

--- a/radix-engine-tests/tests/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel_open_substate.rs
@@ -48,7 +48,7 @@ pub fn test_open_substate_of_invisible_package_address() {
         schema_cache: NonIterMap::new(),
         callback_obj: Vm {
             scrypto_vm: &scrypto_vm,
-            native_vm: native_vm.clone(),
+            native_vm: native_vm,
         },
         modules: SystemModuleMixer::new(
             execution_config.enabled_modules,

--- a/radix-engine-tests/tests/metadata.rs
+++ b/radix-engine-tests/tests/metadata.rs
@@ -238,7 +238,7 @@ fn verify_metadata_set_and_get_success() {
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
     // Assert
-    assert!(String::from_metadata_value(metadata.clone()).is_ok());
+    assert!(String::from_metadata_value(metadata).is_ok());
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn verify_metadata_get_fail() {
     // Act
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
-    let result = u8::from_metadata_value(metadata.clone());
+    let result = u8::from_metadata_value(metadata);
 
     // Assert
     assert_eq!(
@@ -279,7 +279,7 @@ fn verify_metadata_vec_get_fail() {
     // Act
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
-    let result = Vec::<u8>::from_metadata_value(metadata.clone());
+    let result = Vec::<u8>::from_metadata_value(metadata);
 
     // Assert
     assert_eq!(
@@ -311,7 +311,7 @@ fn verify_metadata_array_set_and_get_success() {
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
     // Assert
-    assert!(Vec::<u8>::from_metadata_value(metadata.clone()).is_ok());
+    assert!(Vec::<u8>::from_metadata_value(metadata).is_ok());
 }
 
 #[test]
@@ -333,7 +333,7 @@ fn verify_metadata_array_get_fail() {
     // Act
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
-    let result = u8::from_metadata_value(metadata.clone());
+    let result = u8::from_metadata_value(metadata);
 
     // Assert
     assert_eq!(
@@ -364,7 +364,7 @@ fn verify_metadata_array_get_other_type_fail() {
     // Act
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
-    let result = u32::from_array_metadata_value(metadata.clone());
+    let result = u32::from_array_metadata_value(metadata);
 
     // Assert
     assert_eq!(
@@ -395,7 +395,7 @@ fn verify_metadata_array_get_vec_fail() {
     // Act
     let metadata = test_runner.get_metadata(account.into(), "key").unwrap();
 
-    let result = Vec::<u32>::from_metadata_value(metadata.clone());
+    let result = Vec::<u32>::from_metadata_value(metadata);
 
     // Assert
     assert_eq!(

--- a/radix-engine-tests/tests/metadata_component.rs
+++ b/radix-engine-tests/tests/metadata_component.rs
@@ -366,14 +366,14 @@ fn can_set_instant_metadata_through_manifest() {
 #[test]
 fn can_set_url_metadata_through_manifest() {
     can_set_metadata_through_manifest(MetadataValue::Url(UncheckedUrl::of(
-        "https://radixdlt.com/index.html".to_string(),
+        "https://radixdlt.com/index.html",
     )));
 }
 
 #[test]
 fn can_set_origin_metadata_through_manifest() {
     can_set_metadata_through_manifest(MetadataValue::Origin(UncheckedOrigin::of(
-        "https://radixdlt.com".to_string(),
+        "https://radixdlt.com",
     )));
 }
 

--- a/radix-engine-tests/tests/metadata_component.rs
+++ b/radix-engine-tests/tests/metadata_component.rs
@@ -333,7 +333,7 @@ fn cannot_set_address_metadata_after_freezing() {
     let entry = MetadataValue::GlobalAddress(address.into());
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
-        .set_metadata(component_address, "other_key", entry.clone())
+        .set_metadata(component_address, "other_key", entry)
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
 

--- a/radix-engine-tests/tests/metering.rs
+++ b/radix-engine-tests/tests/metering.rs
@@ -123,11 +123,11 @@ fn execute_with_time_logging(
 pub fn load_cost_breakdown(content: &str) -> (BTreeMap<String, u32>, BTreeMap<String, u32>) {
     let mut execution_breakdown = BTreeMap::<String, u32>::new();
     let mut finalization_breakdown = BTreeMap::<String, u32>::new();
-    let lines: Vec<String> = content.split("\n").map(String::from).collect();
+    let lines: Vec<String> = content.split('\n').map(String::from).collect();
     let mut is_execution = true;
     for i in 8..lines.len() {
-        if lines[i].starts_with("-") {
-            let mut tokens = lines[i].split(",");
+        if lines[i].starts_with('-') {
+            let mut tokens = lines[i].split(',');
             let entry = tokens.next().unwrap().trim()[2..].to_string();
             let cost = tokens.next().unwrap().trim();
             if is_execution {

--- a/radix-engine-tests/tests/native_blueprint_call_validator.rs
+++ b/radix-engine-tests/tests/native_blueprint_call_validator.rs
@@ -27,7 +27,7 @@ fn validator_sees_valid_transfer_manifest_as_valid() {
     // Assert
     validation_result
         .clone()
-        .expect(format!("Validation failed: {:?}", validation_result).as_str())
+        .unwrap_or_else(|_| panic!("Validation failed: {:?}", validation_result))
 }
 
 #[test]
@@ -87,13 +87,12 @@ fn common_manifests_are_all_valid() {
             validate_call_arguments_to_native_components(&manifest.instructions);
 
         // Assert
-        validation_result.clone().expect(
-            format!(
+        validation_result.clone().unwrap_or_else(|_| {
+            panic!(
                 "Validation failed for manifest \"{:?}\" with error: \"{:?}\"",
                 path, validation_result
             )
-            .as_str(),
-        )
+        })
     }
 }
 

--- a/radix-engine-tests/tests/non_fungible.rs
+++ b/radix-engine-tests/tests/non_fungible.rs
@@ -1135,7 +1135,7 @@ fn cant_burn_non_fungible_with_wrong_non_fungible_local_id_type() {
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .withdraw_from_account(account, resource_address, 1)
-        .burn_non_fungible_from_worktop(non_fungible_global_id.clone())
+        .burn_non_fungible_from_worktop(non_fungible_global_id)
         .build();
     let receipt = test_runner.execute_manifest(
         manifest,

--- a/radix-engine-tests/tests/preview.rs
+++ b/radix-engine-tests/tests/preview.rs
@@ -113,7 +113,7 @@ fn test_assume_all_signature_proofs_flag_method_authorization() {
 
     let public_key = Secp256k1PrivateKey::from_u64(99).unwrap().public_key();
     let withdraw_auth = rule!(require(NonFungibleGlobalId::from_public_key(&public_key)));
-    let account = test_runner.new_account_advanced(OwnerRole::Fixed(withdraw_auth.clone()));
+    let account = test_runner.new_account_advanced(OwnerRole::Fixed(withdraw_auth));
     let (_, _, other_account) = test_runner.new_allocated_account();
 
     let preview_flags = PreviewFlags {

--- a/radix-engine-tests/tests/role_assignment.rs
+++ b/radix-engine-tests/tests/role_assignment.rs
@@ -111,7 +111,7 @@ fn role_assignment_method_auth_cant_be_mutated_when_required_proofs_are_not_pres
     let public_key = private_key.public_key();
     let virtual_badge_non_fungible_global_id = NonFungibleGlobalId::from_public_key(&public_key);
     let mut test_runner = MutableRolesTestRunner::new_with_owner(rule!(require(
-        virtual_badge_non_fungible_global_id.clone()
+        virtual_badge_non_fungible_global_id
     )));
 
     // Act
@@ -152,7 +152,7 @@ fn component_role_assignment_can_be_mutated_through_manifest(to_rule: AccessRule
     let mut test_runner = MutableRolesTestRunner::new_with_owner(rule!(require(
         virtual_badge_non_fungible_global_id.clone()
     )));
-    test_runner.add_initial_proof(virtual_badge_non_fungible_global_id.clone());
+    test_runner.add_initial_proof(virtual_badge_non_fungible_global_id);
 
     // Act
     let receipt = test_runner.execute_manifest(

--- a/radix-engine-tests/tests/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/royalty_edge_cases.rs
@@ -462,7 +462,7 @@ fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
         .lock_fee_from_faucet()
         .publish_package_advanced(
             None,
-            code.clone(),
+            code,
             definition.clone(),
             MetadataInit::default(),
             OwnerRole::None,

--- a/radix-engine-tests/tests/transaction_multi_threaded.rs
+++ b/radix-engine-tests/tests/transaction_multi_threaded.rs
@@ -61,7 +61,7 @@ mod multi_threaded_test {
                     vm.clone(),
                     &CostingParameters::default(),
                     &ExecutionConfig::for_test_transaction(),
-                    &TestTransaction::new(manifest.clone(), hash(format!("Account creation: {i}")))
+                    &TestTransaction::new(manifest, hash(format!("Account creation: {i}")))
                         .prepare()
                         .unwrap()
                         .get_executable(btreeset![NonFungibleGlobalId::from_public_key(

--- a/radix-engine-tests/tests/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/typed_substate_layout.rs
@@ -258,19 +258,13 @@ fn typed_native_event_type_contains_all_native_events() {
     for (package_name, package_blueprints) in registered_events.into_iter() {
         let package_definition = package_name_definition_mapping
             .get(package_name.as_str())
-            .expect(
-                format!(
+            .unwrap_or_else(|| {
+                panic!(
                     "No package definition found for a package with the name: \"{package_name}\""
                 )
-                .as_str(),
-            );
+            });
         for (blueprint_name, blueprint_events) in package_blueprints.into_iter() {
-            let blueprint_definition = package_definition.blueprints.get(&blueprint_name).expect(
-                format!(
-                    "Package named \"{package_name}\" has no blueprint named \"{blueprint_name}\""
-                )
-                .as_str(),
-            );
+            let blueprint_definition = package_definition.blueprints.get(&blueprint_name).unwrap_or_else(|| panic!("Package named \"{package_name}\" has no blueprint named \"{blueprint_name}\""));
             let actual_blueprint_events = blueprint_definition
                 .schema
                 .events

--- a/radix-engine-tests/tests/vault_burn.rs
+++ b/radix-engine-tests/tests/vault_burn.rs
@@ -347,7 +347,7 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()]);
+        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -415,7 +415,7 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()]);
+        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -464,7 +464,7 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
@@ -529,7 +529,7 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
@@ -592,7 +592,7 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
@@ -832,7 +832,7 @@ fn can_burn_by_amount_from_fungible_account_vault() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()]);
+        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -875,7 +875,7 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
         .call_method(account, "burn", manifest_args!(resource_address, dec!(1)))
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()]);
+        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -922,7 +922,7 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()]);
+        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();

--- a/radix-engine/benches/wasm_benchmarks.rs
+++ b/radix-engine/benches/wasm_benchmarks.rs
@@ -260,7 +260,7 @@ fn wasmer_get_instance(code: &[u8]) -> wasmer::Instance {
     let instance =
         wasmer::Instance::new(&module, &import_object).expect("Failed to instantiate module");
 
-    env.init_with_instance(&instance.clone()).unwrap();
+    env.init_with_instance(&instance).unwrap();
 
     instance
 }

--- a/radix-engine/benches/wasm_benchmarks.rs
+++ b/radix-engine/benches/wasm_benchmarks.rs
@@ -27,7 +27,7 @@ fn get_wasm_file() -> Vec<u8> {
     }
 
     std::fs::read(WASM_BENCHMARKS_WASM_FILE)
-        .expect(&format!("Cannot read file {:?}", WASM_BENCHMARKS_WASM_FILE))
+        .unwrap_or_else(|_| panic!("Cannot read file {:?}", WASM_BENCHMARKS_WASM_FILE))
 }
 
 fn wasmi_read_memory(

--- a/radix-engine/src/blueprints/access_controller/blueprint.rs
+++ b/radix-engine/src/blueprints/access_controller/blueprint.rs
@@ -57,17 +57,6 @@ pub struct AccessControllerSubstate {
     ),
 }
 
-impl Clone for AccessControllerSubstate {
-    fn clone(&self) -> Self {
-        Self {
-            controlled_asset: Vault(self.controlled_asset.0),
-            timed_recovery_delay_in_minutes: self.timed_recovery_delay_in_minutes.clone(),
-            recovery_badge: self.recovery_badge,
-            state: self.state.clone(),
-        }
-    }
-}
-
 impl AccessControllerSubstate {
     pub fn new(
         controlled_asset: Vault,

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -67,15 +67,6 @@ pub struct ValidatorRewardsSubstate {
     pub rewards_vault: Vault,
 }
 
-impl Clone for ValidatorRewardsSubstate {
-    fn clone(&self) -> Self {
-        Self {
-            proposer_rewards: self.proposer_rewards.clone(),
-            rewards_vault: Vault(self.rewards_vault.0.clone()),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct CurrentValidatorSetSubstate {
     pub validator_set: ActiveValidatorSet,

--- a/radix-engine/src/blueprints/pool/multi_resource_pool/substates.rs
+++ b/radix-engine/src/blueprints/pool/multi_resource_pool/substates.rs
@@ -31,17 +31,3 @@ pub struct MultiResourcePoolSubstate {
     /// The resource manager of the pool unit resource that the pool works with.
     pub pool_unit_resource_manager: ResourceManager,
 }
-
-impl Clone for MultiResourcePoolSubstate {
-    fn clone(&self) -> Self {
-        let vaults = self
-            .vaults
-            .iter()
-            .map(|(resource_address, vault)| (resource_address.clone(), Vault(vault.0.clone())))
-            .collect();
-        Self {
-            vaults,
-            pool_unit_resource_manager: self.pool_unit_resource_manager.clone(),
-        }
-    }
-}

--- a/radix-engine/src/blueprints/pool/two_resource_pool/substates.rs
+++ b/radix-engine/src/blueprints/pool/two_resource_pool/substates.rs
@@ -22,18 +22,3 @@ impl TwoResourcePoolSubstate {
             .map(|(_, vault)| Vault(vault.0.clone()))
     }
 }
-
-impl Clone for TwoResourcePoolSubstate {
-    fn clone(&self) -> Self {
-        let (resource_address1, vault1) = self.vaults.get(0).unwrap();
-        let (resource_address2, vault2) = self.vaults.get(1).unwrap();
-
-        Self {
-            vaults: [
-                (*resource_address1, Vault(vault1.0.clone())),
-                (*resource_address2, Vault(vault2.0.clone())),
-            ],
-            pool_unit_resource_manager: self.pool_unit_resource_manager.clone(),
-        }
-    }
-}

--- a/radix-engine/src/blueprints/resource/auth_zone/auth_zone_substates.rs
+++ b/radix-engine/src/blueprints/resource/auth_zone/auth_zone_substates.rs
@@ -15,19 +15,6 @@ pub struct AuthZone {
     pub parent: Option<Reference>,
 }
 
-impl Clone for AuthZone {
-    fn clone(&self) -> Self {
-        Self {
-            proofs: self.proofs.iter().map(|p| Proof(p.0)).collect(),
-            virtual_resources: self.virtual_resources.clone(),
-            virtual_non_fungibles: self.virtual_non_fungibles.clone(),
-            local_caller_package_address: self.local_caller_package_address.clone(),
-            global_caller: self.global_caller.clone(),
-            parent: self.parent.clone(),
-        }
-    }
-}
-
 impl AuthZone {
     pub fn new(
         proofs: Vec<Proof>,

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -139,10 +139,12 @@ impl FeeTable {
                     .get(package_address)
                     .and_then(|x| x.get(export_name))
                     .and_then(|value| Some(add(value.1, mul(value.0, cast(*input_size)))))
-                    .expect(&format!(
-                        "Native function not found: {:?}::{}. ",
-                        package_address, export_name
-                    ))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Native function not found: {:?}::{}. ",
+                            package_address, export_name
+                        )
+                    })
             });
 
         native_execution_units / CPU_INSTRUCTIONS_TO_COST_UNIT

--- a/radix-engine/src/transaction/system_structure.rs
+++ b/radix-engine/src/transaction/system_structure.rs
@@ -239,7 +239,7 @@ impl<'a, S: SubstateDatabase> SubstateSchemaMapper<'a, S> {
                 let info = self
                     .system_reader
                     .get_kv_store_type_target(node_id)
-                    .expect(&format!("Could not get type info for node {node_id:?}"));
+                    .unwrap_or_else(|_| panic!("Could not get type info for node {node_id:?}"));
 
                 let key_full_type_id = match info.kv_store_type.key_generic_substitution {
                     GenericSubstitution::Local(type_id) => type_id.under_node(*node_id),
@@ -247,7 +247,7 @@ impl<'a, S: SubstateDatabase> SubstateSchemaMapper<'a, S> {
                         .system_reader
                         .get_blueprint_type_schema(&type_id)
                         .map(|x| x.1.under_node(type_id.package_address.into_node_id()))
-                        .expect(&format!("Could not get type info {type_id:?}")),
+                        .unwrap_or_else(|_| panic!("Could not get type info {type_id:?}")),
                 };
                 let value_full_type_id = match info.kv_store_type.value_generic_substitution {
                     GenericSubstitution::Local(type_id) => type_id.under_node(*node_id),
@@ -255,7 +255,7 @@ impl<'a, S: SubstateDatabase> SubstateSchemaMapper<'a, S> {
                         .system_reader
                         .get_blueprint_type_schema(&type_id)
                         .map(|x| x.1.under_node(type_id.package_address.into_node_id()))
-                        .expect(&format!("Could not get type info {type_id:?}")),
+                        .unwrap_or_else(|_| panic!("Could not get type info {type_id:?}")),
                 };
                 SubstateSystemStructure::KeyValueStoreEntry(KeyValueStoreEntryStructure {
                     key_full_type_id,
@@ -266,7 +266,7 @@ impl<'a, S: SubstateDatabase> SubstateSchemaMapper<'a, S> {
                 let bp_type_target = self
                     .system_reader
                     .get_blueprint_type_target(node_id, *module_id)
-                    .expect(&format!("Could not get type info for node {node_id:?}"));
+                    .unwrap_or_else(|_| panic!("Could not get type info for node {node_id:?}"));
 
                 self.resolve_object_substate_structure(
                     &bp_type_target,

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -66,7 +66,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
             api.kernel_close_substate(handle)?;
             vm_type
                 .into_value()
-                .expect(&format!("Vm type not found: {:?}", export))
+                .unwrap_or_else(|| panic!("Vm type not found: {:?}", export))
         };
 
         let output = match vm_type.into_latest().vm_type {
@@ -91,7 +91,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
                     api.kernel_close_substate(handle)?;
                     original_code
                         .into_value()
-                        .expect(&format!("Original code not found: {:?}", export))
+                        .unwrap_or_else(|| panic!("Original code not found: {:?}", export))
                 };
 
                 let mut vm_instance = api
@@ -124,7 +124,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
                     api.kernel_close_substate(handle)?;
                     instrumented_code
                         .into_value()
-                        .expect(&format!("Instrumented code not found: {:?}", export))
+                        .unwrap_or_else(|| panic!("Instrumented code not found: {:?}", export))
                         .into_latest()
                 };
 

--- a/sbor-tests/benches/data/mod.rs
+++ b/sbor-tests/benches/data/mod.rs
@@ -22,7 +22,7 @@ pub struct SimpleStruct {
 pub fn get_simple_dataset(repeat: usize) -> SimpleStruct {
     let mut data = SimpleStruct {
         number: 12345678901234567890,
-        string: "dummy".repeat(repeat).to_owned(),
+        string: "dummy".repeat(repeat),
         bytes: vec![123u8; repeat],
         vector: vec![12345u16; repeat],
         enumeration: vec![

--- a/sbor/src/versioned.rs
+++ b/sbor/src/versioned.rs
@@ -279,7 +279,7 @@ mod tests {
         let v3 = ExampleV3(5);
         validate_latest(v3, expected_latest.clone());
         let v4 = ExampleV4::of(5);
-        validate_latest(v4, expected_latest.clone());
+        validate_latest(v4, expected_latest);
     }
 
     fn validate_latest(
@@ -311,7 +311,7 @@ mod tests {
         let v1_model: GenericModel<_> = GenericModelV1(51u64);
         let versioned = VersionedGenericModel::from(v1_model.clone());
         let versioned_2 = v1_model.clone().into_versioned();
-        assert_eq!(versioned.clone().into_latest(), v1_model.clone());
+        assert_eq!(versioned.clone().into_latest(), v1_model);
         assert_eq!(versioned, versioned_2);
     }
 }

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -453,8 +453,8 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
                     import_blueprint.blueprint
                 };
 
-                let owned_typed_name = format!("Owned{}", blueprint.to_string());
-                let global_typed_name = format!("Global{}", blueprint.to_string());
+                let owned_typed_name = format!("Owned{}", blueprint);
+                let global_typed_name = format!("Global{}", blueprint);
                 let blueprint_functions_ident = format_ident!("{}Functions", blueprint);
 
                 let mut methods = Vec::new();
@@ -1371,7 +1371,7 @@ fn create_argument_ident(argument: &Pat, index: usize) -> Result<Ident> {
     Ok(match argument {
         // If we have a standard parameter name - use that
         Pat::Ident(ident_pattern) => {
-            let ident = if ident_pattern.ident.to_string().starts_with("_") {
+            let ident = if ident_pattern.ident.to_string().starts_with('_') {
                 // Handle parameters starting with `_` - strip them to pass validation
                 Ident::new(
                     ident_pattern.ident.to_string().trim_start_matches('_'),
@@ -1795,7 +1795,7 @@ fn type_replacement(ty: &Type, bp_name: Option<&str>) -> Type {
     let global_pattern = Regex::new(r"Global<.+?>").unwrap();
     let owned_pattern = Regex::new(r"Owned<.+?>").unwrap();
 
-    let mut str = ty.to_token_stream().to_string().replace(" ", "");
+    let mut str = ty.to_token_stream().to_string().replace(' ', "");
     if let Some(bp_name) = bp_name {
         str = str.replace(format!("Owned<{}>", bp_name).as_str(), "Self");
         str = str.replace(format!("Global<{}>", bp_name).as_str(), "Self");

--- a/scrypto-test/src/sdk/package.rs
+++ b/scrypto-test/src/sdk/package.rs
@@ -101,7 +101,7 @@ impl Compile {
                 std::fs::read_to_string(&cargo).expect("Failed to read the Cargo.toml file");
             Self::extract_crate_name(&content)
                 .expect("Failed to extract crate name from the Cargo.toml file")
-                .replace("-", "_")
+                .replace('-', "_")
         } else {
             // file name
             package_dir
@@ -111,7 +111,7 @@ impl Compile {
                 .to_str()
                 .unwrap()
                 .to_owned()
-                .replace("-", "_")
+                .replace('-', "_")
         };
         let mut path = PathBuf::from_str(&Self::get_cargo_target_directory(&cargo)).unwrap(); // Infallible;
         path.push("wasm32-unknown-unknown");

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -110,7 +110,7 @@ impl Compile {
             let content = fs::read_to_string(&cargo).expect("Failed to read the Cargo.toml file");
             Self::extract_crate_name(&content)
                 .expect("Failed to extract crate name from the Cargo.toml file")
-                .replace("-", "_")
+                .replace('-', "_")
         } else {
             // file name
             package_dir
@@ -120,7 +120,7 @@ impl Compile {
                 .to_str()
                 .unwrap()
                 .to_owned()
-                .replace("-", "_")
+                .replace('-', "_")
         };
         let mut path = PathBuf::from_str(&get_cargo_target_directory(&cargo)).unwrap(); // Infallible;
         path.push("wasm32-unknown-unknown");

--- a/transaction-scenarios/src/scenarios/metadata.rs
+++ b/transaction-scenarios/src/scenarios/metadata.rs
@@ -389,9 +389,7 @@ fn create_metadata() -> BTreeMap<String, MetadataValue> {
         &mut metadata,
         "non_fungible_local_id",
         &[
-            NonFungibleLocalId::String(
-                StringNonFungibleLocalId::new("Hello_world".to_owned()).unwrap(),
-            ),
+            NonFungibleLocalId::String(StringNonFungibleLocalId::new("Hello_world").unwrap()),
             NonFungibleLocalId::Integer(IntegerNonFungibleLocalId::new(42)),
             NonFungibleLocalId::Bytes(BytesNonFungibleLocalId::new(vec![1u8]).unwrap()),
             NonFungibleLocalId::RUID(RUIDNonFungibleLocalId::new([1; 32])),
@@ -407,12 +405,12 @@ fn create_metadata() -> BTreeMap<String, MetadataValue> {
     add(
         &mut metadata,
         "url",
-        &[UncheckedUrl::of("https://www.radixdlt.com".to_owned())],
+        &[UncheckedUrl::of("https://www.radixdlt.com")],
     );
     add(
         &mut metadata,
         "origin",
-        &[UncheckedOrigin::of("https://www.radixdlt.com".to_owned())],
+        &[UncheckedOrigin::of("https://www.radixdlt.com")],
     );
     add(
         &mut metadata,

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -1298,7 +1298,7 @@ impl ManifestBuilder {
                 code: code_blob_ref,
                 definition,
                 metadata: metadata_init!(),
-                owner_role: OwnerRole::Fixed(rule!(require(owner_badge.clone()))),
+                owner_role: OwnerRole::Fixed(rule!(require(owner_badge))),
             }),
         })
     }

--- a/transaction/src/model/mod.rs
+++ b/transaction/src/model/mod.rs
@@ -45,14 +45,14 @@ mod tests {
             .to_string(display_context);
         let actual_clean: String = actual
             .trim()
-            .split("\n")
+            .split('\n')
             .map(|line| line.trim())
             .collect::<Vec<&str>>()
             .join("\n");
 
         let expected_clean: String = expected
             .trim()
-            .split("\n")
+            .split('\n')
             .map(|line| line.split("//").next().unwrap().trim())
             .collect::<Vec<&str>>()
             .join("\n");

--- a/transaction/src/model/versioned.rs
+++ b/transaction/src/model/versioned.rs
@@ -153,10 +153,10 @@ mod tests {
         assert_eq!(
             intent_as_versioned,
             VersionedTransactionPayload::IntentV1 {
-                header: header_v1.clone(),
-                instructions: instructions_v1.clone(),
-                blobs: blobs_v1.clone(),
-                message: message_v1.clone(),
+                header: header_v1,
+                instructions: instructions_v1,
+                blobs: blobs_v1,
+                message: message_v1,
             }
         );
 
@@ -272,8 +272,8 @@ mod tests {
         assert_eq!(
             notarized_transaction_as_versioned,
             VersionedTransactionPayload::NotarizedTransactionV1 {
-                signed_intent: signed_intent_v1.clone(),
-                notary_signature: notary_signature_v1.clone(),
+                signed_intent: signed_intent_v1,
+                notary_signature: notary_signature_v1,
             }
         );
 


### PR DESCRIPTION
## Summary

Various code clean-ups:
- Remove dead code
- Apply `clippy::perf` lint group
   - Remove redundant clone
   - Replace `expect_fun_call` with `unwrap_or_else`
   - And others
- Apply `clippy::correctness` lint group

It might worth considering other lint groups as well.

Suggested review: commit-by-commit
