### PR TITLE
Add costing to `CryptoUtils` API

### DIFF
--- a/radix-engine-profiling/resources-tracker-macro/scripts/run_tests.sh
+++ b/radix-engine-profiling/resources-tracker-macro/scripts/run_tests.sh
@@ -4,7 +4,7 @@
 
 qemu_app=/home/ubuntu/qemu/qemu-x86_64
 qemu_plugin=/home/ubuntu/qemu/libscrypto-qemu-plugin.so
-qemu_cpu="Westmere-v1"
+#qemu_cpu="Westmere-v1" # disabled due to some issue with missing CPU instructions in BLS implementation
 
 if [ -z "$*" ]; then echo "Provide path to folder with binaries to execute."; exit; fi
 
@@ -18,7 +18,7 @@ for i in $list; do [ -x $i ] && list_count=$((list_count+1)); done
 for i in $list; do
     if [ -x $i ]; then
         echo "Running $idx/$list_count: $i"
-        $qemu_app -cpu $qemu_cpu -plugin $qemu_plugin -d plugin -D log.txt $i --show-output --test --test-threads 1 > out.txt
+        $qemu_app -plugin $qemu_plugin -d plugin -D log.txt $i --show-output --test --test-threads 1 > out.txt
         idx=$((idx+1))
     fi
 done

--- a/radix-engine-tests/tests/system/crypto_utils.rs
+++ b/radix-engine-tests/tests/system/crypto_utils.rs
@@ -24,6 +24,36 @@ macro_rules! get_failure {
     };
 }
 
+fn get_aggregate_verify_test_data(
+    cnt: u32,
+    msg_size: usize,
+) -> (
+    Vec<Bls12381G1PrivateKey>,
+    Vec<Bls12381G1PublicKey>,
+    Vec<Vec<u8>>,
+    Vec<Bls12381G2Signature>,
+) {
+    let sks: Vec<Bls12381G1PrivateKey> = (1..(cnt + 1))
+        .map(|i| Bls12381G1PrivateKey::from_u64(i.into()).unwrap())
+        .collect();
+
+    let msgs: Vec<Vec<u8>> = (1..(cnt + 1))
+        .map(|i| {
+            let u: u8 = (i % u8::MAX as u32) as u8;
+            vec![u; msg_size]
+        })
+        .collect();
+    let sigs: Vec<Bls12381G2Signature> = sks
+        .iter()
+        .zip(msgs.clone())
+        .map(|(sk, msg)| sk.sign_v1(&msg))
+        .collect();
+
+    let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
+
+    (sks, pks, msgs, sigs)
+}
+
 fn crypto_scrypto_bls12381_v1_verify(
     runner: &mut TestRunner<NoExtension, InMemorySubstateDatabase>,
     package_address: PackageAddress,
@@ -180,18 +210,7 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate() {
 
     let package_address = test_runner.publish_package_simple(PackageLoader::get("crypto_scrypto"));
 
-    let sks: Vec<Bls12381G1PrivateKey> = (1..11)
-        .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())
-        .collect();
-
-    // Multiple messages
-    let msgs: Vec<Vec<u8>> = (1u8..11).map(|i| vec![i; 10]).collect();
-
-    let sigs: Vec<Bls12381G2Signature> = sks
-        .iter()
-        .zip(msgs.clone())
-        .map(|(sk, msg)| sk.sign_v1(&msg))
-        .collect();
+    let (_sks, _pks, _msgs, sigs) = get_aggregate_verify_test_data(10, 10);
 
     // Aggregate the signature
     let agg_sig_multiple_msgs = Bls12381G2Signature::aggregate(&sigs).unwrap();
@@ -202,6 +221,9 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate() {
             .expect_commit_success()
             .output(1);
 
+    // Assert
+    assert_eq!(agg_sig_multiple_msgs, agg_sig_from_scrypto);
+
     // Attempt to aggregate signature from empty input
     let error_message =
         crypto_scrypto_bls12381_g2_signature_aggregate(&mut test_runner, package_address, vec![])
@@ -211,7 +233,6 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate() {
             .to_string();
 
     // Assert
-    assert_eq!(agg_sig_multiple_msgs, agg_sig_from_scrypto);
     assert!(error_message.contains("InputDataEmpty"));
 }
 
@@ -222,20 +243,7 @@ fn test_crypto_scrypto_bls12381_aggregate_verify() {
 
     let package_address = test_runner.publish_package_simple(PackageLoader::get("crypto_scrypto"));
 
-    let sks: Vec<Bls12381G1PrivateKey> = (1..11)
-        .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())
-        .collect();
-
-    // Multiple messages
-    let msgs: Vec<Vec<u8>> = (1u8..11).map(|i| vec![i; 10]).collect();
-
-    let sigs: Vec<Bls12381G2Signature> = sks
-        .iter()
-        .zip(msgs.clone())
-        .map(|(sk, msg)| sk.sign_v1(&msg))
-        .collect();
-
-    let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
+    let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(10, 10);
 
     // Aggregate the signature
     let agg_sig_multiple_msgs = Bls12381G2Signature::aggregate(&sigs).unwrap();
@@ -554,21 +562,8 @@ fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("crypto_scrypto"));
 
     for msg_size in [100usize, 200, 500, 1024, 10 * 1024, 20 * 1024] {
-        for cnt in [1u8, 2, 5, 10, 20] {
-            let sks: Vec<Bls12381G1PrivateKey> = (1..(cnt + 1))
-                .map(|i| Bls12381G1PrivateKey::from_u64(i.into()).unwrap())
-                .collect();
-
-            // Multiple messages
-            let msgs: Vec<Vec<u8>> = (1..(cnt + 1)).map(|i| vec![i; msg_size]).collect();
-
-            let sigs: Vec<Bls12381G2Signature> = sks
-                .iter()
-                .zip(msgs.clone())
-                .map(|(sk, msg)| sk.sign_v1(&msg))
-                .collect();
-
-            let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
+        for cnt in [1u32, 2, 5, 10, 20] {
+            let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(cnt, msg_size);
 
             let agg_sig_multiple_msgs = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
@@ -581,6 +576,67 @@ fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
             );
         }
     }
+}
+
+#[test]
+fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing_2() {
+    let mut test_runner = TestRunnerBuilder::new().build();
+
+    let package_address = test_runner.publish_package_simple(PackageLoader::get("crypto_scrypto"));
+
+    for (cnt, msg_size) in [
+        (1, 100 * 1024),
+        (2, 50 * 1024),
+        (5, 20 * 1024),
+        (10, 10 * 1024),
+        (100, 1024),
+        (1024, 100),
+    ] {
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(cnt, msg_size);
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
+
+        let _ = crypto_scrypto_bls12381_v1_aggregate_verify(
+            &mut test_runner,
+            package_address,
+            msgs,
+            pks,
+            agg_sig,
+        );
+    }
+
+    // 1x 99kB and 1000x1B
+    let (mut sks1, mut pks1, mut msgs1, mut sigs1) = get_aggregate_verify_test_data(1, 99 * 1024);
+    let (mut sks2, mut pks2, mut msgs2, mut sigs2) = get_aggregate_verify_test_data(1000, 1);
+    sks1.append(&mut sks2);
+    pks1.append(&mut pks2);
+    msgs1.append(&mut msgs2);
+    sigs1.append(&mut sigs2);
+    let agg_sig = Bls12381G2Signature::aggregate(&sigs1).unwrap();
+
+    let _ = crypto_scrypto_bls12381_v1_aggregate_verify(
+        &mut test_runner,
+        package_address,
+        msgs1,
+        pks1,
+        agg_sig,
+    );
+
+    // 1x 90kB and 10 x 1kB
+    let (mut sks1, mut pks1, mut msgs1, mut sigs1) = get_aggregate_verify_test_data(1, 90 * 1024);
+    let (mut sks2, mut pks2, mut msgs2, mut sigs2) = get_aggregate_verify_test_data(10, 1024);
+    sks1.append(&mut sks2);
+    pks1.append(&mut pks2);
+    msgs1.append(&mut msgs2);
+    sigs1.append(&mut sigs2);
+    let agg_sig = Bls12381G2Signature::aggregate(&sigs1).unwrap();
+
+    let _ = crypto_scrypto_bls12381_v1_aggregate_verify(
+        &mut test_runner,
+        package_address,
+        msgs1,
+        pks1,
+        agg_sig,
+    );
 }
 
 #[test]

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -252,6 +252,7 @@ pub enum SystemError {
     BlueprintTypeNotFound(String),
 
     BlsError(String),
+    InputDataEmpty,
 
     /// A panic that's occurred in the system-layer or below. We're calling it system panic since
     /// we're treating the system as a black-box here.

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,13 +2881,17 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
-                keys_cnt: public_keys.len(),
-            },
-        )?;
-        Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+        if !messages.is_empty() && !public_keys.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381V1AggregateVerify {
+                    size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
+                    keys_cnt: public_keys.len(),
+                },
+            )?;
+            Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=message.len(), log=public_keys.len())]
@@ -2897,13 +2901,17 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
-                size: message.len(),
-                keys_cnt: public_keys.len(),
-            },
-        )?;
-        Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
+        if !public_keys.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
+                    size: message.len(),
+                    keys_cnt: public_keys.len(),
+                },
+            )?;
+            Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=signatures.len())]
@@ -2911,13 +2919,17 @@ where
         &mut self,
         signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381G2SignatureAggregate {
-                signatures_cnt: signatures.len(),
-            },
-        )?;
-        Bls12381G2Signature::aggregate(signatures)
-            .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
+        if !signatures.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381G2SignatureAggregate {
+                    signatures_cnt: signatures.len(),
+                },
+            )?;
+            Bls12381G2Signature::aggregate(signatures)
+                .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=data.len())]

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,11 +2881,10 @@ where
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
         if !pub_keys_and_msgs.is_empty() {
+            let sizes: Vec<usize> = pub_keys_and_msgs.iter().map(|(_, msg)| msg.len()).collect();
             self.api.kernel_get_system().modules.apply_execution_cost(
                 ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                    size: pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()
-                        / pub_keys_and_msgs.len(),
-                    keys_cnt: pub_keys_and_msgs.len(),
+                    sizes: sizes.as_slice(),
                 },
             )?;
             Ok(aggregate_verify_bls12381_v1(pub_keys_and_msgs, signature) as u32)

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2874,7 +2874,7 @@ where
     }
 
     // Trace average message length and number of public_keys
-    #[trace_resources(log={pub_keys_and_msgs.iter().map(|(_, msg)| msg.len()).sum::<usize>()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
+    #[trace_resources(log={pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
@@ -2883,10 +2883,7 @@ where
         if !pub_keys_and_msgs.is_empty() {
             self.api.kernel_get_system().modules.apply_execution_cost(
                 ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                    size: pub_keys_and_msgs
-                        .iter()
-                        .map(|(_, msg)| msg.len())
-                        .sum::<usize>()
+                    size: pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()
                         / pub_keys_and_msgs.len(),
                     keys_cnt: pub_keys_and_msgs.len(),
                 },

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2865,7 +2865,11 @@ where
         public_key: &Bls12381G1PublicKey,
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO: apply execution costs
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1Verify {
+                size: message.len(),
+            },
+        )?;
         Ok(verify_bls12381_v1(message, public_key, signature) as u32)
     }
 
@@ -2904,7 +2908,10 @@ where
 
     #[trace_resources(log=data.len())]
     fn keccak256_hash(&mut self, data: &[u8]) -> Result<Hash, RuntimeError> {
-        // TODO: apply execution costs
+        self.api
+            .kernel_get_system()
+            .modules
+            .apply_execution_cost(ExecutionCostingEntry::Keccak256Hash { size: data.len() })?;
         Ok(keccak256_hash(data))
     }
 }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,7 +2881,12 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO costing
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1AggregateVerify {
+                size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
+                keys_cnt: public_keys.len(),
+            },
+        )?;
         Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
     }
 
@@ -2892,7 +2897,12 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO costing
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
+                size: message.len(),
+                keys_cnt: public_keys.len(),
+            },
+        )?;
         Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
     }
 
@@ -2901,7 +2911,11 @@ where
         &mut self,
         signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        // TODO: apply execution costs
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381G2SignatureAggregate {
+                signatures_cnt: signatures.len(),
+            },
+        )?;
         Bls12381G2Signature::aggregate(signatures)
             .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
     }

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -115,6 +115,17 @@ pub enum ExecutionCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
+    Bls12381V1AggregateVerify {
+        size: usize,
+        keys_cnt: usize,
+    },
+    Bls12381V1FastAggregateVerify {
+        size: usize,
+        keys_cnt: usize,
+    },
+    Bls12381G2SignatureAggregate {
+        signatures_cnt: usize,
+    },
     Keccak256Hash {
         size: usize,
     },
@@ -181,6 +192,15 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            ExecutionCostingEntry::Bls12381V1AggregateVerify { size, keys_cnt } => {
+                ft.bls12381_v1_aggregate_verify_cost(*size, *keys_cnt)
+            }
+            ExecutionCostingEntry::Bls12381V1FastAggregateVerify { size, keys_cnt } => {
+                ft.bls12381_v1_fast_aggregate_verify_cost(*size, *keys_cnt)
+            }
+            ExecutionCostingEntry::Bls12381G2SignatureAggregate { signatures_cnt } => {
+                ft.bls12381_g2_signature_aggregate_cost(*signatures_cnt)
+            }
             ExecutionCostingEntry::Keccak256Hash { size } => ft.keccak256_hash_cost(*size),
         }
     }

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -116,8 +116,7 @@ pub enum ExecutionCostingEntry<'a> {
         size: usize,
     },
     Bls12381V1AggregateVerify {
-        size: usize,
-        keys_cnt: usize,
+        sizes: &'a [usize],
     },
     Bls12381V1FastAggregateVerify {
         size: usize,
@@ -192,8 +191,8 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
-            ExecutionCostingEntry::Bls12381V1AggregateVerify { size, keys_cnt } => {
-                ft.bls12381_v1_aggregate_verify_cost(*size, *keys_cnt)
+            ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
+                ft.bls12381_v1_aggregate_verify_cost(sizes)
             }
             ExecutionCostingEntry::Bls12381V1FastAggregateVerify { size, keys_cnt } => {
                 ft.bls12381_v1_fast_aggregate_verify_cost(*size, *keys_cnt)

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -110,6 +110,14 @@ pub enum ExecutionCostingEntry<'a> {
     Panic {
         size: usize,
     },
+
+    /* crypto utils */
+    Bls12381V1Verify {
+        size: usize,
+    },
+    Keccak256Hash {
+        size: usize,
+    },
 }
 
 #[derive(Debug, IntoStaticStr)]
@@ -172,6 +180,8 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitEvent { size } => ft.emit_event_cost(*size),
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
+            ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            ExecutionCostingEntry::Keccak256Hash { size } => ft.keccak256_hash_cost(*size),
         }
     }
 }

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -386,14 +386,63 @@ impl FeeTable {
         // Based on  `test_crypto_scrypto_verify_bls12381_v1_costing`
         // - For sizes less than 1024, instruction count remains the same.
         // - For greater sizes following linear equation might be applied:
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
         //   instructions_cnt = 34.55672 * size + 10577803.13
         //   Lets round:
         //    34.55672       -> 35
         //    10577803.13    -> 10577804
         let size = if size < 1024 { 1024 } else { cast(size) };
-        let instructions_cnt = mul(size, 35) + 10577804;
+        let instructions_cnt = add(mul(size, 35), 10577804);
         // Convert to cost units
-        div(instructions_cnt, CPU_INSTRUCTIONS_TO_COST_UNIT)
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_v1_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_v1_aggregate_verify_costing`
+        // - For sizes less than 1024, instruction count remains the same.
+        // - For greater sizes following linear equation might be applied:
+        //   instructions_cnt = 87.3416 * size + 1438527.7574 * keys_cnt + 9058827.9112
+        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
+        //   Lets round:
+        //    87.3416      -> 88
+        //    1438527.757  -> 1438528
+        //    9058827.911  -> 9058828
+        let size = if size < 1024 { 1024 } else { cast(size) };
+        let instructions_cnt = add(add(mul(size, 88), mul(cast(keys_cnt), 1438528)), 9058828);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_v1_fast_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_v1_fast_aggregate_verify_costing`
+        // - For sizes less than 1024, instruction count remains the same.
+        // - For greater sizes following linear equation might be applied:
+        //   instructions_cnt = 32.1717 * size + 624919.5254 * keys_cnt + 9058827.9112
+        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
+        //   Lets round:
+        //    32.1717      -> 33
+        //    624919.5254  -> 624920
+        //    10096964.55  -> 10096965
+        let size = if size < 1024 { 1024 } else { cast(size) };
+        let instructions_cnt = add(add(mul(size, 33), mul(cast(keys_cnt), 624920)), 10096965);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_g2_signature_aggregate_cost(&self, signatures_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_g2_signature_aggregate_costing`
+        // Following linear equation might be applied:
+        //   instructions_cnt = 879553.91557 * signatures_cnt - 567872.58948
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
+        //   Lets round:
+        //    879553.91557 -> 879554
+        //    567872.5895  -> 567873
+        let instructions_cnt = sub(mul(cast(signatures_cnt), 879554), 567873);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
     }
 
     #[inline]
@@ -402,13 +451,14 @@ impl FeeTable {
         // - For sizes less than 100, instruction count remains the same.
         // - For greater sizes following linear equation might be applied:
         //   instructions_cnt = 46.41919 * size + 2641.66077
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
         //   Lets round:
         //     46.41919  -> 47
         //     2641.66077 -> 2642
         let size = if size < 100 { 100 } else { cast(size) };
-        let instructions_cnt = mul(size, 47) + 2642;
+        let instructions_cnt = add(mul(size, 47), 2642);
         // Convert to cost units
-        div(instructions_cnt, CPU_INSTRUCTIONS_TO_COST_UNIT)
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
     }
 
     //======================
@@ -458,11 +508,11 @@ fn add(a: u32, b: u32) -> u32 {
 }
 
 #[inline]
-fn mul(a: u32, b: u32) -> u32 {
-    a.checked_mul(b).unwrap_or(u32::MAX)
+fn sub(a: u32, b: u32) -> u32 {
+    a.checked_sub(b).unwrap_or(u32::MAX)
 }
 
 #[inline]
-fn div(a: u32, b: u32) -> u32 {
-    a.checked_div(b).unwrap_or(u32::MAX)
+fn mul(a: u32, b: u32) -> u32 {
+    a.checked_mul(b).unwrap_or(u32::MAX)
 }

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -398,20 +398,17 @@ impl FeeTable {
     }
 
     #[inline]
-    pub fn bls12381_v1_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
-        // Based on  `test_crypto_scrypto_bls12381_v1_aggregate_verify_costing`
-        // - For sizes less than 1024, instruction count remains the same.
-        // - For greater sizes following linear equation might be applied:
-        //   instructions_cnt = 87.3416 * size + 1438527.7574 * keys_cnt + 9058827.9112
-        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
-        //   Lets round:
-        //    87.3416      -> 88
-        //    1438527.757  -> 1438528
-        //    9058827.911  -> 9058828
-        let size = if size < 1024 { 1024 } else { cast(size) };
-        let instructions_cnt = add(add(mul(size, 88), mul(cast(keys_cnt), 1438528)), 9058828);
-        // Convert to cost units
-        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    pub fn bls12381_v1_aggregate_verify_cost(&self, sizes: &[usize]) -> u32 {
+        // Below approach does not take aggregation into account.
+        // Summing costs pers size gives greater values.
+        // We've found somewhat difficult to find a proper and effective equation to estimate
+        // the instructions count collected with `test_crypto_scrypto_verify_bls12381_v1_costing`
+        // TODO: Find more adequate cost estimation
+        let mut cost: u32 = 0;
+        for size in sizes {
+            cost += self.bls12381_v1_verify_cost(*size);
+        }
+        cost
     }
 
     #[inline]


### PR DESCRIPTION
## Summary
Costing is based on instruction count measured by [QEMU costing job](https://github.com/radixdlt/radixdlt-scrypto/actions/runs/7410771396)

## Details

For methods that rely on one input [this regression calculator](https://www.socscistatistics.com/tests/regression/default.aspx) was used
Methods:
- `bls12381_v1_verify_cost()` - costing depends on message size
- `bls12381_g2_signature_aggregate_cost()` - depends on signatures count
- `keccak256_hash_cost()` - depends on message size

For methods that rely on two input [this multiple regression calculator](https://www.socscistatistics.com/tests/multipleregression/default.aspx) was used
Methods:
- `bls12381_v1_aggregate_verify_cost()` - costing depends on messages sizes (used average message size for simplicity) and keys count
- `bls12381_v1_fast_aggregate_verify_cost()` - costing depends on message size and keys count

Used following [spreadsheet](https://docs.google.com/spreadsheets/d/1rV0KyB7UQrg2tOenbh2MQ1fo9MXwrwPFW4l0_CVO-6o/edit?usp=sharing) to visualize the results.


## Testing
Added costing tests to easily reproduce the costing process procedure if needed.

