### PR TITLE
Architecture: Remove Hash Tree mut Requirement

### DIFF
--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hello-world"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "radix-engine",
  "sbor",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "native-sdk"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "radix-engine-common",
  "radix-engine-derive",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-common"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-derive"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -752,6 +752,7 @@ dependencies = [
  "regex",
  "sbor",
  "scrypto-schema",
+ "serde",
  "serde_json",
  "strum",
  "utils",
@@ -759,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-macros"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -770,14 +771,14 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "fixedstr",
 ]
 
 [[package]]
 name = "radix-engine-queries"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "hex",
  "itertools",
@@ -792,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-store-interface"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "hex",
  "itertools",
@@ -805,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-stores"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "hex",
  "itertools",
@@ -893,7 +894,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "resources-tracker-macro"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -946,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "const-sha1",
  "hex",
@@ -959,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -967,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "const-sha1",
  "itertools",
@@ -993,7 +994,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypto"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -1014,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto-derive"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1029,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto-schema"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bitflags 1.3.2",
  "radix-engine-common",
@@ -1039,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto-unit"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "radix-engine",
  "radix-engine-interface",
@@ -1260,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "transaction"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "bech32",
  "ed25519-dalek",
@@ -1309,7 +1310,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "utils"
-version = "1.1.0-dev"
+version = "1.0.2-dev"
 dependencies = [
  "indexmap 2.0.0-pre",
  "serde",

--- a/radix-engine-stores/src/hash_tree/mod.rs
+++ b/radix-engine-stores/src/hash_tree/mod.rs
@@ -79,15 +79,15 @@ pub fn list_substate_hashes_at_version<S: ReadableTreeStore>(
         let db_node_key = node_tier_leaf.leaf_key().bytes.clone();
         let mut partition_tier_store = NestedTreeStore::new(node_tier_store, db_node_key.clone());
         for partition_tier_leaf in
-            list_leaves(&mut partition_tier_store, node_tier_leaf.payload().clone())
+            list_leaves(&partition_tier_store, node_tier_leaf.payload().clone())
         {
             let db_partition_num =
                 DbPartitionNum::from_be_bytes(copy_u8_array(&partition_tier_leaf.leaf_key().bytes));
-            let mut substate_tier_store =
+            let substate_tier_store =
                 NestedTreeStore::new(&mut partition_tier_store, vec![db_partition_num]);
             let mut by_db_sort_key = index_map_new();
             for substate_tier_leaf in list_leaves(
-                &mut substate_tier_store,
+                &substate_tier_store,
                 partition_tier_leaf.payload().clone(),
             ) {
                 by_db_sort_key.insert(
@@ -110,7 +110,7 @@ pub fn list_substate_hashes_at_version<S: ReadableTreeStore>(
 // only internals below
 
 fn list_leaves<S: ReadableTreeStore>(
-    tree_store: &mut S,
+    tree_store: &S,
     version: Version,
 ) -> Vec<LeafNode<Version>> {
     let mut leaves = Vec::new();
@@ -119,7 +119,7 @@ fn list_leaves<S: ReadableTreeStore>(
 }
 
 fn list_leaves_recursively<S: ReadableTreeStore>(
-    tree_store: &mut S,
+    tree_store: &S,
     key: NodeKey,
     results: &mut Vec<LeafNode<Version>>,
 ) {

--- a/radix-engine-stores/src/hash_tree/mod.rs
+++ b/radix-engine-stores/src/hash_tree/mod.rs
@@ -86,10 +86,9 @@ pub fn list_substate_hashes_at_version<S: ReadableTreeStore>(
             let substate_tier_store =
                 NestedTreeStore::new(&mut partition_tier_store, vec![db_partition_num]);
             let mut by_db_sort_key = index_map_new();
-            for substate_tier_leaf in list_leaves(
-                &substate_tier_store,
-                partition_tier_leaf.payload().clone(),
-            ) {
+            for substate_tier_leaf in
+                list_leaves(&substate_tier_store, partition_tier_leaf.payload().clone())
+            {
                 by_db_sort_key.insert(
                     DbSortKey(substate_tier_leaf.leaf_key().bytes.clone()),
                     substate_tier_leaf.value_hash(),
@@ -109,10 +108,7 @@ pub fn list_substate_hashes_at_version<S: ReadableTreeStore>(
 
 // only internals below
 
-fn list_leaves<S: ReadableTreeStore>(
-    tree_store: &S,
-    version: Version,
-) -> Vec<LeafNode<Version>> {
+fn list_leaves<S: ReadableTreeStore>(tree_store: &S, version: Version) -> Vec<LeafNode<Version>> {
     let mut leaves = Vec::new();
     list_leaves_recursively(tree_store, NodeKey::new_empty_path(version), &mut leaves);
     leaves
@@ -356,11 +352,11 @@ impl<'s, S: ReadableTreeStore> ReadableTreeStore for NestedTreeStore<'s, S> {
 }
 
 impl<'s, S: WriteableTreeStore> WriteableTreeStore for NestedTreeStore<'s, S> {
-    fn insert_node(&mut self, key: NodeKey, node: TreeNode) {
+    fn insert_node(&self, key: NodeKey, node: TreeNode) {
         self.underlying.insert_node(self.prefixed(&key), node);
     }
 
-    fn record_stale_tree_part(&mut self, part: StaleTreePart) {
+    fn record_stale_tree_part(&self, part: StaleTreePart) {
         self.underlying.record_stale_tree_part(match part {
             StaleTreePart::Node(key) => StaleTreePart::Node(self.prefixed(&key)),
             StaleTreePart::Subtree(key) => StaleTreePart::Subtree(self.prefixed(&key)),

--- a/radix-engine-stores/src/hash_tree/mod.rs
+++ b/radix-engine-stores/src/hash_tree/mod.rs
@@ -42,7 +42,7 @@ mod types;
 /// Panics if a root node for `node_root_version` does not exist. The caller should use `None` to
 /// denote an empty, initial state of the tree (i.e. inserting at version 1).
 pub fn put_at_next_version<S: TreeStore>(
-    node_tier_store: &mut S,
+    node_tier_store: &S,
     node_root_version: Option<Version>,
     database_updates: &DatabaseUpdates,
 ) -> Hash {
@@ -71,7 +71,7 @@ pub fn put_at_next_version<S: TreeStore>(
 }
 
 pub fn list_substate_hashes_at_version<S: ReadableTreeStore>(
-    node_tier_store: &mut S,
+    node_tier_store: &S,
     node_root_version: Version,
 ) -> IndexMap<DbPartitionKey, IndexMap<DbSortKey, Hash>> {
     let mut by_db_partition = index_map_new();
@@ -140,7 +140,7 @@ fn list_leaves_recursively<S: ReadableTreeStore>(
 }
 
 fn apply_node_database_updates<S: TreeStore>(
-    node_tier_store: &mut S,
+    node_tier_store: &S,
     node_root_version: Option<Version>,
     node_key: &DbNodeKey,
     node_database_updates: &NodeDatabaseUpdates,
@@ -174,7 +174,7 @@ fn apply_node_database_updates<S: TreeStore>(
 }
 
 fn apply_partition_database_updates<S: TreeStore>(
-    partition_tier_store: &mut S,
+    partition_tier_store: &S,
     partition_root_version: Option<Version>,
     partition_num: &DbPartitionNum,
     partition_database_updates: &PartitionDatabaseUpdates,
@@ -263,7 +263,7 @@ impl LeafHashChange {
 }
 
 fn put_leaf_hash_changes<S: TreeStore>(
-    store: &mut S,
+    store: &S,
     current_version: Option<Version>,
     next_version: Version,
     changes: Vec<LeafHashChange>,
@@ -290,7 +290,7 @@ struct LeafChange {
 }
 
 fn put_leaf_changes<S: TreeStore>(
-    store: &mut S,
+    store: &S,
     current_version: Option<Version>,
     next_version: Version,
     changes: Vec<LeafChange>,
@@ -317,14 +317,14 @@ fn put_leaf_changes<S: TreeStore>(
 }
 
 struct NestedTreeStore<'s, S> {
-    underlying: &'s mut S,
+    underlying: &'s S,
     key_prefix_bytes: Vec<u8>,
 }
 
 impl<'s, S> NestedTreeStore<'s, S> {
     const TIER_SEPARATOR: u8 = b'_';
 
-    pub fn new(underlying: &'s mut S, parent_tier_key_bytes: Vec<u8>) -> NestedTreeStore<'s, S> {
+    pub fn new(underlying: &'s S, parent_tier_key_bytes: Vec<u8>) -> NestedTreeStore<'s, S> {
         let mut key_prefix_bytes = parent_tier_key_bytes;
         key_prefix_bytes.push(Self::TIER_SEPARATOR);
         NestedTreeStore {

--- a/radix-engine-stores/src/hash_tree/test.rs
+++ b/radix-engine-stores/src/hash_tree/test.rs
@@ -403,14 +403,13 @@ fn serialized_keys_are_strictly_increasing() {
     tester.put_substate_changes(vec![change(3, 6, 4, Some(90))]);
     let previous_keys = tester
         .tree_store
-        .memory
-        .borrow()
+        .memory()
         .keys()
         .cloned()
         .collect::<HashSet<_>>();
     tester.put_substate_changes(vec![change(1, 7, 2, Some(80))]);
-    let binding = tester.tree_store.memory.borrow();
-    let min_next_key = binding
+    let tree_store_mem = tester.tree_store.memory();
+    let min_next_key = tree_store_mem
         .keys()
         .filter(|key| !previous_keys.contains(*key))
         .max()

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -3,8 +3,8 @@ pub use super::types::{Nibble, NibblePath, NodeKey, Version};
 
 use radix_engine_common::crypto::Hash;
 use radix_engine_common::data::scrypto::{scrypto_decode, scrypto_encode};
-use sbor::*;
 use sbor::rust::cell::RefCell;
+use sbor::*;
 use utils::rust::collections::VecDeque;
 use utils::rust::collections::{hash_map_new, HashMap};
 use utils::rust::vec::Vec;

--- a/radix-engine-stores/src/hash_tree/tree_store.rs
+++ b/radix-engine-stores/src/hash_tree/tree_store.rs
@@ -3,6 +3,7 @@ pub use super::types::{Nibble, NibblePath, NodeKey, Version};
 
 use radix_engine_common::crypto::Hash;
 use radix_engine_common::data::scrypto::{scrypto_decode, scrypto_encode};
+use sbor::rust::cell::Ref;
 use sbor::rust::cell::RefCell;
 use sbor::*;
 use utils::rust::collections::VecDeque;
@@ -160,8 +161,8 @@ impl WriteableTreeStore for TypedInMemoryTreeStore {
 /// A `TreeStore` based on serialized payloads stored in memory.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SerializedInMemoryTreeStore {
-    pub memory: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
-    pub stale_part_buffer: RefCell<Vec<Vec<u8>>>,
+    memory: RefCell<HashMap<Vec<u8>, Vec<u8>>>,
+    stale_part_buffer: RefCell<Vec<Vec<u8>>>,
 }
 
 impl SerializedInMemoryTreeStore {
@@ -171,6 +172,10 @@ impl SerializedInMemoryTreeStore {
             memory: RefCell::new(hash_map_new()),
             stale_part_buffer: RefCell::new(Vec::new()),
         }
+    }
+
+    pub fn memory(&self) -> Ref<HashMap<Vec<u8>, Vec<u8>>> {
+        self.memory.borrow()
     }
 }
 

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -201,7 +201,7 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         // derive and put new JMT nodes (also record references to stale parts, for later amortized background GC [not implemented here!])
         let (state_hash_tree_update, new_root_hash) =
             compute_state_tree_update(self, parent_state_version, database_updates);
-        for (key, node) in state_hash_tree_update.new_nodes.borrow() {
+        for (key, node) in state_hash_tree_update.new_nodes.take() {
             batch.put_cf(
                 self.cf(MERKLE_NODES_CF),
                 encode_key(&key),
@@ -232,7 +232,7 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         self.db.write(batch).unwrap();
 
         if self.pruning_enabled {
-            for part in state_hash_tree_update.stale_tree_parts.borrow() {
+            for part in state_hash_tree_update.stale_tree_parts.take() {
                 match part {
                     StaleTreePart::Node(node_key) => {
                         self.db

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -201,7 +201,7 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         // derive and put new JMT nodes (also record references to stale parts, for later amortized background GC [not implemented here!])
         let (state_hash_tree_update, new_root_hash) =
             compute_state_tree_update(self, parent_state_version, database_updates);
-        for (key, node) in state_hash_tree_update.new_nodes {
+        for (key, node) in state_hash_tree_update.new_nodes.borrow() {
             batch.put_cf(
                 self.cf(MERKLE_NODES_CF),
                 encode_key(&key),
@@ -232,7 +232,7 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
         self.db.write(batch).unwrap();
 
         if self.pruning_enabled {
-            for part in state_hash_tree_update.stale_tree_parts {
+            for part in state_hash_tree_update.stale_tree_parts.borrow() {
                 match part {
                     StaleTreePart::Node(node_key) => {
                         self.db

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use crate::hash_tree::put_at_next_version;
 use crate::hash_tree::tree_store::{
     NodeKey, ReadableTreeStore, StaleTreePart, TreeNode, WriteableTreeStore,
@@ -41,15 +42,15 @@ impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
 
 #[derive(Clone)]
 pub struct StateHashTreeDiff {
-    pub new_nodes: Vec<(NodeKey, TreeNode)>,
-    pub stale_tree_parts: Vec<StaleTreePart>,
+    pub new_nodes: RefCell<Vec<(NodeKey, TreeNode)>>,
+    pub stale_tree_parts: RefCell<Vec<StaleTreePart>>,
 }
 
 impl StateHashTreeDiff {
     pub fn new() -> Self {
         Self {
-            new_nodes: Vec::new(),
-            stale_tree_parts: Vec::new(),
+            new_nodes: RefCell::new(Vec::new()),
+            stale_tree_parts: RefCell::new(Vec::new()),
         }
     }
 }

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -30,11 +30,11 @@ impl<'s, S: ReadableTreeStore> ReadableTreeStore for CollectingTreeStore<'s, S> 
 }
 
 impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
-    fn insert_node(&mut self, key: NodeKey, node: TreeNode) {
+    fn insert_node(&self, key: NodeKey, node: TreeNode) {
         self.diff.new_nodes.push((key, node));
     }
 
-    fn record_stale_tree_part(&mut self, part: StaleTreePart) {
+    fn record_stale_tree_part(&self, part: StaleTreePart) {
         self.diff.stale_tree_parts.push(part);
     }
 }

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -1,10 +1,10 @@
-use std::cell::RefCell;
 use crate::hash_tree::put_at_next_version;
 use crate::hash_tree::tree_store::{
     NodeKey, ReadableTreeStore, StaleTreePart, TreeNode, WriteableTreeStore,
 };
 use radix_engine_common::prelude::Hash;
 use radix_engine_store_interface::interface::DatabaseUpdates;
+use std::cell::RefCell;
 
 struct CollectingTreeStore<'s, S> {
     readable_delegate: &'s S,
@@ -32,11 +32,11 @@ impl<'s, S: ReadableTreeStore> ReadableTreeStore for CollectingTreeStore<'s, S> 
 
 impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
     fn insert_node(&self, key: NodeKey, node: TreeNode) {
-        self.diff.new_nodes.push((key, node));
+        self.diff.new_nodes.borrow_mut().push((key, node));
     }
 
     fn record_stale_tree_part(&self, part: StaleTreePart) {
-        self.diff.stale_tree_parts.push(part);
+        self.diff.stale_tree_parts.borrow_mut().push(part);
     }
 }
 


### PR DESCRIPTION
Remove mut requirement on hash tree methods. Replaced with interior mutability implementation.