### PR TITLE
Enable BLS aggregate verify

### DIFF
--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -49,10 +49,6 @@ serde = ["dep:serde", "utils/serde", "sbor/serde", "hex/serde"]
 std = ["hex/std", "sbor/std", "utils/std", "radix-engine-derive/std", "serde_json/std", "ed25519-dalek/std", "secp256k1/std", "blake2/std", "sha3/std" ]
 alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", "serde_json/alloc", "ed25519-dalek/alloc", "secp256k1/alloc", "lazy_static/spin_no_std", "blst/no-threads" ]
 
-# Temporary switch to disable code related to BLS aggregate verify
-# It does not work for WASM32 and no_std
-enable_bls_aggregate_verify = []
-
 # This flag is set by fuzz-tests framework and it is used to disable/enable some optional features
 # to let fuzzing work
 radix_engine_fuzzing = ["arbitrary", "serde", "bnum/arbitrary", "bnum/serde", "sbor/radix_engine_fuzzing", "utils/radix_engine_fuzzing"]

--- a/radix-engine-common/Cargo.toml
+++ b/radix-engine-common/Cargo.toml
@@ -47,7 +47,7 @@ harness = false
 default = ["std"]
 serde = ["dep:serde", "utils/serde", "sbor/serde", "hex/serde"]
 std = ["hex/std", "sbor/std", "utils/std", "radix-engine-derive/std", "serde_json/std", "ed25519-dalek/std", "secp256k1/std", "blake2/std", "sha3/std" ]
-alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", "serde_json/alloc", "ed25519-dalek/alloc", "secp256k1/alloc", "lazy_static/spin_no_std" ]
+alloc = ["hex/alloc", "sbor/alloc", "utils/alloc", "radix-engine-derive/alloc", "serde_json/alloc", "ed25519-dalek/alloc", "secp256k1/alloc", "lazy_static/spin_no_std", "blst/no-threads" ]
 
 # Temporary switch to disable code related to BLS aggregate verify
 # It does not work for WASM32 and no_std

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -82,7 +82,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn sign_and_verify_aggregated() {
         let sks: Vec<Bls12381G1PrivateKey> = (1..11)
             .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -168,7 +168,10 @@ mod tests {
             pks.iter().zip(msgs_rev).map(|(pk, sk)| (*pk, sk)).collect();
 
         // Verify the messages in reversed order against public keys and aggregated signature
-        assert!(!aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+        assert_eq!(
+            aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig),
+            false
+        );
     }
 
     #[test]
@@ -178,7 +181,7 @@ mod tests {
         // Aggregate the signature
         let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
-        // Skip the last key, msg tuple
+        // Skip the last key and message tuple
         let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> = pks
             .iter()
             .zip(msgs)
@@ -188,7 +191,10 @@ mod tests {
 
         // Verify the incomplete messages against public keys and aggregated
         // signature from all messages
-        assert!(!aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+        assert_eq!(
+            aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig),
+            false
+        );
 
         // Aggregate the signatures from incomplete messages
         let agg_sig = Bls12381G2Signature::aggregate(&sigs[0..9]).unwrap();

--- a/radix-engine-common/src/crypto/bls12381/private_key.rs
+++ b/radix-engine-common/src/crypto/bls12381/private_key.rs
@@ -41,6 +41,48 @@ mod tests {
     use super::*;
     use sbor::rust::str::FromStr;
 
+    fn get_aggregate_verify_test_data(
+        cnt: u32,
+        msg_cnt: u32,
+        msg_size: usize,
+    ) -> (
+        Vec<Bls12381G1PrivateKey>,
+        Vec<Bls12381G1PublicKey>,
+        Vec<Vec<u8>>,
+        Vec<Bls12381G2Signature>,
+    ) {
+        let sks: Vec<Bls12381G1PrivateKey> = (1..(cnt + 1))
+            .map(|i| Bls12381G1PrivateKey::from_u64(i.into()).unwrap())
+            .collect();
+
+        let (msgs, sigs): (Vec<Vec<u8>>, Vec<Bls12381G2Signature>) = if msg_cnt == cnt {
+            let msgs: Vec<Vec<u8>> = (1..(cnt + 1))
+                .map(|i| {
+                    let u: u8 = (i % u8::MAX as u32) as u8;
+                    vec![u; msg_size]
+                })
+                .collect();
+            let sigs: Vec<Bls12381G2Signature> = sks
+                .iter()
+                .zip(msgs.clone())
+                .map(|(sk, msg)| sk.sign_v1(&msg))
+                .collect();
+            (msgs, sigs)
+        } else if msg_cnt == 1 {
+            let msgs: Vec<Vec<u8>> = vec![vec![(msg_size % u8::MAX as usize) as u8; msg_size]];
+
+            let sigs: Vec<Bls12381G2Signature> =
+                sks.iter().map(|sk| sk.sign_v1(&msgs[0])).collect();
+            (msgs, sigs)
+        } else {
+            panic!("msg_cnt {} might be equal to cnt {} or 1", msg_cnt, cnt);
+        };
+
+        let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
+
+        (sks, pks, msgs, sigs)
+    }
+
     #[test]
     fn sign_and_verify() {
         let test_sk = "408157791befddd702672dcfcfc99da3512f9c0ea818890fcb6ab749580ef2cf";
@@ -82,20 +124,8 @@ mod tests {
     }
 
     #[test]
-    fn sign_and_verify_aggregated() {
-        let sks: Vec<Bls12381G1PrivateKey> = (1..11)
-            .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())
-            .collect();
-
-        let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
-
-        let msgs: Vec<Vec<u8>> = (1..11).map(|i| vec![i; 10]).collect();
-
-        let sigs: Vec<Bls12381G2Signature> = sks
-            .iter()
-            .zip(&msgs)
-            .map(|(sk, msg)| sk.sign_v1(msg))
-            .collect();
+    fn sign_and_verify_aggregated_multiple_messages() {
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(10, 10, 10);
 
         // Aggregate the signature
         let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
@@ -104,25 +134,81 @@ mod tests {
             pks.iter().zip(msgs).map(|(pk, sk)| (*pk, sk)).collect();
 
         // Verify the messages against public keys and aggregated signature
-        assert!(aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig))
+        assert!(aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+    }
+
+    #[test]
+    fn sign_and_verify_aggregated_single_message() {
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(1, 1, 10);
+
+        // Aggregate the signature (in fact it does not make sense to aggregate one signature)
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
+
+        // Aggregated signature of one signature must be the same
+        assert_eq!(agg_sig, sigs[0]);
+
+        let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> =
+            pks.iter().zip(msgs).map(|(pk, sk)| (*pk, sk)).collect();
+
+        // Aggregate verify a single message over a single key and aggregated signature
+        assert!(aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+    }
+
+    #[test]
+    fn sign_and_verify_aggregated_reverse_order() {
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(10, 10, 10);
+
+        // Aggregate the signature
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
+
+        let mut msgs_rev = msgs.clone();
+        msgs_rev.reverse();
+
+        let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> =
+            pks.iter().zip(msgs_rev).map(|(pk, sk)| (*pk, sk)).collect();
+
+        // Verify the messages in reversed order against public keys and aggregated signature
+        assert!(!aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+    }
+
+    #[test]
+    fn sign_and_verify_aggregated_missing_message() {
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(10, 10, 10);
+
+        // Aggregate the signature
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
+
+        // Skip the last key, msg tuple
+        let pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)> = pks
+            .iter()
+            .zip(msgs)
+            .take(9)
+            .map(|(pk, sk)| (*pk, sk))
+            .collect();
+
+        // Verify the incomplete messages against public keys and aggregated
+        // signature from all messages
+        assert!(!aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
+
+        // Aggregate the signatures from incomplete messages
+        let agg_sig = Bls12381G2Signature::aggregate(&sigs[0..9]).unwrap();
+        // Verify the incomplete messages against public keys and aggregated
+        // signature from incomplete messages
+        assert!(aggregate_verify_bls12381_v1(&pub_keys_msgs, &agg_sig));
     }
 
     #[test]
     fn sign_and_verify_fast_aggregated() {
-        let sks: Vec<Bls12381G1PrivateKey> = (1..11)
-            .map(|i| Bls12381G1PrivateKey::from_u64(i).unwrap())
-            .collect();
-
-        let pks: Vec<Bls12381G1PublicKey> = sks.iter().map(|sk| sk.public_key()).collect();
-
-        let msg = "One message to sign for all".as_bytes();
-
-        let sigs: Vec<Bls12381G2Signature> = sks.iter().map(|sk| sk.sign_v1(msg)).collect();
+        let (_sks, pks, msgs, sigs) = get_aggregate_verify_test_data(10, 1, 10);
 
         // Aggregate the signature
         let agg_sig = Bls12381G2Signature::aggregate(&sigs).unwrap();
 
         // Verify the message against public keys and aggregated signature
-        assert!(fast_aggregate_verify_bls12381_v1(msg, &pks, &agg_sig))
+        assert!(fast_aggregate_verify_bls12381_v1(
+            msgs[0].as_slice(),
+            &pks,
+            &agg_sig
+        ));
     }
 }

--- a/radix-engine-common/src/crypto/signature_validator.rs
+++ b/radix-engine-common/src/crypto/signature_validator.rs
@@ -75,36 +75,92 @@ pub fn verify_bls12381_v1(
     false
 }
 
+#[cfg(any(target_arch = "wasm32", feature = "alloc"))]
+/// Local implementation of aggregated verify for no_std and WASM32 variants (no threads)
+/// see: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-coreaggregateverify
+/// Inspired with blst::min_pk::Signature::aggregate_verify
+fn aggregate_verify_bls12381_v1_no_threads(
+    pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
+    signature: blst::min_pk::Signature,
+) -> bool {
+    // Below structs are copies of PublicKey and Signature
+    // Redefining them to be able to access point field, which is private for PublicKey and Signature
+    struct LocalPublicKey {
+        point: blst::blst_p1_affine,
+    }
+    struct LocalSignature {
+        point: blst::blst_p2_affine,
+    }
+    let mut pairing = blst::Pairing::new(true, BLS12381_CIPHERSITE_V1);
+
+    // Aggregate
+    for (pk, msg) in pub_keys_and_msgs.iter() {
+        if let Ok(pk) = blst::min_pk::PublicKey::from_bytes(&pk.0) {
+            // transmute to LocalPublicKey to access point field
+            let local_pk: LocalPublicKey = unsafe { core::mem::transmute(pk) };
+
+            if pairing.aggregate(
+                &local_pk.point,
+                true,
+                &unsafe { core::ptr::null::<blst::blst_p2_affine>().as_ref() },
+                false,
+                msg,
+                &[],
+            ) != blst::BLST_ERROR::BLST_SUCCESS
+            {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    pairing.commit();
+
+    if let Err(_err) = signature.validate(false) {
+        return false;
+    }
+
+    // transmute to LocalSignature to access point field
+    let local_sig: LocalSignature = unsafe { core::mem::transmute(signature) };
+    let mut gtsig = blst::blst_fp12::default();
+    blst::Pairing::aggregated(&mut gtsig, &local_sig.point);
+
+    pairing.finalverify(Some(&gtsig))
+}
+
 /// Performs BLS12-381 G2 aggregated signature verification of
 /// multiple messages each signed with different key.
 /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
-#[cfg(feature = "enable_bls_aggregate_verify")]
 pub fn aggregate_verify_bls12381_v1(
     pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
     signature: &Bls12381G2Signature,
 ) -> bool {
     if let Ok(sig) = blst::min_pk::Signature::from_bytes(&signature.0) {
-        let mut pks = vec![];
-        let mut msg_refs = vec![];
-        for (pk, msg) in pub_keys_and_msgs.iter() {
-            if let Ok(pk) = blst::min_pk::PublicKey::from_bytes(&pk.0) {
-                pks.push(pk);
-            } else {
-                return false;
+        #[cfg(not(any(target_arch = "wasm32", feature = "alloc")))]
+        {
+            let mut pks = vec![];
+            let mut msg_refs = vec![];
+            for (pk, msg) in pub_keys_and_msgs.iter() {
+                if let Ok(pk) = blst::min_pk::PublicKey::from_bytes(&pk.0) {
+                    pks.push(pk);
+                } else {
+                    return false;
+                }
+                msg_refs.push(msg.as_slice());
             }
-            msg_refs.push(msg.as_slice());
-        }
-        let pks_refs: Vec<&blst::min_pk::PublicKey> = pks.iter().collect();
+            let pks_refs: Vec<&blst::min_pk::PublicKey> = pks.iter().collect();
 
-        let result = sig.aggregate_verify(true, &msg_refs, BLS12381_CIPHERSITE_V1, &pks_refs, true);
+            let result =
+                sig.aggregate_verify(true, &msg_refs, BLS12381_CIPHERSITE_V1, &pks_refs, true);
 
-        match result {
-            blst::BLST_ERROR::BLST_SUCCESS => return true,
-            _ => return false,
+            matches!(result, blst::BLST_ERROR::BLST_SUCCESS)
         }
+
+        #[cfg(any(target_arch = "wasm32", feature = "alloc"))]
+        aggregate_verify_bls12381_v1_no_threads(pub_keys_and_msgs, sig)
+    } else {
+        false
     }
-
-    false
 }
 
 /// Performs BLS12-381 G2 aggregated signature verification

--- a/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
+++ b/radix-engine-interface/src/api/system_modules/crypto_utils_api.rs
@@ -8,7 +8,6 @@ pub trait ClientCryptoUtilsApi<E> {
         signature: &Bls12381G2Signature,
     ) -> Result<u32, E>;
 
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/src/lib.rs
@@ -13,15 +13,12 @@ mod component_module {
             CryptoUtils::bls12381_v1_verify(message, pub_key, signature)
         }
 
-        /*
-         * Uncomment once supported again: #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn bls12381_v1_aggregate_verify(
             pub_keys_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
             signature: Bls12381G2Signature,
         ) -> bool {
             CryptoUtils::bls12381_v1_aggregate_verify(pub_keys_msgs, signature)
         }
-        */
 
         pub fn bls12381_v1_fast_aggregate_verify(
             message: Vec<u8>,

--- a/radix-engine-tests/tests/system/crypto_utils.rs
+++ b/radix-engine-tests/tests/system/crypto_utils.rs
@@ -75,7 +75,6 @@ fn crypto_scrypto_bls12381_v1_verify(
     )
 }
 
-#[cfg(feature = "enable_bls_aggregate_verify")]
 fn crypto_scrypto_bls12381_v1_aggregate_verify(
     runner: &mut TestRunner<NoExtension, InMemorySubstateDatabase>,
     package_address: PackageAddress,
@@ -237,7 +236,6 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate() {
 }
 
 #[test]
-#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_aggregate_verify() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
@@ -548,7 +546,6 @@ fn test_crypto_scrypto_bls12381_g2_signature_aggregate_costing() {
 }
 
 #[test]
-#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
     let mut test_runner = TestRunnerBuilder::new().build();
 
@@ -572,7 +569,6 @@ fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing() {
 }
 
 #[test]
-#[cfg(feature = "enable_bls_aggregate_verify")]
 fn test_crypto_scrypto_bls12381_v1_aggregate_verify_costing_2() {
     let mut test_runner = TestRunnerBuilder::new().build();
 

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2875,7 +2875,6 @@ where
 
     // Trace average message length and number of public_keys
     #[trace_resources(log={pub_keys_and_msgs.iter().flat_map(|(_, msg)| msg).count()/pub_keys_and_msgs.len()},log=pub_keys_and_msgs.len())]
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -115,7 +115,6 @@ pub enum ExecutionCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     Bls12381V1AggregateVerify {
         sizes: &'a [usize],
     },
@@ -192,7 +191,6 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EmitLog { size } => ft.emit_log_cost(*size),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
-            #[cfg(feature = "enable_bls_aggregate_verify")]
             ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
                 ft.bls12381_v1_aggregate_verify_cost(sizes)
             }

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -398,7 +398,6 @@ impl FeeTable {
     }
 
     #[inline]
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     pub fn bls12381_v1_aggregate_verify_cost(&self, sizes: &[usize]) -> u32 {
         // Below approach does not take aggregation into account.
         // Summing costs pers size gives greater values.

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -81,7 +81,6 @@ pub const SYS_PANIC_FUNCTION_NAME: &str = "sys_panic";
 // Crypto Utils
 //=================
 pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME: &str = "crypto_utils_bls12381_v1_verify";
-#[cfg(feature = "enable_bls_aggregate_verify")]
 pub const CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_v1_aggregate_verify";
 pub const CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME: &str =

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -764,7 +764,6 @@ impl WasmModule {
                             ));
                         }
                     }
-                    #[cfg(feature = "enable_bls_aggregate_verify")]
                     CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => {
                         if minor_version < 1 {
                             return Err(PrepareError::InvalidImport(

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -208,7 +208,6 @@ pub trait WasmRuntime {
         signature: Vec<u8>,
     ) -> Result<u32, InvokeError<WasmRuntimeError>>;
 
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/radix-engine/src/vm/wasm/wasmer.rs
+++ b/radix-engine/src/vm/wasm/wasmer.rs
@@ -695,7 +695,6 @@ impl WasmerModule {
             runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
         }
 
-        #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn bls12381_v1_aggregate_verify(
             env: &WasmerInstanceEnv,
             pub_keys_and_msgs_ptr: u32,
@@ -863,8 +862,7 @@ impl WasmerModule {
                 SYS_GENERATE_RUID_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), sys_generate_ruid),
                 BUFFER_CONSUME_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), buffer_consume),
                 CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_verify),
-                // TODO: Uncomment once supported #[cfg(feature = "enable_bls_aggregate_verify")]
-                //CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
+                CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_v1_fast_aggregate_verify),
                 CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), bls12381_g2_signature_aggregate),
                 CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME => Function::new_native_with_env(self.module.store(), env.clone(), keccak256_hash),

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -691,7 +691,6 @@ fn bls12381_v1_verify(
     runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
 }
 
-#[cfg(feature = "enable_bls_aggregate_verify")]
 fn bls12381_v1_aggregate_verify(
     mut caller: Caller<'_, HostState>,
     pub_keys_and_msgs_ptr: u32,
@@ -1364,7 +1363,6 @@ impl WasmiModule {
             },
         );
 
-        #[cfg(feature = "enable_bls_aggregate_verify")]
         let host_bls12381_v1_aggregate_verify = Func::wrap(
             store.as_context_mut(),
             |caller: Caller<'_, HostState>,
@@ -1587,7 +1585,6 @@ impl WasmiModule {
             CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME,
             host_bls12381_v1_verify
         );
-        #[cfg(feature = "enable_bls_aggregate_verify")]
         linker_define!(
             linker,
             CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -315,7 +315,6 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -577,7 +577,6 @@ where
         Ok(result)
     }
 
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     fn crypto_utils_bls12381_v1_aggregate_verify(
         &mut self,
         pub_keys_and_msgs: Vec<u8>,

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -275,19 +275,6 @@ implement_client_api! {
         tip_percentage: (&mut self) -> Result<u32, RuntimeError>,
         fee_balance: (&mut self) -> Result<Decimal, RuntimeError>,
     },
-}
-
-#[cfg(not(feature = "enable_bls_aggregate_verify"))]
-implement_client_api! {
-    ClientCryptoUtilsApi: {
-        bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_v1_fast_aggregate_verify: (&mut self, message: &[u8], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
-        keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
-    },
-}
-#[cfg(feature = "enable_bls_aggregate_verify")]
-implement_client_api! {
     ClientCryptoUtilsApi: {
         bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
         bls12381_v1_aggregate_verify: (&mut self, pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -33,7 +33,6 @@ impl CryptoUtils {
     /// Performs BLS12-381 G2 aggregated signature verification of
     /// multiple messages each signed with different key.
     /// Domain specifier tag: BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_
-    #[cfg(feature = "enable_bls_aggregate_verify")]
     pub fn bls12381_v1_aggregate_verify(
         pub_keys_and_msgs: Vec<(Bls12381G1PublicKey, Vec<u8>)>,
         signature: Bls12381G2Signature,

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -297,7 +297,6 @@ pub mod crypto_utils {
             signature_ptr: *const u8,
             signature_len: usize) -> u32;
 
-        #[cfg(feature = "enable_bls_aggregate_verify")]
         pub fn crypto_utils_bls12381_v1_aggregate_verify(
             pub_keys_and_msgs_ptr: *const u8,
             pub_keys_and_msgs_len: usize,


### PR DESCRIPTION
## Summary
Enable BLS aggregate verify for Radix Engine and Scrypto.

## Details
For `wasm32` and `no_std` added our local implementation of `aggregate_verify_bls12381_v1_no_threads()` which does not rely on threads.
It follows [CoreAggregateVerify](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-coreaggregateverify) description.
And is inspired with [`aggregate_verify()` implementation](https://github.com/supranational/blst/blob/master/bindings/rust/src/lib.rs#L1095) from `blst` crate.

## Testing
Added a few positive and negative tests.  
