### PR TITLE
Add BLS aggregation features to `CryptoUtils` module

### DIFF
--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -47,10 +47,11 @@ harness = false
 default = ["std"]
 serde = ["dep:serde", "utils/serde", "sbor/serde", "hex/serde"]
 std = ["hex/std", "sbor/std", "utils/std", "radix-engine-derive/std", "serde_json/std", "ed25519-dalek/std", "secp256k1/std", "blake2/std", "sha3/std" ]
-alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", "serde_json/alloc", "ed25519-dalek/alloc", "secp256k1/alloc", "lazy_static/spin_no_std"]
+alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", "serde_json/alloc", "ed25519-dalek/alloc", "secp256k1/alloc", "lazy_static/spin_no_std" ]
 
-# Include crypto primitives
-#crypto = ["dep:ed25519-dalek", "dep:secp256k1", "dep:blst", "dep:sha3"]
+# Temporary switch to disable code related to BLS aggregate verify
+# It does not work for WASM32 and no_std
+enable_bls_aggregate_verify = []
 
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -82,6 +82,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn sign_and_verify_aggregated() {
         let sks: Vec<Bls12381G1PrivateKey> = (1..11)
             .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -100,10 +100,11 @@ mod tests {
         // Aggregate the signature
         let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
-        let msgs_ref: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+        let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> =
+            pks.iter().zip(msgs).map(|(pk, sk)| (*pk, sk)).collect();
 
         // Verify the messages against public keys and aggregated signature
-        assert!(aggregate_verify_bls12381_v1(&msgs_ref, &pks, &agg_sig))
+        assert!(aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig))
     }
 
     #[test]

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -98,7 +98,7 @@ mod tests {
             .collect();
 
         // Aggregate the signature
-        let agg_sig = Bls12381G2Signature::from_aggregate(&sigs).unwrap();
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
         let msgs_ref: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
 
@@ -119,7 +119,7 @@ mod tests {
         let sigs: Vec<Bls12381G2Signature> = sks.iter().map(|sk| sk.sign_v1(msg)).collect();
 
         // Aggregate the signature
-        let agg_sig = Bls12381G2Signature::from_aggregate(&sigs).unwrap();
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
         // Verify the message against public keys and aggregated signature
         assert!(fast_aggregate_verify_bls12381_v1(msg, &pks, &agg_sig))

--- a/radix-engine-common/src/crypto/bls12381/public_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/public_key.rs
@@ -1,6 +1,8 @@
 use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
+use blst::min_pk::{AggregatePublicKey, PublicKey};
+use blst::BLST_ERROR;
 
 /// Represents a BLS12-381 G1 public key.
 #[cfg_attr(feature = "radix_engine_fuzzing", derive(Arbitrary))]
@@ -16,6 +18,27 @@ impl Bls12381G1PublicKey {
 
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    fn to_native_public_key(self) -> Result<PublicKey, ParseBlsPublicKeyError> {
+        PublicKey::from_bytes(&self.0).map_err(|err| err.into())
+    }
+
+    pub fn from_aggregate(
+        public_keys: &[Bls12381G1PublicKey],
+    ) -> Result<Self, ParseBlsPublicKeyError> {
+        if !public_keys.is_empty() {
+            let pk_first = public_keys[0].to_native_public_key()?;
+
+            let mut agg_pk = AggregatePublicKey::from_public_key(&pk_first);
+
+            for pk in public_keys.iter().skip(1) {
+                agg_pk.add_public_key(&pk.to_native_public_key()?, true)?;
+            }
+            Ok(Bls12381G1PublicKey(agg_pk.to_public_key().to_bytes()))
+        } else {
+            Err(ParseBlsPublicKeyError::NoPublicKeysGiven)
+        }
     }
 }
 
@@ -35,11 +58,20 @@ impl TryFrom<&[u8]> for Bls12381G1PublicKey {
 // error
 //======
 
+impl From<BLST_ERROR> for ParseBlsPublicKeyError {
+    fn from(error: BLST_ERROR) -> Self {
+        let err_msg = format!("{:?}", error);
+        Self::BlsError(err_msg)
+    }
+}
+
 /// Represents an error when parsing BLS public key from hex.
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ParseBlsPublicKeyError {
     InvalidHex(String),
     InvalidLength(usize),
+    NoPublicKeysGiven,
+    BlsError(String),
 }
 
 #[cfg(not(feature = "alloc"))]

--- a/radix-engine-common/src/crypto/bls12381/public_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/public_key.rs
@@ -1,7 +1,6 @@
 use crate::internal_prelude::*;
 #[cfg(feature = "radix_engine_fuzzing")]
 use arbitrary::Arbitrary;
-#[cfg(not(target_arch = "wasm32"))]
 use blst::{
     min_pk::{AggregatePublicKey, PublicKey},
     BLST_ERROR,
@@ -23,12 +22,10 @@ impl Bls12381G1PublicKey {
         self.0.to_vec()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn to_native_public_key(self) -> Result<PublicKey, ParseBlsPublicKeyError> {
         PublicKey::from_bytes(&self.0).map_err(|err| err.into())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     /// Aggregate multiple public keys into a single one
     pub fn aggregate(public_keys: &[Bls12381G1PublicKey]) -> Result<Self, ParseBlsPublicKeyError> {
         if !public_keys.is_empty() {
@@ -62,7 +59,6 @@ impl TryFrom<&[u8]> for Bls12381G1PublicKey {
 // error
 //======
 
-#[cfg(not(target_arch = "wasm32"))]
 impl From<BLST_ERROR> for ParseBlsPublicKeyError {
     fn from(error: BLST_ERROR) -> Self {
         let err_msg = format!("{:?}", error);

--- a/radix-engine-common/src/crypto/bls12381/signature.rs
+++ b/radix-engine-common/src/crypto/bls12381/signature.rs
@@ -1,5 +1,4 @@
 use crate::internal_prelude::*;
-#[cfg(not(target_arch = "wasm32"))]
 use blst::{
     min_pk::{AggregateSignature, Signature},
     BLST_ERROR,
@@ -38,12 +37,10 @@ impl Bls12381G2Signature {
         self.0.to_vec()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn to_native_signature(self) -> Result<Signature, ParseBlsSignatureError> {
         Signature::from_bytes(&self.0).map_err(|err| err.into())
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     /// Aggregate multiple signatures into a single one
     pub fn aggregate(signatures: &[Bls12381G2Signature]) -> Result<Self, ParseBlsSignatureError> {
         if !signatures.is_empty() {
@@ -77,7 +74,6 @@ impl TryFrom<&[u8]> for Bls12381G2Signature {
 // error
 //======
 
-#[cfg(not(target_arch = "wasm32"))]
 impl From<BLST_ERROR> for ParseBlsSignatureError {
     fn from(error: BLST_ERROR) -> Self {
         let err_msg = format!("{:?}", error);

--- a/radix-engine-common/src/crypto/bls12381/signature.rs
+++ b/radix-engine-common/src/crypto/bls12381/signature.rs
@@ -98,7 +98,6 @@ pub enum ParseBlsSignatureError {
 #[cfg(not(feature = "alloc"))]
 impl std::error::Error for ParseBlsSignatureError {}
 
-#[cfg(not(feature = "alloc"))]
 impl fmt::Display for ParseBlsSignatureError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/radix-engine-common/src/crypto/bls12381/signature.rs
+++ b/radix-engine-common/src/crypto/bls12381/signature.rs
@@ -1,4 +1,6 @@
 use crate::internal_prelude::*;
+use blst::min_pk::{AggregateSignature, Signature};
+use blst::BLST_ERROR;
 use sbor::rust::borrow::ToOwned;
 use sbor::rust::fmt;
 use sbor::rust::str::FromStr;
@@ -32,6 +34,27 @@ impl Bls12381G2Signature {
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }
+
+    fn to_native_signature(self) -> Result<Signature, ParseBlsSignatureError> {
+        Signature::from_bytes(&self.0).map_err(|err| err.into())
+    }
+
+    pub fn from_aggregate(
+        signatures: &[Bls12381G2Signature],
+    ) -> Result<Self, ParseBlsSignatureError> {
+        if !signatures.is_empty() {
+            let sig_first = signatures[0].to_native_signature()?;
+
+            let mut agg_sig = AggregateSignature::from_signature(&sig_first);
+
+            for sig in signatures.iter().skip(1) {
+                agg_sig.add_signature(&sig.to_native_signature()?, true)?;
+            }
+            Ok(Bls12381G2Signature(agg_sig.to_signature().to_bytes()))
+        } else {
+            Err(ParseBlsSignatureError::NoSignatureGiven)
+        }
+    }
 }
 
 impl TryFrom<&[u8]> for Bls12381G2Signature {
@@ -50,10 +73,19 @@ impl TryFrom<&[u8]> for Bls12381G2Signature {
 // error
 //======
 
+impl From<BLST_ERROR> for ParseBlsSignatureError {
+    fn from(error: BLST_ERROR) -> Self {
+        let err_msg = format!("{:?}", error);
+        Self::BlsError(err_msg)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum ParseBlsSignatureError {
     InvalidHex(String),
     InvalidLength(usize),
+    NoSignatureGiven,
+    BlsError(String),
 }
 
 /// Represents an error when parsing BLS signature from hex.

--- a/radix-engine-common/src/crypto/signature_validator.rs
+++ b/radix-engine-common/src/crypto/signature_validator.rs
@@ -78,6 +78,7 @@ pub fn verify_bls12381_v1(
 /// Performs BLS12-381 G2 aggregated signature verification of
 /// multiple messages each signed with different key.
 /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+#[cfg(feature = "enable_bls_aggregate_verify")]
 pub fn aggregate_verify_bls12381_v1(
     pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
     signature: &Bls12381G2Signature,

--- a/radix-engine-common/src/crypto/signature_validator.rs
+++ b/radix-engine-common/src/crypto/signature_validator.rs
@@ -54,8 +54,8 @@ pub fn verify_ed25519(
     false
 }
 
-/// Performs BLS12-381 G2 signature verification using following
-/// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+/// Performs BLS12-381 G2 signature verification.
+/// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
 pub fn verify_bls12381_v1(
     message: &[u8],
     public_key: &Bls12381G1PublicKey,
@@ -75,8 +75,9 @@ pub fn verify_bls12381_v1(
     false
 }
 
-/// Performs BLS12-381 G2 aggregated signature verification using following
-/// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+/// Performs BLS12-381 G2 aggregated signature verification of
+/// multiple messages each signed with different key.
+/// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
 pub fn aggregate_verify_bls12381_v1(
     messages: &[&[u8]],
     public_keys: &[Bls12381G1PublicKey],
@@ -104,14 +105,15 @@ pub fn aggregate_verify_bls12381_v1(
     false
 }
 
-/// Performs BLS12-381 G2 aggregated signature verification using following
-/// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+/// Performs BLS12-381 G2 aggregated signature verification
+/// one message signed with multiple keys.
+/// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
 pub fn fast_aggregate_verify_bls12381_v1(
     message: &[u8],
     public_keys: &[Bls12381G1PublicKey],
     signature: &Bls12381G2Signature,
 ) -> bool {
-    if let Ok(agg_pk) = Bls12381G1PublicKey::from_aggregate(public_keys) {
+    if let Ok(agg_pk) = Bls12381G1PublicKey::aggregate(public_keys) {
         return verify_bls12381_v1(message, &agg_pk, signature);
     }
 

--- a/radix-engine-common/src/crypto/signature_validator.rs
+++ b/radix-engine-common/src/crypto/signature_validator.rs
@@ -74,3 +74,46 @@ pub fn verify_bls12381_v1(
 
     false
 }
+
+/// Performs BLS12-381 G2 aggregated signature verification using following
+/// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+pub fn aggregate_verify_bls12381_v1(
+    messages: &[&[u8]],
+    public_keys: &[Bls12381G1PublicKey],
+    signature: &Bls12381G2Signature,
+) -> bool {
+    if let Ok(sig) = blst::min_pk::Signature::from_bytes(&signature.0) {
+        let mut pks = vec![];
+        for pk in public_keys {
+            if let Ok(pk) = blst::min_pk::PublicKey::from_bytes(&pk.0) {
+                pks.push(pk);
+            } else {
+                return false;
+            }
+        }
+        let pks_refs: Vec<&blst::min_pk::PublicKey> = pks.iter().collect();
+
+        let result = sig.aggregate_verify(true, messages, BLS12381_CIPHERSITE_V1, &pks_refs, true);
+
+        match result {
+            blst::BLST_ERROR::BLST_SUCCESS => return true,
+            _ => return false,
+        }
+    }
+
+    false
+}
+
+/// Performs BLS12-381 G2 aggregated signature verification using following
+/// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+pub fn fast_aggregate_verify_bls12381_v1(
+    message: &[u8],
+    public_keys: &[Bls12381G1PublicKey],
+    signature: &Bls12381G2Signature,
+) -> bool {
+    if let Ok(agg_pk) = Bls12381G1PublicKey::from_aggregate(public_keys) {
+        return verify_bls12381_v1(message, &agg_pk, signature);
+    }
+
+    false
+}

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -4,15 +4,15 @@ use crate::internal_prelude::Vec;
 pub trait ClientCryptoUtilsApi<E> {
     fn bls12381_v1_verify(
         &mut self,
-        message: Vec<u8>,
-        public_key: Bls12381G1PublicKey,
-        signature: Bls12381G2Signature,
+        message: &[u8],
+        public_key: &Bls12381G1PublicKey,
+        signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;
 
     fn bls12381_g2_signature_aggregate(
         &mut self,
-        signatures: Vec<Bls12381G2Signature>,
+        signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, E>;
 
-    fn keccak256_hash(&mut self, data: Vec<u8>) -> Result<Hash, E>;
+    fn keccak256_hash(&mut self, data: &[u8]) -> Result<Hash, E>;
 }

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -9,6 +9,13 @@ pub trait ClientCryptoUtilsApi<E> {
         signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;
 
+    fn bls12381_v1_aggregate_verify(
+        &mut self,
+        messages: &[&[u8]],
+        public_keys: &[Bls12381G1PublicKey],
+        signature: &Bls12381G2Signature,
+    ) -> Result<u32, E>;
+
     fn bls12381_g2_signature_aggregate(
         &mut self,
         signatures: &[Bls12381G2Signature],

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -10,8 +10,7 @@ pub trait ClientCryptoUtilsApi<E> {
 
     fn bls12381_v1_aggregate_verify(
         &mut self,
-        messages: &[&[u8]],
-        public_keys: &[Bls12381G1PublicKey],
+        pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;
 

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -1,4 +1,3 @@
-use crate::crypto::*;
 use crate::internal_prelude::*;
 
 pub trait ClientCryptoUtilsApi<E> {

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -8,6 +8,7 @@ pub trait ClientCryptoUtilsApi<E> {
         signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;
 
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -9,5 +9,10 @@ pub trait ClientCryptoUtilsApi<E> {
         signature: Bls12381G2Signature,
     ) -> Result<u32, E>;
 
+    fn bls12381_g2_signature_aggregate(
+        &mut self,
+        signatures: Vec<Bls12381G2Signature>,
+    ) -> Result<Bls12381G2Signature, E>;
+
     fn keccak256_hash(&mut self, data: Vec<u8>) -> Result<Hash, E>;
 }

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -1,5 +1,5 @@
 use crate::crypto::*;
-use crate::internal_prelude::Vec;
+use crate::internal_prelude::*;
 
 pub trait ClientCryptoUtilsApi<E> {
     fn bls12381_v1_verify(
@@ -12,6 +12,13 @@ pub trait ClientCryptoUtilsApi<E> {
     fn bls12381_v1_aggregate_verify(
         &mut self,
         messages: &[&[u8]],
+        public_keys: &[Bls12381G1PublicKey],
+        signature: &Bls12381G2Signature,
+    ) -> Result<u32, E>;
+
+    fn bls12381_v1_fast_aggregate_verify(
+        &mut self,
+        message: &[u8],
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;

--- a/radix-engine-profiling/resources-tracker-macro/scripts/run_tests.sh
+++ b/radix-engine-profiling/resources-tracker-macro/scripts/run_tests.sh
@@ -4,7 +4,7 @@
 
 qemu_app=/home/ubuntu/qemu/qemu-x86_64
 qemu_plugin=/home/ubuntu/qemu/libscrypto-qemu-plugin.so
-qemu_cpu="Westmere-v1"
+#qemu_cpu="Westmere-v1" # disabled due to some issue with missing CPU instructions in BLS implementation
 
 if [ -z "$*" ]; then echo "Provide path to folder with binaries to execute."; exit; fi
 
@@ -18,7 +18,7 @@ for i in $list; do [ -x $i ] && list_count=$((list_count+1)); done
 for i in $list; do
     if [ -x $i ]; then
         echo "Running $idx/$list_count: $i"
-        $qemu_app -cpu $qemu_cpu -plugin $qemu_plugin -d plugin -D log.txt $i --show-output --test --test-threads 1 > out.txt
+        $qemu_app -plugin $qemu_plugin -d plugin -D log.txt $i --show-output --test --test-threads 1 > out.txt
         idx=$((idx+1))
     fi
 done

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -13,6 +13,12 @@ mod component_module {
             CryptoUtils::bls12381_v1_verify(message, pub_key, signature)
         }
 
+        pub fn bls12381_g2_signature_aggregate(
+            signatures: Vec<Bls12381G2Signature>,
+        ) -> Bls12381G2Signature {
+            CryptoUtils::bls12381_g2_signature_aggregate(signatures)
+        }
+
         pub fn keccak256_hash(data: Vec<u8>) -> Hash {
             let hash = CryptoUtils::keccak256_hash(data);
             hash

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -13,6 +13,14 @@ mod component_module {
             CryptoUtils::bls12381_v1_verify(message, pub_key, signature)
         }
 
+        pub fn bls12381_v1_aggregate_verify(
+            messages: Vec<Vec<u8>>,
+            pub_keys: Vec<Bls12381G1PublicKey>,
+            signature: Bls12381G2Signature,
+        ) -> bool {
+            CryptoUtils::bls12381_v1_aggregate_verify(messages, pub_keys, signature)
+        }
+
         pub fn bls12381_g2_signature_aggregate(
             signatures: Vec<Bls12381G2Signature>,
         ) -> Bls12381G2Signature {

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -14,11 +14,10 @@ mod component_module {
         }
 
         pub fn bls12381_v1_aggregate_verify(
-            messages: Vec<Vec<u8>>,
-            pub_keys: Vec<Bls12381G1PublicKey>,
+            pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
             signature: Bls12381G2Signature,
         ) -> bool {
-            CryptoUtils::bls12381_v1_aggregate_verify(messages, pub_keys, signature)
+            CryptoUtils::bls12381_v1_aggregate_verify(pub_keys_msgs, signature)
         }
 
         pub fn bls12381_v1_fast_aggregate_verify(

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -13,12 +13,15 @@ mod component_module {
             CryptoUtils::bls12381_v1_verify(message, pub_key, signature)
         }
 
+        /*
+         * Uncomment once supported again: #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn bls12381_v1_aggregate_verify(
             pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
             signature: Bls12381G2Signature,
         ) -> bool {
             CryptoUtils::bls12381_v1_aggregate_verify(pub_keys_msgs, signature)
         }
+        */
 
         pub fn bls12381_v1_fast_aggregate_verify(
             message: Vec<u8>,

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -21,6 +21,14 @@ mod component_module {
             CryptoUtils::bls12381_v1_aggregate_verify(messages, pub_keys, signature)
         }
 
+        pub fn bls12381_v1_fast_aggregate_verify(
+            message: Vec<u8>,
+            pub_keys: Vec<Bls12381G1PublicKey>,
+            signature: Bls12381G2Signature,
+        ) -> bool {
+            CryptoUtils::bls12381_v1_fast_aggregate_verify(message, pub_keys, signature)
+        }
+
         pub fn bls12381_g2_signature_aggregate(
             signatures: Vec<Bls12381G2Signature>,
         ) -> Bls12381G2Signature {

--- a/radix-engine-tests/tests/system/crypto_utils.rs
+++ b/radix-engine-tests/tests/system/crypto_utils.rs
@@ -52,6 +52,12 @@ fn crypto_scrypto_bls12381_v1_aggregate_verify(
     pub_keys: Vec<Bls12381G1PublicKey>,
     signature: Bls12381G2Signature,
 ) -> TransactionReceiptV1 {
+    let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> = pub_keys
+        .iter()
+        .zip(msgs)
+        .map(|(pk, sk)| (*pk, sk))
+        .collect();
+
     runner.execute_manifest(
         ManifestBuilder::new()
             .lock_fee(runner.faucet_component(), 500u32)
@@ -59,7 +65,7 @@ fn crypto_scrypto_bls12381_v1_aggregate_verify(
                 package_address,
                 "CryptoScrypto",
                 "bls12381_v1_aggregate_verify",
-                manifest_args!(msgs, pub_keys, signature),
+                manifest_args!(pub_keys_msgs, signature),
             )
             .build(),
         vec![],

--- a/radix-engine-tests/tests/system/crypto_utils.rs
+++ b/radix-engine-tests/tests/system/crypto_utils.rs
@@ -75,6 +75,7 @@ fn crypto_scrypto_bls12381_v1_verify(
     )
 }
 
+#[cfg(feature = "enable_bls_aggregate_verify")]
 fn crypto_scrypto_bls12381_v1_aggregate_verify(
     runner: &mut TestRunner<NoExtension, InMemorySubstateDatabase>,
     package_address: PackageAddress,
@@ -236,6 +237,7 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate() {
 }
 
 #[test]
+#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_aggregate_verify() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
@@ -546,6 +548,7 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate_costing() {
 }
 
 #[test]
+#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
     let mut test_runner = TestRunnerBuilder::new().build();
 
@@ -569,6 +572,7 @@ fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
 }
 
 #[test]
+#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing_2() {
     let mut test_runner = TestRunnerBuilder::new().build();
 

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -251,6 +251,8 @@ pub enum SystemError {
 
     BlueprintTypeNotFound(String),
 
+    BlsError(String),
+
     /// A panic that's occurred in the system-layer or below. We're calling it system panic since
     /// we're treating the system as a black-box here.
     #[cfg(feature = "std")]

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -252,6 +252,7 @@ pub enum SystemError {
     BlueprintTypeNotFound(String),
 
     BlsError(String),
+    InputDataEmpty,
 
     /// A panic that's occurred in the system-layer or below. We're calling it system panic since
     /// we're treating the system as a black-box here.

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2870,9 +2870,7 @@ where
     }
 
     // Trace average message length and number of public_keys
-    // FIXME: Improve resource tracker, because below line causes panic in resource tracker
-    //#[trace_resources(log=(messages.iter().map(|m| m.len()).sum::<usize>()/messages.len()),log=public_keys.len())]
-    #[trace_resources(log=messages.len(),log=public_keys.len())]
+    #[trace_resources(log={messages.iter().map(|m| m.len()).sum::<usize>()/messages.len()},log=public_keys.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         messages: &[&[u8]],

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,13 +2881,17 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
-                keys_cnt: public_keys.len(),
-            },
-        )?;
-        Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+        if !messages.is_empty() && !public_keys.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381V1AggregateVerify {
+                    size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
+                    keys_cnt: public_keys.len(),
+                },
+            )?;
+            Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=message.len(), log=public_keys.len())]
@@ -2897,13 +2901,17 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
-                size: message.len(),
-                keys_cnt: public_keys.len(),
-            },
-        )?;
-        Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
+        if !public_keys.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
+                    size: message.len(),
+                    keys_cnt: public_keys.len(),
+                },
+            )?;
+            Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=signatures.len())]
@@ -2911,13 +2919,17 @@ where
         &mut self,
         signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381G2SignatureAggregate {
-                signatures_cnt: signatures.len(),
-            },
-        )?;
-        Bls12381G2Signature::aggregate(signatures)
-            .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
+        if !signatures.is_empty() {
+            self.api.kernel_get_system().modules.apply_execution_cost(
+                ExecutionCostingEntry::Bls12381G2SignatureAggregate {
+                    signatures_cnt: signatures.len(),
+                },
+            )?;
+            Bls12381G2Signature::aggregate(signatures)
+                .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
+        } else {
+            Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
+        }
     }
 
     #[trace_resources(log=data.len())]

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2869,6 +2869,17 @@ where
         Ok(verify_bls12381_v1(message, public_key, signature) as u32)
     }
 
+    #[trace_resources(log=messages.len())]
+    fn bls12381_v1_aggregate_verify(
+        &mut self,
+        messages: &[&[u8]],
+        public_keys: &[Bls12381G1PublicKey],
+        signature: &Bls12381G2Signature,
+    ) -> Result<u32, RuntimeError> {
+        // TODO costing
+        Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+    }
+
     #[trace_resources(log=signatures.len())]
     fn bls12381_g2_signature_aggregate(
         &mut self,

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2870,7 +2870,9 @@ where
     }
 
     // Trace average message length and number of public_keys
-    #[trace_resources(log=messages.iter().map(Vec::len).sum::<usize>()/messages.len(),log=public_keys.len())]
+    // FIXME: Improve resource tracker, because below line causes panic in resource tracker
+    //#[trace_resources(log=(messages.iter().map(|m| m.len()).sum::<usize>()/messages.len()),log=public_keys.len())]
+    #[trace_resources(log=messages.len(),log=public_keys.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         messages: &[&[u8]],

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2875,6 +2875,7 @@ where
 
     // Trace average message length and number of public_keys
     #[trace_resources(log={pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,6 +2881,17 @@ where
         Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
     }
 
+    #[trace_resources(log=message.len(), log=public_keys.len())]
+    fn bls12381_v1_fast_aggregate_verify(
+        &mut self,
+        message: &[u8],
+        public_keys: &[Bls12381G1PublicKey],
+        signature: &Bls12381G2Signature,
+    ) -> Result<u32, RuntimeError> {
+        // TODO costing
+        Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
+    }
+
     #[trace_resources(log=signatures.len())]
     fn bls12381_g2_signature_aggregate(
         &mut self,

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,11 +2881,10 @@ where
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
         if !pub_keys_and_msgs.is_empty() {
+            let sizes: Vec<usize> = pub_keys_and_msgs.iter().map(|(_, msg)| msg.len()).collect();
             self.api.kernel_get_system().modules.apply_execution_cost(
                 ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                    size: pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()
-                        / pub_keys_and_msgs.len(),
-                    keys_cnt: pub_keys_and_msgs.len(),
+                    sizes: sizes.as_slice(),
                 },
             )?;
             Ok(aggregate_verify_bls12381_v1(pub_keys_and_msgs, signature) as u32)

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2874,7 +2874,7 @@ where
     }
 
     // Trace average message length and number of public_keys
-    #[trace_resources(log={pub_keys_and_msgs.iter().map(|(_, msg)| msg.len()).sum::<usize>()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
+    #[trace_resources(log={pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
@@ -2883,10 +2883,7 @@ where
         if !pub_keys_and_msgs.is_empty() {
             self.api.kernel_get_system().modules.apply_execution_cost(
                 ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                    size: pub_keys_and_msgs
-                        .iter()
-                        .map(|(_, msg)| msg.len())
-                        .sum::<usize>()
+                    size: pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()
                         / pub_keys_and_msgs.len(),
                     keys_cnt: pub_keys_and_msgs.len(),
                 },

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2861,28 +2861,28 @@ where
     #[trace_resources(log=message.len())]
     fn bls12381_v1_verify(
         &mut self,
-        message: Vec<u8>,
-        public_key: Bls12381G1PublicKey,
-        signature: Bls12381G2Signature,
+        message: &[u8],
+        public_key: &Bls12381G1PublicKey,
+        signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
         // TODO: apply execution costs
-        Ok(verify_bls12381_v1(&message, &public_key, &signature) as u32)
+        Ok(verify_bls12381_v1(message, public_key, signature) as u32)
     }
 
     #[trace_resources(log=signatures.len())]
     fn bls12381_g2_signature_aggregate(
         &mut self,
-        signatures: Vec<Bls12381G2Signature>,
+        signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        // TODO costing
-        Bls12381G2Signature::aggregate(&signatures)
+        // TODO: apply execution costs
+        Bls12381G2Signature::aggregate(signatures)
             .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
     }
 
     #[trace_resources(log=data.len())]
-    fn keccak256_hash(&mut self, data: Vec<u8>) -> Result<Hash, RuntimeError> {
+    fn keccak256_hash(&mut self, data: &[u8]) -> Result<Hash, RuntimeError> {
         // TODO: apply execution costs
-        Ok(keccak256_hash(&data))
+        Ok(keccak256_hash(data))
     }
 }
 

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2858,7 +2858,7 @@ where
     Y: KernelApi<SystemConfig<V>>,
     V: SystemCallbackObject,
 {
-    #[trace_resources]
+    #[trace_resources(log=message.len())]
     fn bls12381_v1_verify(
         &mut self,
         message: Vec<u8>,
@@ -2869,7 +2869,7 @@ where
         Ok(verify_bls12381_v1(&message, &public_key, &signature) as u32)
     }
 
-    #[trace_resources]
+    #[trace_resources(log=data.len())]
     fn keccak256_hash(&mut self, data: Vec<u8>) -> Result<Hash, RuntimeError> {
         // TODO: apply execution costs
         Ok(keccak256_hash(&data))

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2869,6 +2869,22 @@ where
         Ok(verify_bls12381_v1(&message, &public_key, &signature) as u32)
     }
 
+    #[trace_resources(log=signatures.len())]
+    fn bls12381_g2_signature_aggregate(
+        &mut self,
+        signatures: Vec<Bls12381G2Signature>,
+    ) -> Result<Bls12381G2Signature, RuntimeError> {
+        /*
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1Verify {
+                size: message.len(),
+            },
+        )?;
+        */
+        Bls12381G2Signature::aggregate(&signatures)
+            .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
+    }
+
     #[trace_resources(log=data.len())]
     fn keccak256_hash(&mut self, data: Vec<u8>) -> Result<Hash, RuntimeError> {
         // TODO: apply execution costs

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2865,7 +2865,11 @@ where
         public_key: &Bls12381G1PublicKey,
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO: apply execution costs
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1Verify {
+                size: message.len(),
+            },
+        )?;
         Ok(verify_bls12381_v1(message, public_key, signature) as u32)
     }
 
@@ -2904,7 +2908,10 @@ where
 
     #[trace_resources(log=data.len())]
     fn keccak256_hash(&mut self, data: &[u8]) -> Result<Hash, RuntimeError> {
-        // TODO: apply execution costs
+        self.api
+            .kernel_get_system()
+            .modules
+            .apply_execution_cost(ExecutionCostingEntry::Keccak256Hash { size: data.len() })?;
         Ok(keccak256_hash(data))
     }
 }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2881,7 +2881,12 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO costing
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1AggregateVerify {
+                size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
+                keys_cnt: public_keys.len(),
+            },
+        )?;
         Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
     }
 
@@ -2892,7 +2897,12 @@ where
         public_keys: &[Bls12381G1PublicKey],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        // TODO costing
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381V1FastAggregateVerify {
+                size: message.len(),
+                keys_cnt: public_keys.len(),
+            },
+        )?;
         Ok(fast_aggregate_verify_bls12381_v1(message, public_keys, signature) as u32)
     }
 
@@ -2901,7 +2911,11 @@ where
         &mut self,
         signatures: &[Bls12381G2Signature],
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        // TODO: apply execution costs
+        self.api.kernel_get_system().modules.apply_execution_cost(
+            ExecutionCostingEntry::Bls12381G2SignatureAggregate {
+                signatures_cnt: signatures.len(),
+            },
+        )?;
         Bls12381G2Signature::aggregate(signatures)
             .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
     }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2874,13 +2874,7 @@ where
         &mut self,
         signatures: Vec<Bls12381G2Signature>,
     ) -> Result<Bls12381G2Signature, RuntimeError> {
-        /*
-        self.api.kernel_get_system().modules.apply_execution_cost(
-            ExecutionCostingEntry::Bls12381V1Verify {
-                size: message.len(),
-            },
-        )?;
-        */
+        // TODO costing
         Bls12381G2Signature::aggregate(&signatures)
             .map_err(|err| RuntimeError::SystemError(SystemError::BlsError(err.to_string())))
     }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2874,21 +2874,24 @@ where
     }
 
     // Trace average message length and number of public_keys
-    #[trace_resources(log={messages.iter().map(|m| m.len()).sum::<usize>()/messages.len()},log=public_keys.len())]
+    #[trace_resources(log={pub_keys_and_msgs.iter().map(|(_, msg)| msg.len()).sum::<usize>()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
-        messages: &[&[u8]],
-        public_keys: &[Bls12381G1PublicKey],
+        pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
         signature: &Bls12381G2Signature,
     ) -> Result<u32, RuntimeError> {
-        if !messages.is_empty() && !public_keys.is_empty() {
+        if !pub_keys_and_msgs.is_empty() {
             self.api.kernel_get_system().modules.apply_execution_cost(
                 ExecutionCostingEntry::Bls12381V1AggregateVerify {
-                    size: messages.iter().map(|m| m.len()).sum::<usize>() / messages.len(),
-                    keys_cnt: public_keys.len(),
+                    size: pub_keys_and_msgs
+                        .iter()
+                        .map(|(_, msg)| msg.len())
+                        .sum::<usize>()
+                        / pub_keys_and_msgs.len(),
+                    keys_cnt: pub_keys_and_msgs.len(),
                 },
             )?;
-            Ok(aggregate_verify_bls12381_v1(messages, public_keys, signature) as u32)
+            Ok(aggregate_verify_bls12381_v1(pub_keys_and_msgs, signature) as u32)
         } else {
             Err(RuntimeError::SystemError(SystemError::InputDataEmpty))
         }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2869,7 +2869,8 @@ where
         Ok(verify_bls12381_v1(message, public_key, signature) as u32)
     }
 
-    #[trace_resources(log=messages.len())]
+    // Trace average message length and number of public_keys
+    #[trace_resources(log=messages.iter().map(Vec::len).sum::<usize>()/messages.len(),log=public_keys.len())]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         messages: &[&[u8]],

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -115,6 +115,17 @@ pub enum ExecutionCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
+    Bls12381V1AggregateVerify {
+        size: usize,
+        keys_cnt: usize,
+    },
+    Bls12381V1FastAggregateVerify {
+        size: usize,
+        keys_cnt: usize,
+    },
+    Bls12381G2SignatureAggregate {
+        signatures_cnt: usize,
+    },
     Keccak256Hash {
         size: usize,
     },
@@ -181,6 +192,15 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            ExecutionCostingEntry::Bls12381V1AggregateVerify { size, keys_cnt } => {
+                ft.bls12381_v1_aggregate_verify_cost(*size, *keys_cnt)
+            }
+            ExecutionCostingEntry::Bls12381V1FastAggregateVerify { size, keys_cnt } => {
+                ft.bls12381_v1_fast_aggregate_verify_cost(*size, *keys_cnt)
+            }
+            ExecutionCostingEntry::Bls12381G2SignatureAggregate { signatures_cnt } => {
+                ft.bls12381_g2_signature_aggregate_cost(*signatures_cnt)
+            }
             ExecutionCostingEntry::Keccak256Hash { size } => ft.keccak256_hash_cost(*size),
         }
     }

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -116,8 +116,7 @@ pub enum ExecutionCostingEntry<'a> {
         size: usize,
     },
     Bls12381V1AggregateVerify {
-        size: usize,
-        keys_cnt: usize,
+        sizes: &'a [usize],
     },
     Bls12381V1FastAggregateVerify {
         size: usize,
@@ -192,8 +191,8 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
-            ExecutionCostingEntry::Bls12381V1AggregateVerify { size, keys_cnt } => {
-                ft.bls12381_v1_aggregate_verify_cost(*size, *keys_cnt)
+            ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
+                ft.bls12381_v1_aggregate_verify_cost(sizes)
             }
             ExecutionCostingEntry::Bls12381V1FastAggregateVerify { size, keys_cnt } => {
                 ft.bls12381_v1_fast_aggregate_verify_cost(*size, *keys_cnt)

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -110,6 +110,14 @@ pub enum ExecutionCostingEntry<'a> {
     Panic {
         size: usize,
     },
+
+    /* crypto utils */
+    Bls12381V1Verify {
+        size: usize,
+    },
+    Keccak256Hash {
+        size: usize,
+    },
 }
 
 #[derive(Debug, IntoStaticStr)]
@@ -172,6 +180,8 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitEvent { size } => ft.emit_event_cost(*size),
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
+            ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            ExecutionCostingEntry::Keccak256Hash { size } => ft.keccak256_hash_cost(*size),
         }
     }
 }

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -115,6 +115,7 @@ pub enum ExecutionCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     Bls12381V1AggregateVerify {
         sizes: &'a [usize],
     },
@@ -191,6 +192,7 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            #[cfg(feature = "enable_bls_aggregate_verify")]
             ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
                 ft.bls12381_v1_aggregate_verify_cost(sizes)
             }

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -386,14 +386,63 @@ impl FeeTable {
         // Based on  `test_crypto_scrypto_verify_bls12381_v1_costing`
         // - For sizes less than 1024, instruction count remains the same.
         // - For greater sizes following linear equation might be applied:
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
         //   instructions_cnt = 34.55672 * size + 10577803.13
         //   Lets round:
         //    34.55672       -> 35
         //    10577803.13    -> 10577804
         let size = if size < 1024 { 1024 } else { cast(size) };
-        let instructions_cnt = mul(size, 35) + 10577804;
+        let instructions_cnt = add(mul(size, 35), 10577804);
         // Convert to cost units
-        div(instructions_cnt, CPU_INSTRUCTIONS_TO_COST_UNIT)
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_v1_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_v1_aggregate_verify_costing`
+        // - For sizes less than 1024, instruction count remains the same.
+        // - For greater sizes following linear equation might be applied:
+        //   instructions_cnt = 87.3416 * size + 1438527.7574 * keys_cnt + 9058827.9112
+        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
+        //   Lets round:
+        //    87.3416      -> 88
+        //    1438527.757  -> 1438528
+        //    9058827.911  -> 9058828
+        let size = if size < 1024 { 1024 } else { cast(size) };
+        let instructions_cnt = add(add(mul(size, 88), mul(cast(keys_cnt), 1438528)), 9058828);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_v1_fast_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_v1_fast_aggregate_verify_costing`
+        // - For sizes less than 1024, instruction count remains the same.
+        // - For greater sizes following linear equation might be applied:
+        //   instructions_cnt = 32.1717 * size + 624919.5254 * keys_cnt + 9058827.9112
+        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
+        //   Lets round:
+        //    32.1717      -> 33
+        //    624919.5254  -> 624920
+        //    10096964.55  -> 10096965
+        let size = if size < 1024 { 1024 } else { cast(size) };
+        let instructions_cnt = add(add(mul(size, 33), mul(cast(keys_cnt), 624920)), 10096965);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
+    pub fn bls12381_g2_signature_aggregate_cost(&self, signatures_cnt: usize) -> u32 {
+        // Based on  `test_crypto_scrypto_bls12381_g2_signature_aggregate_costing`
+        // Following linear equation might be applied:
+        //   instructions_cnt = 879553.91557 * signatures_cnt - 567872.58948
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
+        //   Lets round:
+        //    879553.91557 -> 879554
+        //    567872.5895  -> 567873
+        let instructions_cnt = sub(mul(cast(signatures_cnt), 879554), 567873);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
     }
 
     #[inline]
@@ -402,13 +451,14 @@ impl FeeTable {
         // - For sizes less than 100, instruction count remains the same.
         // - For greater sizes following linear equation might be applied:
         //   instructions_cnt = 46.41919 * size + 2641.66077
+        //   (used: https://www.socscistatistics.com/tests/regression/default.aspx)
         //   Lets round:
         //     46.41919  -> 47
         //     2641.66077 -> 2642
         let size = if size < 100 { 100 } else { cast(size) };
-        let instructions_cnt = mul(size, 47) + 2642;
+        let instructions_cnt = add(mul(size, 47), 2642);
         // Convert to cost units
-        div(instructions_cnt, CPU_INSTRUCTIONS_TO_COST_UNIT)
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
     }
 
     //======================
@@ -458,11 +508,11 @@ fn add(a: u32, b: u32) -> u32 {
 }
 
 #[inline]
-fn mul(a: u32, b: u32) -> u32 {
-    a.checked_mul(b).unwrap_or(u32::MAX)
+fn sub(a: u32, b: u32) -> u32 {
+    a.checked_sub(b).unwrap_or(u32::MAX)
 }
 
 #[inline]
-fn div(a: u32, b: u32) -> u32 {
-    a.checked_div(b).unwrap_or(u32::MAX)
+fn mul(a: u32, b: u32) -> u32 {
+    a.checked_mul(b).unwrap_or(u32::MAX)
 }

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -398,20 +398,17 @@ impl FeeTable {
     }
 
     #[inline]
-    pub fn bls12381_v1_aggregate_verify_cost(&self, size: usize, keys_cnt: usize) -> u32 {
-        // Based on  `test_crypto_scrypto_bls12381_v1_aggregate_verify_costing`
-        // - For sizes less than 1024, instruction count remains the same.
-        // - For greater sizes following linear equation might be applied:
-        //   instructions_cnt = 87.3416 * size + 1438527.7574 * keys_cnt + 9058827.9112
-        //   (used: https://www.socscistatistics.com/tests/multipleregression/default.aspx)
-        //   Lets round:
-        //    87.3416      -> 88
-        //    1438527.757  -> 1438528
-        //    9058827.911  -> 9058828
-        let size = if size < 1024 { 1024 } else { cast(size) };
-        let instructions_cnt = add(add(mul(size, 88), mul(cast(keys_cnt), 1438528)), 9058828);
-        // Convert to cost units
-        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    pub fn bls12381_v1_aggregate_verify_cost(&self, sizes: &[usize]) -> u32 {
+        // Below approach does not take aggregation into account.
+        // Summing costs pers size gives greater values.
+        // We've found somewhat difficult to find a proper and effective equation to estimate
+        // the instructions count collected with `test_crypto_scrypto_verify_bls12381_v1_costing`
+        // TODO: Find more adequate cost estimation
+        let mut cost: u32 = 0;
+        for size in sizes {
+            cost += self.bls12381_v1_verify_cost(*size);
+        }
+        cost
     }
 
     #[inline]

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -398,6 +398,7 @@ impl FeeTable {
     }
 
     #[inline]
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     pub fn bls12381_v1_aggregate_verify_cost(&self, sizes: &[usize]) -> u32 {
         // Below approach does not take aggregation into account.
         // Summing costs pers size gives greater values.

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -81,6 +81,8 @@ pub const SYS_PANIC_FUNCTION_NAME: &str = "sys_panic";
 // Crypto Utils
 //=================
 pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME: &str = "crypto_utils_bls12381_v1_verify";
+pub const CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME: &str =
+    "crypto_utils_bls12381_g2_signature_aggregate";
 pub const CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME: &str = "crypto_utils_keccak256_hash";
 
 //=================

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -81,6 +81,7 @@ pub const SYS_PANIC_FUNCTION_NAME: &str = "sys_panic";
 // Crypto Utils
 //=================
 pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME: &str = "crypto_utils_bls12381_v1_verify";
+#[cfg(feature = "enable_bls_aggregate_verify")]
 pub const CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_v1_aggregate_verify";
 pub const CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME: &str =

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -83,6 +83,8 @@ pub const SYS_PANIC_FUNCTION_NAME: &str = "sys_panic";
 pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME: &str = "crypto_utils_bls12381_v1_verify";
 pub const CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_v1_aggregate_verify";
+pub const CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
+    "crypto_utils_bls12381_v1_fast_aggregate_verify";
 pub const CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_g2_signature_aggregate";
 pub const CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME: &str = "crypto_utils_keccak256_hash";

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -81,6 +81,8 @@ pub const SYS_PANIC_FUNCTION_NAME: &str = "sys_panic";
 // Crypto Utils
 //=================
 pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME: &str = "crypto_utils_bls12381_v1_verify";
+pub const CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
+    "crypto_utils_bls12381_v1_aggregate_verify";
 pub const CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_g2_signature_aggregate";
 pub const CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME: &str = "crypto_utils_keccak256_hash";

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -156,7 +156,7 @@ pub enum WasmRuntimeError {
 
     InvalidBlsPublicKey(ParseBlsPublicKeyError),
     InvalidBlsSignature(ParseBlsSignatureError),
-    InvalidBlsMessage(DecodeError),
+    InvalidBlsInput(DecodeError),
 }
 
 impl SelfError for WasmRuntimeError {

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -156,7 +156,7 @@ pub enum WasmRuntimeError {
 
     InvalidBlsPublicKey(DecodeError),
     InvalidBlsSignature(DecodeError),
-    InvalidBlsInput(DecodeError),
+    InvalidBlsPublicKeyOrMessage(DecodeError),
 }
 
 impl SelfError for WasmRuntimeError {

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -154,8 +154,8 @@ pub enum WasmRuntimeError {
 
     TooManyBuffers,
 
-    InvalidBlsPublicKey(ParseBlsPublicKeyError),
-    InvalidBlsSignature(ParseBlsSignatureError),
+    InvalidBlsPublicKey(DecodeError),
+    InvalidBlsSignature(DecodeError),
     InvalidBlsInput(DecodeError),
 }
 

--- a/radix-engine/src/vm/wasm/errors.rs
+++ b/radix-engine/src/vm/wasm/errors.rs
@@ -156,6 +156,7 @@ pub enum WasmRuntimeError {
 
     InvalidBlsPublicKey(ParseBlsPublicKeyError),
     InvalidBlsSignature(ParseBlsSignatureError),
+    InvalidBlsMessage(DecodeError),
 }
 
 impl SelfError for WasmRuntimeError {

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -755,6 +755,7 @@ impl WasmModule {
                             ));
                         }
                     }
+                    #[cfg(feature = "enable_bls_aggregate_verify")]
                     CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => {
                         if let TypeRef::Func(type_index) = entry.ty {
                             if Self::function_type_matches(

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -755,6 +755,28 @@ impl WasmModule {
                             ));
                         }
                     }
+                    CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => {
+                        if let TypeRef::Func(type_index) = entry.ty {
+                            if Self::function_type_matches(
+                                &self.module,
+                                type_index,
+                                vec![
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                ],
+                                vec![ValType::I32],
+                            ) {
+                                continue;
+                            }
+                            return Err(PrepareError::InvalidImport(
+                                InvalidImport::InvalidFunctionType(entry.name.to_string()),
+                            ));
+                        }
+                    }
                     CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => {
                         if let TypeRef::Func(type_index) = entry.ty {
                             if Self::function_type_matches(

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -760,14 +760,7 @@ impl WasmModule {
                             if Self::function_type_matches(
                                 &self.module,
                                 type_index,
-                                vec![
-                                    ValType::I32,
-                                    ValType::I32,
-                                    ValType::I32,
-                                    ValType::I32,
-                                    ValType::I32,
-                                    ValType::I32,
-                                ],
+                                vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
                                 vec![ValType::I32],
                             ) {
                                 continue;

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -755,6 +755,21 @@ impl WasmModule {
                             ));
                         }
                     }
+                    CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => {
+                        if let TypeRef::Func(type_index) = entry.ty {
+                            if Self::function_type_matches(
+                                &self.module,
+                                type_index,
+                                vec![ValType::I32, ValType::I32],
+                                vec![ValType::I64],
+                            ) {
+                                continue;
+                            }
+                            return Err(PrepareError::InvalidImport(
+                                InvalidImport::InvalidFunctionType(entry.name.to_string()),
+                            ));
+                        }
+                    }
                     CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => {
                         if let TypeRef::Func(type_index) = entry.ty {
                             if Self::function_type_matches(

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -777,6 +777,28 @@ impl WasmModule {
                             ));
                         }
                     }
+                    CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME => {
+                        if let TypeRef::Func(type_index) = entry.ty {
+                            if Self::function_type_matches(
+                                &self.module,
+                                type_index,
+                                vec![
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                ],
+                                vec![ValType::I32],
+                            ) {
+                                continue;
+                            }
+                            return Err(PrepareError::InvalidImport(
+                                InvalidImport::InvalidFunctionType(entry.name.to_string()),
+                            ));
+                        }
+                    }
                     CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => {
                         if let TypeRef::Func(type_index) = entry.ty {
                             if Self::function_type_matches(

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -215,6 +215,13 @@ pub trait WasmRuntime {
         signatures: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 
+    fn crypto_utils_bls12381_v1_fast_aggregate_verify(
+        &mut self,
+        message: Vec<u8>,
+        public_keys: Vec<u8>,
+        signatures: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>>;
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -208,6 +208,13 @@ pub trait WasmRuntime {
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 
+    fn crypto_utils_bls12381_v1_aggregate_verify(
+        &mut self,
+        messages: Vec<u8>,
+        public_keys: Vec<u8>,
+        signatures: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>>;
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -208,6 +208,11 @@ pub trait WasmRuntime {
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 
+    fn crypto_utils_bls12381_g2_signature_aggregate(
+        &mut self,
+        signatures: Vec<u8>,
+    ) -> Result<Buffer, InvokeError<WasmRuntimeError>>;
+
     fn crypto_utils_keccak256_hash(
         &mut self,
         data: Vec<u8>,

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -208,6 +208,7 @@ pub trait WasmRuntime {
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -210,8 +210,7 @@ pub trait WasmRuntime {
 
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
-        messages: Vec<u8>,
-        public_keys: Vec<u8>,
+        pub_keys_and_msgs: Vec<u8>,
         signatures: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -697,21 +697,18 @@ impl WasmerModule {
 
         pub fn bls12381_v1_aggregate_verify(
             env: &WasmerInstanceEnv,
-            messages_ptr: u32,
-            messages_len: u32,
-            public_keys_ptr: u32,
-            public_keys_len: u32,
+            pub_keys_and_msgs_ptr: u32,
+            pub_keys_and_msgs_len: u32,
             signature_ptr: u32,
             signature_len: u32,
         ) -> Result<u32, InvokeError<WasmRuntimeError>> {
             let (instance, runtime) = grab_runtime!(env);
 
-            let messages = read_memory(&instance, messages_ptr, messages_len)?;
-
-            let public_keys = read_memory(&instance, public_keys_ptr, public_keys_len)?;
+            let pub_keys_and_msgs =
+                read_memory(&instance, pub_keys_and_msgs_ptr, pub_keys_and_msgs_len)?;
             let signature = read_memory(instance, signature_ptr, signature_len)?;
 
-            runtime.crypto_utils_bls12381_v1_aggregate_verify(messages, public_keys, signature)
+            runtime.crypto_utils_bls12381_v1_aggregate_verify(pub_keys_and_msgs, signature)
         }
 
         pub fn bls12381_v1_fast_aggregate_verify(

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -695,6 +695,25 @@ impl WasmerModule {
             runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
         }
 
+        pub fn bls12381_v1_aggregate_verify(
+            env: &WasmerInstanceEnv,
+            messages_ptr: u32,
+            messages_len: u32,
+            public_keys_ptr: u32,
+            public_keys_len: u32,
+            signature_ptr: u32,
+            signature_len: u32,
+        ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+            let (instance, runtime) = grab_runtime!(env);
+
+            let messages = read_memory(&instance, messages_ptr, messages_len)?;
+
+            let public_keys = read_memory(&instance, public_keys_ptr, public_keys_len)?;
+            let signature = read_memory(instance, signature_ptr, signature_len)?;
+
+            runtime.crypto_utils_bls12381_v1_verify(messages, public_keys, signature)
+        }
+
         pub fn bls12381_g2_signature_aggregate(
             env: &WasmerInstanceEnv,
             signatures_ptr: u32,
@@ -827,6 +846,7 @@ impl WasmerModule {
                 SYS_GENERATE_RUID_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), sys_generate_ruid),
                 BUFFER_CONSUME_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), buffer_consume),
                 CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_verify),
+                CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_g2_signature_aggregate),
                 CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), keccak256_hash),
 

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -711,7 +711,7 @@ impl WasmerModule {
             let public_keys = read_memory(&instance, public_keys_ptr, public_keys_len)?;
             let signature = read_memory(instance, signature_ptr, signature_len)?;
 
-            runtime.crypto_utils_bls12381_v1_verify(messages, public_keys, signature)
+            runtime.crypto_utils_bls12381_v1_aggregate_verify(messages, public_keys, signature)
         }
 
         pub fn bls12381_g2_signature_aggregate(

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -695,6 +695,7 @@ impl WasmerModule {
             runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
         }
 
+        #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn bls12381_v1_aggregate_verify(
             env: &WasmerInstanceEnv,
             pub_keys_and_msgs_ptr: u32,
@@ -862,7 +863,8 @@ impl WasmerModule {
                 SYS_GENERATE_RUID_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), sys_generate_ruid),
                 BUFFER_CONSUME_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), buffer_consume),
                 CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_verify),
-                CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
+                // TODO: Uncomment once supported #[cfg(feature = "enable_bls_aggregate_verify")]
+                //CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_fast_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_g2_signature_aggregate),
                 CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), keccak256_hash),

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -695,6 +695,20 @@ impl WasmerModule {
             runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
         }
 
+        pub fn bls12381_g2_signature_aggregate(
+            env: &WasmerInstanceEnv,
+            signatures_ptr: u32,
+            signatures_len: u32,
+        ) -> Result<u64, InvokeError<WasmRuntimeError>> {
+            let (instance, runtime) = grab_runtime!(env);
+
+            let signatures = read_memory(instance, signatures_ptr, signatures_len)?;
+
+            runtime
+                .crypto_utils_bls12381_g2_signature_aggregate(signatures)
+                .map(|buffer| buffer.0)
+        }
+
         pub fn keccak256_hash(
             env: &WasmerInstanceEnv,
             data_ptr: u32,
@@ -813,6 +827,7 @@ impl WasmerModule {
                 SYS_GENERATE_RUID_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), sys_generate_ruid),
                 BUFFER_CONSUME_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), buffer_consume),
                 CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_verify),
+                CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_g2_signature_aggregate),
                 CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), keccak256_hash),
 
                 #[cfg(feature = "radix_engine_tests")]

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -714,6 +714,25 @@ impl WasmerModule {
             runtime.crypto_utils_bls12381_v1_aggregate_verify(messages, public_keys, signature)
         }
 
+        pub fn bls12381_v1_fast_aggregate_verify(
+            env: &WasmerInstanceEnv,
+            message_ptr: u32,
+            message_len: u32,
+            public_keys_ptr: u32,
+            public_keys_len: u32,
+            signature_ptr: u32,
+            signature_len: u32,
+        ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+            let (instance, runtime) = grab_runtime!(env);
+
+            let message = read_memory(&instance, message_ptr, message_len)?;
+
+            let public_keys = read_memory(&instance, public_keys_ptr, public_keys_len)?;
+            let signature = read_memory(instance, signature_ptr, signature_len)?;
+
+            runtime.crypto_utils_bls12381_v1_fast_aggregate_verify(message, public_keys, signature)
+        }
+
         pub fn bls12381_g2_signature_aggregate(
             env: &WasmerInstanceEnv,
             signatures_ptr: u32,
@@ -847,6 +866,7 @@ impl WasmerModule {
                 BUFFER_CONSUME_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), buffer_consume),
                 CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_verify),
                 CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
+                CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_fast_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_g2_signature_aggregate),
                 CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), keccak256_hash),
 

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -693,21 +693,18 @@ fn bls12381_v1_verify(
 
 fn bls12381_v1_aggregate_verify(
     mut caller: Caller<'_, HostState>,
-    messages_ptr: u32,
-    messages_len: u32,
-    public_keys_ptr: u32,
-    public_keys_len: u32,
+    pub_keys_and_msgs_ptr: u32,
+    pub_keys_and_msgs_len: u32,
     signature_ptr: u32,
     signature_len: u32,
 ) -> Result<u32, InvokeError<WasmRuntimeError>> {
     let (memory, runtime) = grab_runtime!(caller);
 
-    let messages = read_memory(caller.as_context_mut(), memory, messages_ptr, messages_len)?;
-    let public_keys = read_memory(
+    let pub_keys_and_msgs = read_memory(
         caller.as_context_mut(),
         memory,
-        public_keys_ptr,
-        public_keys_len,
+        pub_keys_and_msgs_ptr,
+        pub_keys_and_msgs_len,
     )?;
     let signature = read_memory(
         caller.as_context_mut(),
@@ -716,7 +713,7 @@ fn bls12381_v1_aggregate_verify(
         signature_len,
     )?;
 
-    runtime.crypto_utils_bls12381_v1_aggregate_verify(messages, public_keys, signature)
+    runtime.crypto_utils_bls12381_v1_aggregate_verify(pub_keys_and_msgs, signature)
 }
 
 fn bls12381_v1_fast_aggregate_verify(
@@ -1369,19 +1366,15 @@ impl WasmiModule {
         let host_bls12381_v1_aggregate_verify = Func::wrap(
             store.as_context_mut(),
             |caller: Caller<'_, HostState>,
-             messages_ptr: u32,
-             messages_len: u32,
-             public_keys_ptr: u32,
-             public_keys_len: u32,
+             pub_keys_and_msgs_ptr: u32,
+             pub_keys_and_msgs_len: u32,
              signature_ptr: u32,
              signature_len: u32|
              -> Result<u32, Trap> {
                 bls12381_v1_aggregate_verify(
                     caller,
-                    messages_ptr,
-                    messages_len,
-                    public_keys_ptr,
-                    public_keys_len,
+                    pub_keys_and_msgs_ptr,
+                    pub_keys_and_msgs_len,
                     signature_ptr,
                     signature_len,
                 )

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -691,6 +691,7 @@ fn bls12381_v1_verify(
     runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
 }
 
+#[cfg(feature = "enable_bls_aggregate_verify")]
 fn bls12381_v1_aggregate_verify(
     mut caller: Caller<'_, HostState>,
     pub_keys_and_msgs_ptr: u32,
@@ -1363,6 +1364,7 @@ impl WasmiModule {
             },
         );
 
+        #[cfg(feature = "enable_bls_aggregate_verify")]
         let host_bls12381_v1_aggregate_verify = Func::wrap(
             store.as_context_mut(),
             |caller: Caller<'_, HostState>,
@@ -1585,6 +1587,7 @@ impl WasmiModule {
             CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME,
             host_bls12381_v1_verify
         );
+        #[cfg(feature = "enable_bls_aggregate_verify")]
         linker_define!(
             linker,
             CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME,

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -691,6 +691,25 @@ fn bls12381_v1_verify(
     runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
 }
 
+fn bls12381_g2_signature_aggregate(
+    mut caller: Caller<'_, HostState>,
+    signatures_ptr: u32,
+    signatures_len: u32,
+) -> Result<u64, InvokeError<WasmRuntimeError>> {
+    let (memory, runtime) = grab_runtime!(caller);
+
+    let signatures = read_memory(
+        caller.as_context_mut(),
+        memory,
+        signatures_ptr,
+        signatures_len,
+    )?;
+
+    runtime
+        .crypto_utils_bls12381_g2_signature_aggregate(signatures)
+        .map(|buffer| buffer.0)
+}
+
 fn keccak256_hash(
     mut caller: Caller<'_, HostState>,
     data_ptr: u32,
@@ -1291,6 +1310,17 @@ impl WasmiModule {
             },
         );
 
+        let host_bls12381_g2_signature_aggregate = Func::wrap(
+            store.as_context_mut(),
+            |caller: Caller<'_, HostState>,
+             signatures_ptr: u32,
+             signatures_len: u32|
+             -> Result<u64, Trap> {
+                bls12381_g2_signature_aggregate(caller, signatures_ptr, signatures_len)
+                    .map_err(|e| e.into())
+            },
+        );
+
         let host_keccak256_hash = Func::wrap(
             store.as_context_mut(),
             |caller: Caller<'_, HostState>, data_ptr: u32, data_len: u32| -> Result<u64, Trap> {
@@ -1460,6 +1490,12 @@ impl WasmiModule {
             CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME,
             host_bls12381_v1_verify
         );
+        linker_define!(
+            linker,
+            CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME,
+            host_bls12381_g2_signature_aggregate
+        );
+
         linker_define!(
             linker,
             CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -315,6 +315,15 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
+    fn crypto_utils_bls12381_v1_aggregate_verify(
+        &mut self,
+        messages: Vec<u8>,
+        public_keys: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
+    }
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -317,8 +317,7 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
 
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
-        messages: Vec<u8>,
-        public_keys: Vec<u8>,
+        pub_keys_and_msgs: Vec<u8>,
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -315,6 +315,7 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -315,6 +315,13 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
+    fn crypto_utils_bls12381_g2_signature_aggregate(
+        &mut self,
+        signatures: Vec<u8>,
+    ) -> Result<Buffer, InvokeError<WasmRuntimeError>> {
+        Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
+    }
+
     fn crypto_utils_keccak256_hash(
         &mut self,
         data: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -324,6 +324,15 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
+    fn crypto_utils_bls12381_v1_fast_aggregate_verify(
+        &mut self,
+        message: Vec<u8>,
+        public_keys: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
+    }
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -585,7 +585,8 @@ where
         let signature: Bls12381G2Signature =
             scrypto_decode(&signature).map_err(WasmRuntimeError::InvalidBlsSignature)?;
         let pub_keys_and_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> =
-            scrypto_decode(&pub_keys_and_msgs).map_err(WasmRuntimeError::InvalidBlsInput)?;
+            scrypto_decode(&pub_keys_and_msgs)
+                .map_err(WasmRuntimeError::InvalidBlsPublicKeyOrMessage)?;
 
         let result = self
             .api

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -573,7 +573,7 @@ where
             .map_err(WasmRuntimeError::InvalidBlsSignature)?;
         let result = self
             .api
-            .bls12381_v1_verify(message, public_key, signature)?;
+            .bls12381_v1_verify(&message, &public_key, &signature)?;
         Ok(result)
     }
 
@@ -592,7 +592,7 @@ where
             sigs_vec.push(sig);
         }
 
-        let agg_sig = self.api.bls12381_g2_signature_aggregate(sigs_vec)?;
+        let agg_sig = self.api.bls12381_g2_signature_aggregate(&sigs_vec)?;
 
         self.allocate_buffer(agg_sig.to_vec())
     }
@@ -601,7 +601,7 @@ where
         &mut self,
         data: Vec<u8>,
     ) -> Result<Buffer, InvokeError<WasmRuntimeError>> {
-        let hash = self.api.keccak256_hash(data)?;
+        let hash = self.api.keccak256_hash(&data)?;
 
         self.allocate_buffer(hash.to_vec())
     }

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -606,6 +606,31 @@ where
         Ok(result)
     }
 
+    fn crypto_utils_bls12381_v1_fast_aggregate_verify(
+        &mut self,
+        message: Vec<u8>,
+        public_keys: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        let signature = Bls12381G2Signature::try_from(signature.as_slice())
+            .map_err(WasmRuntimeError::InvalidBlsSignature)?;
+        let pks_cnt = public_keys.len() / Bls12381G1PublicKey::LENGTH;
+        let mut pks_vec = vec![];
+
+        for i in 0..pks_cnt {
+            let idx = i * Bls12381G1PublicKey::LENGTH;
+            let pk =
+                Bls12381G1PublicKey::try_from(&public_keys[idx..idx + Bls12381G1PublicKey::LENGTH])
+                    .map_err(WasmRuntimeError::InvalidBlsPublicKey)?;
+            pks_vec.push(pk);
+        }
+
+        let result = self
+            .api
+            .bls12381_v1_fast_aggregate_verify(&message, &pks_vec, &signature)?;
+        Ok(result)
+    }
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -577,6 +577,26 @@ where
         Ok(result)
     }
 
+    fn crypto_utils_bls12381_g2_signature_aggregate(
+        &mut self,
+        signatures: Vec<u8>,
+    ) -> Result<Buffer, InvokeError<WasmRuntimeError>> {
+        let sigs_cnt = signatures.len() / Bls12381G2Signature::LENGTH;
+        let mut sigs_vec = vec![];
+
+        for i in 0..sigs_cnt {
+            let idx = i * Bls12381G2Signature::LENGTH;
+            let sig =
+                Bls12381G2Signature::try_from(&signatures[idx..idx + Bls12381G2Signature::LENGTH])
+                    .map_err(WasmRuntimeError::InvalidBlsSignature)?;
+            sigs_vec.push(sig);
+        }
+
+        let agg_sig = self.api.bls12381_g2_signature_aggregate(sigs_vec)?;
+
+        self.allocate_buffer(agg_sig.to_vec())
+    }
+
     fn crypto_utils_keccak256_hash(
         &mut self,
         data: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -579,30 +579,18 @@ where
 
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
-        messages: Vec<u8>,
-        public_keys: Vec<u8>,
+        pub_keys_and_msgs: Vec<u8>,
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>> {
         let signature = Bls12381G2Signature::try_from(signature.as_slice())
             .map_err(WasmRuntimeError::InvalidBlsSignature)?;
-        let pks_cnt = public_keys.len() / Bls12381G1PublicKey::LENGTH;
-        let mut pks_vec = vec![];
 
-        for i in 0..pks_cnt {
-            let idx = i * Bls12381G1PublicKey::LENGTH;
-            let pk =
-                Bls12381G1PublicKey::try_from(&public_keys[idx..idx + Bls12381G1PublicKey::LENGTH])
-                    .map_err(WasmRuntimeError::InvalidBlsPublicKey)?;
-            pks_vec.push(pk);
-        }
-
-        let messages: Vec<Vec<u8>> =
-            scrypto_decode(&messages).map_err(WasmRuntimeError::InvalidBlsMessage)?;
-        let msgs_ref: Vec<&[u8]> = messages.iter().map(|msg| msg.as_slice()).collect();
+        let pub_keys_and_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> =
+            scrypto_decode(&pub_keys_and_msgs).map_err(WasmRuntimeError::InvalidBlsInput)?;
 
         let result = self
             .api
-            .bls12381_v1_aggregate_verify(&msgs_ref, &pks_vec, &signature)?;
+            .bls12381_v1_aggregate_verify(&pub_keys_and_msgs, &signature)?;
         Ok(result)
     }
 

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -577,6 +577,35 @@ where
         Ok(result)
     }
 
+    fn crypto_utils_bls12381_v1_aggregate_verify(
+        &mut self,
+        messages: Vec<u8>,
+        public_keys: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        let signature = Bls12381G2Signature::try_from(signature.as_slice())
+            .map_err(WasmRuntimeError::InvalidBlsSignature)?;
+        let pks_cnt = public_keys.len() / Bls12381G1PublicKey::LENGTH;
+        let mut pks_vec = vec![];
+
+        for i in 0..pks_cnt {
+            let idx = i * Bls12381G1PublicKey::LENGTH;
+            let pk =
+                Bls12381G1PublicKey::try_from(&public_keys[idx..idx + Bls12381G1PublicKey::LENGTH])
+                    .map_err(WasmRuntimeError::InvalidBlsPublicKey)?;
+            pks_vec.push(pk);
+        }
+
+        let messages: Vec<Vec<u8>> =
+            scrypto_decode(&messages).map_err(WasmRuntimeError::InvalidBlsMessage)?;
+        let msgs_ref: Vec<&[u8]> = messages.iter().map(|msg| msg.as_slice()).collect();
+
+        let result = self
+            .api
+            .bls12381_v1_aggregate_verify(&msgs_ref, &pks_vec, &signature)?;
+        Ok(result)
+    }
+
     fn crypto_utils_bls12381_g2_signature_aggregate(
         &mut self,
         signatures: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -577,6 +577,7 @@ where
         Ok(result)
     }
 
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -277,6 +277,7 @@ implement_client_api! {
     },
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: Vec<u8>, public_key: Bls12381G1PublicKey, signature: Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_g2_signature_aggregate: (&mut self, signatures: Vec<Bls12381G2Signature>) -> Result<Bls12381G2Signature, RuntimeError>,
         keccak256_hash: (&mut self, data: Vec<u8>) -> Result<Hash, RuntimeError>,
     },
 }

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -278,6 +278,7 @@ implement_client_api! {
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_v1_aggregate_verify: (&mut self, messages: &[&[u8]], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_v1_fast_aggregate_verify: (&mut self, message: &[u8], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
         keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
     },

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -277,6 +277,7 @@ implement_client_api! {
     },
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_v1_aggregate_verify: (&mut self, messages: &[&[u8]], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
         keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
     },

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -277,7 +277,7 @@ implement_client_api! {
     },
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_v1_aggregate_verify: (&mut self, messages: &[&[u8]], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_v1_aggregate_verify: (&mut self, pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_v1_fast_aggregate_verify: (&mut self, message: &[u8], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
         keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -276,8 +276,8 @@ implement_client_api! {
         fee_balance: (&mut self) -> Result<Decimal, RuntimeError>,
     },
     ClientCryptoUtilsApi: {
-        bls12381_v1_verify: (&mut self, message: Vec<u8>, public_key: Bls12381G1PublicKey, signature: Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_g2_signature_aggregate: (&mut self, signatures: Vec<Bls12381G2Signature>) -> Result<Bls12381G2Signature, RuntimeError>,
-        keccak256_hash: (&mut self, data: Vec<u8>) -> Result<Hash, RuntimeError>,
+        bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
+        keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
     },
 }

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -275,6 +275,19 @@ implement_client_api! {
         tip_percentage: (&mut self) -> Result<u32, RuntimeError>,
         fee_balance: (&mut self) -> Result<Decimal, RuntimeError>,
     },
+}
+
+#[cfg(not(feature = "enable_bls_aggregate_verify"))]
+implement_client_api! {
+    ClientCryptoUtilsApi: {
+        bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_v1_fast_aggregate_verify: (&mut self, message: &[u8], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
+        bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
+        keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
+    },
+}
+#[cfg(feature = "enable_bls_aggregate_verify")]
+implement_client_api! {
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_v1_aggregate_verify: (&mut self, pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -1,5 +1,7 @@
 use crate::engine::wasm_api::{copy_buffer, crypto_utils};
-use radix_engine_common::prelude::{Bls12381G1PublicKey, Bls12381G2Signature, Hash};
+use radix_engine_common::prelude::{
+    scrypto_encode, Bls12381G1PublicKey, Bls12381G2Signature, Hash,
+};
 use sbor::prelude::Vec;
 
 /// Crypto utilities.
@@ -20,6 +22,24 @@ impl CryptoUtils {
                 message.len(),
                 public_key.0.as_ptr(),
                 public_key.0.len(),
+                signature.0.as_ptr(),
+                signature.0.len(),
+            ) != 0
+        }
+    }
+
+    pub fn crypto_utils_bls12381_v1_aggregate_verify(
+        messages: Vec<Vec<u8>>,
+        public_keys: Vec<Bls12381G1PublicKey>,
+        signature: Bls12381G2Signature,
+    ) -> bool {
+        let messages: Vec<u8> = scrypto_encode(&messages).unwrap();
+        unsafe {
+            crypto_utils::crypto_utils_bls12381_v1_aggregate_verify(
+                messages.as_ptr(),
+                messages.len(),
+                public_keys.as_ptr() as *const u8,
+                public_keys.len() * Bls12381G1PublicKey::LENGTH,
                 signature.0.as_ptr(),
                 signature.0.len(),
             ) != 0

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -32,17 +32,14 @@ impl CryptoUtils {
     /// multiple messages each signed with different key.
     /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
     pub fn bls12381_v1_aggregate_verify(
-        messages: Vec<Vec<u8>>,
-        public_keys: Vec<Bls12381G1PublicKey>,
+        pub_keys_and_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
         signature: Bls12381G2Signature,
     ) -> bool {
-        let messages: Vec<u8> = scrypto_encode(&messages).unwrap();
+        let pub_keys_and_msgs: Vec<u8> = scrypto_encode(&pub_keys_and_msgs).unwrap();
         unsafe {
             crypto_utils::crypto_utils_bls12381_v1_aggregate_verify(
-                messages.as_ptr(),
-                messages.len(),
-                public_keys.as_ptr() as *const u8,
-                public_keys.len() * Bls12381G1PublicKey::LENGTH,
+                pub_keys_and_msgs.as_ptr(),
+                pub_keys_and_msgs.len(),
                 signature.0.as_ptr(),
                 signature.0.len(),
             ) != 0

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -9,8 +9,8 @@ use sbor::prelude::Vec;
 pub struct CryptoUtils {}
 
 impl CryptoUtils {
-    /// Performs BLS12-381 G2 signature verification using following
-    /// domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+    /// Performs BLS12-381 G2 signature verification.
+    /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
     pub fn bls12381_v1_verify(
         message: Vec<u8>,
         public_key: Bls12381G1PublicKey,
@@ -28,7 +28,10 @@ impl CryptoUtils {
         }
     }
 
-    pub fn crypto_utils_bls12381_v1_aggregate_verify(
+    /// Performs BLS12-381 G2 aggregated signature verification of
+    /// multiple messages each signed with different key.
+    /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+    pub fn bls12381_v1_aggregate_verify(
         messages: Vec<Vec<u8>>,
         public_keys: Vec<Bls12381G1PublicKey>,
         signature: Bls12381G2Signature,

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -1,6 +1,6 @@
 use crate::engine::wasm_api::{copy_buffer, crypto_utils};
 use radix_engine_common::prelude::{
-    scrypto_encode, Bls12381G1PublicKey, Bls12381G2Signature, Hash,
+    scrypto_decode, scrypto_encode, Bls12381G1PublicKey, Bls12381G2Signature, Hash,
 };
 use sbor::prelude::Vec;
 
@@ -16,14 +16,16 @@ impl CryptoUtils {
         public_key: Bls12381G1PublicKey,
         signature: Bls12381G2Signature,
     ) -> bool {
+        let public_key: Vec<u8> = scrypto_encode(&public_key).unwrap();
+        let signature: Vec<u8> = scrypto_encode(&signature).unwrap();
         unsafe {
             crypto_utils::crypto_utils_bls12381_v1_verify(
                 message.as_ptr(),
                 message.len(),
-                public_key.0.as_ptr(),
-                public_key.0.len(),
-                signature.0.as_ptr(),
-                signature.0.len(),
+                public_key.as_ptr(),
+                public_key.len(),
+                signature.as_ptr(),
+                signature.len(),
             ) != 0
         }
     }
@@ -36,12 +38,13 @@ impl CryptoUtils {
         signature: Bls12381G2Signature,
     ) -> bool {
         let pub_keys_and_msgs: Vec<u8> = scrypto_encode(&pub_keys_and_msgs).unwrap();
+        let signature: Vec<u8> = scrypto_encode(&signature).unwrap();
         unsafe {
             crypto_utils::crypto_utils_bls12381_v1_aggregate_verify(
                 pub_keys_and_msgs.as_ptr(),
                 pub_keys_and_msgs.len(),
-                signature.0.as_ptr(),
-                signature.0.len(),
+                signature.as_ptr(),
+                signature.len(),
             ) != 0
         }
     }
@@ -54,14 +57,16 @@ impl CryptoUtils {
         public_keys: Vec<Bls12381G1PublicKey>,
         signature: Bls12381G2Signature,
     ) -> bool {
+        let public_keys: Vec<u8> = scrypto_encode(&public_keys).unwrap();
+        let signature: Vec<u8> = scrypto_encode(&signature).unwrap();
         unsafe {
             crypto_utils::crypto_utils_bls12381_v1_fast_aggregate_verify(
                 message.as_ptr(),
                 message.len(),
-                public_keys.as_ptr() as *const u8,
-                public_keys.len() * Bls12381G1PublicKey::LENGTH,
-                signature.0.as_ptr(),
-                signature.0.len(),
+                public_keys.as_ptr(),
+                public_keys.len(),
+                signature.as_ptr(),
+                signature.len(),
             ) != 0
         }
     }
@@ -70,14 +75,15 @@ impl CryptoUtils {
     pub fn bls12381_g2_signature_aggregate(
         signatures: Vec<Bls12381G2Signature>,
     ) -> Bls12381G2Signature {
+        let signatures: Vec<u8> = scrypto_encode(&signatures).unwrap();
         let agg_signature = copy_buffer(unsafe {
             crypto_utils::crypto_utils_bls12381_g2_signature_aggregate(
-                signatures.as_ptr() as *const u8,
-                signatures.len() * Bls12381G2Signature::LENGTH,
+                signatures.as_ptr(),
+                signatures.len(),
             )
         });
 
-        Bls12381G2Signature::try_from(agg_signature.as_slice()).unwrap()
+        scrypto_decode::<Bls12381G2Signature>(&agg_signature).unwrap()
     }
 
     /// Calculates Keccak-256 digest over given vector of bytes

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -26,6 +26,20 @@ impl CryptoUtils {
         }
     }
 
+    /// Aggregate multiple BLS12-381 G2 signatures into single one
+    pub fn bls12381_g2_signature_aggregate(
+        signatures: Vec<Bls12381G2Signature>,
+    ) -> Bls12381G2Signature {
+        let agg_signature = copy_buffer(unsafe {
+            crypto_utils::crypto_utils_bls12381_g2_signature_aggregate(
+                signatures.as_ptr() as *const u8,
+                signatures.len() * Bls12381G2Signature::LENGTH,
+            )
+        });
+
+        Bls12381G2Signature::try_from(agg_signature.as_slice()).unwrap()
+    }
+
     /// Calculates Keccak-256 digest over given vector of bytes
     pub fn keccak256_hash(data: Vec<u8>) -> Hash {
         let hash = copy_buffer(unsafe {

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -49,6 +49,26 @@ impl CryptoUtils {
         }
     }
 
+    /// Performs BLS12-381 G2 aggregated signature verification of
+    /// multiple messages each signed with different key.
+    /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+    pub fn bls12381_v1_fast_aggregate_verify(
+        message: Vec<u8>,
+        public_keys: Vec<Bls12381G1PublicKey>,
+        signature: Bls12381G2Signature,
+    ) -> bool {
+        unsafe {
+            crypto_utils::crypto_utils_bls12381_v1_fast_aggregate_verify(
+                message.as_ptr(),
+                message.len(),
+                public_keys.as_ptr() as *const u8,
+                public_keys.len() * Bls12381G1PublicKey::LENGTH,
+                signature.0.as_ptr(),
+                signature.0.len(),
+            ) != 0
+        }
+    }
+
     /// Aggregate multiple BLS12-381 G2 signatures into single one
     pub fn bls12381_g2_signature_aggregate(
         signatures: Vec<Bls12381G2Signature>,

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -49,8 +49,8 @@ impl CryptoUtils {
         }
     }
 
-    /// Performs BLS12-381 G2 aggregated signature verification of
-    /// multiple messages each signed with different key.
+    /// Performs BLS12-381 G2 aggregated signature verification
+    /// one message signed with multiple keys.
     /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
     pub fn bls12381_v1_fast_aggregate_verify(
         message: Vec<u8>,

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -33,6 +33,7 @@ impl CryptoUtils {
     /// Performs BLS12-381 G2 aggregated signature verification of
     /// multiple messages each signed with different key.
     /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
+    #[cfg(feature = "enable_bls_aggregate_verify")]
     pub fn bls12381_v1_aggregate_verify(
         pub_keys_and_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
         signature: Bls12381G2Signature,

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -297,6 +297,7 @@ pub mod crypto_utils {
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 
+        #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn crypto_utils_bls12381_v1_aggregate_verify(
             pub_keys_and_msgs_ptr: *const u8,
             pub_keys_and_msgs_len: usize,

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -297,6 +297,10 @@ pub mod crypto_utils {
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 
+        pub fn crypto_utils_bls12381_g2_signature_aggregate(
+            signatures_ptr: *const u8,
+            signatures_len: usize) -> Buffer;
+
         pub fn crypto_utils_keccak256_hash(
             message_ptr: *const u8,
             message_len: usize) -> Buffer;

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -297,6 +297,14 @@ pub mod crypto_utils {
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 
+        pub fn crypto_utils_bls12381_v1_aggregate_verify(
+            messages_ptr: *const u8,
+            messages_len: usize,
+            public_keys_ptr: *const u8,
+            public_keys_len: usize,
+            signature_ptr: *const u8,
+            signature_len: usize) -> u32;
+
         pub fn crypto_utils_bls12381_g2_signature_aggregate(
             signatures_ptr: *const u8,
             signatures_len: usize) -> Buffer;

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -298,10 +298,8 @@ pub mod crypto_utils {
             signature_len: usize) -> u32;
 
         pub fn crypto_utils_bls12381_v1_aggregate_verify(
-            messages_ptr: *const u8,
-            messages_len: usize,
-            public_keys_ptr: *const u8,
-            public_keys_len: usize,
+            pub_keys_and_msgs_ptr: *const u8,
+            pub_keys_and_msgs_len: usize,
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -305,6 +305,14 @@ pub mod crypto_utils {
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 
+        pub fn crypto_utils_bls12381_v1_fast_aggregate_verify(
+            messages_ptr: *const u8,
+            messages_len: usize,
+            public_keys_ptr: *const u8,
+            public_keys_len: usize,
+            signature_ptr: *const u8,
+            signature_len: usize) -> u32;
+
         pub fn crypto_utils_bls12381_g2_signature_aggregate(
             signatures_ptr: *const u8,
             signatures_len: usize) -> Buffer;


### PR DESCRIPTION
## Summary
This PR adds following API methods to `CryptoUtils`:
- `bls12381_g2_signature_aggregate()`
Aggregate given BLS12-381 G2 signatures into single one
- `bls12381_v1_aggregate_verify()`
Perform BLS12-381 G2 aggregated signature verification of multiple messages, where each is signed with different key
- `bls12381_v1_fast_aggregate_verify()`
Performs BLS12-381 G2 aggregated signature verification of single message signed with different keys

## Details

Proposed API was inspired by:
-  [Ethereum Beacon chain](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures)
-  `blst` crate [API](https://docs.rs/blst/0.3.11/blst/min_pk/struct.Signature.html)

TODO: Costing

## Testing
- some tests added to `bls12381` (in `radix-engine-common`) module implementation
- Test `CryptoUtils` module using `CryptoScrypto` test blueprint
