### PR TITLE
Chore: remove leftover consensus manager method

### DIFF
--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -314,29 +314,6 @@ pub struct ConsensusManagerCreateValidatorManifestInput {
 
 pub type ConsensusManagerCreateValidatorOutput = (Global<ValidatorObjectTypeInfo>, Bucket, Bucket);
 
-pub const CONSENSUS_MANAGER_UPDATE_VALIDATOR_IDENT: &str = "update_validator";
-
-#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
-pub enum UpdateSecondaryIndex {
-    Create {
-        index_key: SortedKey,
-        key: Secp256k1PublicKey,
-        stake: Decimal,
-    },
-    UpdateStake {
-        index_key: SortedKey,
-        new_index_key: SortedKey,
-        new_stake_amount: Decimal,
-    },
-    UpdatePublicKey {
-        index_key: SortedKey,
-        key: Secp256k1PublicKey,
-    },
-    Remove {
-        index_key: SortedKey,
-    },
-}
-
 pub const VALIDATOR_REGISTER_IDENT: &str = "register";
 
 #[derive(Debug, Clone, Eq, PartialEq, Sbor)]

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -194,6 +194,27 @@ declare_native_blueprint_state! {
 pub type ValidatorStateV1 = ValidatorSubstate;
 pub type ValidatorProtocolUpdateReadinessSignalV1 = ValidatorProtocolUpdateReadinessSignalSubstate;
 
+#[derive(Debug, Clone, Eq, PartialEq, ScryptoSbor, ManifestSbor)]
+enum UpdateSecondaryIndex {
+    Create {
+        index_key: SortedKey,
+        key: Secp256k1PublicKey,
+        stake: Decimal,
+    },
+    UpdateStake {
+        index_key: SortedKey,
+        new_index_key: SortedKey,
+        new_stake_amount: Decimal,
+    },
+    UpdatePublicKey {
+        index_key: SortedKey,
+        key: Secp256k1PublicKey,
+    },
+    Remove {
+        index_key: SortedKey,
+    },
+}
+
 pub struct ValidatorBlueprint;
 
 impl ValidatorBlueprint {
@@ -1536,10 +1557,7 @@ impl ValidatorBlueprint {
         }
     }
 
-    pub(crate) fn update_validator<Y>(
-        update: UpdateSecondaryIndex,
-        api: &mut Y,
-    ) -> Result<(), RuntimeError>
+    fn update_validator<Y>(update: UpdateSecondaryIndex, api: &mut Y) -> Result<(), RuntimeError>
     where
         Y: ClientApi<RuntimeError>,
     {


### PR DESCRIPTION
Pure refactor/chore PR with no intended functional changes.

We no longer publicly expose `update_validator` (at that time in ConsensusManager), instead it is an internal/helper method. Here I remove the `pub(crate)` and the `CONSENSUS_MANAGER_UPDATE_VALIDATOR_IDENT`.