### PR TITLE
Feature: Scrypto Test Builder

### DIFF
--- a/radix-engine-tests/src/pool_stubs.rs
+++ b/radix-engine-tests/src/pool_stubs.rs
@@ -7,7 +7,7 @@ pub const MINT_LIMIT: Decimal = dec!(5708990770823839524233143877.79798054553098
 pub fn with_multi_resource_pool<const N: usize, F, O>(divisibility: [u8; N], callback: F) -> O
 where
     F: FnOnce(
-        &mut TestEnvironment,
+        &mut TestEnvironment<InMemorySubstateDatabase>,
         [(Cloneable<Bucket>, ResourceAddress); N],
         MultiResourcePool<N>,
     ) -> O,

--- a/radix-engine-tests/tests/kernel/test_environment.rs
+++ b/radix-engine-tests/tests/kernel/test_environment.rs
@@ -257,6 +257,7 @@ fn can_read_kv_entries_from_a_store_read_from_state() {
             )
             .unwrap();
         let epoch = env.key_value_entry_get_typed::<Epoch>(handle).unwrap();
+        env.key_value_entry_close(handle).unwrap();
 
         // Assert
         assert!(epoch.is_some())

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -606,6 +606,17 @@ impl SystemModuleMixer {
         }
     }
 
+    pub fn transaction_runtime(&mut self) -> Option<&TransactionRuntimeModule> {
+        if self
+            .enabled_modules
+            .contains(EnabledModules::TRANSACTION_RUNTIME)
+        {
+            Some(&self.transaction_runtime)
+        } else {
+            None
+        }
+    }
+
     pub fn transaction_hash(&self) -> Option<Hash> {
         if self
             .enabled_modules

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -11,6 +11,8 @@ use crate::vm::{NativeVm, NativeVmExtension, ScryptoVm};
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_interface::api::ClientApi;
 
+use super::wasm::SCRYPTO_V1_LATEST_MINOR_VERSION;
+
 pub const BOOT_LOADER_VM_SUBSTATE_FIELD_KEY: FieldKey = 2u8;
 
 pub struct Vm<'g, W: WasmEngine, E: NativeVmExtension> {
@@ -46,6 +48,14 @@ pub trait VmApi {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct VmVersion {
     scrypto_v1_minor_version: u64,
+}
+
+impl VmVersion {
+    pub fn latest() -> Self {
+        Self {
+            scrypto_v1_minor_version: SCRYPTO_V1_LATEST_MINOR_VERSION,
+        }
+    }
 }
 
 impl VmApi for VmVersion {

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -227,10 +227,6 @@ where
             );
             bootstrapper.bootstrap_test_default().unwrap();
         }
-        let database_updates = self.flash_database.database_updates();
-        if !database_updates.node_updates.is_empty() {
-            self.database.commit(&database_updates);
-        }
 
         // Create the Id allocator we will be using throughout this test
         let id_allocator = IdAllocator::new(Self::DEFAULT_INTENT_HASH);
@@ -255,6 +251,12 @@ where
             let state_updates = pools_package_v1_1::generate_state_updates(&self.database);
             let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
             self.database.commit(&db_updates);
+        }
+
+        // If a flash is specified execute it.
+        let database_updates = self.flash_database.database_updates();
+        if !database_updates.node_updates.is_empty() {
+            self.database.commit(&database_updates);
         }
 
         let mut env = TestEnvironment(EncapsulatedRadixEngine::create(

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -236,7 +236,7 @@ where
         let id_allocator = IdAllocator::new(Self::DEFAULT_INTENT_HASH);
 
         // Determine if any protocol updates need to be run against the database.
-        if dbg!(self.protocol_updates.consensus_manager_seconds_precision) {
+        if self.protocol_updates.consensus_manager_seconds_precision {
             let state_updates = generate_seconds_precision_state_updates(&self.database);
             let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
             self.database.commit(&db_updates);

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -1,0 +1,519 @@
+use radix_engine::kernel::call_frame::*;
+use radix_engine::kernel::heap::*;
+use radix_engine::kernel::id_allocator::*;
+use radix_engine::kernel::kernel::*;
+use radix_engine::kernel::substate_io::*;
+use radix_engine::kernel::substate_locks::*;
+use radix_engine::system::actor::*;
+use radix_engine::system::bootstrap::*;
+use radix_engine::system::system::*;
+use radix_engine::system::system_callback::*;
+use radix_engine::system::system_modules::auth::*;
+use radix_engine::system::system_modules::costing::*;
+use radix_engine::system::system_modules::*;
+use radix_engine::track::*;
+use radix_engine::transaction::*;
+use radix_engine::utils::*;
+use radix_engine::vm::wasm::*;
+use radix_engine::vm::*;
+use radix_engine_interface::blueprints::package::*;
+use radix_engine_interface::prelude::*;
+use radix_engine_store_interface::db_key_mapper::DatabaseKeyMapper;
+use radix_engine_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
+use radix_engine_store_interface::interface::*;
+use radix_engine_stores::memory_db::*;
+use transaction::model::*;
+
+use crate::sdk::Package;
+
+use super::*;
+
+pub type DbFlash = IndexMap<DbNodeKey, IndexMap<DbPartitionNum, IndexMap<DbSortKey, Vec<u8>>>>;
+
+pub struct TestEnvironmentBuilder<D>
+where
+    D: SubstateDatabase + CommittableSubstateDatabase + 'static,
+{
+    /// The database to use for the test environment.
+    database: D,
+
+    /// The database that substates are flashed to and then flashed to the actual database at build
+    /// time. This is to make sure that when we add methods for changing the database it doesn't
+    /// matter if flash is called before the set database method.
+    flash_database: FlashSubstateDatabase,
+
+    /// Additional references to add to the root [`CallFrame`] upon its creation.
+    added_global_references: IndexSet<GlobalAddress>,
+
+    /// Specifies whether the builder should run genesis and bootstrap the environment or not.
+    bootstrap: bool,
+
+    /// The protocol updates the the user has opt in to get. This defaults to all true.
+    protocol_updates: ProtocolUpdateOptIns,
+}
+
+impl Default for TestEnvironmentBuilder<InMemorySubstateDatabase> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestEnvironmentBuilder<InMemorySubstateDatabase> {
+    pub fn new() -> Self {
+        TestEnvironmentBuilder {
+            database: InMemorySubstateDatabase::standard(),
+            flash_database: FlashSubstateDatabase::standard(),
+            added_global_references: Default::default(),
+            bootstrap: true,
+            protocol_updates: ProtocolUpdateOptIns {
+                consensus_manager_seconds_precision: true,
+                crypto_utils: true,
+                updated_pools: true,
+            },
+        }
+    }
+}
+
+impl<D> TestEnvironmentBuilder<D>
+where
+    D: SubstateDatabase + CommittableSubstateDatabase + 'static,
+{
+    const DEFAULT_INTENT_HASH: Hash = Hash([0; 32]);
+
+    pub fn flash(mut self, data: DbFlash) -> Self {
+        // Flash the substates to the database.
+        let database_updates = DatabaseUpdates {
+            node_updates: data
+                .into_iter()
+                .map(|(db_node_key, partition_num_to_updates_mapping)| {
+                    (
+                        db_node_key,
+                        NodeDatabaseUpdates {
+                            partition_updates: partition_num_to_updates_mapping
+                                .into_iter()
+                                .map(|(partition_num, substates)| {
+                                    (
+                                        partition_num,
+                                        PartitionDatabaseUpdates::Delta {
+                                            substate_updates: substates
+                                                .into_iter()
+                                                .map(|(db_sort_key, value)| {
+                                                    (db_sort_key, DatabaseUpdate::Set(value))
+                                                })
+                                                .collect(),
+                                        },
+                                    )
+                                })
+                                .collect(),
+                        },
+                    )
+                })
+                .collect(),
+        };
+        self.flash_database.commit(&database_updates);
+
+        self
+            /* Global references found in the NodeKeys */
+            .add_global_references(
+                database_updates
+                    .node_updates
+                    .keys()
+                    .map(SpreadPrefixKeyMapper::from_db_node_key)
+                    .filter_map(|item| GlobalAddress::try_from(item).ok()),
+            )
+            /* Global references found in the Substate Values */
+            .add_global_references(
+                database_updates
+                    .node_updates
+                    .values()
+                    .flat_map(|NodeDatabaseUpdates { partition_updates }| {
+                        partition_updates.values()
+                    })
+                    .filter_map(|item| {
+                        if let PartitionDatabaseUpdates::Delta { substate_updates } = item {
+                            Some(substate_updates.values())
+                        } else {
+                            None
+                        }
+                    })
+                    .flatten()
+                    .filter_map(|item| {
+                        if let DatabaseUpdate::Set(item) = item {
+                            Some(item)
+                        } else {
+                            None
+                        }
+                    })
+                    .flat_map(|value| {
+                        IndexedScryptoValue::from_slice(value)
+                            .unwrap()
+                            .references()
+                            .clone()
+                    })
+                    .filter_map(|item| GlobalAddress::try_from(item).ok()),
+            )
+    }
+
+    pub fn add_global_reference(mut self, global_address: GlobalAddress) -> Self {
+        self.added_global_references.insert(global_address);
+        self
+    }
+
+    pub fn add_global_references(
+        mut self,
+        global_addresses: impl IntoIterator<Item = GlobalAddress>,
+    ) -> Self {
+        self.added_global_references.extend(global_addresses);
+        self
+    }
+
+    pub fn database<ND>(self, database: ND) -> TestEnvironmentBuilder<ND>
+    where
+        ND: SubstateDatabase + CommittableSubstateDatabase,
+    {
+        TestEnvironmentBuilder {
+            database,
+            added_global_references: self.added_global_references,
+            flash_database: self.flash_database,
+            bootstrap: self.bootstrap,
+            protocol_updates: self.protocol_updates,
+        }
+    }
+
+    pub fn with_consensus_manager_seconds_precision_protocol_update(mut self) -> Self {
+        self.protocol_updates.consensus_manager_seconds_precision = true;
+        self
+    }
+
+    pub fn with_crypto_utils_protocol_update(mut self) -> Self {
+        self.protocol_updates.crypto_utils = true;
+        self
+    }
+
+    pub fn with_updated_pools_protocol_update(mut self) -> Self {
+        self.protocol_updates.updated_pools = true;
+        self
+    }
+
+    pub fn without_consensus_manager_seconds_precision_protocol_update(mut self) -> Self {
+        self.protocol_updates.consensus_manager_seconds_precision = false;
+        self
+    }
+
+    pub fn without_crypto_utils_protocol_update(mut self) -> Self {
+        self.protocol_updates.crypto_utils = false;
+        self
+    }
+
+    pub fn without_updated_pools_protocol_update(mut self) -> Self {
+        self.protocol_updates.updated_pools = false;
+        self
+    }
+
+    pub fn bootstrap(mut self, value: bool) -> Self {
+        self.bootstrap = value;
+        self
+    }
+
+    pub fn build(mut self) -> TestEnvironment<D> {
+        // Create the various VMs we will use
+        let native_vm = NativeVm::new();
+        let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
+        let vm = Vm::new(&scrypto_vm, native_vm.clone());
+
+        if self.bootstrap {
+            // Run genesis against the substate store.
+            let mut bootstrapper = Bootstrapper::new(
+                NetworkDefinition::simulator(),
+                &mut self.database,
+                vm,
+                false,
+            );
+            bootstrapper.bootstrap_test_default().unwrap();
+        }
+        let database_updates = self.flash_database.database_updates();
+        if !database_updates.node_updates.is_empty() {
+            self.database.commit(&database_updates);
+        }
+
+        // Create the Id allocator we will be using throughout this test
+        let id_allocator = IdAllocator::new(Self::DEFAULT_INTENT_HASH);
+
+        // Determine if any protocol updates need to be run against the database.
+        if self.protocol_updates.consensus_manager_seconds_precision {
+            let state_updates = generate_seconds_precision_state_updates(&self.database);
+            let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+            self.database.commit(&db_updates);
+        }
+        if self.protocol_updates.crypto_utils {
+            let state_updates = generate_vm_boot_scrypto_minor_version_state_updates();
+            let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+            self.database.commit(&db_updates);
+        }
+        if self.protocol_updates.updated_pools {
+            let state_updates = generate_validator_fee_fix_state_updates(&self.database);
+            let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+            self.database.commit(&db_updates);
+        }
+
+        let mut env = TestEnvironment(EncapsulatedRadixEngine::create(
+            self.database,
+            scrypto_vm,
+            native_vm.clone(),
+            id_allocator,
+            |substate_database| Track::new(substate_database),
+            |scrypto_vm| SystemConfig {
+                blueprint_cache: NonIterMap::new(),
+                auth_cache: NonIterMap::new(),
+                schema_cache: NonIterMap::new(),
+                callback_obj: Vm::new(scrypto_vm, native_vm.clone()),
+                modules: SystemModuleMixer::new(
+                    EnabledModules::LIMITS
+                        | EnabledModules::AUTH
+                        | EnabledModules::TRANSACTION_RUNTIME,
+                    NetworkDefinition::simulator(),
+                    Self::DEFAULT_INTENT_HASH,
+                    AuthZoneParams {
+                        initial_proofs: Default::default(),
+                        virtual_resources: Default::default(),
+                    },
+                    SystemLoanFeeReserve::default(),
+                    FeeTable::new(),
+                    0,
+                    0,
+                    &ExecutionConfig::for_test_transaction().with_kernel_trace(false),
+                ),
+            },
+            |system_config, track, id_allocator| {
+                Kernel::kernel_create_kernel_for_testing(
+                    SubstateIO {
+                        heap: Heap::new(),
+                        store: track,
+                        non_global_node_refs: NonGlobalNodeRefs::new(),
+                        substate_locks: SubstateLocks::new(),
+                        heap_transient_substates: TransientSubstates {
+                            transient_substates: Default::default(),
+                        },
+                        pinned_to_heap: Default::default(),
+                    },
+                    id_allocator,
+                    CallFrame::new_root(Actor::Root),
+                    vec![],
+                    system_config,
+                    VmVersion::latest(),
+                )
+            },
+        ));
+
+        // Adding references to all of the well-known global nodes.
+        env.0.with_kernel_mut(|kernel| {
+            let (_, current_frame) = kernel.kernel_current_frame_mut();
+            for node_id in GLOBAL_VISIBLE_NODES {
+                let Ok(global_address) = GlobalAddress::try_from(node_id.0) else {
+                    continue;
+                };
+                current_frame.add_global_reference(global_address)
+            }
+            for global_address in self.added_global_references.iter() {
+                current_frame.add_global_reference(*global_address)
+            }
+        });
+
+        // Publishing the test-environment package.
+        let test_environment_package = {
+            let code = include_bytes!("../../../assets/test_environment.wasm");
+            let package_definition = manifest_decode::<PackageDefinition>(include_bytes!(
+                "../../../assets/test_environment.rpd"
+            ))
+            .expect("Must succeed");
+
+            env.with_auth_module_disabled(|env| {
+                Package::publish_advanced(
+                    OwnerRole::None,
+                    package_definition,
+                    code.to_vec(),
+                    Default::default(),
+                    None,
+                    env,
+                )
+                .expect("Must succeed")
+            })
+        };
+
+        // Creating the call-frame of the test environment & making it the current call frame
+        {
+            // Creating the auth zone of the next call-frame
+            let auth_zone = env.0.with_kernel_mut(|kernel| {
+                let mut system_service = SystemService {
+                    api: kernel,
+                    phantom: PhantomData,
+                };
+                AuthModule::on_call_fn_mock(
+                    &mut system_service,
+                    Some((TRANSACTION_PROCESSOR_PACKAGE.as_node_id(), false)),
+                    Default::default(),
+                    Default::default(),
+                )
+                .expect("Must succeed")
+            });
+
+            // Define the actor of the next call-frame. This would be a function actor of the test
+            // environment package.
+            let actor = Actor::Function(FunctionActor {
+                blueprint_id: BlueprintId {
+                    package_address: test_environment_package,
+                    blueprint_name: "TestEnvironment".to_owned(),
+                },
+                ident: "run".to_owned(),
+                auth_zone,
+            });
+
+            // Creating the message, call-frame, and doing the replacement.
+            let message = {
+                let mut message =
+                    CallFrameMessage::from_input(&IndexedScryptoValue::from_typed(&()), &actor);
+                for node_id in GLOBAL_VISIBLE_NODES {
+                    message.copy_global_references.push(node_id);
+                }
+                for global_address in self.added_global_references.iter() {
+                    message
+                        .copy_global_references
+                        .push(global_address.into_node_id())
+                }
+                message
+            };
+            env.0.with_kernel_mut(|kernel| {
+                let (substate_io, current_frame) = kernel.kernel_current_frame_mut();
+                let new_frame =
+                    CallFrame::new_child_from_parent(substate_io, current_frame, actor, message)
+                        .expect("Must succeed.");
+                let previous_frame = core::mem::replace(current_frame, new_frame);
+                kernel.kernel_prev_frame_stack_mut().push(previous_frame)
+            });
+        }
+
+        env
+    }
+}
+
+//=========================
+// Flash Substate Database
+//=========================
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FlashSubstateDatabase {
+    partitions: BTreeMap<DbPartitionKey, BTreeMap<DbSortKey, DbSubstateValue>>,
+}
+
+impl FlashSubstateDatabase {
+    pub fn standard() -> Self {
+        Self {
+            partitions: BTreeMap::new(),
+        }
+    }
+
+    pub fn database_updates(self) -> DatabaseUpdates {
+        let mut database_updates = DatabaseUpdates::default();
+
+        self.partitions.into_iter().for_each(
+            |(
+                DbPartitionKey {
+                    node_key,
+                    partition_num,
+                },
+                items,
+            )| {
+                database_updates
+                    .node_updates
+                    .entry(node_key)
+                    .or_default()
+                    .partition_updates
+                    .insert(
+                        partition_num,
+                        PartitionDatabaseUpdates::Delta {
+                            substate_updates: items
+                                .into_iter()
+                                .map(|(key, value)| (key, DatabaseUpdate::Set(value)))
+                                .collect(),
+                        },
+                    );
+            },
+        );
+
+        database_updates
+    }
+}
+
+impl SubstateDatabase for FlashSubstateDatabase {
+    fn get_substate(
+        &self,
+        partition_key: &DbPartitionKey,
+        sort_key: &DbSortKey,
+    ) -> Option<DbSubstateValue> {
+        self.partitions
+            .get(partition_key)
+            .and_then(|partition| partition.get(sort_key))
+            .cloned()
+    }
+
+    fn list_entries_from(
+        &self,
+        partition_key: &DbPartitionKey,
+        from_sort_key: Option<&DbSortKey>,
+    ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
+        let from_sort_key = from_sort_key.cloned();
+        let iter = self
+            .partitions
+            .get(partition_key)
+            .into_iter()
+            .flat_map(|partition| partition.iter())
+            .skip_while(move |(key, _substate)| Some(*key) < from_sort_key.as_ref())
+            .map(|(key, substate)| (key.clone(), substate.clone()));
+
+        Box::new(iter)
+    }
+}
+
+impl CommittableSubstateDatabase for FlashSubstateDatabase {
+    fn commit(&mut self, database_updates: &DatabaseUpdates) {
+        for (node_key, node_updates) in &database_updates.node_updates {
+            for (partition_num, partition_updates) in &node_updates.partition_updates {
+                let partition_key = DbPartitionKey {
+                    node_key: node_key.clone(),
+                    partition_num: *partition_num,
+                };
+                let partition = self.partitions.entry(partition_key.clone()).or_default();
+                match partition_updates {
+                    PartitionDatabaseUpdates::Delta { substate_updates } => {
+                        for (sort_key, update) in substate_updates {
+                            match update {
+                                DatabaseUpdate::Set(substate_value) => {
+                                    partition.insert(sort_key.clone(), substate_value.clone())
+                                }
+                                DatabaseUpdate::Delete => partition.remove(sort_key),
+                            };
+                        }
+                    }
+                    PartitionDatabaseUpdates::Reset {
+                        new_substate_values,
+                    } => {
+                        *partition = BTreeMap::from_iter(
+                            new_substate_values
+                                .iter()
+                                .map(|(sort_key, value)| (sort_key.clone(), value.clone())),
+                        )
+                    }
+                }
+                if partition.is_empty() {
+                    self.partitions.remove(&partition_key);
+                }
+            }
+        }
+    }
+}
+
+struct ProtocolUpdateOptIns {
+    pub consensus_manager_seconds_precision: bool,
+    pub crypto_utils: bool,
+    pub updated_pools: bool,
+}

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -83,7 +83,7 @@ macro_rules! implement_client_api {
                                     .system
                                     .modules
                                     .transaction_runtime()
-                                    .map(|module| module.logs.clone())
+                                    .map(|module| module.logs.iter())
                                     .unwrap_or_default()
                                     .into_iter()
                                     .skip(logs_before)
@@ -316,10 +316,30 @@ implement_client_api! {
         fee_balance: (&mut self) -> Result<Decimal, RuntimeError>,
     },
     ClientCryptoUtilsApi: {
-        bls12381_v1_verify: (&mut self, message: &[u8], public_key: &Bls12381G1PublicKey, signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_v1_aggregate_verify: (&mut self, pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_v1_fast_aggregate_verify: (&mut self, message: &[u8], public_keys: &[Bls12381G1PublicKey], signature: &Bls12381G2Signature) -> Result<u32, RuntimeError>,
-        bls12381_g2_signature_aggregate: (&mut self, signatures: &[Bls12381G2Signature]) -> Result<Bls12381G2Signature, RuntimeError>,
-        keccak256_hash: (&mut self, data: &[u8]) -> Result<Hash, RuntimeError>,
+        bls12381_v1_verify: (
+            &mut self,
+            message: &[u8],
+            public_key: &Bls12381G1PublicKey,
+            signature: &Bls12381G2Signature
+        ) -> Result<u32, RuntimeError>,
+        bls12381_v1_aggregate_verify: (
+            &mut self,
+            pub_keys_and_msgs: &[(Bls12381G1PublicKey, Vec<u8>)],
+            signature: &Bls12381G2Signature
+        ) -> Result<u32, RuntimeError>,
+        bls12381_v1_fast_aggregate_verify: (
+            &mut self,
+            message: &[u8],
+            public_keys: &[Bls12381G1PublicKey],
+            signature: &Bls12381G2Signature
+        ) -> Result<u32, RuntimeError>,
+        bls12381_g2_signature_aggregate: (
+            &mut self,
+            signatures: &[Bls12381G2Signature]
+        ) -> Result<Bls12381G2Signature, RuntimeError>,
+        keccak256_hash: (
+            &mut self,
+            data: &[u8]
+        ) -> Result<Hash, RuntimeError>,
     },
 }

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -51,12 +51,49 @@ macro_rules! implement_client_api {
                 $(
                     #[inline]
                     fn $func_ident(&mut self, $($input_ident: $input_type),*) -> $outputs {
-                        self.0.with_kernel_mut(|kernel| {
+                        let logs_before = self.0.with_kernel_mut(|kernel| {
+                            kernel
+                                .kernel_get_system_state()
+                                .system
+                                .modules
+                                .transaction_runtime()
+                                .map(|runtime| runtime.logs.len())
+                                .unwrap_or(0)
+                        });
+
+                        let rtn = self.0.with_kernel_mut(|kernel| {
                             SystemService {
                                 api: kernel,
                                 phantom: PhantomData,
                             }.$func_ident( $($input_ident),* )
-                        })
+                        });
+
+                        self.0.with_kernel_mut(|kernel| {
+                            let logs_after = kernel
+                                .kernel_get_system_state()
+                                .system
+                                .modules
+                                .transaction_runtime()
+                                .map(|runtime| runtime.logs.len())
+                                .unwrap_or(0);
+
+                            if logs_before != logs_after {
+                                for (level, message) in kernel
+                                    .kernel_get_system_state()
+                                    .system
+                                    .modules
+                                    .transaction_runtime()
+                                    .map(|module| module.logs.clone())
+                                    .unwrap_or_default()
+                                    .into_iter()
+                                    .skip(logs_before)
+                                {
+                                    println!("[{}]: {}", level, message)
+                                }
+                            }
+                        });
+
+                        rtn
                     }
                 )*
             }

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -44,7 +44,10 @@ macro_rules! implement_client_api {
         ),* $(,)*
     ) => {
         $(
-            impl $trait<RuntimeError> for TestEnvironment {
+            impl<D> $trait<RuntimeError> for TestEnvironment<D>
+            where
+                D: SubstateDatabase + CommittableSubstateDatabase + 'static
+            {
                 $(
                     #[inline]
                     fn $func_ident(&mut self, $($input_ident: $input_type),*) -> $outputs {

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -620,22 +620,31 @@ where
     // State
     //=======
 
-    /// Reads the state of a component and SBOR decodes it to the specified generic.
+    /// Reads the state of a component and allows for a callback to be executed over the decoded
+    /// state.
     ///
-    /// This method reads the state of a component and returns it as an instance of [`S`]. Owned
-    /// nodes encountered in the component state are added as transient references to the test call
-    /// frame and references are added as references to the test call frame. This means that all
-    /// nodes in the component state become visible to the tests.
+    /// This method performs the steps needed to read the state of a component and then perform the
+    /// various steps needed before the state can be read or used such as the locking, reading, and
+    /// decoding of the substate and the various steps that need to be performed after the state is
+    /// read such as unlocking the substate.
+    ///
+    /// Users of this method are expected to pass in a callback function to operate over the state
+    /// as this is the main way that this method ensures that references do not escape out of this
+    /// method after the substate is closed.
     ///
     /// # Arguments
     ///
     /// * `node_id`: [`N`] - The address of the component to read the state of. This is a generic
     /// type parameter that's satisfied by any type that implements [`Into<NodeId>`].
+    /// * `callback`: [`F`] - A callback function to call after the component state has been read
+    /// and decoded into the type specified by the generic parameter [`S`]. Anything returned from
+    /// this callback is returned from this method unless an error happens after the callback is
+    /// executed.
     ///
     /// # Returns
     ///
-    /// * [`Result<S, RuntimeError>`] - If the component state could be read successfully then an
-    /// [`Ok`] is returned, otherwise an [`Err`] is returned.
+    /// * [`Result<O, RuntimeError>`] - The output of the callback function passed in or a runtime
+    /// error if one of the steps failed.
     ///
     /// # Panics
     ///

--- a/scrypto-test/src/environment/mod.rs
+++ b/scrypto-test/src/environment/mod.rs
@@ -1,5 +1,6 @@
 //! This module implements the test-environment that all tests run in.
 
+mod builder;
 mod client_api;
 mod constants;
 mod env;
@@ -9,5 +10,6 @@ mod types;
 use constants::*;
 use internal::*;
 
+pub use builder::*;
 pub use env::*;
 pub use types::*;

--- a/scrypto-test/src/environment/types.rs
+++ b/scrypto-test/src/environment/types.rs
@@ -4,7 +4,7 @@
 use crate::prelude::*;
 
 pub type TestVm<'g> = Vm<'g, DefaultWasmEngine, NoExtension>;
-pub type TestTrack<'g> = Track<'g, InMemorySubstateDatabase, SpreadPrefixKeyMapper>;
+pub type TestTrack<'g, D> = Track<'g, D, SpreadPrefixKeyMapper>;
 pub type TestSystemConfig<'g> = SystemConfig<TestVm<'g>>;
-pub type TestKernel<'g> = Kernel<'g, TestSystemConfig<'g>, TestTrack<'g>>;
-pub type TestSystemService<'g> = SystemService<'g, TestKernel<'g>, TestVm<'g>>;
+pub type TestKernel<'g, D> = Kernel<'g, TestSystemConfig<'g>, TestTrack<'g, D>>;
+pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>, TestVm<'g>>;

--- a/scrypto-test/src/sdk/package.rs
+++ b/scrypto-test/src/sdk/package.rs
@@ -7,12 +7,15 @@ use crate::prelude::*;
 pub struct Package;
 
 impl Package {
-    pub fn publish(
+    pub fn publish<D>(
         code: Vec<u8>,
         package_definition: PackageDefinition,
         metadata: MetadataInit,
-        env: &mut TestEnvironment,
-    ) -> Result<(PackageAddress, Bucket), RuntimeError> {
+        env: &mut TestEnvironment<D>,
+    ) -> Result<(PackageAddress, Bucket), RuntimeError>
+    where
+        D: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         env.with_auth_module_disabled(|env| {
             env.call_function_typed::<PackagePublishWasmInput, PackagePublishWasmOutput>(
                 PACKAGE_PACKAGE,
@@ -27,14 +30,17 @@ impl Package {
         })
     }
 
-    pub fn publish_advanced(
+    pub fn publish_advanced<D>(
         owner_role: OwnerRole,
         definition: PackageDefinition,
         code: Vec<u8>,
         metadata: MetadataInit,
         package_address: Option<GlobalAddressReservation>,
-        env: &mut TestEnvironment,
-    ) -> Result<PackageAddress, RuntimeError> {
+        env: &mut TestEnvironment<D>,
+    ) -> Result<PackageAddress, RuntimeError>
+    where
+        D: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         env.with_auth_module_disabled(|env| {
             env.call_function_typed::<PackagePublishWasmAdvancedInput, PackagePublishWasmAdvancedOutput>(
                 PACKAGE_PACKAGE,
@@ -51,12 +57,13 @@ impl Package {
         })
     }
 
-    pub fn compile_and_publish<P>(
+    pub fn compile_and_publish<P, D>(
         path: P,
-        env: &mut TestEnvironment,
+        env: &mut TestEnvironment<D>,
     ) -> Result<PackageAddress, RuntimeError>
     where
         P: AsRef<Path>,
+        D: SubstateDatabase + CommittableSubstateDatabase + 'static,
     {
         let (wasm, package_definition) = Self::compile(path);
         Self::publish_advanced(

--- a/scrypto-test/src/sdk/resource/bucket_factory.rs
+++ b/scrypto-test/src/sdk/resource/bucket_factory.rs
@@ -4,12 +4,15 @@ use crate::prelude::*;
 pub struct BucketFactory;
 
 impl BucketFactory {
-    pub fn create_fungible_bucket(
+    pub fn create_fungible_bucket<S>(
         resource_address: ResourceAddress,
         amount: Decimal,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
-    ) -> Result<Bucket, RuntimeError> {
+        env: &mut TestEnvironment<S>,
+    ) -> Result<Bucket, RuntimeError>
+    where
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         Self::create_bucket(
             FactoryResourceSpecifier::Amount(resource_address, amount),
             creation_strategy,
@@ -17,15 +20,16 @@ impl BucketFactory {
         )
     }
 
-    pub fn create_non_fungible_bucket<I, D>(
+    pub fn create_non_fungible_bucket<I, D, S>(
         resource_address: ResourceAddress,
         non_fungibles: I,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
+        env: &mut TestEnvironment<S>,
     ) -> Result<Bucket, RuntimeError>
     where
         I: IntoIterator<Item = (NonFungibleLocalId, D)>,
         D: ScryptoEncode,
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
     {
         Self::create_bucket(
             FactoryResourceSpecifier::Ids(
@@ -46,11 +50,14 @@ impl BucketFactory {
         )
     }
 
-    pub fn create_bucket(
+    pub fn create_bucket<S>(
         resource_specifier: FactoryResourceSpecifier,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
-    ) -> Result<Bucket, RuntimeError> {
+        env: &mut TestEnvironment<S>,
+    ) -> Result<Bucket, RuntimeError>
+    where
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         match (&resource_specifier, creation_strategy) {
             (
                 FactoryResourceSpecifier::Amount(resource_address, amount),
@@ -109,7 +116,7 @@ impl BucketFactory {
                                     non_fungible_handle,
                                 )?;
 
-                            if let Some(..) = cur_non_fungible {
+                            if cur_non_fungible.is_some() {
                                 return Err(RuntimeError::ApplicationError(
                                     ApplicationError::NonFungibleResourceManagerError(
                                         NonFungibleResourceManagerError::NonFungibleAlreadyExists(Box::new(
@@ -139,10 +146,13 @@ impl BucketFactory {
         }
     }
 
-    fn validate_resource_specifier(
+    fn validate_resource_specifier<S>(
         resource_specifier: &FactoryResourceSpecifier,
-        env: &mut TestEnvironment,
-    ) -> Result<bool, RuntimeError> {
+        env: &mut TestEnvironment<S>,
+    ) -> Result<bool, RuntimeError>
+    where
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         // Validating the resource is correct - can't mint IDs of a fungible resource and can't mint
         // an amount of a non-fungible resource.
         match resource_specifier {

--- a/scrypto-test/src/sdk/resource/proof_factory.rs
+++ b/scrypto-test/src/sdk/resource/proof_factory.rs
@@ -4,25 +4,29 @@ use crate::prelude::*;
 pub struct ProofFactory;
 
 impl ProofFactory {
-    pub fn create_fungible_proof(
+    pub fn create_fungible_proof<S>(
         resource_address: ResourceAddress,
         amount: Decimal,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
-    ) -> Result<Proof, RuntimeError> {
+        env: &mut TestEnvironment<S>,
+    ) -> Result<Proof, RuntimeError>
+    where
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         BucketFactory::create_fungible_bucket(resource_address, amount, creation_strategy, env)
             .and_then(|bucket| bucket.create_proof_of_all(env))
     }
 
-    pub fn create_non_fungible_proof<I, D>(
+    pub fn create_non_fungible_proof<I, D, S>(
         resource_address: ResourceAddress,
         non_fungibles: I,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
+        env: &mut TestEnvironment<S>,
     ) -> Result<Proof, RuntimeError>
     where
         I: IntoIterator<Item = (NonFungibleLocalId, D)>,
         D: ScryptoEncode,
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
     {
         BucketFactory::create_non_fungible_bucket(
             resource_address,
@@ -33,11 +37,14 @@ impl ProofFactory {
         .and_then(|bucket| bucket.create_proof_of_all(env))
     }
 
-    pub fn create_proof(
+    pub fn create_proof<S>(
         resource_specifier: FactoryResourceSpecifier,
         creation_strategy: CreationStrategy,
-        env: &mut TestEnvironment,
-    ) -> Result<Proof, RuntimeError> {
+        env: &mut TestEnvironment<S>,
+    ) -> Result<Proof, RuntimeError>
+    where
+        S: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
         BucketFactory::create_bucket(resource_specifier, creation_strategy, env)
             .and_then(|bucket| bucket.create_proof_of_all(env))
     }


### PR DESCRIPTION
## Summary

This PR includes a number of changes and improvements to the scrypto-test framework. The following are the changes made:

* Created a new `TestEnvironmentBuilder` that allows for configuring the environment prior to creation. Additionally the `TestEnvironment` can now operate over any database and not just an in-memory database.
* Added a better way for reading state in the testing environment. This new method ensures that the states are opened and closed when they need to be. It also ensures that the references provided as a result of the state reads do not escape outside of the closure.
* Added logging support to the testing environment. It is currently enabled by default and quite rudimentary. 