### PR TITLE
make resim display resource names rather than symbols

### DIFF
--- a/simulator/src/resim/dumper.rs
+++ b/simulator/src/resim/dumper.rs
@@ -117,13 +117,19 @@ pub fn dump_component<T: SubstateDatabase, O: std::io::Write>(
         } else {
             "?"
         };
+        let symbol_text = if let Some(MetadataValue::String(symbol)) = metadata.get("symbol") {
+            format!(" ({})", symbol)
+        } else {
+            "".to_string()
+        };
         writeln!(
             output,
-            "{} {}: {} {}",
+            "{} {}: {} {}{}",
             list_item_prefix(last),
             resource_address.display(&address_bech32_encoder),
             amount,
             name,
+            symbol_text,
         );
     }
 
@@ -135,18 +141,24 @@ pub fn dump_component<T: SubstateDatabase, O: std::io::Write>(
     );
     for (last, (resource_address, ids)) in resources.non_fungibles.iter().identify_last() {
         let metadata = get_entity_metadata(resource_address.as_node_id(), substate_db);
-        let symbol = if let Some(MetadataValue::String(symbol)) = metadata.get("symbol") {
-            symbol.as_str()
+        let name = if let Some(MetadataValue::String(name)) = metadata.get("name") {
+            name.as_str()
         } else {
             "?"
         };
+        let symbol_text = if let Some(MetadataValue::String(symbol)) = metadata.get("symbol") {
+            format!(" ({})", symbol)
+        } else {
+            "".to_string()
+        };
         writeln!(
             output,
-            "{} {}: {} {}",
+            "{} {}: {} {}{}",
             list_item_prefix(last),
             resource_address.display(&address_bech32_encoder),
             ids.len(),
-            symbol,
+            name,
+            symbol_text,
         );
         for (last, id) in ids.iter().identify_last() {
             writeln!(output, "   {} {}", list_item_prefix(last), id);

--- a/simulator/src/resim/dumper.rs
+++ b/simulator/src/resim/dumper.rs
@@ -112,8 +112,8 @@ pub fn dump_component<T: SubstateDatabase, O: std::io::Write>(
     );
     for (last, (resource_address, amount)) in resources.balances.iter().identify_last() {
         let metadata = get_entity_metadata(resource_address.as_node_id(), substate_db);
-        let symbol = if let Some(MetadataValue::String(symbol)) = metadata.get("symbol") {
-            symbol.as_str()
+        let name = if let Some(MetadataValue::String(name)) = metadata.get("name") {
+            name.as_str()
         } else {
             "?"
         };
@@ -123,7 +123,7 @@ pub fn dump_component<T: SubstateDatabase, O: std::io::Write>(
             list_item_prefix(last),
             resource_address.display(&address_bech32_encoder),
             amount,
-            symbol,
+            name,
         );
     }
 


### PR DESCRIPTION
## Summary
When displaying component details resim shows resource addresses followed by metadata symbols. This PR exchanges the symbols for names

Original
<img width="1107" alt="Screenshot 2024-01-19 at 11 56 25" src="https://github.com/radixdlt/radixdlt-scrypto/assets/64193693/bc78f243-3652-4f30-a530-3aab16cf2694">


Updated
<img width="1105" alt="Screenshot 2024-01-19 at 11 53 34" src="https://github.com/radixdlt/radixdlt-scrypto/assets/64193693/dc2564bb-5029-48d0-b107-c1f5c74d1652">

