### PR TITLE
Disallow PubKey as PrivKey for `cmd_set_default_account` command - display error if user accidentally pass wrong key.

### DIFF
--- a/simulator/src/resim/cmd_new_account.rs
+++ b/simulator/src/resim/cmd_new_account.rs
@@ -124,7 +124,7 @@ impl NewAccount {
                 || configs.default_owner_badge.is_none()
             {
                 configs.default_account = Some(account);
-                configs.default_private_key = Some(hex::encode(private_key.to_bytes()));
+                configs.default_private_key = Some(private_key.to_hex());
                 configs.default_owner_badge = Some(owner_badge);
                 set_configs(&configs)?;
 

--- a/simulator/src/resim/cmd_set_default_account.rs
+++ b/simulator/src/resim/cmd_set_default_account.rs
@@ -35,3 +35,31 @@ impl SetDefaultAccount {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[test]
+fn test_validation() {
+    let mut out = std::io::stdout();
+    let private_key = Secp256k1PrivateKey::from_hex(
+        "6847c11e2d602548dbf38789e0a1f4543c1e7719e4f591d4aa6e5684f5c13d9c",
+    )
+    .unwrap();
+    let public_key = private_key.public_key().to_string();
+
+    let make_cmd = |key_string: String| {
+        return SetDefaultAccount {
+            component_address: SimulatorComponentAddress::from_str(
+                "account_sim1c9yeaya6pehau0fn7vgavuggeev64gahsh05dauae2uu25njk224xz",
+            )
+            .unwrap(),
+            private_key: key_string,
+            owner_badge: SimulatorNonFungibleGlobalId::from_str(
+                "resource_sim1ngvrads4uj3rgq2v9s78fzhvry05dw95wzf3p9r8skhqusf44dlvmr:#1#",
+            )
+            .unwrap(),
+        };
+    };
+
+    assert!(make_cmd(private_key.to_hex()).run(&mut out).is_ok());
+    assert!(make_cmd(public_key.to_string()).run(&mut out).is_err());
+}

--- a/simulator/src/resim/cmd_set_default_account.rs
+++ b/simulator/src/resim/cmd_set_default_account.rs
@@ -19,8 +19,15 @@ pub struct SetDefaultAccount {
 impl SetDefaultAccount {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<(), Error> {
         let mut configs = get_configs()?;
+        let private_key = parse_private_key_from_str(&self.private_key).map_err(|e| {
+            if Secp256k1PublicKey::from_str(&self.private_key).is_ok() {
+                Error::GotPublicKeyExpectedPrivateKey
+            } else {
+                e
+            }
+        })?;
         configs.default_account = Some(self.component_address.0);
-        configs.default_private_key = Some(self.private_key.clone());
+        configs.default_private_key = Some(private_key.to_hex());
         configs.default_owner_badge = Some(self.owner_badge.clone().0);
         set_configs(&configs)?;
 

--- a/simulator/src/resim/config.rs
+++ b/simulator/src/resim/config.rs
@@ -59,7 +59,7 @@ pub fn get_default_account() -> Result<ComponentAddress, Error> {
 pub fn get_default_private_key() -> Result<Secp256k1PrivateKey, Error> {
     get_configs()?
         .default_private_key
-        .map(|v| Secp256k1PrivateKey::from_bytes(&hex::decode(&v).unwrap()).unwrap())
+        .map(|v| Secp256k1PrivateKey::from_hex(&v).unwrap())
         .ok_or(Error::NoDefaultPrivateKey)
 }
 

--- a/simulator/src/resim/error.rs
+++ b/simulator/src/resim/error.rs
@@ -67,6 +67,9 @@ pub enum Error {
 
     InvalidPrivateKey,
 
+    /// e.g. if you accidentally pass in a public key in `set_default_account` command.
+    GotPublicKeyExpectedPrivateKey,
+
     NonFungibleGlobalIdError(ParseNonFungibleGlobalIdError),
 
     FailedToBuildArguments(BuildCallArgumentError),

--- a/transaction/src/signing/secp256k1/private_key.rs
+++ b/transaction/src/signing/secp256k1/private_key.rs
@@ -27,6 +27,16 @@ impl Secp256k1PrivateKey {
         self.0.secret_bytes().to_vec()
     }
 
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.to_bytes())
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self, ()> {
+        hex::decode(s)
+            .map_err(|_| ())
+            .and_then(|v| Self::from_bytes(&v))
+    }
+
     pub fn from_bytes(slice: &[u8]) -> Result<Self, ()> {
         if slice.len() != Secp256k1PrivateKey::LENGTH {
             return Err(());


### PR DESCRIPTION
## Summary

Validate input to `cmd_set_default_account`, ensuring we don't accidentally pass in PublicKey instead of PrivateKey.

## Details

In `main` it is possible to accidentally pass in the PublicKey to the PrivateKey value for command `cmd_set_default_account`. This results in confusing state and error when trying to e.g. perform a transfer.

<img width="1130" alt="Screenshot 2023-11-10 at 15 55 19" src="https://github.com/radixdlt/radixdlt-scrypto/assets/864410/f33386a7-aa03-41a8-8f29-b92527c31337">

N.B: we don't get any information on what went wrong, that is because of the program panics at [unwrap at line 62](https://github.com/radixdlt/radixdlt-scrypto/blob/main/simulator/src/resim/config.rs#L62), so we never reach the next line, with more info: `Error::NoDefaultPrivateKey`. This should also be fix (I can do another PR), but this PR fixes so that should never happen...

I got into this state since I accidentally copied the PublicKey instead of the PrivateKey, resulting in this bad state.
<img width="684" alt="Screenshot 2023-11-10 at 15 55 33" src="https://github.com/radixdlt/radixdlt-scrypto/assets/864410/ab6f4289-e185-4e80-a764-c407281745ec">

## Testing
<img width="1512" alt="Screenshot 2023-11-10 at 16 03 31" src="https://github.com/radixdlt/radixdlt-scrypto/assets/864410/4a471ea4-423f-4272-8a89-2bceb6a9a9aa">

Now it is not possible to pass in the PublicKey instead of PrivateKey anymore, and we display a very informative error `GotPublicKeyExpectedPrivateKey`.

Added a unit test.
