### PR TITLE
Make it possible to run only 'resim show' using default account's address

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,48 +16,48 @@ Binaries, including libraries, CLIs and docker images, are licensed under the [R
 ## Installation
 
 1. Install Rust - this requires Rust 1.70+ (if rust is already installed, upgrade with `rustup update`)
-    * Windows:
-        * Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)
-        * Install "Desktop development with C++" with [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-        * Install [LLVM 13.0.1](https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.exe) (make sure you tick the option that adds LLVM to the system PATH)
-        * Enable git long path support:
-        ```bash
-        git config --system core.longpaths true
-        ```   
-    *  macOS:
-        * Make sure you have the xcode command line tools: `xcode-select --install`.
-        * Install cmake: `brew install cmake`
-        * Install the Rust compiler:
-        ```bash
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-        ```
-    * Linux:
-        * Make sure a C++ compiler, LLVM and cmake is installed (`sudo apt install build-essential llvm cmake`).
-        * Install the Rust compiler:
-        ```bash
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-        ```
+   - Windows:
+     - Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)
+     - Install "Desktop development with C++" with [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
+     - Install [LLVM 13.0.1](https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/LLVM-13.0.1-win64.exe) (make sure you tick the option that adds LLVM to the system PATH)
+     - Enable git long path support:
+     ```bash
+     git config --system core.longpaths true
+     ```
+   - macOS:
+     - Make sure you have the xcode command line tools: `xcode-select --install`.
+     - Install cmake: `brew install cmake`
+     - Install the Rust compiler:
+     ```bash
+     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+     ```
+   - Linux:
+     - Make sure a C++ compiler, LLVM and cmake is installed (`sudo apt install build-essential llvm cmake`).
+     - Install the Rust compiler:
+     ```bash
+     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+     ```
 2. Enable `cargo` in the current shell:
-   * Windows:
-       * Start a new PowerShell
-   * Linux and macOS:
-       ```bash
-       source $HOME/.cargo/env
-       ```
+   - Windows:
+     - Start a new PowerShell
+   - Linux and macOS:
+     ```bash
+     source $HOME/.cargo/env
+     ```
 3. Add WebAssembly target
-    ```bash
-    rustup target add wasm32-unknown-unknown
-    ```
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
 4. Install simulator
-    ```bash
-    git clone https://github.com/radixdlt/radixdlt-scrypto.git
-    cd radixdlt-scrypto
-    cargo install --path ./simulator
-    ```
+   ```bash
+   git clone https://github.com/radixdlt/radixdlt-scrypto.git
+   cd radixdlt-scrypto
+   cargo install --path ./simulator
+   ```
 5. (Optional) Open Scrypto documentation for later use
-    ```bash
-    ./doc.sh
-    ```
+   ```bash
+   ./doc.sh
+   ```
 
 ## Getting Started
 
@@ -66,68 +66,81 @@ If you want a quick walkthrough of how to deploy and run some code, please see t
 ### Writing Scrypto Code
 
 1. Start by creating a new package:
+
 ```bash
 scrypto new-package <package_name>
 cd <package_name>
 ```
+
 2. Check out the files under your current directory:
-  - Source code is within `src/lib.rs`;
-  - Test code is within `tests/lib.rs`.
+
+- Source code is within `src/lib.rs`;
+- Test code is within `tests/lib.rs`.
+
 3. Build your package:
+
 ```bash
 scrypto build
 ```
+
 4. Run tests:
+
 ```bash
 scrypto test
 ```
 
 ### Playing with Radix Engine
 
-| Action                             | Command                                                                                              |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Create an account                  | ``` resim new-account ```                                                                            |
-| Change the default account         | ``` resim set-default-account <account_address> <account_public_key> ```                             |
-| Create a token with fixed supply   | ``` resim new-token-fixed <amount> ```                                                               |
-| Create a token with mutable supply | ``` resim new-token-mutable <minter_resource_address> ```                                            |
-| Create a badge with fixed supply   | ``` resim new-badge-fixed <amount> ```                                                               |
-| Create a badge with mutable supply | ``` resim new-badge-mutable <minter_resource_address> ```                                            |
-| Mint resource                      | ``` resim mint <amount> <resource_address> <minter_resource_address> ```                             |
-| Transfer resource                  | ``` resim transfer <amount> <resource_address> <recipient_component_address> ```                     |
-| Publish a package                  | ``` resim publish <path_to_package_dir> ```                                                          |
-| Call a function                    | ``` resim call-function <package_address> <blueprint_name> <function> <args> ```                     |
-| Call a method                      | ``` resim call-method <component_address> <method> <args> ```                                        |
-| Export the definition of a package | ``` resim export-package-definition <package_address> <output>```                                    |
-| Show info about an entity          | ``` resim show <id> ```                                                                              |
-| List all entities in simulator     | ``` resim show-ledger  ```                                                                           |
-| Reset simulator state              | ``` resim reset ```                                                                                  |
+| Action                             | Command                                                                    |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| Create an account                  | `resim new-account`                                                        |
+| Change the default account         | `resim set-default-account <account_address> <account_public_key>`         |
+| Create a token with fixed supply   | `resim new-token-fixed <amount>`                                           |
+| Create a token with mutable supply | `resim new-token-mutable <minter_resource_address>`                        |
+| Create a badge with fixed supply   | `resim new-badge-fixed <amount>`                                           |
+| Create a badge with mutable supply | `resim new-badge-mutable <minter_resource_address>`                        |
+| Mint resource                      | `resim mint <amount> <resource_address> <minter_resource_address>`         |
+| Transfer resource                  | `resim transfer <amount> <resource_address> <recipient_component_address>` |
+| Publish a package                  | `resim publish <path_to_package_dir>`                                      |
+| Call a function                    | `resim call-function <package_address> <blueprint_name> <function> <args>` |
+| Call a method                      | `resim call-method <component_address> <method> <args>`                    |
+| Export the definition of a package | ` resim export-package-definition <package_address> <output>`              |
+| Show info about an entity          | `resim show <id>`                                                          |
+| Show info about default account    | ` resim show`                                                              |
+| List all entities in simulator     | `resim show-ledger `                                                       |
+| Reset simulator state              | `resim reset`                                                              |
 
 **Note:** The commands use the default account as transaction sender.
 
 ## Compile blueprints with dockerized simulator
+
 Follow this guide to build reproducible WASM and RDP files for your Scrypto blueprints.
 
 ### Using local docker image
-The Dockerfile in the root of the repo should be work to build a docker image which will contain all the dependencies needed to be able build a blueprint using scrypto. 
+
+The Dockerfile in the root of the repo should be work to build a docker image which will contain all the dependencies needed to be able build a blueprint using scrypto.
 
 Build the docker image like. From the repo root
+
 ```bash
 docker build -t radixdlt/simulator .
 ```
 
 Then build your package by just running
+
 ```bash
 docker run -v <path-to-your-scrypto-crate>:/src radixdlt/simulator
 ```
 
 ### Using published docker image
+
 If you would like to avoid building the docker image, you can skip the build step and do the second step directly, docker will automatically download the docker image we publish
 
 Build your blueprints directly with
+
 ```bash
 docker run -v <path-to-your-scrypto-crate>:/src radixdlt/simulator
 ```
-
 
 ## Project Layout
 
@@ -144,19 +157,20 @@ docker run -v <path-to-your-scrypto-crate>:/src radixdlt/simulator
 
 Assets under `assets-lfs` are stored in Git LFS.
 
-
 To fetch files from LFS, install `git-lfs` first:
+
 - MacOS
-    ```
-    brew install git-lfs
-    ```
+  ```
+  brew install git-lfs
+  ```
 - Ubuntu
-    ```
-    curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-    sudo apt-get install git-lfs
-    ```
+  ```
+  curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+  sudo apt-get install git-lfs
+  ```
 
 and then:
+
 ```
 git lfs install
 git lfs pull

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -5,19 +5,20 @@ A good "Hello, World!" example provides the simplest possible piece of code to u
 ## File Structure
 
 For every new Scrypto package, there are mainly three files/folders:
+
 - The `src` folder, which contains all the source code;
 - The `test` folder, which contains all the test code;
 - The `Cargo.toml` file which specifies all the dependencies and compile configurations.
 
 ## Blueprint
 
-A *blueprint* is the code that defines a shared data structure and implementation. Multiple blueprints are grouped into a *package*.
+A _blueprint_ is the code that defines a shared data structure and implementation. Multiple blueprints are grouped into a _package_.
 
 In this example, we have only one blueprint in the package called `Hello`, which defines:
 
-* The state structure of all `Hello` components (a single *vault*, which is a container for *resources*);
-* A function `instantiate_hello`,  which instantiates a `Hello` component;
-* A method `free_token`, which returns a bucket of `HelloToken` each time invoked.
+- The state structure of all `Hello` components (a single _vault_, which is a container for _resources_);
+- A function `instantiate_hello`, which instantiates a `Hello` component;
+- A method `free_token`, which returns a bucket of `HelloToken` each time invoked.
 
 ```rust
 use scrypto::prelude::*;
@@ -53,7 +54,7 @@ Self {
 
 ## Resource, Vault and Bucket
 
-In Scrypto, assets like tokens, NFTs, and more are not implemented as blueprints or components. Instead, they are types of *resources* that are configured and requested directly from the system.
+In Scrypto, assets like tokens, NFTs, and more are not implemented as blueprints or components. Instead, they are types of _resources_ that are configured and requested directly from the system.
 
 To define a new resource, we use the `ResourceBuilder`, specifying the metadata and initial supply. We can use the `ResourceBuilder` to create a simple fungible-supply token called `HelloToken` like this:
 
@@ -65,6 +66,7 @@ let my_bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
 ```
 
 Once created, the 1000 resource-based `HelloToken` tokens are held in transient container `my_bucket`. To permanently store the created resources, we need to put them into a `Vault` like this:
+
 ```rust
 let vault: Vault = Vault::with_bucket(my_bucket);
 ```
@@ -72,22 +74,39 @@ let vault: Vault = Vault::with_bucket(my_bucket);
 ## How to Play?
 
 1. Create a new account, and save the account component address
+
 ```
 resim new-account
 ```
+
 2. Publish the package, and save the package ID
+
 ```
 resim publish .
 ```
+
 3. Call the `instantiate_hello` function to instantiate a component, and save the component address
+
 ```
 resim call-function <PACKAGE_ADDRESS> Hello instantiate_hello
 ```
+
 4. Call the `free_token` method of the component we just instantiated
+
 ```
 resim call-method <COMPONENT_ADDRESS> free_token
 ```
+
 5. Check out our balance
+
 ```
 resim show <ACCOUNT_COMPONENT_ADDRESS>
 ```
+
+or simply:
+
+```
+resim show
+```
+
+To show balance of default account.

--- a/simulator/src/resim/cmd_show.rs
+++ b/simulator/src/resim/cmd_show.rs
@@ -6,8 +6,9 @@ use radix_engine_stores::rocks_db::RocksdbSubstateStore;
 /// Show an entity in the ledger state
 #[derive(Parser, Debug)]
 pub struct Show {
-    /// The address of a package, component or resource manager
-    pub address: String,
+    /// The address of a package, component or resource manager, if no
+    /// address is provided, then we default to `show <DEFAULT_ACCOUNT_ADDRESS>`.
+    pub address: Option<String>,
 }
 
 impl Show {
@@ -19,14 +20,45 @@ impl Show {
         Bootstrapper::new(NetworkDefinition::simulator(), &mut substate_db, vm, false)
             .bootstrap_test_default();
 
-        if let Ok(a) = SimulatorPackageAddress::from_str(&self.address) {
-            dump_package(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
-        } else if let Ok(a) = SimulatorComponentAddress::from_str(&self.address) {
-            dump_component(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
-        } else if let Ok(a) = SimulatorResourceAddress::from_str(&self.address) {
-            dump_resource_manager(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
-        } else {
-            Err(Error::InvalidId(self.address.clone()))
+        match &self.address {
+            Some(address) => {
+                if let Ok(a) = SimulatorPackageAddress::from_str(address) {
+                    dump_package(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
+                } else if let Ok(a) = SimulatorComponentAddress::from_str(address) {
+                    dump_component(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
+                } else if let Ok(a) = SimulatorResourceAddress::from_str(address) {
+                    dump_resource_manager(a.0, &substate_db, out).map_err(Error::LedgerDumpError)
+                } else {
+                    Err(Error::InvalidId(address.clone()))
+                }
+            }
+            None => get_configs()
+                .and_then(|c| {
+                    c.default_account.ok_or(Error::LedgerDumpError(
+                        EntityDumpError::NoAddressProvidedAndNotDefaultAccountSet,
+                    ))
+                })
+                .and_then(|x| dump_component(x, &substate_db, out).map_err(Error::LedgerDumpError)),
         }
     }
+}
+
+#[cfg(test)]
+#[test]
+fn test_no_value() {
+    let mut out = std::io::stdout();
+    let mut configs = get_configs().unwrap();
+    configs.default_account = None;
+    set_configs(&configs).unwrap();
+    let sim_address = SimulatorComponentAddress::from_str(
+        "account_sim1c9yeaya6pehau0fn7vgavuggeev64gahsh05dauae2uu25njk224xz",
+    )
+    .unwrap();
+    let address = ComponentAddress::from(sim_address);
+    let mut cmd = Show { address: None };
+    assert!(cmd.run(&mut out).is_err());
+    configs.default_account = Some(address);
+    set_configs(&configs).unwrap();
+    cmd = Show { address: None };
+    assert!(cmd.run(&mut out).is_ok());
 }

--- a/simulator/src/resim/dumper.rs
+++ b/simulator/src/resim/dumper.rs
@@ -21,6 +21,8 @@ pub enum EntityDumpError {
     ComponentNotFound,
     ResourceManagerNotFound,
     InvalidStore(String),
+    /// If you run `resim show`, without any address but no default account address has been set.
+    NoAddressProvidedAndNotDefaultAccountSet,
 }
 
 /// Dump a package into console.


### PR DESCRIPTION
## Summary
Change so that `resim show` is possible, without specifying an address, which will try to use the default account's address.

## Details
Make `address` optional for `resim show` command, defaulting to address of default account (set with `set-default-account`).

## Testing

<img width="945" alt="Screenshot 2023-11-10 at 17 57 48" src="https://github.com/radixdlt/radixdlt-scrypto/assets/864410/012b836e-e2b3-4153-9172-cf3285d31aa9">

If `resim show` is called without a default account set, a new error `NoAddressProvidedAndNotDefaultAccountSet` will be thrown.

I've added unit tests and update README.