### PR TITLE
Code coverage support for tests (scrypto coverage command)

### DIFF
--- a/assets/template/.gitignore
+++ b/assets/template/.gitignore
@@ -1,1 +1,2 @@
 /target
+/coverage

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -51,6 +51,8 @@ radix_engine_fuzzing = ["arbitrary", "serde", "bnum/arbitrary", "bnum/serde", "s
 resource_tracker=[]
 full_math_benches = [ "dep:rug", "dep:ethnum"]
 
+coverage = []
+
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
 doctest = false

--- a/radix-engine-common/src/constants/transaction_execution.rs
+++ b/radix-engine-common/src/constants/transaction_execution.rs
@@ -26,10 +26,16 @@ pub const MAX_TRACK_SUBSTATE_TOTAL_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_SUBSTATE_KEY_SIZE: usize = 1024;
 
 /// The maximum substate read and write size.
+#[cfg(not(feature = "coverage"))]
 pub const MAX_SUBSTATE_VALUE_SIZE: usize = 2 * 1024 * 1024;
+#[cfg(feature = "coverage")]
+pub const MAX_SUBSTATE_VALUE_SIZE: usize = 64 * 1024 * 1024;
 
 /// The maximum invoke payload size.
+#[cfg(not(feature = "coverage"))]
 pub const MAX_INVOKE_PAYLOAD_SIZE: usize = 1 * 1024 * 1024;
+#[cfg(feature = "coverage")]
+pub const MAX_INVOKE_PAYLOAD_SIZE: usize = 32 * 1024 * 1024;
 
 /// The proposer's share of tips
 pub const TIPS_PROPOSER_SHARE_PERCENTAGE: u8 = 100;

--- a/radix-engine-common/src/constants/wasm.rs
+++ b/radix-engine-common/src/constants/wasm.rs
@@ -1,5 +1,8 @@
 /// The maximum memory size (per call frame): 64 * 64KiB = 4MiB
+#[cfg(not(feature = "coverage"))]
 pub const MAX_MEMORY_SIZE_IN_PAGES: u32 = 64;
+#[cfg(feature = "coverage")]
+pub const MAX_MEMORY_SIZE_IN_PAGES: u32 = 512;
 
 /// The maximum initial table size
 pub const MAX_INITIAL_TABLE_SIZE: u32 = 1024;

--- a/radix-engine/Cargo.toml
+++ b/radix-engine/Cargo.toml
@@ -95,6 +95,9 @@ radix_engine_tests = []
 
 full_wasm_benchmarks = []
 
+# This flag disables package size limit, memory size limit and fee limit
+coverage = [ "radix-engine-common/coverage" ]
+
 # Ref: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 [lib]
 doctest = false

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -59,6 +59,7 @@ pub struct CostingParameters {
 }
 
 impl Default for CostingParameters {
+    #[cfg(not(feature = "coverage"))]
     fn default() -> Self {
         Self {
             execution_cost_unit_price: EXECUTION_COST_UNIT_PRICE_IN_XRD.try_into().unwrap(),
@@ -69,6 +70,19 @@ impl Default for CostingParameters {
             usd_price: USD_PRICE_IN_XRD.try_into().unwrap(),
             state_storage_price: STATE_STORAGE_PRICE_IN_XRD.try_into().unwrap(),
             archive_storage_price: ARCHIVE_STORAGE_PRICE_IN_XRD.try_into().unwrap(),
+        }
+    }
+    #[cfg(feature = "coverage")]
+    fn default() -> Self {
+        Self {
+            execution_cost_unit_price: Decimal::zero(),
+            execution_cost_unit_limit: u32::MAX,
+            execution_cost_unit_loan: u32::MAX,
+            finalization_cost_unit_price: Decimal::zero(),
+            finalization_cost_unit_limit: u32::MAX,
+            usd_price: USD_PRICE_IN_XRD.try_into().unwrap(),
+            state_storage_price: Decimal::zero(),
+            archive_storage_price: Decimal::zero(),
         }
     }
 }

--- a/radix-engine/src/utils/coverage.rs
+++ b/radix-engine/src/utils/coverage.rs
@@ -1,0 +1,29 @@
+use crate::types::*;
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+#[cfg(feature = "coverage")]
+pub fn save_coverage_data(blueprint_name: &String, coverage_data: &Vec<u8>) {
+    if let Some(dir) = env::var_os("COVERAGE_DIRECTORY") {
+        let mut file_path = Path::new(&dir).to_path_buf();
+        file_path.push(blueprint_name);
+
+        // Check if the blueprint directory exists, if not create it
+        if !file_path.exists() {
+            // error is ignored because when multiple tests are running it may fail
+            fs::create_dir(&file_path).ok();
+        }
+
+        // Write .profraw binary data
+        let file_name = hash(&coverage_data);
+        let file_name: String = file_name.0[..16]
+            .iter()
+            .map(|byte| format!("{:02x}", byte))
+            .collect();
+        file_path.push(format!("{}.profraw", file_name));
+        let mut file = File::create(file_path).unwrap();
+        file.write_all(&coverage_data).unwrap();
+    }
+}

--- a/radix-engine/src/utils/mod.rs
+++ b/radix-engine/src/utils/mod.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "coverage")]
+mod coverage;
 mod macros;
 mod native_blueprint_call_validator;
 mod package_extractor;
 mod panics;
 
+#[cfg(feature = "coverage")]
+pub use coverage::*;
 pub use macros::*;
 pub use native_blueprint_call_validator::*;
 pub use package_extractor::*;

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -983,15 +983,18 @@ impl WasmModule {
         mut self,
         rules: &R,
     ) -> Result<Self, PrepareError> {
-        let backend = gas_metering::host_function::Injector::new(
-            MODULE_ENV_NAME,
-            COSTING_CONSUME_WASM_EXECUTION_UNITS_FUNCTION_NAME,
-        );
-        gas_metering::inject(&mut self.module, backend, rules).map_err(|err| {
-            PrepareError::RejectedByInstructionMetering {
-                reason: err.to_string(),
-            }
-        })?;
+        #[cfg(not(feature = "coverage"))]
+        {
+            let backend = gas_metering::host_function::Injector::new(
+                MODULE_ENV_NAME,
+                COSTING_CONSUME_WASM_EXECUTION_UNITS_FUNCTION_NAME,
+            );
+            gas_metering::inject(&mut self.module, backend, rules).map_err(|err| {
+                PrepareError::RejectedByInstructionMetering {
+                    reason: err.to_string(),
+                }
+            })?;
+        }
 
         Ok(self)
     }

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -1,5 +1,7 @@
 use crate::errors::InvokeError;
 use crate::types::*;
+#[cfg(feature = "coverage")]
+use crate::utils::save_coverage_data;
 use crate::vm::wasm::constants::*;
 use crate::vm::wasm::errors::*;
 use crate::vm::wasm::traits::*;
@@ -835,13 +837,37 @@ impl WasmInstance for WasmerInstance {
             .map_err(|e| {
                 let err: InvokeError<WasmRuntimeError> = e.into();
                 err
-            })?;
+            });
 
-        if let Some(v) = return_data.as_ref().get(0).and_then(|x| x.i64()) {
-            read_slice(&self.instance, Slice::transmute_i64(v)).map_err(InvokeError::SelfError)
-        } else {
-            Err(InvokeError::SelfError(WasmRuntimeError::InvalidWasmPointer))
+        let result = match return_data {
+            Ok(data) => {
+                if let Some(v) = data.as_ref().get(0).and_then(|x| x.i64()) {
+                    read_slice(&self.instance, Slice::transmute_i64(v)).map_err(InvokeError::SelfError)
+                } else {
+                    Err(InvokeError::SelfError(WasmRuntimeError::InvalidWasmPointer))
+                }        
+            }
+            Err(err) => Err(err)
+        };
+
+        #[cfg(feature = "coverage")]
+        if let Ok(dump_coverage) = self.instance.exports.get_function("dump_coverage") {
+            if let Ok(blueprint_buffer) = runtime.actor_get_blueprint_name() {
+                let blueprint_name =
+                    String::from_utf8(runtime.buffer_consume(blueprint_buffer.id()).unwrap())
+                        .unwrap();
+
+                let mut ret = dump_coverage.call(&[]).unwrap().as_ref().get(0).and_then(|x| x.i64()).unwrap();
+                let coverage_data = read_slice(
+                    &self.instance,
+                    Slice::transmute_i64(ret),
+                )
+                .unwrap();
+                save_coverage_data(&blueprint_name, &coverage_data);
+            }
         }
+
+        result
     }
 }
 

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -842,12 +842,13 @@ impl WasmInstance for WasmerInstance {
         let result = match return_data {
             Ok(data) => {
                 if let Some(v) = data.as_ref().get(0).and_then(|x| x.i64()) {
-                    read_slice(&self.instance, Slice::transmute_i64(v)).map_err(InvokeError::SelfError)
+                    read_slice(&self.instance, Slice::transmute_i64(v))
+                        .map_err(InvokeError::SelfError)
                 } else {
                     Err(InvokeError::SelfError(WasmRuntimeError::InvalidWasmPointer))
-                }        
+                }
             }
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         };
 
         #[cfg(feature = "coverage")]
@@ -857,12 +858,14 @@ impl WasmInstance for WasmerInstance {
                     String::from_utf8(runtime.buffer_consume(blueprint_buffer.id()).unwrap())
                         .unwrap();
 
-                let mut ret = dump_coverage.call(&[]).unwrap().as_ref().get(0).and_then(|x| x.i64()).unwrap();
-                let coverage_data = read_slice(
-                    &self.instance,
-                    Slice::transmute_i64(ret),
-                )
-                .unwrap();
+                let mut ret = dump_coverage
+                    .call(&[])
+                    .unwrap()
+                    .as_ref()
+                    .get(0)
+                    .and_then(|x| x.i64())
+                    .unwrap();
+                let coverage_data = read_slice(&self.instance, Slice::transmute_i64(ret)).unwrap();
                 save_coverage_data(&blueprint_name, &coverage_data);
             }
         }

--- a/scrypto-unit/Cargo.toml
+++ b/scrypto-unit/Cargo.toml
@@ -28,6 +28,7 @@ lru = ["radix-engine/lru", "radix-engine-queries/lru"]
 
 rocksdb = ["radix-engine-stores/rocksdb"]
 post_run_db_check = []
+coverage = ["radix-engine/coverage"]
 
 [lib]
 doctest = false

--- a/scrypto-unit/src/test_runner.rs
+++ b/scrypto-unit/src/test_runner.rs
@@ -125,13 +125,13 @@ impl Compile {
                 coverage_path.set_extension("rpd");
                 let definition = fs::read(&coverage_path).unwrap_or_else(|err| {
                     panic!(
-                        "Failed to read manifest definition from path {:?} - {:?}",
+                        "Failed to read package definition from path {:?} - {:?}",
                         &coverage_path, err
                     )
                 });
                 let definition = manifest_decode(&definition).unwrap_or_else(|err| {
                     panic!(
-                        "Failed to parse manifest definition from path {:?} - {:?}",
+                        "Failed to parse package definition from path {:?} - {:?}",
                         &coverage_path, err
                     )
                 });

--- a/scrypto/Cargo.toml
+++ b/scrypto/Cargo.toml
@@ -19,6 +19,7 @@ paste = { version = "1.0.13" }
 serde = { version = "1.0.144", default-features = false, optional = true }
 strum = { version = "0.24", default-features = false, features = ["derive"] }
 const-sha1 = { git = "https://github.com/radixdlt/const-sha1", default-features = false } # Chosen because of its small size and 0 transitive dependencies
+minicov = { version = "0.3", optional = true }
 
 [features]
 # You should enable either `std` or `alloc`
@@ -37,6 +38,9 @@ log-warn = []
 log-info = []
 log-debug = []
 log-trace = []
+
+# Feature to generate code coverage for WASM
+coverage = ["minicov"]
 
 [lib]
 doctest = false

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -35,6 +35,7 @@ pub use macros::*;
 
 // Re-export Scrypto derive.
 extern crate scrypto_derive;
+
 pub use scrypto_derive::{blueprint, NonFungibleData};
 
 // Re-export Radix Engine Interface modules.
@@ -77,4 +78,12 @@ pub fn set_up_panic_hook() {
 
         crate::runtime::Runtime::panic(message);
     }));
+}
+
+#[cfg(all(feature = "coverage"))]
+#[no_mangle]
+pub unsafe extern "C" fn dump_coverage() -> types::Slice {
+    let mut coverage = vec![];
+    minicov::capture_coverage(&mut coverage).unwrap();
+    engine::wasm_api::forget_vec(coverage)
 }

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "tempfile",
  "transaction",
  "utils",
+ "walkdir",
  "wasm-opt",
 ]
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -35,6 +35,7 @@ proc-macro2 = { version = "1.0.38" }
 heck = "0.4.1"
 tempfile = "3.8.0"
 flume = { version = "0.11.0" }
+walkdir = "2.3.3"
 
 [[bin]]
 name = "resim"

--- a/simulator/src/resim/cmd_publish.rs
+++ b/simulator/src/resim/cmd_publish.rs
@@ -66,6 +66,7 @@ impl Publish {
                 false,
                 self.disable_wasm_opt,
                 self.log_level.unwrap_or(Level::default()),
+                false,
             )
             .map_err(Error::BuildError)?
         } else {

--- a/simulator/src/scrypto/cmd_build.rs
+++ b/simulator/src/scrypto/cmd_build.rs
@@ -34,6 +34,7 @@ impl Build {
             false,
             self.disable_wasm_opt,
             self.log_level.unwrap_or(Level::default()),
+            false,
         )
         .map(|_| ())
         .map_err(Error::BuildError)

--- a/simulator/src/scrypto/cmd_coverage.rs
+++ b/simulator/src/scrypto/cmd_coverage.rs
@@ -1,0 +1,204 @@
+use clap::Parser;
+use radix_engine_interface::types::Level;
+use regex::Regex;
+use std::env;
+use std::env::current_dir;
+use std::fs;
+use std::io::Read;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use walkdir::WalkDir;
+
+use crate::scrypto::*;
+use crate::utils::*;
+
+/// Run Scrypto tests and generate code coverage report
+#[derive(Parser, Debug)]
+pub struct Coverage {
+    /// The arguments to be passed to the test executable
+    arguments: Vec<String>,
+
+    /// The package directory
+    #[clap(long)]
+    path: Option<PathBuf>,
+}
+
+impl Coverage {
+    fn check_command_availability(command: String) -> Result<(), Error> {
+        if Command::new(&command).arg("--version").output().is_err() {
+            println!("Missing command: {}. Please install LLVM version matching rustc LLVM version, which is {}.", 
+                command, command.split('-').last().unwrap_or("Unknown"));
+            println!("For more information, check https://apt.llvm.org/");
+            return Err(Error::CoverageError(CoverageError::MissingLLVM));
+        }
+        Ok(())
+    }
+
+    pub fn run(&self) -> Result<(), Error> {
+        let output = Command::new("rustc")
+            .arg("--version")
+            .arg("--verbose")
+            .output()
+            .expect("Failed to execute rustc command");
+
+        let output_str = String::from_utf8(output.stdout).expect("Failed to read rustc output");
+        let is_nightly = output_str.contains("nightly");
+        let llvm_major_version = Regex::new(r"LLVM version: (\d+)")
+            .unwrap()
+            .captures(&output_str)
+            .and_then(|cap| cap.get(1).map(|m| m.as_str()))
+            .expect("Failed to read LLVM version of rustc");
+
+        if !is_nightly {
+            println!("Coverage tool requries nightly version of rust toolchain");
+            println!("You can install it by using the following commands:");
+            println!("rustup default nightly");
+            println!("rustup target add wasm32-unknown-unknown --toolchain=nightly");
+            return Err(Error::CoverageError(CoverageError::IncorrectRustVersion));
+        }
+
+        // Verify that all llvm tools required to generate coverage report are installed
+        Self::check_command_availability(format!("clang-{}", llvm_major_version))?;
+        Self::check_command_availability(format!("llvm-cov-{}", llvm_major_version))?;
+        Self::check_command_availability(format!("llvm-profdata-{}", llvm_major_version))?;
+
+        // Build package
+        let path = self.path.clone().unwrap_or(current_dir().unwrap());
+        let (wasm_path, _) = build_package(&path, false, false, true, Level::Trace, true)
+            .map_err(Error::BuildError)?;
+        assert!(wasm_path.is_file());
+
+        // Remove wasm32-unknown-unknown/release/file.wasm from wasm_path
+        let mut coverage_path = wasm_path.clone();
+        coverage_path.pop();
+        coverage_path.pop();
+        coverage_path.pop();
+        assert!(coverage_path.ends_with("coverage"));
+        assert!(coverage_path.is_dir());
+
+        // Remove "data" directory from coverage directory if it exists, then create it
+        let data_path = coverage_path.join("data");
+        if data_path.exists() {
+            fs::remove_dir_all(&data_path).unwrap();
+        }
+        fs::create_dir_all(&data_path).unwrap();
+
+        // Set enviromental variable COVERAGE_DIRECTORY
+        env::set_var("COVERAGE_DIRECTORY", data_path.to_str().unwrap());
+
+        // Run tests
+        test_package(path, self.arguments.clone(), true)
+            .map(|_| ())
+            .map_err(Error::TestError)?;
+
+        // Merge profraw files into profdata file
+        let profraw_files: Vec<String> = WalkDir::new(&data_path)
+            .into_iter()
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                if path.extension()? == "profraw" {
+                    Some(path.to_str()?.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if profraw_files.is_empty() {
+            println!("No .profraw files found in the coverage/data directory");
+            return Err(Error::CoverageError(CoverageError::NoProfrawFiles));
+        }
+
+        let profdata_path = data_path.join("coverage.profdata");
+        let output = Command::new(format!("llvm-profdata-{}", llvm_major_version))
+            .args(&["merge", "-sparse"])
+            .args(profraw_files)
+            .arg("-o")
+            .arg(profdata_path.to_str().unwrap())
+            .output()
+            .expect("Failed to execute llvm-profdata command");
+        if !output.status.success() {
+            eprintln!(
+                "llvm-profdata failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(Error::CoverageError(CoverageError::ProfdataMergeFailed));
+        }
+
+        // Generate object file from intermediate representation (.ll) file
+        let ir_path = wasm_path.with_extension("ll");
+        let ir_path = ir_path
+            .parent()
+            .unwrap()
+            .join("deps")
+            .join(ir_path.file_name().unwrap());
+
+        let mut ir_contents = String::new();
+        fs::File::open(&ir_path)
+            .expect(&format!("Failed to open IR file {ir_path:?}"))
+            .read_to_string(&mut ir_contents)
+            .expect("Failed to read IR file");
+
+        let modified_ir_contents = Regex::new(r"(?ms)^(define[^\n]*\n).*?^}\s*$")
+            .unwrap()
+            .replace_all(&ir_contents, "${1}start:\n  unreachable\n}\n")
+            .to_string();
+
+        let new_ir_path = data_path.join(ir_path.file_name().unwrap());
+        let mut new_ir_file =
+            fs::File::create(&new_ir_path).expect("Failed to create modified IR file");
+        new_ir_file
+            .write_all(modified_ir_contents.as_bytes())
+            .expect("Failed to write modified IR file");
+
+        // Generate Object File from IR File
+        let object_file_path = new_ir_path.with_extension("o");
+        let output = Command::new(format!("clang-{}", llvm_major_version))
+            .args(&[
+                new_ir_path.to_str().unwrap(),
+                "-Wno-override-module",
+                "-c",
+                "-o",
+            ])
+            .arg(object_file_path.to_str().unwrap())
+            .output()
+            .expect("Failed to execute clang command");
+
+        if !output.status.success() {
+            eprintln!("clang failed: {}", String::from_utf8_lossy(&output.stderr));
+            return Err(Error::CoverageError(CoverageError::ClangFailed));
+        }
+
+        // Generate Coverage Report
+        let coverage_report_path = coverage_path.join("report");
+        if coverage_report_path.exists() {
+            fs::remove_dir_all(&coverage_report_path).unwrap();
+        }
+
+        let output = Command::new(format!("llvm-cov-{}", llvm_major_version))
+            .args(&["show", "--instr-profile=coverage/data/coverage.profdata"])
+            .arg(object_file_path.to_str().unwrap())
+            .args(&[
+                "--show-instantiations=false",
+                "--format=html",
+                "--output-dir",
+            ])
+            .arg(coverage_report_path.to_str().unwrap())
+            .output()
+            .expect("Failed to execute llvm-cov command");
+
+        if !output.status.success() {
+            eprintln!(
+                "llvm-cov failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(Error::CoverageError(CoverageError::LlvmCovFailed));
+        }
+
+        println!("Coverage report was succesfully generated, it is available in {coverage_report_path:?} directory.");
+
+        Ok(())
+    }
+}

--- a/simulator/src/scrypto/cmd_test.rs
+++ b/simulator/src/scrypto/cmd_test.rs
@@ -21,6 +21,7 @@ impl Test {
         test_package(
             self.path.clone().unwrap_or(current_dir().unwrap()),
             self.arguments.clone(),
+            false,
         )
         .map(|_| ())
         .map_err(Error::TestError)

--- a/simulator/src/scrypto/error.rs
+++ b/simulator/src/scrypto/error.rs
@@ -13,4 +13,6 @@ pub enum Error {
     FormatError(FormatError),
 
     PackageAlreadyExists,
+
+    CoverageError(CoverageError),
 }

--- a/simulator/src/scrypto/mod.rs
+++ b/simulator/src/scrypto/mod.rs
@@ -1,10 +1,12 @@
 mod cmd_build;
+mod cmd_coverage;
 mod cmd_fmt;
 mod cmd_new_package;
 mod cmd_test;
 mod error;
 
 pub use cmd_build::*;
+pub use cmd_coverage::*;
 pub use cmd_fmt::*;
 pub use cmd_new_package::*;
 pub use cmd_test::*;
@@ -23,6 +25,7 @@ pub struct ScryptoCli {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     Build(Build),
+    Coverage(Coverage),
     Fmt(Fmt),
     NewPackage(NewPackage),
     Test(Test),
@@ -33,6 +36,7 @@ pub fn run() -> Result<(), Error> {
 
     match cli.command {
         Command::Build(cmd) => cmd.run(),
+        Command::Coverage(cmd) => cmd.run(),
         Command::Fmt(cmd) => cmd.run(),
         Command::NewPackage(cmd) => cmd.run(),
         Command::Test(cmd) => cmd.run(),

--- a/simulator/src/scrypto_bindgen/mod.rs
+++ b/simulator/src/scrypto_bindgen/mod.rs
@@ -117,7 +117,10 @@ where
     S: SubstateDatabase,
 {
     fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<VersionedScryptoSchema> {
-        self.1.get_schema(self.0.as_node_id(), schema_hash).ok().map(|x| x.as_ref().clone())
+        self.1
+            .get_schema(self.0.as_node_id(), schema_hash)
+            .ok()
+            .map(|x| x.as_ref().clone())
     }
 
     fn resolve_type_kind(

--- a/simulator/src/utils/coverage.rs
+++ b/simulator/src/utils/coverage.rs
@@ -1,0 +1,9 @@
+#[derive(Debug)]
+pub enum CoverageError {
+    IncorrectRustVersion,
+    MissingLLVM,
+    NoProfrawFiles,
+    ProfdataMergeFailed,
+    ClangFailed,
+    LlvmCovFailed,
+}

--- a/simulator/src/utils/coverage.rs
+++ b/simulator/src/utils/coverage.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum CoverageError {
+    MissingWasm32Target,
     IncorrectRustVersion,
     MissingLLVM,
     NoProfrawFiles,

--- a/simulator/src/utils/mod.rs
+++ b/simulator/src/utils/mod.rs
@@ -1,11 +1,13 @@
 mod cargo;
 mod common_instructions;
+mod coverage;
 mod display;
 mod iter;
 mod resource_specifier;
 
 pub use cargo::*;
 pub use common_instructions::*;
+pub use coverage::*;
 pub use display::list_item_prefix;
 pub use iter::{IdentifyLast, Iter};
 pub use resource_specifier::*;

--- a/simulator/tests/scrypto_coverage.sh
+++ b/simulator/tests/scrypto_coverage.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script requires rust nightly and wasm32-unknown-unknown target. 
+# Additionally, LLVM needs to be installed and its version should match the major version of your rust nightly compiler.
+
+set -x
+set -e
+
+cd "$(dirname "$0")/.."
+
+scrypto="cargo run --bin scrypto $@ --"
+test_pkg="./target/temp/hello-world"
+
+# Create package
+rm -fr $test_pkg
+$scrypto new-package hello-world --path $test_pkg --local
+
+# Generate coverage report
+$scrypto coverage --path $test_pkg
+
+# Check if coverage report was generated
+if [ -f "$test_pkg/coverage/report/index.html" ]; then
+    echo "Coverage report generated successfully."
+else
+    echo "Error: Coverage report not found."
+    exit 1
+fi
+
+# Clean up
+rm -fr $test_pkg


### PR DESCRIPTION
## Summary
This PR adds new command `scrypto coverage` which allows to create code coverage report from tests. It was implemented based on https://github.com/hknio/code-coverage-for-webassembly findings.

Please let me know what you think, in same cases I had to use ugly approach like:
```rust
/// The maximum invoke payload size.
#[cfg(not(feature = "coverage"))]
pub const MAX_INVOKE_PAYLOAD_SIZE: usize = 1 * 1024 * 1024;
#[cfg(feature = "coverage")]
pub const MAX_INVOKE_PAYLOAD_SIZE: usize = 32 * 1024 * 1024;
```
If you have better idea how it could be implemented, please let me know.

In the next commit I'll add test_coverage.sh script, the only problem is I'll need to install nightly version of rust and the same version of llvm as nightly rustc is using. Should I add it in Dockerfile or somewhere else?