### PR TITLE
Adding `SubstateDatabase::list_entries_from()` variant

### DIFF
--- a/radix-engine-profiling/src/rocks_db_metrics/mod.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/mod.rs
@@ -102,11 +102,12 @@ impl<S: SubstateDatabase + CommittableSubstateDatabase> SubstateDatabase
         }
     }
 
-    fn list_entries(
+    fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
-        self.db.list_entries(partition_key)
+        self.db.list_entries_from(partition_key, from_sort_key)
     }
 }
 

--- a/radix-engine-queries/src/query/traverse.rs
+++ b/radix-engine-queries/src/query/traverse.rs
@@ -248,7 +248,7 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
                         blueprint_def.interface.state.collections.iter().enumerate()
                     {
                         let (iter, partition_number) = system_db_reader
-                            .collection_iter_advanced(&node_id, ModuleId::Main, index as u8)
+                            .collection_iter_advanced(&node_id, ModuleId::Main, index as u8, None)
                             .unwrap();
 
                         for (substate_key, value) in iter {

--- a/radix-engine-queries/src/query/traverse.rs
+++ b/radix-engine-queries/src/query/traverse.rs
@@ -103,7 +103,10 @@ impl<'s, 'v, S: SubstateDatabase, V: StateTreeVisitor + 'v> StateTreeTraverser<'
 
         match type_info {
             TypeInfoSubstate::KeyValueStore(_) => {
-                for (key, value) in system_db_reader.key_value_store_iter(&node_id).unwrap() {
+                for (key, value) in system_db_reader
+                    .key_value_store_iter(&node_id, None)
+                    .unwrap()
+                {
                     let (_, owned_nodes, _) =
                         IndexedScryptoValue::from_slice(&value).unwrap().unpack();
                     for child_node_id in owned_nodes {

--- a/radix-engine-store-interface/src/interface.rs
+++ b/radix-engine-store-interface/src/interface.rs
@@ -140,12 +140,26 @@ pub trait SubstateDatabase {
         sort_key: &DbSortKey,
     ) -> Option<DbSubstateValue>;
 
+    /// Iterates over all entries of the given partition (starting either from the beginning, or
+    /// from the given [`DbSortKey`]), in a lexicographical order (ascending) of the [`DbSortKey`]s.
+    /// Note: If the exact given starting key does not exist, the iteration starts with its
+    /// immediate successor.
+    fn list_entries_from(
+        &self,
+        partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
+    ) -> Box<dyn Iterator<Item = PartitionEntry> + '_>;
+
     /// Iterates over all entries of the given partition, in a lexicographical order (ascending)
     /// of the [`DbSortKey`]s.
+    /// This is a convenience method, equivalent to [`Self::list_entries_from()`] with the starting
+    /// key set to [`None`].
     fn list_entries(
         &self,
         partition_key: &DbPartitionKey,
-    ) -> Box<dyn Iterator<Item = PartitionEntry> + '_>;
+    ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
+        self.list_entries_from(partition_key, None)
+    }
 }
 
 /// A write interface between Track and a database vendor.

--- a/radix-engine-stores/src/hash_tree_support.rs
+++ b/radix-engine-stores/src/hash_tree_support.rs
@@ -55,11 +55,13 @@ impl<D: SubstateDatabase> SubstateDatabase for HashTreeUpdatingDatabase<D> {
         self.underlying.get_substate(partition_key, sort_key)
     }
 
-    fn list_entries(
+    fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
-        self.underlying.list_entries(partition_key)
+        self.underlying
+            .list_entries_from(partition_key, from_sort_key)
     }
 }
 

--- a/radix-engine-stores/src/memory_db.rs
+++ b/radix-engine-stores/src/memory_db.rs
@@ -26,15 +26,18 @@ impl SubstateDatabase for InMemorySubstateDatabase {
             .cloned()
     }
 
-    fn list_entries(
+    fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
+        let from_sort_key = from_sort_key.cloned();
         let iter = self
             .partitions
             .get(partition_key)
             .into_iter()
             .flat_map(|partition| partition.iter())
+            .skip_while(move |(key, _substate)| Some(*key) < from_sort_key.as_ref())
             .map(|(key, substate)| (key.clone(), substate.clone()));
 
         Box::new(iter)

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -57,7 +57,8 @@ impl SubstateDatabase for RocksdbSubstateStore {
         from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
         let partition_key = partition_key.clone();
-        let from_sort_key = from_sort_key.unwrap_or(&DbSortKey(vec![]));
+        let empty_sort_key = DbSortKey(vec![]);
+        let from_sort_key = from_sort_key.unwrap_or(&empty_sort_key);
         let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, from_sort_key);
         let iter = self
             .db

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -51,12 +51,14 @@ impl SubstateDatabase for RocksdbSubstateStore {
         self.db.get_cf(self.cf(), &key_bytes).expect("IO Error")
     }
 
-    fn list_entries(
+    fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
         let partition_key = partition_key.clone();
-        let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![]));
+        let from_sort_key = from_sort_key.unwrap_or(&DbSortKey(vec![]));
+        let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, from_sort_key);
         let iter = self
             .db
             .iterator_cf(

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -107,12 +107,14 @@ impl SubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
             .expect("IO Error")
     }
 
-    fn list_entries(
+    fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
         let partition_key = partition_key.clone();
-        let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![]));
+        let from_sort_key = from_sort_key.unwrap_or(&DbSortKey(vec![]));
+        let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, from_sort_key);
         let iter = self
             .db
             .iterator_cf(

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -113,7 +113,8 @@ impl SubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
         let partition_key = partition_key.clone();
-        let from_sort_key = from_sort_key.unwrap_or(&DbSortKey(vec![]));
+        let empty_sort_key = DbSortKey(vec![]);
+        let from_sort_key = from_sort_key.unwrap_or(&empty_sort_key);
         let start_key_bytes = encode_to_rocksdb_bytes(&partition_key, from_sort_key);
         let iter = self
             .db

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -373,7 +373,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         module_id: ModuleId,
         collection_index: CollectionIndex,
     ) -> Result<Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>, SystemReaderError> {
-        self.collection_iter_advanced(node_id, module_id, collection_index)
+        self.collection_iter_advanced(node_id, module_id, collection_index, None)
             .map(|x| x.0)
     }
 
@@ -382,6 +382,7 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         node_id: &NodeId,
         module_id: ModuleId,
         collection_index: CollectionIndex,
+        from_substate_key: Option<&SubstateKey>,
     ) -> Result<
         (
             Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>,
@@ -412,9 +413,11 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
         };
 
         let partition_key = SpreadPrefixKeyMapper::to_db_partition_key(node_id, partition_number);
+        let from_sort_key = from_substate_key
+            .map(|substate_key| SpreadPrefixKeyMapper::to_db_sort_key(substate_key));
         let iter = self
             .substate_db
-            .list_entries(&partition_key)
+            .list_entries_from(&partition_key, from_sort_key.as_ref())
             .filter_map(move |entry| {
                 let key = match schema {
                     BlueprintCollectionSchema::KeyValueStore(..)


### PR DESCRIPTION
This **non-breaking, internal-only change** PR adds a `list_entries_from(from_sort_key)` next to the existing `list_entries()` in `SubstateDatabase`.

### Why?
Node needs to be capable of starting substate listing from a specific key/prefix, in order to implement pagination in Browse API endpoints (like https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3189211214/RNP-12+-+Browse+API+sub-API+within+Core+API#5.-Object-Collection-Listing).
Node could reach out directly to its RocksDB (and avoid changes to `SubstateDatabase` interface), but Node tries hard (successfully) to implement Browse API through the Engine's `SystemDatabaseReader` API, and that's why I prefer to propagate this change here.
The exact Node `TODO`: https://github.com/radixdlt/babylon-node/pull/741/files#diff-148a2d8426fe568c7f0cab8adda124b9958ea5f3bc23e41c490d566bc8ffe103R822
