### PR TITLE
Update `scrypto-bindgen` implementation

### DIFF
--- a/simulator/src/scrypto_bindgen/ast.rs
+++ b/simulator/src/scrypto_bindgen/ast.rs
@@ -1,17 +1,37 @@
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, ToTokens};
-use radix_engine_interface::types::PackageAddress;
+use proc_macro2::*;
+use quote::*;
+use radix_engine_interface::prelude::*;
+
+use crate::token_stream_from_str;
+
+pub struct PackageStub {
+    pub blueprints: Vec<BlueprintStub>,
+    pub auxiliary_types: Vec<AuxiliaryType>,
+}
+
+impl ToTokens for PackageStub {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let blueprints = &self.blueprints;
+        let auxiliary_types = &self.auxiliary_types;
+        quote! {
+            #(#blueprints)*
+            #(#auxiliary_types)*
+        }
+        .to_tokens(tokens)
+    }
+}
 
 /// Objects of this struct are generated as part of the generation process. This struct can then be
 /// used inside the quote macro and printed out.
 pub struct BlueprintStub {
     pub blueprint_name: String,
     pub fn_signatures: Vec<FnSignature>,
+    pub package_address: PackageAddress,
 }
 
-impl BlueprintStub {
-    pub fn to_token_stream(&self, package_address: PackageAddress) -> TokenStream {
-        let package_address_bytes = package_address.to_vec();
+impl ToTokens for BlueprintStub {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let package_address_bytes = self.package_address.to_vec();
         let blueprint_name = self.blueprint_name.clone();
         let owned_blueprint_name = format!("Owned{}", self.blueprint_name);
         let global_blueprint_name = format!("Global{}", self.blueprint_name);
@@ -49,13 +69,14 @@ impl BlueprintStub {
                 }
             }
         }
+        .to_tokens(tokens)
     }
 }
 
 pub struct FnSignature {
     pub ident: syn::Ident,
-    pub inputs: Vec<(syn::Ident, proc_macro2::TokenStream)>,
-    pub output: proc_macro2::TokenStream,
+    pub inputs: Vec<(syn::Ident, TokenStream)>,
+    pub output: TokenStream,
     pub fn_type: FnType,
 }
 
@@ -65,7 +86,7 @@ pub enum FnType {
 }
 
 impl ToTokens for FnSignature {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let ident = &self.ident;
         let input_names = &self.inputs.iter().map(|(k, _)| k).collect::<Vec<_>>();
         let input_types = &self.inputs.iter().map(|(_, v)| v).collect::<Vec<_>>();
@@ -94,6 +115,156 @@ impl ToTokens for FnSignature {
                 fn #ident( &self #sep #( #input_names: #input_types ),* ) -> #output
             }
             .to_tokens(tokens),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuxiliaryType {
+    TupleStruct {
+        struct_name: String,
+        field_types: Vec<String>,
+    },
+    NamedFieldsStruct {
+        struct_name: String,
+        fields: IndexMap<String, String>,
+    },
+    Enum {
+        enum_name: String,
+        variants: Vec<EnumVariant>,
+    },
+}
+
+impl ToTokens for AuxiliaryType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::TupleStruct {
+                struct_name,
+                field_types,
+            } => {
+                let struct_name = token_stream_from_str!(struct_name);
+                let field_types = field_types
+                    .iter()
+                    .map(|string| token_stream_from_str!(string));
+
+                quote! {
+                    #[derive(::scrypto::prelude::ScryptoSbor)]
+                    pub struct #struct_name(
+                        #(
+                            #field_types
+                        ),*
+                    );
+                }
+                .to_tokens(tokens)
+            }
+            Self::NamedFieldsStruct {
+                struct_name,
+                fields,
+            } => {
+                let struct_name = token_stream_from_str!(struct_name);
+                let field_names = fields.keys().map(|string| token_stream_from_str!(string));
+                let field_types = fields.values().map(|string| token_stream_from_str!(string));
+
+                quote! {
+                    #[derive(::scrypto::prelude::ScryptoSbor)]
+                    pub struct #struct_name {
+                        #(
+                            #field_names: #field_types
+                        ),*
+                    }
+                }
+                .to_tokens(tokens)
+            }
+            Self::Enum {
+                enum_name,
+                variants,
+            } => {
+                let enum_name = token_stream_from_str!(enum_name);
+
+                quote! {
+                    #[derive(::scrypto::prelude::ScryptoSbor)]
+                    pub enum #enum_name {
+                        #(
+                            #variants
+                        ),*
+                    }
+                }
+                .to_tokens(tokens)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnumVariant {
+    Unit {
+        variant_name: String,
+        variant_index: u8,
+    },
+    Tuple {
+        variant_name: String,
+        variant_index: u8,
+        field_types: Vec<String>,
+    },
+    NamedFields {
+        variant_name: String,
+        variant_index: u8,
+        fields: IndexMap<String, String>,
+    },
+}
+
+impl ToTokens for EnumVariant {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Unit {
+                variant_name,
+                variant_index,
+            } => {
+                let variant_name = token_stream_from_str!(variant_name);
+                quote! {
+                    #[sbor(discriminator( #variant_index ))]
+                    #variant_name
+                }
+                .to_tokens(tokens)
+            }
+            Self::Tuple {
+                variant_name,
+                variant_index,
+                field_types,
+            } => {
+                let variant_name = token_stream_from_str!(variant_name);
+                let field_types = field_types
+                    .iter()
+                    .map(|string| token_stream_from_str!(string));
+                quote! {
+                    #[sbor(discriminator( #variant_index ))]
+                    #variant_name (
+                        #(
+                            #field_types
+                        ),*
+                    )
+                }
+                .to_tokens(tokens)
+            }
+            Self::NamedFields {
+                variant_name,
+                variant_index,
+                fields,
+            } => {
+                let variant_name = token_stream_from_str!(variant_name);
+                let field_names = fields.keys().map(|string| token_stream_from_str!(string));
+                let field_types = fields.values().map(|string| token_stream_from_str!(string));
+
+                quote! {
+                    #[sbor(discriminator( #variant_index ))]
+                    #variant_name {
+                        #(
+                            #field_names: #field_types
+                        ),*
+                    }
+                }
+                .to_tokens(tokens)
+            }
         }
     }
 }

--- a/simulator/src/scrypto_bindgen/macros.rs
+++ b/simulator/src/scrypto_bindgen/macros.rs
@@ -1,0 +1,14 @@
+#[macro_export]
+macro_rules! token_stream_from_str {
+    ($string: expr) => {
+        <proc_macro2::TokenStream as std::str::FromStr>::from_str($string)
+            .expect("Obtained from schema, must be valid!")
+    };
+}
+
+#[macro_export]
+macro_rules! ident {
+    ($ident: expr) => {
+        syn::Ident::new($ident, proc_macro2::Span::call_site())
+    };
+}

--- a/simulator/src/scrypto_bindgen/mod.rs
+++ b/simulator/src/scrypto_bindgen/mod.rs
@@ -1,6 +1,7 @@
-mod ast;
-mod schema;
-mod translation;
+pub mod ast;
+pub mod macros;
+pub mod schema;
+pub mod translation;
 
 use clap::Parser;
 use radix_engine::system::{bootstrap::*, system_db_reader::SystemDatabaseReader};
@@ -14,7 +15,6 @@ use std::io::Write;
 use crate::resim::*;
 
 use self::schema::*;
-use self::translation::blueprint_schema_interface_to_ast_interface;
 
 /// Generates interfaces for Scrypto packages to ease the use of external packages.
 #[derive(Parser, Debug)]
@@ -79,27 +79,30 @@ pub fn run() -> Result<(), Error> {
     let bindings = {
         let reader = SystemDatabaseReader::new(&substate_db);
         let definition = reader.get_package_definition(package_address);
+        let schema_resolver = SchemaResolver::new(package_address, &substate_db);
 
-        let schema_resolver = SchemaResolver::new(package_address, reader);
-        derive_blueprint_interfaces(definition, &schema_resolver)
-            .map_err(Error::SchemaError)?
-            .into_iter()
-            .map(|blueprint_interface| {
-                blueprint_schema_interface_to_ast_interface(blueprint_interface, &schema_resolver)
-                    .map(|blueprint_interface| blueprint_interface.to_token_stream(package_address))
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Error::SchemaError)?
+        let package_interface =
+            schema::package_interface_from_package_definition(definition, &schema_resolver)
+                .map_err(Error::SchemaError)?;
+        let mut ast_package_interface = translation::package_schema_interface_to_ast_interface(
+            package_interface,
+            package_address,
+            &schema_resolver,
+        )
+        .map_err(Error::SchemaError)?;
+
+        // Scrypto-bindgen does not generate the aux-types. Only ledger-tools does.
+        ast_package_interface.auxiliary_types = Default::default();
+
+        ast_package_interface
     };
 
-    for binding in bindings {
-        writeln!(&mut out, "{}", binding).map_err(Error::IOError)?
-    }
+    writeln!(&mut out, "{}", quote::quote!(#bindings)).map_err(Error::IOError)?;
 
     Ok(())
 }
 
-struct SchemaResolver<'s, S>(PackageAddress, SystemDatabaseReader<'s, S>)
+pub struct SchemaResolver<'s, S>(PackageAddress, SystemDatabaseReader<'s, S>)
 where
     S: SubstateDatabase;
 
@@ -107,7 +110,8 @@ impl<'s, S> SchemaResolver<'s, S>
 where
     S: SubstateDatabase,
 {
-    pub fn new(node_id: PackageAddress, reader: SystemDatabaseReader<'s, S>) -> Self {
+    pub fn new(node_id: PackageAddress, substate_database: &'s S) -> Self {
+        let reader = SystemDatabaseReader::new(substate_database);
         Self(node_id, reader)
     }
 }
@@ -116,11 +120,8 @@ impl<'s, S> PackageSchemaResolver for SchemaResolver<'s, S>
 where
     S: SubstateDatabase,
 {
-    fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<VersionedScryptoSchema> {
-        self.1
-            .get_schema(self.0.as_node_id(), schema_hash)
-            .ok()
-            .map(|x| x.as_ref().clone())
+    fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<Rc<VersionedScryptoSchema>> {
+        self.1.get_schema(self.0.as_node_id(), schema_hash).ok()
     }
 
     fn resolve_type_kind(
@@ -128,10 +129,13 @@ where
         type_identifier: &ScopedTypeId,
     ) -> Result<SchemaTypeKind<ScryptoCustomSchema>, schema::SchemaError> {
         self.lookup_schema(&type_identifier.0)
-            .ok_or(SchemaError::FailedToGetSchemaFromSchemaHash)?
-            .into_latest()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
+            .as_latest_ref()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
             .resolve_type_kind(type_identifier.1)
-            .ok_or(SchemaError::NonExistentLocalTypeIndex(type_identifier.1))
+            .ok_or(schema::SchemaError::NonExistentLocalTypeIndex(
+                type_identifier.1,
+            ))
             .cloned()
     }
 
@@ -140,10 +144,13 @@ where
         type_identifier: &ScopedTypeId,
     ) -> Result<TypeMetadata, schema::SchemaError> {
         self.lookup_schema(&type_identifier.0)
-            .ok_or(SchemaError::FailedToGetSchemaFromSchemaHash)?
-            .into_latest()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
+            .as_latest_ref()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
             .resolve_type_metadata(type_identifier.1)
-            .ok_or(SchemaError::NonExistentLocalTypeIndex(type_identifier.1))
+            .ok_or(schema::SchemaError::NonExistentLocalTypeIndex(
+                type_identifier.1,
+            ))
             .cloned()
     }
 
@@ -152,10 +159,13 @@ where
         type_identifier: &ScopedTypeId,
     ) -> Result<TypeValidation<ScryptoCustomTypeValidation>, schema::SchemaError> {
         self.lookup_schema(&type_identifier.0)
-            .ok_or(SchemaError::FailedToGetSchemaFromSchemaHash)?
-            .into_latest()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
+            .as_latest_ref()
+            .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
             .resolve_type_validation(type_identifier.1)
-            .ok_or(SchemaError::NonExistentLocalTypeIndex(type_identifier.1))
+            .ok_or(schema::SchemaError::NonExistentLocalTypeIndex(
+                type_identifier.1,
+            ))
             .cloned()
     }
 

--- a/simulator/src/scrypto_bindgen/schema.rs
+++ b/simulator/src/scrypto_bindgen/schema.rs
@@ -3,10 +3,9 @@ use std::fmt::{Debug, Display};
 
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::prelude::*;
-use sbor::prelude::IndexMap;
 
 pub trait PackageSchemaResolver {
-    fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<VersionedScryptoSchema>;
+    fn lookup_schema(&self, schema_hash: &SchemaHash) -> Option<Rc<VersionedScryptoSchema>>;
 
     fn resolve_type_kind(
         &self,
@@ -26,89 +25,131 @@ pub trait PackageSchemaResolver {
     fn package_address(&self) -> PackageAddress;
 }
 
-pub fn derive_blueprint_interfaces<S>(
+pub fn package_interface_from_package_definition<S>(
     package_definition: BTreeMap<BlueprintVersionKey, BlueprintDefinition>,
     schema_resolver: &S,
-) -> Result<Vec<BlueprintInterface>, SchemaError>
+) -> Result<PackageInterface, SchemaError>
 where
     S: PackageSchemaResolver,
 {
-    let mut blueprint_interfaces = vec![];
+    let mut package_interface = PackageInterface::default();
 
     for (blueprint_key, blueprint_definition) in package_definition.into_iter() {
-        let blueprint_ident = blueprint_key.blueprint;
+        let blueprint_name = blueprint_key.blueprint;
 
-        let mut functions = vec![];
-        for (fn_ident, fn_schema) in blueprint_definition.interface.functions {
-            let BlueprintPayloadDef::Static(args_type_identifier) = &fn_schema.input else {
+        if let Some((_, fields)) = blueprint_definition.interface.state.fields {
+            for field in fields {
+                if let BlueprintPayloadDef::Static(scoped_type_id) = field.field {
+                    package_interface.auxiliary_types.insert(scoped_type_id);
+                }
+            }
+        }
+
+        let functions = &mut package_interface
+            .blueprints
+            .entry(blueprint_name)
+            .or_default()
+            .functions;
+
+        for (function_name, function_schema) in blueprint_definition.interface.functions {
+            let BlueprintPayloadDef::Static(input_type_identifier) = &function_schema.input else {
                 Err(SchemaError::GenericTypeRefsNotSupported)?
             };
 
-            // Arg types
-            let arg_type_indices = {
-                let args_type_kind = schema_resolver.resolve_type_kind(args_type_identifier)?;
-                if let TypeKind::Tuple { field_types } = args_type_kind {
-                    Ok(field_types)
+            // Input Types
+            let inputs_scoped_type_id = {
+                let type_kind = schema_resolver.resolve_type_kind(input_type_identifier)?;
+                if let TypeKind::Tuple { field_types } = type_kind {
+                    Ok(field_types
+                        .into_iter()
+                        .map(|local_type_id| ScopedTypeId(input_type_identifier.0, local_type_id))
+                        .collect::<Vec<_>>())
                 } else {
-                    Err(SchemaError::FunctionInputIsNotATuple(*args_type_identifier))
+                    Err(SchemaError::FunctionInputIsNotATuple(
+                        *input_type_identifier,
+                    ))
                 }
             }?;
 
-            // Arg Names
-            let arg_names = {
-                let args_type_metadata =
-                    schema_resolver.resolve_type_metadata(args_type_identifier)?;
-                args_type_metadata
-                    .child_names
-                    .as_ref()
-                    .map_or(Vec::new(), |names| match names {
-                        ChildNames::NamedFields(named_fields) => named_fields
-                            .iter()
-                            .map(|v| v.clone().into_owned())
-                            .collect(),
-                        ChildNames::EnumVariants(..) => panic!("Impossible Case"),
-                    })
+            // Input Field Names
+            let inputs_field_names = {
+                let type_metadata = schema_resolver.resolve_type_metadata(input_type_identifier)?;
+                match type_metadata.child_names.as_ref() {
+                    /* Encountered a struct with field names, return them. */
+                    Some(ChildNames::NamedFields(field_names)) => field_names
+                        .iter()
+                        .map(|entry| entry.as_ref().to_owned())
+                        .collect::<Vec<_>>(),
+                    /* A struct that has enum variants?? */
+                    Some(ChildNames::EnumVariants(..)) => {
+                        panic!(
+                            "We have checked that this is a Tuple and it can't have enum variants."
+                        )
+                    }
+                    /* Encountered a tuple-struct. Generate field names as `arg{n}` */
+                    None => (0..inputs_scoped_type_id.len())
+                        .map(|i| format!("arg{i}"))
+                        .collect::<Vec<_>>(),
+                }
             };
 
-            assert_eq!(
-                arg_names.len(),
-                arg_type_indices.len(),
-                "Arg names length != arg names type identifiers length"
-            );
+            // Output types
+            let BlueprintPayloadDef::Static(output_local_type_index) = &function_schema.output
+            else {
+                return Err(SchemaError::GenericTypeRefsNotSupported);
+            };
+
+            // Auxiliary types
+            // The auxiliary types are found by walking the input and output of each function and
+            // storing the type-ids encountered in the inputs and outputs.
+            for input_type in inputs_scoped_type_id.iter() {
+                get_scoped_type_ids_in_path(
+                    input_type,
+                    schema_resolver,
+                    &mut package_interface.auxiliary_types,
+                )?;
+            }
+            get_scoped_type_ids_in_path(
+                output_local_type_index,
+                schema_resolver,
+                &mut package_interface.auxiliary_types,
+            )?;
 
             let function = Function {
-                ident: fn_ident.to_owned(),
-                receiver: fn_schema.receiver.clone(),
-                arguments: arg_names
+                ident: function_name.to_owned(),
+                receiver: function_schema.receiver.clone(),
+                arguments: inputs_field_names
                     .into_iter()
-                    .zip(arg_type_indices.iter().map(|local_type_index| {
-                        ScopedTypeId(args_type_identifier.0, *local_type_index)
-                    }))
+                    .zip(inputs_scoped_type_id)
                     .collect::<IndexMap<String, ScopedTypeId>>(),
-                returns: if let BlueprintPayloadDef::Static(output_local_type_index) =
-                    &fn_schema.output
-                {
-                    *output_local_type_index
-                } else {
-                    Err(SchemaError::GenericTypeRefsNotSupported)?
-                },
+                returns: *output_local_type_index,
             };
             functions.push(function);
         }
-        blueprint_interfaces.push(BlueprintInterface {
-            functions,
-            blueprint_name: blueprint_ident.to_owned(),
-        })
     }
 
-    Ok(blueprint_interfaces)
+    Ok(package_interface)
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct PackageInterface {
+    /// The interface definition of the various blueprints contained in the package. The key is the
+    /// blueprint name and the value is the interface of the blueprint.
+    pub blueprints: IndexMap<String, BlueprintInterface>,
+    /// A set of [`ScopedTypeId`] of the auxiliary types found in the package interface. Auxiliary
+    /// types are types which appear somewhere in the interface of the package. As an example, an
+    /// enum that appears as a function input that requires generation for the interface to make
+    /// sense.
+    pub auxiliary_types: HashSet<ScopedTypeId>,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct BlueprintInterface {
-    pub blueprint_name: String,
+    /// The functions and methods encountered in the blueprint interface.
     pub functions: Vec<Function>,
 }
 
+#[derive(Clone, Debug)]
 pub struct Function {
     pub ident: String,
     pub receiver: Option<ReceiverInfo>,
@@ -116,11 +157,76 @@ pub struct Function {
     pub returns: ScopedTypeId,
 }
 
+fn get_scoped_type_ids_in_path<S>(
+    type_id: &ScopedTypeId,
+    schema_resolver: &S,
+    collection: &mut HashSet<ScopedTypeId>,
+) -> Result<(), SchemaError>
+where
+    S: PackageSchemaResolver,
+{
+    if !collection.insert(*type_id) {
+        return Ok(());
+    }
+
+    let type_kind = schema_resolver.resolve_type_kind(type_id)?;
+
+    match type_kind {
+        TypeKind::Any
+        | TypeKind::Bool
+        | TypeKind::I8
+        | TypeKind::I16
+        | TypeKind::I32
+        | TypeKind::I64
+        | TypeKind::I128
+        | TypeKind::U8
+        | TypeKind::U16
+        | TypeKind::U32
+        | TypeKind::U64
+        | TypeKind::U128
+        | TypeKind::String
+        | TypeKind::Custom(ScryptoCustomTypeKind::Reference)
+        | TypeKind::Custom(ScryptoCustomTypeKind::Own)
+        | TypeKind::Custom(ScryptoCustomTypeKind::Decimal)
+        | TypeKind::Custom(ScryptoCustomTypeKind::PreciseDecimal)
+        | TypeKind::Custom(ScryptoCustomTypeKind::NonFungibleLocalId) => {}
+        TypeKind::Array { element_type } => {
+            let scoped_type_id = ScopedTypeId(type_id.0, element_type);
+            get_scoped_type_ids_in_path(&scoped_type_id, schema_resolver, collection)?;
+        }
+        TypeKind::Tuple { field_types } => {
+            for field_type in field_types {
+                let scoped_type_id = ScopedTypeId(type_id.0, field_type);
+                get_scoped_type_ids_in_path(&scoped_type_id, schema_resolver, collection)?;
+            }
+        }
+        TypeKind::Enum { variants } => {
+            for field_types in variants.values() {
+                for field_type in field_types {
+                    let scoped_type_id = ScopedTypeId(type_id.0, *field_type);
+                    get_scoped_type_ids_in_path(&scoped_type_id, schema_resolver, collection)?;
+                }
+            }
+        }
+        TypeKind::Map {
+            key_type,
+            value_type,
+        } => {
+            let scoped_type_id = ScopedTypeId(type_id.0, key_type);
+            get_scoped_type_ids_in_path(&scoped_type_id, schema_resolver, collection)?;
+
+            let scoped_type_id = ScopedTypeId(type_id.0, value_type);
+            get_scoped_type_ids_in_path(&scoped_type_id, schema_resolver, collection)?;
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Clone, Debug)]
 pub enum SchemaError {
     FunctionInputIsNotATuple(ScopedTypeId),
     NonExistentLocalTypeIndex(LocalTypeId),
-    SchemaValidationError(SchemaValidationError),
     FailedToGetSchemaFromSchemaHash,
     GenericTypeRefsNotSupported,
     NoNameFound,


### PR DESCRIPTION
## Summary

Move the updated stubs generation logic from `ledger-tools` and into this repo such that both `ledger-tools` and `scrypto-bindgen` use the same logic. This is related to radixdlt/ledger-tools#10