### PR TITLE
Adding the remaining "partial conversion" methods to `DatabaseKeyMapp…

### DIFF
--- a/radix-engine-store-interface/src/db_key_mapper.rs
+++ b/radix-engine-store-interface/src/db_key_mapper.rs
@@ -100,7 +100,9 @@ impl DatabaseKeyMapper for SpreadPrefixKeyMapper {
     }
 
     fn from_db_node_key(db_node_key: &DbNodeKey) -> NodeId {
-        NodeId(copy_u8_array(SpreadPrefixKeyMapper::from_hash_prefixed(db_node_key)))
+        NodeId(copy_u8_array(SpreadPrefixKeyMapper::from_hash_prefixed(
+            db_node_key,
+        )))
     }
 
     fn to_db_partition_num(partition_num: PartitionNumber) -> DbPartitionNum {


### PR DESCRIPTION
This **non-breaking, internal-only change** PR adds some "missing" partial-conversion methods to the  `DatabaseKeyMapper` (i.e. `from_db_node_key(), from_db_partition_num()`).

### Why?
Node's new Browse API needs to list "entity addresses" (see https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3189211214/RNP-12+-+Browse+API+sub-API+within+Core+API#1.-Entity-Listing), which are effectively RE Node IDs, converted from DB Node keys. The Engine's mapper so far only provided the conversion for a `(DB Node key, DB partition num)` pair, which forced Node to use a mild-but-avoidable hack.
The exact Node `TODO`: https://github.com/radixdlt/babylon-node/pull/736/files#diff-148a2d8426fe568c7f0cab8adda124b9958ea5f3bc23e41c490d566bc8ffe103R279
