### PR TITLE
Fix issues in substate stores

### DIFF
--- a/radix-engine-common/src/crypto/hash.rs
+++ b/radix-engine-common/src/crypto/hash.rs
@@ -1,5 +1,4 @@
 use crate::crypto::blake2b_256_hash;
-use crate::ScryptoSbor;
 use sbor::rust::borrow::ToOwned;
 use sbor::rust::convert::TryFrom;
 use sbor::rust::fmt;

--- a/radix-engine-store-interface/src/interface.rs
+++ b/radix-engine-store-interface/src/interface.rs
@@ -1,6 +1,5 @@
 use radix_engine_common::Sbor;
 use utils::prelude::index_map_new;
-use utils::prelude::vec;
 use utils::rust::boxed::Box;
 use utils::rust::collections::IndexMap;
 use utils::rust::vec::Vec;
@@ -17,24 +16,6 @@ pub type DbPartitionNum = u8;
 pub struct DbPartitionKey {
     pub node_key: DbNodeKey,
     pub partition_num: DbPartitionNum,
-}
-
-impl DbPartitionKey {
-    /// Calculates a hypothetical "next partition" key in the database.
-    /// This method is suitable for constructing an open right bound of a database key range; the
-    /// partition of the returned key may in practice not even exist in the database.
-    pub fn next(&self) -> Self {
-        self.partition_num
-            .checked_add(1)
-            .map(|next_partition_num| DbPartitionKey {
-                node_key: self.node_key.clone(),
-                partition_num: next_partition_num,
-            })
-            .unwrap_or_else(|| DbPartitionKey {
-                node_key: [self.node_key.clone(), vec![0]].concat(),
-                partition_num: 0,
-            })
-    }
 }
 
 /// A database-level key of a substate within a known partition.

--- a/radix-engine-stores/Cargo.toml
+++ b/radix-engine-stores/Cargo.toml
@@ -13,8 +13,11 @@ rocksdb = { version = "0.21.0", optional = true }
 itertools = { version = "0.10.3", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 
+[dev-dependencies]
+tempfile = "3.8.0"
+
 [features]
-default = ["std"]
+default = ["std", "rocksdb"]
 std = ["hex/std", "sbor/std", "utils/std", "radix-engine-common/std", "radix-engine-derive/std", "radix-engine-store-interface/std", "itertools/use_std"]
 alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-common/alloc", "radix-engine-derive/alloc", "radix-engine-store-interface/alloc", "itertools/use_alloc"]
 

--- a/radix-engine-stores/Cargo.toml
+++ b/radix-engine-stores/Cargo.toml
@@ -17,7 +17,7 @@ hex = { version = "0.4.3", default-features = false }
 tempfile = "3.8.0"
 
 [features]
-default = ["std", "rocksdb"]
+default = ["std"]
 std = ["hex/std", "sbor/std", "utils/std", "radix-engine-common/std", "radix-engine-derive/std", "radix-engine-store-interface/std", "itertools/use_std"]
 alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-common/alloc", "radix-engine-derive/alloc", "radix-engine-store-interface/alloc", "itertools/use_alloc"]
 

--- a/radix-engine-stores/src/rocks_db.rs
+++ b/radix-engine-stores/src/rocks_db.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use radix_engine_common::constants::MAX_SUBSTATE_KEY_SIZE;
 use radix_engine_store_interface::interface::*;
 pub use rocksdb::{BlockBasedOptions, LogLevel, Options};
 use rocksdb::{
@@ -108,7 +109,10 @@ impl CommittableSubstateDatabase for RocksdbSubstateStore {
                             .delete_range_cf(
                                 self.cf(),
                                 encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![])),
-                                encode_to_rocksdb_bytes(&partition_key.next(), &DbSortKey(vec![])),
+                                encode_to_rocksdb_bytes(
+                                    &partition_key,
+                                    &DbSortKey(vec![u8::MAX; 2 * MAX_SUBSTATE_KEY_SIZE]),
+                                ),
                             )
                             .expect("IO error");
                         for (sort_key, value_bytes) in new_substate_values {

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -2,6 +2,7 @@ use crate::hash_tree::tree_store::{
     encode_key, NodeKey, ReadableTreeStore, StaleTreePart, TreeNode, TreeNodeV1, VersionedTreeNode,
 };
 use itertools::Itertools;
+use radix_engine_common::constants::MAX_SUBSTATE_KEY_SIZE;
 use radix_engine_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_engine_common::prelude::Hash;
 use radix_engine_derive::ScryptoSbor;
@@ -184,7 +185,10 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
                             .delete_range_cf(
                                 self.cf(SUBSTATES_CF),
                                 encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![])),
-                                encode_to_rocksdb_bytes(&partition_key.next(), &DbSortKey(vec![])),
+                                encode_to_rocksdb_bytes(
+                                    &partition_key,
+                                    &DbSortKey(vec![u8::MAX; 2 * MAX_SUBSTATE_KEY_SIZE]),
+                                ),
                             )
                             .expect("IO error");
                         for (sort_key, value_bytes) in new_substate_values {

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -312,3 +312,59 @@ struct Metadata {
     current_state_version: u64,
     current_state_root_hash: Hash,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use radix_engine_store_interface::interface::{
+        CommittableSubstateDatabase, DatabaseUpdates, DbSortKey, NodeDatabaseUpdates,
+        PartitionDatabaseUpdates,
+    };
+
+    #[cfg(not(feature = "alloc"))]
+    #[test]
+    fn test_partition_deletion() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut db = RocksDBWithMerkleTreeSubstateStore::standard(temp_dir.into_path());
+
+        let node_updates = NodeDatabaseUpdates {
+            partition_updates: indexmap! {
+                0 => PartitionDatabaseUpdates::Reset {
+                    new_substate_values: indexmap! {
+                        DbSortKey(vec![5]) => vec![6]
+                    }
+                },
+                1 => PartitionDatabaseUpdates::Reset {
+                    new_substate_values: indexmap! {
+                        DbSortKey(vec![7]) => vec![8]
+                    }
+                },
+                255 => PartitionDatabaseUpdates::Reset {
+                    new_substate_values: indexmap! {
+                        DbSortKey(vec![9]) => vec![10]
+                    }
+                }
+            },
+        };
+        let updates = DatabaseUpdates {
+            node_updates: indexmap! {
+                vec![0] => node_updates.clone(),
+                vec![1] => node_updates.clone(),
+                vec![255] => node_updates.clone(),
+            },
+        };
+        db.commit(&updates);
+
+        assert_eq!(db.list_partition_keys().count(), 9);
+        db.commit(&DatabaseUpdates {
+            node_updates: indexmap! {
+                vec![0] => NodeDatabaseUpdates {
+                    partition_updates: indexmap!{
+                        255 => PartitionDatabaseUpdates::Reset { new_substate_values: indexmap!{} }
+                    }
+                }
+            },
+        });
+        assert_eq!(db.list_partition_keys().count(), 8);
+    }
+}

--- a/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-engine-stores/src/rocks_db_with_merkle_tree/mod.rs
@@ -284,7 +284,7 @@ impl ListableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
     fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_> {
         Box::new(
             self.db
-                .iterator(IteratorMode::Start)
+                .iterator_cf(self.cf(SUBSTATES_CF), IteratorMode::Start)
                 .map(|kv| {
                     let (iter_key_bytes, _) = kv.as_ref().unwrap();
                     let (iter_key, _) = decode_from_rocksdb_bytes(iter_key_bytes);


### PR DESCRIPTION
## Summary

- Fixed a bug in partition deletion for `RocksdbSubstateStore` and `RocksDBWithMerkleTreeSubstateStore`
- Fixed a bug in `list_partition_keys` for `RocksDBWithMerkleTreeSubstateStore`

_(The two stores are used by `resim` and `ledger-tools` only)_

## Testing

New tests added.

