### PR TITLE
Clean up TestRunner options and execute_xxx methods

### DIFF
--- a/assets/template/tests/lib.rs
+++ b/assets/template/tests/lib.rs
@@ -17,6 +17,7 @@ fn test_hello() {
 
     // Test the `instantiate_hello` function.
     let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "Hello",
@@ -24,7 +25,7 @@ fn test_hello() {
             manifest_args!(),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -33,6 +34,7 @@ fn test_hello() {
 
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component, "free_token", manifest_args!())
         .call_method(
             account,
@@ -40,7 +42,7 @@ fn test_hello() {
             manifest_args!(ManifestExpression::EntireWorktop),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -15,6 +15,7 @@ fn test_hello() {
 
     // Test the `instantiate_hello` function.
     let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "Hello",
@@ -22,7 +23,7 @@ fn test_hello() {
             manifest_args!(),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -31,6 +32,7 @@ fn test_hello() {
 
     // Test the `free_token` method.
     let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component, "free_token", manifest_args!())
         .call_method(
             account,
@@ -38,7 +40,7 @@ fn test_hello() {
             manifest_args!(ManifestExpression::EntireWorktop),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/format.sh
+++ b/format.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$0")"
     | xargs -I '{}' bash -c "set -x; cargo fmt --manifest-path {}"
 )
 (
-    find "radix-engine-tests/tests/blueprints" -mindepth 2 -maxdepth 2 -type f \( -name Cargo.toml \) -print \
+    find "radix-engine-tests/assets/blueprints" -mindepth 2 -maxdepth 2 -type f \( -name Cargo.toml \) -print \
     | xargs -I '{}' bash -c "set -x; cargo fmt --manifest-path {}"
 )
 (

--- a/monkey-tests/src/lib.rs
+++ b/monkey-tests/src/lib.rs
@@ -695,9 +695,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
 
         for uuid in 0u64..num_txns {
             // Build new transaction
-            let mut builder = ManifestBuilder::new()
-                .lock_fee_from_faucet()
-                .lock_fee_from_faucet();
+            let mut builder = ManifestBuilder::new().lock_fee_from_faucet();
             let mut trivial = false;
             let fuzz_txn_intent = T::next_txn_intent(&mut self.fuzzer);
             for fuzz_action in &fuzz_txn_intent {

--- a/monkey-tests/src/lib.rs
+++ b/monkey-tests/src/lib.rs
@@ -403,6 +403,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
 
             let (pool_component, pool_unit_resource) = {
                 let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .call_function(
                         POOL_PACKAGE,
                         TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -415,7 +416,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
                         },
                     )
                     .build();
-                let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
                 let commit_result = receipt.expect_commit_success();
 
                 (
@@ -452,6 +453,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
 
             let (pool_component, pool_unit_resource) = {
                 let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .call_function(
                         POOL_PACKAGE,
                         MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -464,7 +466,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
                         },
                     )
                     .build();
-                let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+                let receipt = test_runner.execute_manifest(manifest, vec![]);
                 let commit_result = receipt.expect_commit_success();
 
                 (
@@ -494,8 +496,9 @@ impl<T: TxnFuzzer> FuzzTest<T> {
         );
 
         let fungible_vault_component = {
-            let receipt = test_runner.execute_manifest_ignoring_fee(
+            let receipt = test_runner.execute_manifest(
                 ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .create_fungible_resource(
                         OwnerRole::None,
                         true,
@@ -525,8 +528,9 @@ impl<T: TxnFuzzer> FuzzTest<T> {
 
             fuzzer.add_resource(resource_address);
 
-            let receipt = test_runner.execute_manifest_ignoring_fee(
+            let receipt = test_runner.execute_manifest(
                 ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .call_function(
                         package_address,
                         BLUEPRINT_NAME,
@@ -554,8 +558,9 @@ impl<T: TxnFuzzer> FuzzTest<T> {
                 .map(|id| (id, ()))
                 .collect();
             let amount = ids.len();
-            let receipt = test_runner.execute_manifest_ignoring_fee(
+            let receipt = test_runner.execute_manifest(
                 ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .create_non_fungible_resource(
                         OwnerRole::None,
                         NonFungibleIdType::Integer,
@@ -587,7 +592,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
             fuzzer.add_resource(resource_address);
 
             let manifest = {
-                let mut builder = ManifestBuilder::new();
+                let mut builder = ManifestBuilder::new().lock_fee_from_faucet();
                 if !amount.is_zero() {
                     builder = builder.withdraw_from_account(account, resource_address, amount);
                 }
@@ -604,8 +609,7 @@ impl<T: TxnFuzzer> FuzzTest<T> {
                     .build()
             };
 
-            let receipt =
-                test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+            let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
             let component_address = receipt.expect_commit_success().new_component_addresses()[0];
 
             let vault_id = test_runner.get_component_vaults(component_address, resource_address)[0];
@@ -691,7 +695,9 @@ impl<T: TxnFuzzer> FuzzTest<T> {
 
         for uuid in 0u64..num_txns {
             // Build new transaction
-            let mut builder = ManifestBuilder::new();
+            let mut builder = ManifestBuilder::new()
+                .lock_fee_from_faucet()
+                .lock_fee_from_faucet();
             let mut trivial = false;
             let fuzz_txn_intent = T::next_txn_intent(&mut self.fuzzer);
             for fuzz_action in &fuzz_txn_intent {
@@ -719,18 +725,16 @@ impl<T: TxnFuzzer> FuzzTest<T> {
                     .build();
 
                 let receipt = if let Some(error_after_count) = error_after_system_callback_count {
-                    self.test_runner.execute_manifest_with_fee_from_faucet_with_system::<_, InjectSystemCostingError<'_, OverridePackageCode<ResourceTestInvoke>>>(
+                    self.test_runner.execute_manifest_with_system::<_, InjectSystemCostingError<'_, OverridePackageCode<ResourceTestInvoke>>>(
                         manifest,
-                        self.fuzzer.next_fee(),
                         vec![NonFungibleGlobalId::from_public_key(
                             &self.account_public_key,
                         )],
                         error_after_count,
                     )
                 } else {
-                    self.test_runner.execute_manifest_with_fee_from_faucet(
+                    self.test_runner.execute_manifest(
                         manifest,
-                        self.fuzzer.next_fee(),
                         vec![NonFungibleGlobalId::from_public_key(
                             &self.account_public_key,
                         )],

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -192,7 +192,7 @@ fn bench_deserialize_wasm(c: &mut Criterion) {
 }
 
 fn bench_prepare_wasm(c: &mut Criterion) {
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let code = include_workspace_asset_bytes!("radiswap.wasm").to_vec();
     let package_definition: PackageDefinition =
         manifest_decode(include_workspace_asset_bytes!("radiswap.rpd")).unwrap();

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -37,7 +37,7 @@ fn bench_radiswap(c: &mut Criterion) {
         .with_custom_database(RocksDBWithMerkleTreeSubstateStore::clear(PathBuf::from(
             "/tmp/radiswap",
         )))
-        .without_trace()
+        .without_kernel_trace()
         .build();
     #[cfg(not(feature = "rocksdb"))]
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -40,7 +40,7 @@ fn bench_radiswap(c: &mut Criterion) {
         .without_trace()
         .build();
     #[cfg(not(feature = "rocksdb"))]
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Create account and publish package
     let (pk, _, account) = test_runner.new_allocated_account();

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -380,6 +380,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
             )
             .build(),
         ResourceType::NonFungible { id_type } => ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 id_type,
@@ -396,7 +397,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
             )
             .build(),
     };
-    let result = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let result = test_runner.execute_manifest(manifest, vec![]);
     let mintable_non_fungible_resource_address =
         result.expect_commit(true).new_resource_addresses()[0].clone();
 

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -1,9 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::{metadata, metadata_init, mint_roles};
+use radix_engine_tests::common::*;
 use scrypto::prelude::Pow;
 use scrypto::NonFungibleData;
 use scrypto_test::prelude::TestRunnerBuilder;
@@ -61,7 +61,9 @@ fn multi_account_fund_transfer_succeeds() {
         3,
         |this_account_address, other_accounts, address_bech32_encoder| {
             let manifest = replace_variables!(
-                include_workspace_transaction_examples_str!("account/multi_account_resource_transfer.rtm"),
+                include_workspace_transaction_examples_str!(
+                    "account/multi_account_resource_transfer.rtm"
+                ),
                 xrd_resource_address = XRD.display(address_bech32_encoder),
                 this_account_address = address_bech32_encoder
                     .encode(this_account_address.as_ref())
@@ -80,7 +82,9 @@ fn multi_account_fund_transfer_succeeds() {
 fn creating_a_fungible_resource_with_no_initial_supply_succeeds() {
     run_manifest(|account_address, address_bech32_encoder| {
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/fungible/no_initial_supply.rtm"),
+            include_workspace_transaction_examples_str!(
+                "resources/creation/fungible/no_initial_supply.rtm"
+            ),
             account_address = account_address.display(address_bech32_encoder)
         );
         (manifest, Vec::new())
@@ -95,7 +99,9 @@ fn creating_a_fungible_resource_with_initial_supply_succeeds() {
         let initial_supply = dec!("10000000");
 
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/fungible/with_initial_supply.rtm"),
+            include_workspace_transaction_examples_str!(
+                "resources/creation/fungible/with_initial_supply.rtm"
+            ),
             initial_supply = initial_supply,
             account_address = account_address.display(address_bech32_encoder)
         );
@@ -111,7 +117,9 @@ fn creating_a_fungible_resource_with_max_initial_supply_succeeds() {
         let initial_supply = Decimal(I192::from(2).pow(152));
 
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/fungible/with_initial_supply.rtm"),
+            include_workspace_transaction_examples_str!(
+                "resources/creation/fungible/with_initial_supply.rtm"
+            ),
             initial_supply = initial_supply,
             account_address = account_address.display(address_bech32_encoder)
         );
@@ -127,7 +135,9 @@ fn creating_a_fungible_resource_with_exceeded_initial_supply_fails() {
         let initial_supply = Decimal(I192::from(2).pow(152) + I192::ONE);
 
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/fungible/with_initial_supply.rtm"),
+            include_workspace_transaction_examples_str!(
+                "resources/creation/fungible/with_initial_supply.rtm"
+            ),
             initial_supply = initial_supply,
             account_address = account_address.display(address_bech32_encoder)
         );
@@ -141,7 +151,9 @@ fn creating_a_fungible_resource_with_exceeded_initial_supply_fails() {
 fn creating_a_non_fungible_resource_with_no_initial_supply_succeeds() {
     run_manifest(|account_address, address_bech32_encoder| {
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/non_fungible/no_initial_supply.rtm"),
+            include_workspace_transaction_examples_str!(
+                "resources/creation/non_fungible/no_initial_supply.rtm"
+            ),
             account_address = account_address.display(address_bech32_encoder)
         );
         (manifest, Vec::new())
@@ -154,10 +166,11 @@ fn creating_a_non_fungible_resource_with_no_initial_supply_succeeds() {
 fn creating_a_non_fungible_resource_with_initial_supply_succeeds() {
     run_manifest(|account_address, address_bech32_encoder| {
         let manifest = replace_variables!(
-            include_workspace_transaction_examples_str!("resources/creation/non_fungible/with_initial_supply.rtm"),
-            account_address =
-                account_address.display(address_bech32_encoder),
-                non_fungible_local_id = "#1#"
+            include_workspace_transaction_examples_str!(
+                "resources/creation/non_fungible/with_initial_supply.rtm"
+            ),
+            account_address = account_address.display(address_bech32_encoder),
+            non_fungible_local_id = "#1#"
         );
         (manifest, Vec::new())
     })

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -377,6 +377,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
 
     let manifest = match resource_type {
         ResourceType::Fungible { divisibility } => ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 false,

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -348,7 +348,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
     ) -> (String, Vec<Vec<u8>>),
 {
     // Creating a new test runner
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Creating the account component required for this test
     let (public_key, _, component_address) = test_runner.new_account(false);
@@ -424,7 +424,7 @@ where
     F: Fn(&ComponentAddress, &[ComponentAddress], &AddressBech32Encoder) -> (String, Vec<Vec<u8>>),
 {
     // Creating a new test runner
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Creating the account component required for this test
     let (public_key, _, component_address) = test_runner.new_account(false);

--- a/radix-engine-tests/tests/application/determinism.rs
+++ b/radix-engine-tests/tests/application/determinism.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto::resource::DIVISIBILITY_MAXIMUM;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_simple_deterministic_execution() {

--- a/radix-engine-tests/tests/application/execution_trace.rs
+++ b/radix-engine-tests/tests/application/execution_trace.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::system::system_modules::execution_trace::{
     ApplicationFnIdentifier, ExecutionTrace, ResourceSpecifier, TraceOrigin, WorktopChange,
 };
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::model::PreviewFlags;
-
 
 #[test]
 fn test_trace_resource_transfers() {

--- a/radix-engine-tests/tests/application/local_component.rs
+++ b/radix-engine-tests/tests/application/local_component.rs
@@ -1,10 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::limits::TransactionLimitsError;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn local_component_should_be_callable_read_only() {

--- a/radix-engine-tests/tests/application/metering.rs
+++ b/radix-engine-tests/tests/application/metering.rs
@@ -13,7 +13,6 @@ use scrypto::prelude::metadata;
 use scrypto::prelude::metadata_init;
 use scrypto_test::prelude::*;
 
-
 // For WASM-specific metering tests, see `wasm_metering.rs`.
 
 #[cfg(not(feature = "alloc"))]

--- a/radix-engine-tests/tests/application/metering.rs
+++ b/radix-engine-tests/tests/application/metering.rs
@@ -670,7 +670,7 @@ fn run_mint_large_size_nfts_from_manifest(mode: Mode) {
 
 fn run_mint_nfts_from_manifest(mode: Mode, nft_data: TestNonFungibleData) {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_allocated_account();
 
     // Act

--- a/radix-engine-tests/tests/application/stake_reconciliation.rs
+++ b/radix-engine-tests/tests/application/stake_reconciliation.rs
@@ -1,7 +1,9 @@
 use radix_engine_common::prelude::*;
-use radix_engine_store_interface::{interface::*, db_key_mapper::{SpreadPrefixKeyMapper, DatabaseKeyMapper}};
+use radix_engine_store_interface::{
+    db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper},
+    interface::*,
+};
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_stake_reconciliation() {
@@ -30,7 +32,8 @@ fn test_stake_reconciliation() {
     receipt.expect_commit_success();
 
     // Store current DB substate value hashes for comparision after staking execution
-    let mut pre_transaction_substates: HashMap<(DbPartitionKey, DbSortKey), Vec<u8>> = HashMap::new();
+    let mut pre_transaction_substates: HashMap<(DbPartitionKey, DbSortKey), Vec<u8>> =
+        HashMap::new();
     let db = test_runner.substate_db();
     let old_keys: Vec<DbPartitionKey> = db.list_partition_keys().collect();
     for key in old_keys {
@@ -213,14 +216,16 @@ fn test_stake_reconciliation() {
     for (full_key, (expected_old_value, _)) in expected_updated_substates.iter() {
         let database_value = &pre_transaction_substates[full_key];
         let address = AddressBech32Encoder::for_simulator()
-            .encode(&SpreadPrefixKeyMapper::from_db_partition_key(&full_key.0).0.0)
+            .encode(
+                &SpreadPrefixKeyMapper::from_db_partition_key(&full_key.0)
+                    .0
+                     .0,
+            )
             .unwrap();
         assert_eq!(
-            database_value,
-            expected_old_value,
+            database_value, expected_old_value,
             "The pre-transaction value of updated substate under {} is not expected: {:?}",
-            address,
-            full_key
+            address, full_key
         );
         // For printing:
         // let (db_partition_key, db_sort_key) = full_key;
@@ -250,7 +255,11 @@ fn test_stake_reconciliation() {
         for (sort_key, current_value) in partition_entries {
             let full_key = (key.clone(), sort_key.clone());
             let address = AddressBech32Encoder::for_simulator()
-                .encode(&SpreadPrefixKeyMapper::from_db_partition_key(&full_key.0).0.0)
+                .encode(
+                    &SpreadPrefixKeyMapper::from_db_partition_key(&full_key.0)
+                        .0
+                         .0,
+                )
                 .unwrap();
 
             if let Some(old_value) = pre_transaction_substates.get(&full_key) {
@@ -258,7 +267,8 @@ fn test_stake_reconciliation() {
                     same_substates_count += 1;
                 } else {
                     changed_substates_count += 1;
-                    let expected_updated_value = expected_updated_substates.get(&full_key).map(|x| &x.1);
+                    let expected_updated_value =
+                        expected_updated_substates.get(&full_key).map(|x| &x.1);
                     assert_eq!(
                         Some(&current_value),
                         expected_updated_value,

--- a/radix-engine-tests/tests/application/storage.rs
+++ b/radix-engine-tests/tests/application/storage.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_kv_store_with_many_large_keys() {

--- a/radix-engine-tests/tests/application/storage.rs
+++ b/radix-engine-tests/tests/application/storage.rs
@@ -6,7 +6,7 @@ use scrypto_test::prelude::*;
 #[test]
 fn test_kv_store_with_many_large_keys() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("storage"));
 
     // Act

--- a/radix-engine-tests/tests/application/stored_external_component.rs
+++ b/radix-engine-tests/tests/application/stored_external_component.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn stored_component_addresses_in_non_globalized_component_are_invocable() {

--- a/radix-engine-tests/tests/application/stored_local_component.rs
+++ b/radix-engine-tests/tests/application/stored_local_component.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn should_be_able_to_call_read_method_on_a_stored_component_in_owned_component() {

--- a/radix-engine-tests/tests/application/stored_resource.rs
+++ b/radix-engine-tests/tests/application/stored_resource.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn stored_resource_is_invokeable() {

--- a/radix-engine-tests/tests/application/transaction.rs
+++ b/radix-engine-tests/tests/application/transaction.rs
@@ -1,10 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::transaction_processor::*;
 use radix_engine::errors::*;
 use radix_engine::transaction::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::validation::*;
 

--- a/radix-engine-tests/tests/blueprints/access_controller.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller.rs
@@ -1980,7 +1980,7 @@ impl AccessControllerTestRunner {
     }
 
     fn execute_manifest(&mut self, manifest: TransactionManifestV1) -> TransactionReceipt {
-        self.test_runner.execute_manifest_ignoring_fee(
+        self.test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&self.account.1)],
         )
@@ -1992,7 +1992,8 @@ impl AccessControllerTestRunner {
             Role::Recovery => self.recovery_role_badge,
             Role::Confirmation => self.confirmation_role_badge,
         };
-        ManifestBuilder::new().create_proof_from_account_of_amount(
+        ManifestBuilder::new()
+        .lock_fee_from_faucet().create_proof_from_account_of_amount(
             self.account.0,
             resource_address,
             dec!(1),

--- a/radix-engine-tests/tests/blueprints/access_controller.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller.rs
@@ -210,6 +210,7 @@ pub fn stop_timed_recovery_with_no_access_fails() {
     let mut test_runner = AccessControllerTestRunner::new(Some(10));
 
     let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             test_runner.access_controller_address,
             "stop_timed_recovery",
@@ -1761,7 +1762,7 @@ impl AccessControllerTestRunner {
         let manifest_builder = if create_proof {
             self.manifest_builder(as_role)
         } else {
-            ManifestBuilder::new()
+            ManifestBuilder::new().lock_fee_from_faucet()
         };
 
         let manifest = manifest_builder

--- a/radix-engine-tests/tests/blueprints/access_controller.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller.rs
@@ -10,7 +10,6 @@ use radix_engine_interface::blueprints::access_controller::*;
 use scrypto_test::prelude::{CustomGenesis, DefaultTestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
 
-
 #[test]
 pub fn creating_an_access_controller_succeeds() {
     AccessControllerTestRunner::new(Some(10));
@@ -1993,11 +1992,8 @@ impl AccessControllerTestRunner {
             Role::Confirmation => self.confirmation_role_badge,
         };
         ManifestBuilder::new()
-        .lock_fee_from_faucet().create_proof_from_account_of_amount(
-            self.account.0,
-            resource_address,
-            dec!(1),
-        )
+            .lock_fee_from_faucet()
+            .create_proof_from_account_of_amount(self.account.0, resource_address, dec!(1))
     }
 
     fn set_current_minute(&mut self, minutes: i64) {

--- a/radix-engine-tests/tests/blueprints/access_controller.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller.rs
@@ -1651,7 +1651,7 @@ struct AccessControllerTestRunner {
 impl AccessControllerTestRunner {
     pub fn new(timed_recovery_delay_in_minutes: Option<u32>) -> Self {
         let mut test_runner = TestRunnerBuilder::new()
-            .without_trace()
+            .without_kernel_trace()
             .with_custom_genesis(CustomGenesis::default(
                 Epoch::of(1),
                 CustomGenesis::default_consensus_manager_config(),

--- a/radix-engine-tests/tests/blueprints/account.rs
+++ b/radix-engine-tests/tests/blueprints/account.rs
@@ -8,7 +8,6 @@ use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn can_securify_virtual_account() {
     securify_account(true, true, true);
@@ -227,7 +226,10 @@ fn account_to_bucket_to_virtual_account() {
 #[test]
 fn create_account_and_bucket_fail() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet().new_account().build();
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
+        .new_account()
+        .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_specific_failure(|e| {
         matches!(

--- a/radix-engine-tests/tests/blueprints/account.rs
+++ b/radix-engine-tests/tests/blueprints/account.rs
@@ -227,8 +227,8 @@ fn account_to_bucket_to_virtual_account() {
 #[test]
 fn create_account_and_bucket_fail() {
     let mut test_runner = TestRunnerBuilder::new().build();
-    let manifest = ManifestBuilder::new().new_account().build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet().new_account().build();
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_specific_failure(|e| {
         matches!(
             e,

--- a/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
+++ b/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
@@ -819,7 +819,6 @@ fn authorized_depositor_badge_is_ignored_when_deposit_batch_is_permitted_without
     ] {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .call_method(
                 account,
@@ -851,7 +850,6 @@ fn authorized_depositor_badge_is_ignored_when_deposit_is_permitted_without_it() 
     ] {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .take_all_from_worktop(XRD, "bucket")
             .with_bucket("bucket", |builder, bucket| {
@@ -886,7 +884,6 @@ fn authorized_depositor_badge_is_checked_when_deposit_cant_go_without_it() {
     ] {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .lock_fee(FAUCET, 10)
             .call_method(
                 account,
                 ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -928,7 +925,6 @@ fn authorized_depositor_badge_permits_caller_to_deposit() {
     ] {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .lock_fee(FAUCET, 10)
             .call_method(
                 account,
                 ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,

--- a/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
+++ b/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
@@ -64,8 +64,8 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -84,7 +84,7 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -101,7 +101,7 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -117,8 +117,8 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -139,7 +139,7 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -154,7 +154,7 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -170,8 +170,8 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -192,7 +192,7 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -208,7 +208,7 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -223,8 +223,8 @@ fn authorized_depositor_can_be_removed_later() {
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -245,7 +245,7 @@ fn authorized_depositor_can_be_removed_later() {
         .expect_commit_success();
 
     // Act 1
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -261,13 +261,13 @@ fn authorized_depositor_can_be_removed_later() {
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert 1
     receipt.expect_commit_success();
 
     // Act 2
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             account1,
             ACCOUNT_REMOVE_AUTHORIZED_DEPOSITOR,
@@ -277,10 +277,10 @@ fn authorized_depositor_can_be_removed_later() {
         )
         .build();
     test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk1)])
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk1)])
         .expect_commit_success();
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -296,7 +296,7 @@ fn authorized_depositor_can_be_removed_later() {
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert 2
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -311,8 +311,8 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -331,7 +331,7 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -348,7 +348,7 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -364,8 +364,8 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -386,7 +386,7 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -401,7 +401,7 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -417,8 +417,8 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -439,7 +439,7 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -455,7 +455,7 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -470,8 +470,8 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -490,7 +490,7 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -507,7 +507,7 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -523,8 +523,8 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -545,7 +545,7 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -560,7 +560,7 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -576,8 +576,8 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -598,7 +598,7 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -614,7 +614,7 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -629,8 +629,8 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -649,7 +649,7 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -666,7 +666,7 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -682,8 +682,8 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -704,7 +704,7 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -719,7 +719,7 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -735,8 +735,8 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
 
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
-        .execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        .execute_manifest(
+            ManifestBuilder::new().lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -757,7 +757,7 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -773,7 +773,7 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
         })
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -790,7 +790,7 @@ fn authorized_depositor_badge_is_ignored_when_deposit_batch_is_permitted_without
         ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_BATCH_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .call_method(
@@ -821,7 +821,7 @@ fn authorized_depositor_badge_is_ignored_when_deposit_is_permitted_without_it() 
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .take_all_from_worktop(XRD, "bucket")
@@ -855,7 +855,7 @@ fn authorized_depositor_badge_is_checked_when_deposit_cant_go_without_it() {
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(
                 account,
@@ -896,7 +896,7 @@ fn authorized_depositor_badge_permits_caller_to_deposit() {
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(
                 account,
@@ -960,7 +960,7 @@ fn test_depositors_operation_method_auth(
 
     // Act
     let manifest = {
-        let mut builder = ManifestBuilder::new();
+        let mut builder = ManifestBuilder::new().lock_fee_from_faucet();
         builder = match operation {
             DepositorsOperation::Add { badge } => builder.call_method(
                 account,
@@ -975,7 +975,7 @@ fn test_depositors_operation_method_auth(
         };
         builder.build()
     };
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, initial_proofs);
+    let receipt = test_runner.execute_manifest(manifest, initial_proofs);
 
     // Assert
     assertion(&receipt)

--- a/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
+++ b/radix-engine-tests/tests/blueprints/account_authorized_depositors.rs
@@ -6,7 +6,6 @@ use radix_engine_interface::blueprints::account::*;
 use scrypto_test::prelude::TestRunnerBuilder;
 use transaction::prelude::*;
 
-
 #[test]
 fn account_add_authorized_depositor_without_owner_auth_fails() {
     test_depositors_operation_method_auth(
@@ -65,7 +64,8 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -84,7 +84,8 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -100,8 +101,8 @@ fn try_authorized_deposit_or_refund_performs_a_refund_when_badge_is_not_in_depos
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -118,7 +119,8 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -139,7 +141,8 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -153,8 +156,8 @@ fn try_authorized_deposit_or_refund_panics_when_badge_is_in_depositors_list_but_
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -171,7 +174,8 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -192,7 +196,8 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -207,8 +212,8 @@ fn try_authorized_deposit_or_refund_accepts_deposit_when_depositor_is_authorized
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -224,7 +229,8 @@ fn authorized_depositor_can_be_removed_later() {
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -245,7 +251,8 @@ fn authorized_depositor_can_be_removed_later() {
         .expect_commit_success();
 
     // Act 1
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -260,14 +267,15 @@ fn authorized_depositor_can_be_removed_later() {
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert 1
     receipt.expect_commit_success();
 
     // Act 2
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             account1,
             ACCOUNT_REMOVE_AUTHORIZED_DEPOSITOR,
@@ -280,7 +288,8 @@ fn authorized_depositor_can_be_removed_later() {
         .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk1)])
         .expect_commit_success();
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -295,8 +304,8 @@ fn authorized_depositor_can_be_removed_later() {
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert 2
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -312,7 +321,8 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -331,7 +341,8 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -347,8 +358,8 @@ fn try_authorized_deposit_batch_or_refund_performs_a_refund_when_badge_is_not_in
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -365,7 +376,8 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -386,7 +398,8 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -400,8 +413,8 @@ fn try_authorized_deposit_batch_or_refund_panics_when_badge_is_in_depositors_lis
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -418,7 +431,8 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -439,7 +453,8 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -454,8 +469,8 @@ fn try_authorized_deposit_batch_or_refund_accepts_deposit_when_depositor_is_auth
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -471,7 +486,8 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -490,7 +506,8 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -506,8 +523,8 @@ fn try_authorized_deposit_or_abort_performs_an_abort_when_badge_is_not_in_deposi
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -524,7 +541,8 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -545,7 +563,8 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -559,8 +578,8 @@ fn try_authorized_deposit_or_abort_panics_when_badge_is_in_depositors_list_but_i
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -577,7 +596,8 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -598,7 +618,8 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -613,8 +634,8 @@ fn try_authorized_deposit_or_abort_accepts_deposit_when_depositor_is_authorized_
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -630,7 +651,8 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -649,7 +671,8 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -665,8 +688,8 @@ fn try_authorized_deposit_batch_or_abort_performs_an_abort_when_badge_is_not_in_
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_specific_failure(is_account_not_an_authorized_depositor_error);
@@ -683,7 +706,8 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -704,7 +728,8 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -718,8 +743,8 @@ fn try_authorized_deposit_batch_or_abort_panics_when_badge_is_in_depositors_list
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_auth_assertion_failure();
@@ -736,7 +761,8 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
     let badge = ResourceOrNonFungible::Resource(XRD);
     test_runner
         .execute_manifest(
-            ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     account1,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -757,7 +783,8 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
         .expect_commit_success();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account2, XRD, 1)
         .withdraw_from_account(account2, XRD, 1)
         .take_all_from_worktop(XRD, "bucket")
@@ -772,8 +799,8 @@ fn try_authorized_deposit_batch_or_abort_accepts_deposit_when_depositor_is_autho
             )
         })
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, vec![NonFungibleGlobalId::from_public_key(&pk2)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -790,7 +817,8 @@ fn authorized_depositor_badge_is_ignored_when_deposit_batch_is_permitted_without
         ACCOUNT_TRY_DEPOSIT_BATCH_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_BATCH_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .call_method(
@@ -821,7 +849,8 @@ fn authorized_depositor_badge_is_ignored_when_deposit_is_permitted_without_it() 
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(FAUCET, "free", ())
             .take_all_from_worktop(XRD, "bucket")
@@ -855,7 +884,8 @@ fn authorized_depositor_badge_is_checked_when_deposit_cant_go_without_it() {
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(
                 account,
@@ -896,7 +926,8 @@ fn authorized_depositor_badge_permits_caller_to_deposit() {
         ACCOUNT_TRY_DEPOSIT_OR_ABORT_IDENT,
         ACCOUNT_TRY_DEPOSIT_OR_REFUND_IDENT,
     ] {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_fee(FAUCET, 10)
             .call_method(
                 account,

--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -101,8 +101,9 @@ fn account_try_deposit_batch_or_refund_method_is_callable_with_array_of_resource
     let mut test_runner = TestRunnerBuilder::new().build();
     let (_, _, account_address) = test_runner.new_account(true);
 
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .get_free_xrd_from_faucet()
             .take_all_from_worktop(XRD, "xrd_1a")
             .take_all_from_worktop(XRD, "xrd_1b")
@@ -609,7 +610,7 @@ impl AccountDepositModesTestRunner {
         manifest: TransactionManifestV1,
         sign: bool,
     ) -> TransactionReceipt {
-        self.test_runner.execute_manifest_ignoring_fee(
+        self.test_runner.execute_manifest(
             manifest,
             if sign {
                 vec![self.virtual_signature_badge()]

--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -484,6 +484,7 @@ impl AccountDepositModesTestRunner {
         sign: bool,
     ) -> TransactionReceipt {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, 1)
             .take_all_from_worktop(resource_address, "bucket")
             .with_bucket("bucket", |builder, bucket| {
@@ -499,6 +500,7 @@ impl AccountDepositModesTestRunner {
         sign: bool,
     ) -> TransactionReceipt {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .get_free_xrd_from_faucet()
             .take_all_from_worktop(XRD, "free_tokens")
             .with_bucket("free_tokens", |builder, bucket| {
@@ -514,6 +516,7 @@ impl AccountDepositModesTestRunner {
         sign: bool,
     ) -> TransactionReceipt {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.component_address,
                 ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -530,6 +533,7 @@ impl AccountDepositModesTestRunner {
         sign: bool,
     ) -> TransactionReceipt {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.component_address,
                 ACCOUNT_SET_RESOURCE_PREFERENCE_IDENT,
@@ -548,6 +552,7 @@ impl AccountDepositModesTestRunner {
         sign: bool,
     ) -> TransactionReceipt {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.component_address,
                 ACCOUNT_REMOVE_RESOURCE_PREFERENCE_IDENT,
@@ -596,6 +601,7 @@ impl AccountDepositModesTestRunner {
             .test_runner
             .get_component_balance(self.component_address, resource_address);
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(self.component_address, resource_address, balance)
             .try_deposit_entire_worktop_or_refund(virtual_account, None)
             .build();

--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -7,7 +7,6 @@ use radix_engine_queries::typed_substate_layout::AccountError;
 use scrypto_test::prelude::{DefaultTestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
 
-
 #[test]
 fn account_deposit_method_is_callable_with_owner_signature() {
     // Arrange

--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -467,7 +467,7 @@ struct AccountDepositModesTestRunner {
 
 impl AccountDepositModesTestRunner {
     pub fn new(virtual_account: bool) -> Self {
-        let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+        let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
         let (public_key, _, component_address) = test_runner.new_account(virtual_account);
 
         Self {

--- a/radix-engine-tests/tests/blueprints/clock.rs
+++ b/radix-engine-tests/tests/blueprints/clock.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::blueprints::consensus_manager::{
     ConsensusManagerNextRoundInput, CONSENSUS_MANAGER_NEXT_ROUND_IDENT,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn sdk_clock_reads_timestamp_set_by_validator_next_round() {

--- a/radix-engine-tests/tests/blueprints/native_blueprint_call_validator.rs
+++ b/radix-engine-tests/tests/blueprints/native_blueprint_call_validator.rs
@@ -1,15 +1,14 @@
-use radix_engine_tests::common::*;
 use radix_engine::utils::{
     validate_call_arguments_to_native_components, InstructionSchemaValidationError,
     LocatedInstructionSchemaValidationError,
 };
 use radix_engine_common::prelude::NetworkDefinition;
+use radix_engine_tests::common::*;
 use scrypto::prelude::*;
+use transaction::manifest::e2e::apply_address_replacements;
 use transaction::manifest::{compile, MockBlobProvider};
 use transaction::prelude::*;
 use walkdir::WalkDir;
-use transaction::manifest::e2e::apply_address_replacements;
-
 
 #[test]
 fn validator_sees_valid_transfer_manifest_as_valid() {

--- a/radix-engine-tests/tests/blueprints/non_fungible.rs
+++ b/radix-engine-tests/tests/blueprints/non_fungible.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::{
     InvalidNonFungibleSchema, NonFungibleResourceManagerError,
 };
@@ -9,9 +8,9 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
+use radix_engine_tests::common::*;
 use scrypto::NonFungibleData;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn create_non_fungible_resource_with_supply_and_ruid_should_fail() {

--- a/radix-engine-tests/tests/blueprints/non_fungible_add_remove.rs
+++ b/radix-engine-tests/tests/blueprints/non_fungible_add_remove.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn add_and_remove_of_non_fungible_should_succeed() {

--- a/radix-engine-tests/tests/blueprints/non_fungible_big_vault.rs
+++ b/radix-engine-tests/tests/blueprints/non_fungible_big_vault.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::costing::CostingError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn get_non_fungibles_on_big_vault(size: u32, expect_success: bool) {
     // Arrange

--- a/radix-engine-tests/tests/blueprints/non_fungible_vault.rs
+++ b/radix-engine-tests/tests/blueprints/non_fungible_vault.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::NonFungibleVaultError;
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn get_non_fungibles_on_vault(vault_size: usize, non_fungibles_size: u32, expected_size: usize) {
     // Arrange

--- a/radix-engine-tests/tests/blueprints/own.rs
+++ b/radix-engine-tests/tests/blueprints/own.rs
@@ -3,7 +3,6 @@ use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto::prelude::{WORKTOP_BLUEPRINT, WORKTOP_DROP_IDENT};
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn mis_typed_own_passed_to_worktop_drop_function() {
     // Basic setup

--- a/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
@@ -1,3 +1,6 @@
+use radix_engine::blueprints::pool::v1::constants::*;
+use radix_engine::blueprints::pool::v1::errors::multi_resource_pool::Error as MultiResourcePoolError;
+use radix_engine::blueprints::pool::v1::events::multi_resource_pool::*;
 use radix_engine::errors::{SystemError, SystemModuleError};
 use radix_engine::{
     errors::{ApplicationError, RuntimeError},
@@ -10,9 +13,6 @@ use radix_engine_interface::blueprints::pool::*;
 use scrypto::prelude::Pow;
 use scrypto_test::prelude::{is_auth_error, DefaultTestRunner, TestRunnerBuilder};
 use transaction::prelude::*;
-use radix_engine::blueprints::pool::v1::constants::*;
-use radix_engine::blueprints::pool::v1::errors::multi_resource_pool::Error as MultiResourcePoolError;
-use radix_engine::blueprints::pool::v1::events::multi_resource_pool::*;
 
 #[test]
 fn multi_resource_pool_can_be_instantiated() {
@@ -46,7 +46,8 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
@@ -412,7 +413,8 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -843,7 +845,8 @@ impl<const N: usize> TestEnvironment<N> {
         });
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+            let manifest = ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -896,7 +899,8 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -923,7 +927,8 @@ impl<const N: usize> TestEnvironment<N> {
         amount: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, amount.into())
             .take_all_from_worktop(resource_address, "to_deposit")
             .with_name_lookup(|builder, lookup| {
@@ -945,7 +950,8 @@ impl<const N: usize> TestEnvironment<N> {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -982,7 +988,8 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     fn get_vault_amounts(&mut self, sign: bool) -> MultiResourcePoolGetVaultAmountsOutput {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_GET_VAULT_AMOUNTS_IDENT,
@@ -1007,7 +1014,8 @@ impl<const N: usize> TestEnvironment<N> {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,

--- a/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
@@ -406,7 +406,7 @@ fn contributing_tokens_that_do_not_belong_to_pool_fails() {
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
 
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
@@ -829,7 +829,7 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     pub fn new_with_owner(divisibility: [u8; N], owner_role: OwnerRole) -> Self {
-        let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+        let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
         let (public_key, _, account) = test_runner.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
@@ -46,12 +46,12 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
         .test_runner
-        .execute_manifest_ignoring_fee(manifest, initial_proofs);
+        .execute_manifest(manifest, initial_proofs);
 
     // Assert
     result(receipt);
@@ -412,7 +412,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -425,7 +425,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(
@@ -843,7 +843,7 @@ impl<const N: usize> TestEnvironment<N> {
         });
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new()
+            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -856,7 +856,7 @@ impl<const N: usize> TestEnvironment<N> {
                     },
                 )
                 .build();
-            let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+            let receipt = test_runner.execute_manifest(manifest, vec![]);
             let commit_result = receipt.expect_commit_success();
 
             (
@@ -880,7 +880,7 @@ impl<const N: usize> TestEnvironment<N> {
         resource_to_amount_mapping: IndexMap<ResourceAddress, Decimal>,
         sign: bool,
     ) -> TransactionReceipt {
-        let mut manifest_builder = ManifestBuilder::new();
+        let mut manifest_builder = ManifestBuilder::new().lock_fee_from_faucet();
         for (resource_address, amount) in resource_to_amount_mapping.iter() {
             manifest_builder = manifest_builder.mint_fungible(*resource_address, *amount)
         }
@@ -896,7 +896,7 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -923,7 +923,7 @@ impl<const N: usize> TestEnvironment<N> {
         amount: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, amount.into())
             .take_all_from_worktop(resource_address, "to_deposit")
             .with_name_lookup(|builder, lookup| {
@@ -945,7 +945,7 @@ impl<const N: usize> TestEnvironment<N> {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -966,7 +966,7 @@ impl<const N: usize> TestEnvironment<N> {
         sign: bool,
     ) -> TransactionReceipt {
         self.test_runner
-            .execute_manifest_ignoring_fee(manifest, self.initial_proofs(sign))
+            .execute_manifest(manifest, self.initial_proofs(sign))
     }
 
     fn virtual_signature_badge(&self) -> NonFungibleGlobalId {
@@ -982,7 +982,7 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     fn get_vault_amounts(&mut self, sign: bool) -> MultiResourcePoolGetVaultAmountsOutput {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_GET_VAULT_AMOUNTS_IDENT,
@@ -1007,7 +1007,7 @@ impl<const N: usize> TestEnvironment<N> {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 MULTI_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,

--- a/radix-engine-tests/tests/blueprints/pool_one_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_one_resource.rs
@@ -10,7 +10,6 @@ use radix_engine_interface::blueprints::pool::*;
 use scrypto::prelude::Pow;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn one_resource_pool_can_be_instantiated() {
     TestEnvironment::new(18);
@@ -43,7 +42,8 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
@@ -447,7 +447,8 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -729,7 +730,8 @@ impl TestEnvironment {
         );
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+            let manifest = ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -762,7 +764,8 @@ impl TestEnvironment {
     }
 
     fn contribute<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(self.resource_address, amount.into())
             .take_all_from_worktop(self.resource_address, "contribution")
             .with_name_lookup(|builder, lookup| {
@@ -780,7 +783,8 @@ impl TestEnvironment {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -802,7 +806,8 @@ impl TestEnvironment {
     }
 
     fn protected_deposit<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(self.resource_address, amount.into())
             .take_all_from_worktop(self.resource_address, "to_deposit")
             .with_name_lookup(|builder, lookup| {
@@ -824,7 +829,8 @@ impl TestEnvironment {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -852,7 +858,8 @@ impl TestEnvironment {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,
@@ -865,7 +872,8 @@ impl TestEnvironment {
     }
 
     fn get_vault_amount(&mut self, sign: bool) -> Decimal {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_GET_VAULT_AMOUNT_IDENT,

--- a/radix-engine-tests/tests/blueprints/pool_one_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_one_resource.rs
@@ -43,12 +43,12 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
         .test_runner
-        .execute_manifest_ignoring_fee(manifest, initial_proofs);
+        .execute_manifest(manifest, initial_proofs);
 
     // Assert
     result(receipt);
@@ -447,7 +447,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -460,7 +460,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt
@@ -729,7 +729,7 @@ impl TestEnvironment {
         );
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new()
+            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -742,7 +742,7 @@ impl TestEnvironment {
                     },
                 )
                 .build();
-            let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+            let receipt = test_runner.execute_manifest(manifest, vec![]);
             let commit_result = receipt.expect_commit_success();
 
             (
@@ -762,7 +762,7 @@ impl TestEnvironment {
     }
 
     fn contribute<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(self.resource_address, amount.into())
             .take_all_from_worktop(self.resource_address, "contribution")
             .with_name_lookup(|builder, lookup| {
@@ -780,7 +780,7 @@ impl TestEnvironment {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -802,7 +802,7 @@ impl TestEnvironment {
     }
 
     fn protected_deposit<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(self.resource_address, amount.into())
             .take_all_from_worktop(self.resource_address, "to_deposit")
             .with_name_lookup(|builder, lookup| {
@@ -824,7 +824,7 @@ impl TestEnvironment {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -852,7 +852,7 @@ impl TestEnvironment {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,
@@ -865,7 +865,7 @@ impl TestEnvironment {
     }
 
     fn get_vault_amount(&mut self, sign: bool) -> Decimal {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 ONE_RESOURCE_POOL_GET_VAULT_AMOUNT_IDENT,
@@ -882,7 +882,7 @@ impl TestEnvironment {
         sign: bool,
     ) -> TransactionReceipt {
         self.test_runner
-            .execute_manifest_ignoring_fee(manifest, self.initial_proofs(sign))
+            .execute_manifest(manifest, self.initial_proofs(sign))
     }
 
     fn virtual_signature_badge(&self) -> NonFungibleGlobalId {

--- a/radix-engine-tests/tests/blueprints/pool_one_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_one_resource.rs
@@ -441,7 +441,7 @@ fn protected_deposit_into_the_pool_increases_how_much_resources_the_pool_units_a
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
 
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
@@ -717,7 +717,7 @@ impl TestEnvironment {
     }
 
     fn new_with_owner(divisibility: u8, owner_role: OwnerRole) -> Self {
-        let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+        let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
         let (public_key, _, account) = test_runner.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/blueprints/pool_two_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_two_resource.rs
@@ -11,7 +11,6 @@ use radix_engine_queries::typed_substate_layout::FungibleResourceManagerError;
 use scrypto::prelude::Pow;
 use scrypto_test::prelude::*;
 
-
 #[test]
 pub fn two_resource_pool_can_be_instantiated() {
     TestEnvironment::new((18, 18));
@@ -44,7 +43,8 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
@@ -454,7 +454,8 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -907,7 +908,8 @@ fn contribution_of_large_values_should_not_cause_panic() {
     let max_mint_amount = Decimal(I192::from(2).pow(152));
     let mut test_runner = TestEnvironment::new((18, 18));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource2, max_mint_amount)
@@ -974,7 +976,8 @@ fn contributing_to_a_pool_with_very_large_difference_in_reserves_succeeds() {
     let max_mint_amount = Decimal(I192::from(2).pow(152));
     let mut test_runner = TestEnvironment::new((18, 18));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource2, dec!("1"))
         .take_all_from_worktop(test_runner.pool_resource1, "resource_1")
@@ -1058,7 +1061,8 @@ impl TestEnvironment {
         );
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+            let manifest = ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -1101,7 +1105,8 @@ impl TestEnvironment {
         A: Into<Decimal>,
         B: Into<Decimal>,
     {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address1, amount1.into())
             .mint_fungible(resource_address2, amount2.into())
             .take_all_from_worktop(resource_address1, "resource_1")
@@ -1123,7 +1128,8 @@ impl TestEnvironment {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -1149,7 +1155,8 @@ impl TestEnvironment {
         amount: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, amount.into())
             .take_all_from_worktop(resource_address, "deposit")
             .with_name_lookup(|builder, lookup| {
@@ -1172,7 +1179,8 @@ impl TestEnvironment {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 TWO_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -1222,7 +1230,8 @@ impl TestEnvironment {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 TWO_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,

--- a/radix-engine-tests/tests/blueprints/pool_two_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_two_resource.rs
@@ -44,12 +44,12 @@ pub fn test_set_metadata<F: FnOnce(TransactionReceipt)>(
     } else {
         vec![]
     };
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .set_metadata(global_address, key, MetadataValue::Bool(false))
         .build();
     let receipt = test_runner
         .test_runner
-        .execute_manifest_ignoring_fee(manifest, initial_proofs);
+        .execute_manifest(manifest, initial_proofs);
 
     // Assert
     result(receipt);
@@ -454,7 +454,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             POOL_PACKAGE,
             TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -467,7 +467,7 @@ fn creating_a_pool_with_non_fungible_resources_fails() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt
@@ -907,7 +907,7 @@ fn contribution_of_large_values_should_not_cause_panic() {
     let max_mint_amount = Decimal(I192::from(2).pow(152));
     let mut test_runner = TestEnvironment::new((18, 18));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource2, max_mint_amount)
@@ -974,7 +974,7 @@ fn contributing_to_a_pool_with_very_large_difference_in_reserves_succeeds() {
     let max_mint_amount = Decimal(I192::from(2).pow(152));
     let mut test_runner = TestEnvironment::new((18, 18));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .mint_fungible(test_runner.pool_resource1, max_mint_amount)
         .mint_fungible(test_runner.pool_resource2, dec!("1"))
         .take_all_from_worktop(test_runner.pool_resource1, "resource_1")
@@ -1058,7 +1058,7 @@ impl TestEnvironment {
         );
 
         let (pool_component, pool_unit_resource) = {
-            let manifest = ManifestBuilder::new()
+            let manifest = ManifestBuilder::new().lock_fee_from_faucet()
                 .call_function(
                     POOL_PACKAGE,
                     TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -1071,7 +1071,7 @@ impl TestEnvironment {
                     },
                 )
                 .build();
-            let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+            let receipt = test_runner.execute_manifest(manifest, vec![]);
             let commit_result = receipt.expect_commit_success();
 
             (
@@ -1101,7 +1101,7 @@ impl TestEnvironment {
         A: Into<Decimal>,
         B: Into<Decimal>,
     {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address1, amount1.into())
             .mint_fungible(resource_address2, amount2.into())
             .take_all_from_worktop(resource_address1, "resource_1")
@@ -1123,7 +1123,7 @@ impl TestEnvironment {
     }
 
     fn redeem<D: Into<Decimal>>(&mut self, amount: D, sign: bool) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(
                 self.account_component_address,
                 self.pool_unit_resource_address,
@@ -1149,7 +1149,7 @@ impl TestEnvironment {
         amount: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, amount.into())
             .take_all_from_worktop(resource_address, "deposit")
             .with_name_lookup(|builder, lookup| {
@@ -1172,7 +1172,7 @@ impl TestEnvironment {
         withdraw_strategy: WithdrawStrategy,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 TWO_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
@@ -1193,7 +1193,7 @@ impl TestEnvironment {
         sign: bool,
     ) -> TransactionReceipt {
         self.test_runner
-            .execute_manifest_ignoring_fee(manifest, self.initial_proofs(sign))
+            .execute_manifest(manifest, self.initial_proofs(sign))
     }
 
     fn virtual_signature_badge(&self) -> NonFungibleGlobalId {
@@ -1222,7 +1222,7 @@ impl TestEnvironment {
         amount_of_pool_units: D,
         sign: bool,
     ) -> TransactionReceipt {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_method(
                 self.pool_component_address,
                 TWO_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,

--- a/radix-engine-tests/tests/blueprints/pool_two_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_two_resource.rs
@@ -448,7 +448,7 @@ fn contributing_tokens_that_do_not_belong_to_the_pool_fails() {
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
 
     let non_fungible_resource = test_runner.create_non_fungible_resource(account);
@@ -1040,7 +1040,7 @@ impl TestEnvironment {
     }
 
     pub fn new_with_owner((divisibility1, divisibility2): (u8, u8), owner_role: OwnerRole) -> Self {
-        let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+        let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
         let (public_key, _, account) = test_runner.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/blueprints/proof.rs
+++ b/radix-engine-tests/tests/blueprints/proof.rs
@@ -369,15 +369,16 @@ fn can_move_restricted_proofs_internally() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let (public_key, _, account) = test_runner.new_allocated_account();
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "Outer", "instantiate", manifest_args!())
             .build();
-        let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+        let receipt = test_runner.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success().new_component_addresses()[0]
     };
 
     // Act
     let manifest = ManifestBuilder::new()
+    .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .create_proof_from_auth_zone_of_all(XRD, "proof")
         .with_name_lookup(|builder, lookup| {
@@ -388,7 +389,7 @@ fn can_move_restricted_proofs_internally() {
             )
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         vec![NonFungibleGlobalId::from_public_key(&public_key)],
     );

--- a/radix-engine-tests/tests/blueprints/proof.rs
+++ b/radix-engine-tests/tests/blueprints/proof.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto::resource::DIVISIBILITY_MAXIMUM;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_create_clone_and_drop_bucket_proof() {
@@ -369,7 +368,8 @@ fn can_move_restricted_proofs_internally() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("proof"));
     let (public_key, _, account) = test_runner.new_allocated_account();
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "Outer", "instantiate", manifest_args!())
             .build();
         let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -378,7 +378,7 @@ fn can_move_restricted_proofs_internally() {
 
     // Act
     let manifest = ManifestBuilder::new()
-    .lock_fee_from_faucet()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .create_proof_from_auth_zone_of_all(XRD, "proof")
         .with_name_lookup(|builder, lookup| {

--- a/radix-engine-tests/tests/blueprints/proof_creation.rs
+++ b/radix-engine-tests/tests/blueprints/proof_creation.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{ApplicationError, RuntimeError},
     types::*,
 };
 use radix_engine_queries::typed_substate_layout::{AuthZoneError, ComposeProofError};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn create_proof_internal(function_name: &str, error: Option<&str>) {
     // Arrange

--- a/radix-engine-tests/tests/blueprints/reentrancy.rs
+++ b/radix-engine-tests/tests/blueprints/reentrancy.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn mut_reentrancy_should_not_be_possible() {

--- a/radix-engine-tests/tests/blueprints/resource.rs
+++ b/radix-engine-tests/tests/blueprints/resource.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::FungibleResourceManagerError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
@@ -6,8 +5,8 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_interface::{metadata, metadata_init};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_take_from_vault_after_mint() {

--- a/radix-engine-tests/tests/blueprints/static_dependencies.rs
+++ b/radix-engine-tests/tests/blueprints/static_dependencies.rs
@@ -95,19 +95,19 @@ fn static_component_should_be_callable() {
     let package_address = PackageAddress::new_or_panic(PRE_ALLOCATED_PACKAGE);
     test_runner
         .publish_package_at_address(PackageLoader::get("static_dependencies"), package_address);
-    let receipt = test_runner.execute_system_transaction_with_preallocated_addresses(
+    let receipt = test_runner.execute_system_transaction(
         vec![InstructionV1::CallFunction {
             package_address: package_address.into(),
             blueprint_name: "Preallocated".to_string(),
             function_name: "new".to_string(),
             args: manifest_args!(ManifestAddressReservation(0), "my_secret".to_string()).into(),
         }],
+        btreeset!(),
         vec![(
             BlueprintId::new(&package_address, "Preallocated"),
             GlobalAddress::new_or_panic(PRE_ALLOCATED),
         )
             .into()],
-        btreeset!(),
     );
     receipt.expect_commit_success();
 
@@ -142,7 +142,7 @@ fn static_resource_should_be_callable() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let (key, _priv, account) = test_runner.new_account(false);
-    let receipt = test_runner.execute_system_transaction_with_preallocated_addresses(
+    let receipt = test_runner.execute_system_transaction(
         vec![
             InstructionV1::CallFunction {
                 package_address: RESOURCE_PACKAGE.into(),
@@ -170,12 +170,12 @@ fn static_resource_should_be_callable() {
                 args: manifest_args!(ManifestExpression::EntireWorktop).into(),
             },
         ],
+        btreeset!(NonFungibleGlobalId::from_public_key(&key)),
         vec![(
             BlueprintId::new(&RESOURCE_PACKAGE, FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT),
             GlobalAddress::new_or_panic(PRE_ALLOCATED_RESOURCE),
         )
             .into()],
-        btreeset!(NonFungibleGlobalId::from_public_key(&key)),
     );
     receipt.expect_commit_success();
 

--- a/radix-engine-tests/tests/blueprints/static_dependencies.rs
+++ b/radix-engine-tests/tests/blueprints/static_dependencies.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::account::ACCOUNT_DEPOSIT_BATCH_IDENT;
 use radix_engine_interface::{metadata, metadata_init};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::model::InstructionV1;
-
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack

--- a/radix-engine-tests/tests/blueprints/time.rs
+++ b/radix-engine-tests/tests/blueprints/time.rs
@@ -1,5 +1,5 @@
 use radix_engine_common::types::{Epoch, Round};
-use radix_engine_interface::blueprints::consensus_manager::{TimePrecision};
+use radix_engine_interface::blueprints::consensus_manager::TimePrecision;
 use radix_engine_interface::time::UtcDateTime;
 use scrypto_test::prelude::*;
 

--- a/radix-engine-tests/tests/blueprints/tx_processor_access.rs
+++ b/radix-engine-tests/tests/blueprints/tx_processor_access.rs
@@ -1,13 +1,12 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::transaction_processor::{
     TRANSACTION_PROCESSOR_BLUEPRINT, TRANSACTION_PROCESSOR_RUN_IDENT,
 };
+use radix_engine_tests::common::*;
 use scrypto::prelude::FromPublicKey;
 use scrypto_test::prelude::*;
-
 
 #[derive(Debug, Eq, PartialEq, ManifestSbor)]
 pub struct ManifestTransactionProcessorRunInput {

--- a/radix-engine-tests/tests/blueprints/validator.rs
+++ b/radix-engine-tests/tests/blueprints/validator.rs
@@ -10,7 +10,6 @@ use radix_engine_interface::blueprints::consensus_manager::{
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_test::prelude::*;
 
-
 fn signal_protocol_update_test<F>(as_owner: bool, name_len: usize, result_check: F)
 where
     F: Fn(TransactionReceipt) -> (),

--- a/radix-engine-tests/tests/db/jmt_consistency.rs
+++ b/radix-engine-tests/tests/db/jmt_consistency.rs
@@ -20,8 +20,7 @@ fn substate_store_matches_hash_tree_after_each_scenario() {
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt =
-                        test_runner.execute_raw_transaction(  &next.raw_transaction);
+                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
                     // TODO(when figured out): We could run this assert as part of the existing
                     // `post_run_db_check` feature; however, it is tricky to implement (syntactically),
                     // due to the assert only being available for certain `TestDatabase` impl.

--- a/radix-engine-tests/tests/db/jmt_consistency.rs
+++ b/radix-engine-tests/tests/db/jmt_consistency.rs
@@ -20,7 +20,7 @@ fn substate_store_matches_hash_tree_after_each_scenario() {
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
+                    let receipt = test_runner.execute_notarized_transaction(&next.raw_transaction);
                     // TODO(when figured out): We could run this assert as part of the existing
                     // `post_run_db_check` feature; however, it is tricky to implement (syntactically),
                     // due to the assert only being available for certain `TestDatabase` impl.

--- a/radix-engine-tests/tests/db/jmt_consistency.rs
+++ b/radix-engine-tests/tests/db/jmt_consistency.rs
@@ -21,7 +21,7 @@ fn substate_store_matches_hash_tree_after_each_scenario() {
             match next {
                 NextAction::Transaction(next) => {
                     let receipt =
-                        test_runner.execute_raw_transaction(&network, &next.raw_transaction);
+                        test_runner.execute_raw_transaction(  &next.raw_transaction);
                     // TODO(when figured out): We could run this assert as part of the existing
                     // `post_run_db_check` feature; however, it is tricky to implement (syntactically),
                     // due to the assert only being available for certain `TestDatabase` impl.

--- a/radix-engine-tests/tests/dec_macros/Cargo.toml
+++ b/radix-engine-tests/tests/dec_macros/Cargo.toml
@@ -28,4 +28,3 @@ path = "src/dec_err_expr_not_supported.rs"
 default = ["std"]
 std = ["radix-engine-interface/std"]
 alloc = ["radix-engine-interface/alloc"]
-

--- a/radix-engine-tests/tests/flash/crypto_utils.rs
+++ b/radix-engine-tests/tests/flash/crypto_utils.rs
@@ -1,12 +1,12 @@
+use radix_engine::blueprints::package::PackageError;
+use radix_engine::errors::ApplicationError;
 use radix_engine::errors::RuntimeError;
+use radix_engine::types::*;
+use radix_engine::utils::generate_vm_boot_scrypto_minor_version_state_updates;
 use radix_engine_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_engine_store_interface::interface::CommittableSubstateDatabase;
 use radix_engine_tests::common::PackageLoader;
 use scrypto_test::prelude::{CustomGenesis, TestRunnerBuilder};
-use radix_engine::utils::generate_vm_boot_scrypto_minor_version_state_updates;
-use radix_engine::types::*;
-use radix_engine::errors::ApplicationError;
-use radix_engine::blueprints::package::PackageError;
 
 #[test]
 fn publishing_crypto_utils_without_state_flash_should_fail() {
@@ -43,7 +43,9 @@ fn run_flash_test(flash_substates: bool, expect_success: bool) {
         receipt.expect_specific_failure(|e| {
             matches!(
                 e,
-                RuntimeError::ApplicationError(ApplicationError::PackageError(PackageError::InvalidWasm(..)))
+                RuntimeError::ApplicationError(ApplicationError::PackageError(
+                    PackageError::InvalidWasm(..)
+                ))
             )
         });
     }

--- a/radix-engine-tests/tests/flash/pools.rs
+++ b/radix-engine-tests/tests/flash/pools.rs
@@ -10,7 +10,7 @@ fn database_is_consistent_before_and_after_protocol_update() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new()
         .without_pools_v1_1()
-        .without_trace()
+        .without_kernel_trace()
         .build();
 
     let (pk, _, account) = test_runner.new_account(false);
@@ -80,7 +80,7 @@ fn single_sided_contributions_to_two_resource_pool_are_only_allowed_after_protoc
     // Arrange
     let mut test_runner = TestRunnerBuilder::new()
         .without_pools_v1_1()
-        .without_trace()
+        .without_kernel_trace()
         .build();
 
     let (pk, _, account) = test_runner.new_account(false);
@@ -243,7 +243,7 @@ fn single_sided_contributions_to_multi_resource_pool_are_only_allowed_after_prot
     // Arrange
     let mut test_runner = TestRunnerBuilder::new()
         .without_pools_v1_1()
-        .without_trace()
+        .without_kernel_trace()
         .build();
 
     let (pk, _, account) = test_runner.new_account(false);

--- a/radix-engine-tests/tests/flash/seconds_precision.rs
+++ b/radix-engine-tests/tests/flash/seconds_precision.rs
@@ -6,7 +6,9 @@ use radix_engine_common::constants::CONSENSUS_MANAGER;
 use radix_engine_common::prelude::{manifest_args, Round};
 use radix_engine_common::types::Epoch;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::blueprints::consensus_manager::{CONSENSUS_MANAGER_NEXT_ROUND_IDENT, ConsensusManagerNextRoundInput};
+use radix_engine_interface::blueprints::consensus_manager::{
+    ConsensusManagerNextRoundInput, CONSENSUS_MANAGER_NEXT_ROUND_IDENT,
+};
 use radix_engine_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_engine_store_interface::interface::CommittableSubstateDatabase;
 use radix_engine_tests::common::PackageLoader;
@@ -71,7 +73,9 @@ fn run_flash_test(flash_substates: bool, expect_success: bool) {
         receipt.expect_specific_failure(|e| {
             matches!(
                 e,
-                RuntimeError::SystemError(SystemError::TypeCheckError(TypeCheckError::BlueprintPayloadValidationError(..)))
+                RuntimeError::SystemError(SystemError::TypeCheckError(
+                    TypeCheckError::BlueprintPayloadValidationError(..)
+                ))
             )
         });
     }

--- a/radix-engine-tests/tests/kernel/frame.rs
+++ b/radix-engine-tests/tests/kernel/frame.rs
@@ -1,10 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::limits::TransactionLimitsError;
 use radix_engine::types::*;
 use radix_engine_common::constants::MAX_CALL_DEPTH;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_max_call_depth_success() {

--- a/radix-engine-tests/tests/system/address.rs
+++ b/radix-engine-tests/tests/system/address.rs
@@ -430,6 +430,7 @@ fn can_instantiate_with_preallocated_address() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     // Act + Assert
     let manifest = ManifestBuilder::new()
+    .lock_fee_from_faucet()
         .call_function(
             package_address,
             "PreallocationComponent",
@@ -437,7 +438,7 @@ fn can_instantiate_with_preallocated_address() {
             manifest_args!(),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success();
 }
 
@@ -448,8 +449,9 @@ fn errors_if_unused_preallocated_address() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act + Assert 1
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
+        .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",
@@ -462,8 +464,9 @@ fn errors_if_unused_preallocated_address() {
     receipt.expect_commit_failure();
 
     // Act + Assert 2
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
+        .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",
@@ -483,8 +486,9 @@ fn errors_if_assigns_same_address_to_two_components() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
 
     // Act + Assert
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
+        .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",

--- a/radix-engine-tests/tests/system/address.rs
+++ b/radix-engine-tests/tests/system/address.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{KernelError, RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::account::ACCOUNT_BLUEPRINT;
 use radix_engine_interface::blueprints::transaction_processor::TRANSACTION_PROCESSOR_BLUEPRINT;
 use radix_engine_queries::typed_substate_layout::PACKAGE_BLUEPRINT;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn get_global_address_in_local_in_function_should_fail() {
@@ -430,7 +429,7 @@ fn can_instantiate_with_preallocated_address() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("address"));
     // Act + Assert
     let manifest = ManifestBuilder::new()
-    .lock_fee_from_faucet()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "PreallocationComponent",
@@ -451,7 +450,7 @@ fn errors_if_unused_preallocated_address() {
     // Act + Assert 1
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-        .lock_fee_from_faucet()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",
@@ -466,7 +465,7 @@ fn errors_if_unused_preallocated_address() {
     // Act + Assert 2
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-        .lock_fee_from_faucet()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",
@@ -488,7 +487,7 @@ fn errors_if_assigns_same_address_to_two_components() {
     // Act + Assert
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-        .lock_fee_from_faucet()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "PreallocationComponent",

--- a/radix-engine-tests/tests/system/allocated_address.rs
+++ b/radix-engine-tests/tests/system/allocated_address.rs
@@ -1,10 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{CannotGlobalizeError, KernelError, RuntimeError, SystemError},
     types::*,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_create_and_return() {

--- a/radix-engine-tests/tests/system/arguments.rs
+++ b/radix-engine-tests/tests/system/arguments.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn vector_of_buckets_argument_should_succeed() {

--- a/radix-engine-tests/tests/system/auth_account.rs
+++ b/radix-engine-tests/tests/system/auth_account.rs
@@ -345,7 +345,7 @@ fn cannot_set_royalty_on_accounts() {
 #[test]
 fn can_call_function_requiring_count_of_zero() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (pk, _, account) = test_runner.new_account(false);
     let package_address = test_runner.publish_package_simple(PackageLoader::get("auth_scenarios"));
 

--- a/radix-engine-tests/tests/system/auth_account.rs
+++ b/radix-engine-tests/tests/system/auth_account.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::rule;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn test_auth_rule(
     test_runner: &mut DefaultTestRunner,

--- a/radix-engine-tests/tests/system/auth_component.rs
+++ b/radix-engine-tests/tests/system/auth_component.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use radix_engine_interface::rule;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn create_secured_component(
     test_runner: &mut DefaultTestRunner,

--- a/radix-engine-tests/tests/system/auth_mutability.rs
+++ b/radix-engine-tests/tests/system/auth_mutability.rs
@@ -71,8 +71,10 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     let role_key = action.action_role_key();
     let updater_role_key = action.updater_role_key();
     test_runner
-        .execute_manifest_ignoring_fee(
+        .execute_manifest(
             ManifestBuilder::new()
+
+        .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -99,8 +101,9 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     let role_key = action.action_role_key();
     let updater_role_key = action.updater_role_key();
     test_runner
-        .execute_manifest_ignoring_fee(
+        .execute_manifest(
             ManifestBuilder::new()
+            .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -127,8 +130,9 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     {
         let role_key = action.updater_role_key();
         test_runner
-            .execute_manifest_ignoring_fee(
+            .execute_manifest(
                 ManifestBuilder::new()
+                .lock_fee_from_faucet()
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         admin_auth,
@@ -144,8 +148,9 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     // Act 3 - After locking, now attempting to update the action or updater role should fail
     let role_key = action.action_role_key();
     test_runner
-        .execute_manifest_ignoring_fee(
+        .execute_manifest(
             ManifestBuilder::new()
+            .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -164,8 +169,9 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
 
     let role_key = action.updater_role_key();
     test_runner
-        .execute_manifest_ignoring_fee(
+        .execute_manifest(
             ManifestBuilder::new()
+            .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,

--- a/radix-engine-tests/tests/system/auth_mutability.rs
+++ b/radix-engine-tests/tests/system/auth_mutability.rs
@@ -5,7 +5,6 @@ use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_test::prelude::*;
 
-
 pub enum TestResourceAction {
     Mint,
     Burn,
@@ -73,8 +72,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     test_runner
         .execute_manifest(
             ManifestBuilder::new()
-
-        .lock_fee_from_faucet()
+                .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -103,7 +101,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     test_runner
         .execute_manifest(
             ManifestBuilder::new()
-            .lock_fee_from_faucet()
+                .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -132,7 +130,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
         test_runner
             .execute_manifest(
                 ManifestBuilder::new()
-                .lock_fee_from_faucet()
+                    .lock_fee_from_faucet()
                     .create_proof_from_account_of_non_fungibles(
                         account,
                         admin_auth,
@@ -150,7 +148,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     test_runner
         .execute_manifest(
             ManifestBuilder::new()
-            .lock_fee_from_faucet()
+                .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,
@@ -171,7 +169,7 @@ pub fn assert_locked_auth_can_no_longer_be_updated(action: TestResourceAction) {
     test_runner
         .execute_manifest(
             ManifestBuilder::new()
-            .lock_fee_from_faucet()
+                .lock_fee_from_faucet()
                 .create_proof_from_account_of_non_fungibles(
                     account,
                     admin_auth,

--- a/radix-engine-tests/tests/system/auth_package_token.rs
+++ b/radix-engine-tests/tests/system/auth_package_token.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_call_self_with_package_token() {

--- a/radix-engine-tests/tests/system/auth_resource.rs
+++ b/radix-engine-tests/tests/system/auth_resource.rs
@@ -5,7 +5,6 @@ use radix_engine_interface::api::ModuleId;
 use radix_engine_interface::blueprints::resource::{require, FromPublicKey};
 use scrypto_test::prelude::*;
 
-
 enum Action {
     Mint,
     Burn,

--- a/radix-engine-tests/tests/system/auth_scenarios.rs
+++ b/radix-engine-tests/tests/system/auth_scenarios.rs
@@ -64,8 +64,8 @@ impl AuthScenariosEnv {
             },
             acco,
         );
-        test_runner.execute_manifest_ignoring_fee(
-            ManifestBuilder::new()
+        test_runner.execute_manifest(
+             ManifestBuilder::new().lock_fee_from_faucet()
                 .call_role_assignment_method(
                     cerb,
                     ROLE_ASSIGNMENT_SET_IDENT,
@@ -82,18 +82,18 @@ impl AuthScenariosEnv {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("auth_scenarios"));
 
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "Swappy", "create", manifest_args!(cerb))
             .deposit_batch(acco)
             .build();
-        let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![virtua_sig.clone()]);
+        let receipt = test_runner.execute_manifest(manifest, vec![virtua_sig.clone()]);
         let result = receipt.expect_commit_success();
         let swappy = result.new_component_addresses()[0];
         let swappy_resource = result.new_resource_addresses()[0];
         let swappy_badge =
             NonFungibleGlobalId::new(swappy_resource, NonFungibleLocalId::integer(0u64));
 
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "BigFi",
@@ -102,7 +102,7 @@ impl AuthScenariosEnv {
             )
             .deposit_batch(acco)
             .build();
-        let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![virtua_sig.clone()]);
+        let receipt = test_runner.execute_manifest(manifest, vec![virtua_sig.clone()]);
         let result = receipt.expect_commit_success();
         let big_fi = result.new_component_addresses()[0];
         let vault_id = test_runner.get_component_vaults(big_fi, cerb)[0];
@@ -128,11 +128,11 @@ fn scenario_1() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_method(env.swappy, "protected_method", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -146,12 +146,12 @@ fn scenario_1_with_injected_costing_error() {
     let mut inject_err_after_count = 1u64;
 
     loop {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
             .call_method(env.swappy, "protected_method", manifest_args!())
             .build();
-        let receipt = test_runner.execute_manifest_with_fee_from_faucet_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(
-            manifest, dec!("500"), vec![env.virtua_sig.clone()], inject_err_after_count);
+        let receipt = test_runner.execute_manifest_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(
+            manifest,   vec![env.virtua_sig.clone()], inject_err_after_count);
         if receipt.is_commit_success() {
             break;
         }
@@ -169,11 +169,11 @@ fn scenario_2() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_method(env.big_fi, "call_swappy", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -193,7 +193,7 @@ fn scenario_3() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -201,7 +201,7 @@ fn scenario_3() {
             builder.call_method(env.big_fi, "deposit_cerb", manifest_args!(bucket))
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -214,7 +214,7 @@ fn scenario_4() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -226,7 +226,7 @@ fn scenario_4() {
             )
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -239,12 +239,12 @@ fn scenario_5() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .call_method(env.big_fi, "mint_cerb", manifest_args!())
         .deposit_batch(env.acco)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -264,12 +264,12 @@ fn scenario_6() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .call_method(env.swappy, "protected_method", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -289,7 +289,7 @@ fn scenario_7() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .with_name_lookup(|builder, lookup| {
@@ -297,7 +297,7 @@ fn scenario_7() {
             builder.call_method(env.swappy, "public_method", manifest_args!(proof))
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -315,7 +315,7 @@ fn scenario_8() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .with_name_lookup(|builder, lookup| {
@@ -323,7 +323,7 @@ fn scenario_8() {
             builder.call_method(env.swappy, "put_proof_in_auth_zone", manifest_args!(proof))
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -341,12 +341,12 @@ fn scenario_9() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .create_proof_from_auth_zone_of_all(env.swappy_badge.resource_address(), "Bennet")
         .call_method(env.swappy, "protected_method", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -359,12 +359,12 @@ fn scenario_10() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .call_method(env.big_fi, "recall_cerb", manifest_args!(env.cerb_vault))
         .deposit_batch(env.acco)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -384,7 +384,7 @@ fn scenario_11() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_metadata_method(
             env.swappy,
@@ -395,7 +395,7 @@ fn scenario_11() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -408,11 +408,11 @@ fn scenario_12() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "set_swappy_metadata", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -432,11 +432,11 @@ fn scenario_13() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "set_metadata", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -456,13 +456,13 @@ fn scenario_14() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "some_method", manifest_args!())
         .call_function(env.package, "BigFi", "some_function", manifest_args!())
         .call_method(env.swappy, "protected_method", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -475,7 +475,7 @@ fn scenario_15() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
         .take_all_from_worktop(env.swappy_badge.resource_address(), "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -483,7 +483,7 @@ fn scenario_15() {
         })
         .deposit_batch(env.acco)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -496,11 +496,11 @@ fn scenario_16() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "another_protected_method", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -513,11 +513,11 @@ fn scenario_17() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "another_protected_method2", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -537,7 +537,7 @@ fn scenario_18() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_role_assignment_method(
             env.swappy,
@@ -549,7 +549,7 @@ fn scenario_18() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -562,11 +562,11 @@ fn scenario_19() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "update_swappy_metadata_rule", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -586,11 +586,11 @@ fn scenario_20() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "update_metadata_rule", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -610,7 +610,7 @@ fn scenario_21() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge.clone())
         .call_role_assignment_method(
             env.cerb,
@@ -622,7 +622,7 @@ fn scenario_21() {
             },
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -635,11 +635,11 @@ fn scenario_22() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "update_cerb_rule", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -659,7 +659,7 @@ fn scenario_23() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_function(
             env.package,
@@ -668,7 +668,7 @@ fn scenario_23() {
             manifest_args!(env.swappy),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -688,11 +688,11 @@ fn scenario_24() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(env.acco, XRD, 1)
         .call_method(env.big_fi, "call_swappy_function", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -712,7 +712,7 @@ fn scenario_25() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "bucket")
@@ -720,7 +720,7 @@ fn scenario_25() {
             builder.call_method(env.big_fi, "burn_bucket", manifest_args!(bucket))
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -740,7 +740,7 @@ fn scenario_26() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -749,7 +749,7 @@ fn scenario_26() {
         })
         .call_method(env.big_fi, "burn_vault", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -762,7 +762,7 @@ fn scenario_27() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
@@ -776,7 +776,7 @@ fn scenario_27() {
         })
         .deposit_batch(env.acco)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_specific_failure(|e| {
@@ -794,7 +794,7 @@ fn scenario_28() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
@@ -812,7 +812,7 @@ fn scenario_28() {
         })
         .deposit_batch(env.acco)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -825,7 +825,7 @@ fn scenario_29() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(
             env.acco,
             NonFungibleGlobalId::new(env.cerb, NonFungibleLocalId::integer(1)),
@@ -839,7 +839,7 @@ fn scenario_29() {
             )
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();
@@ -852,7 +852,7 @@ fn scenario_30() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 3)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -861,7 +861,7 @@ fn scenario_30() {
         })
         .call_method(env.big_fi, "create_and_pass_proof", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![env.virtua_sig]);
+    let receipt = test_runner.execute_manifest(manifest, vec![env.virtua_sig]);
 
     // Assert
     receipt.expect_commit_success();

--- a/radix-engine-tests/tests/system/auth_scenarios.rs
+++ b/radix-engine-tests/tests/system/auth_scenarios.rs
@@ -1,13 +1,13 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
 use radix_engine::vm::NoExtension;
 use radix_engine_interface::api::node_modules::auth::{
-    RoleAssignmentSetInput, ROLE_ASSIGNMENT_SET_IDENT, 
+    RoleAssignmentSetInput, ROLE_ASSIGNMENT_SET_IDENT,
 };
 use radix_engine_interface::rule;
 use radix_engine_stores::memory_db::InMemorySubstateDatabase;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::InjectSystemCostingError;
 use scrypto_test::prelude::*;
 
@@ -65,7 +65,8 @@ impl AuthScenariosEnv {
             acco,
         );
         test_runner.execute_manifest(
-             ManifestBuilder::new().lock_fee_from_faucet()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_role_assignment_method(
                     cerb,
                     ROLE_ASSIGNMENT_SET_IDENT,
@@ -82,7 +83,8 @@ impl AuthScenariosEnv {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("auth_scenarios"));
 
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "Swappy", "create", manifest_args!(cerb))
             .deposit_batch(acco)
             .build();
@@ -93,7 +95,8 @@ impl AuthScenariosEnv {
         let swappy_badge =
             NonFungibleGlobalId::new(swappy_resource, NonFungibleLocalId::integer(0u64));
 
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 "BigFi",
@@ -128,7 +131,8 @@ fn scenario_1() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_method(env.swappy, "protected_method", manifest_args!())
         .build();
@@ -146,12 +150,17 @@ fn scenario_1_with_injected_costing_error() {
     let mut inject_err_after_count = 1u64;
 
     loop {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
             .call_method(env.swappy, "protected_method", manifest_args!())
             .build();
-        let receipt = test_runner.execute_manifest_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(
-            manifest,   vec![env.virtua_sig.clone()], inject_err_after_count);
+        let receipt = test_runner
+            .execute_manifest_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(
+                manifest,
+                vec![env.virtua_sig.clone()],
+                inject_err_after_count,
+            );
         if receipt.is_commit_success() {
             break;
         }
@@ -169,7 +178,8 @@ fn scenario_2() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_method(env.big_fi, "call_swappy", manifest_args!())
         .build();
@@ -193,7 +203,8 @@ fn scenario_3() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -214,7 +225,8 @@ fn scenario_4() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -239,7 +251,8 @@ fn scenario_5() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .call_method(env.big_fi, "mint_cerb", manifest_args!())
         .deposit_batch(env.acco)
@@ -264,7 +277,8 @@ fn scenario_6() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .call_method(env.swappy, "protected_method", manifest_args!())
@@ -289,7 +303,8 @@ fn scenario_7() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .with_name_lookup(|builder, lookup| {
@@ -315,7 +330,8 @@ fn scenario_8() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .pop_from_auth_zone("Arnold")
         .with_name_lookup(|builder, lookup| {
@@ -341,7 +357,8 @@ fn scenario_9() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .create_proof_from_auth_zone_of_all(env.swappy_badge.resource_address(), "Bennet")
         .call_method(env.swappy, "protected_method", manifest_args!())
@@ -359,7 +376,8 @@ fn scenario_10() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .call_method(env.big_fi, "recall_cerb", manifest_args!(env.cerb_vault))
         .deposit_batch(env.acco)
@@ -384,7 +402,8 @@ fn scenario_11() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_metadata_method(
             env.swappy,
@@ -408,7 +427,8 @@ fn scenario_12() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "set_swappy_metadata", manifest_args!())
         .build();
@@ -432,7 +452,8 @@ fn scenario_13() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "set_metadata", manifest_args!())
         .build();
@@ -456,7 +477,8 @@ fn scenario_14() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "some_method", manifest_args!())
         .call_function(env.package, "BigFi", "some_function", manifest_args!())
@@ -475,7 +497,8 @@ fn scenario_15() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
         .take_all_from_worktop(env.swappy_badge.resource_address(), "bucket")
         .with_bucket("bucket", |builder, bucket| {
@@ -496,7 +519,8 @@ fn scenario_16() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "another_protected_method", manifest_args!())
         .build();
@@ -513,7 +537,8 @@ fn scenario_17() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "another_protected_method2", manifest_args!())
         .build();
@@ -537,7 +562,8 @@ fn scenario_18() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_role_assignment_method(
             env.swappy,
@@ -562,7 +588,8 @@ fn scenario_19() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "update_swappy_metadata_rule", manifest_args!())
         .build();
@@ -586,7 +613,8 @@ fn scenario_20() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.swappy, "update_metadata_rule", manifest_args!())
         .build();
@@ -610,7 +638,8 @@ fn scenario_21() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge.clone())
         .call_role_assignment_method(
             env.cerb,
@@ -635,7 +664,8 @@ fn scenario_22() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge.clone())
         .call_method(env.big_fi, "update_cerb_rule", manifest_args!())
         .build();
@@ -659,7 +689,8 @@ fn scenario_23() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.swappy_badge)
         .call_function(
             env.package,
@@ -688,7 +719,8 @@ fn scenario_24() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(env.acco, XRD, 1)
         .call_method(env.big_fi, "call_swappy_function", manifest_args!())
         .build();
@@ -712,7 +744,8 @@ fn scenario_25() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "bucket")
@@ -740,7 +773,8 @@ fn scenario_26() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .take_all_from_worktop(env.cerb, "cerbs")
@@ -762,7 +796,8 @@ fn scenario_27() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
@@ -794,7 +829,8 @@ fn scenario_28() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 1)
         .withdraw_from_account(env.acco, env.swappy_badge.resource_address(), 1)
@@ -825,7 +861,8 @@ fn scenario_29() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(
             env.acco,
             NonFungibleGlobalId::new(env.cerb, NonFungibleLocalId::integer(1)),
@@ -852,7 +889,8 @@ fn scenario_30() {
     let env = AuthScenariosEnv::init(&mut test_runner);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_non_fungible(env.acco, env.cerb_badge)
         .withdraw_from_account(env.acco, env.cerb, 3)
         .take_all_from_worktop(env.cerb, "cerbs")

--- a/radix-engine-tests/tests/system/auth_vault.rs
+++ b/radix-engine-tests/tests/system/auth_vault.rs
@@ -2,7 +2,6 @@ use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn cannot_withdraw_restricted_transfer_from_my_account_with_no_auth() {
     // Arrange

--- a/radix-engine-tests/tests/system/auth_zone.rs
+++ b/radix-engine-tests/tests/system/auth_zone.rs
@@ -8,7 +8,6 @@ use radix_engine_interface::api::{ClientApi, ACTOR_REF_AUTH_ZONE};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn should_not_be_able_to_move_auth_zone() {
     // Arrange

--- a/radix-engine-tests/tests/system/balance_changes.rs
+++ b/radix-engine-tests/tests/system/balance_changes.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::{transaction::BalanceChange, types::*};
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_balance_changes_when_success() {

--- a/radix-engine-tests/tests/system/bootstrap.rs
+++ b/radix-engine-tests/tests/system/bootstrap.rs
@@ -746,11 +746,12 @@ fn test_bootstrap_should_create_consensus_manager_with_sorted_validator_index() 
 
     let reader = SystemDatabaseReader::new(&substate_db);
 
-    let validator_sort_key = reader.collection_iter(
-        CONSENSUS_MANAGER.as_node_id(),
-        ModuleId::Main,
-        0
-    ).expect("collection not found").map(|(key, _value)| key).next().expect("collection empty");
+    let validator_sort_key = reader
+        .collection_iter(CONSENSUS_MANAGER.as_node_id(), ModuleId::Main, 0)
+        .expect("collection not found")
+        .map(|(key, _value)| key)
+        .next()
+        .expect("collection empty");
 
     let SubstateKey::Sorted((sort_prefix, address)) = validator_sort_key else {
         panic!("collection not a sorted index");
@@ -758,16 +759,19 @@ fn test_bootstrap_should_create_consensus_manager_with_sorted_validator_index() 
     let address: ComponentAddress = scrypto_decode(address.as_slice()).expect("not an address");
     let validator = reader
         .read_object_collection_entry::<_, VersionedConsensusManagerRegisteredValidatorByStake>(
-        CONSENSUS_MANAGER.as_node_id(),
-        ModuleId::Main,
-        ObjectCollectionKey::SortedIndex(0, u16::from_be_bytes(sort_prefix), &address)
+            CONSENSUS_MANAGER.as_node_id(),
+            ModuleId::Main,
+            ObjectCollectionKey::SortedIndex(0, u16::from_be_bytes(sort_prefix), &address),
         )
         .expect("validator cannot be read")
         .map(|versioned| versioned.into_latest())
         .expect("validator not found");
 
-    assert_eq!(validator, Validator {
-        key: validator_key,
-        stake: stake_xrd,
-    });
+    assert_eq!(
+        validator,
+        Validator {
+            key: validator_key,
+            stake: stake_xrd,
+        }
+    );
 }

--- a/radix-engine-tests/tests/system/bucket.rs
+++ b/radix-engine-tests/tests/system/bucket.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::{
     FungibleResourceManagerError, NonFungibleResourceManagerError, ProofError, VaultError,
 };
@@ -10,8 +9,8 @@ use radix_engine::{
     kernel::call_frame::DropNodeError,
     types::*,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn test_bucket_internal(method_name: &str, args: ManifestValue, expect_success: bool) {
     // Arrange

--- a/radix-engine-tests/tests/system/component.rs
+++ b/radix-engine-tests/tests/system/component.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::DropNodeError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_component() {

--- a/radix-engine-tests/tests/system/consensus_manager.rs
+++ b/radix-engine-tests/tests/system/consensus_manager.rs
@@ -2909,7 +2909,7 @@ fn consensus_manager_create_should_fail_with_supervisor_privilege() {
         )
             .into(),
     );
-    let receipt = test_runner.execute_system_transaction_with_preallocation(
+    let receipt = test_runner.execute_system_transaction(
         vec![InstructionV1::CallFunction {
             package_address: CONSENSUS_MANAGER_PACKAGE.into(),
             blueprint_name: CONSENSUS_MANAGER_BLUEPRINT.to_string(),
@@ -2962,7 +2962,7 @@ fn consensus_manager_create_should_succeed_with_system_privilege() {
         )
             .into(),
     );
-    let receipt = test_runner.execute_system_transaction_with_preallocation(
+    let receipt = test_runner.execute_system_transaction(
         vec![InstructionV1::CallFunction {
             package_address: CONSENSUS_MANAGER_PACKAGE.into(),
             blueprint_name: CONSENSUS_MANAGER_BLUEPRINT.to_string(),

--- a/radix-engine-tests/tests/system/consensus_manager.rs
+++ b/radix-engine-tests/tests/system/consensus_manager.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::consensus_manager::UnstakeData;
 use radix_engine::blueprints::consensus_manager::{
     Validator, ValidatorEmissionAppliedEvent, ValidatorError,
@@ -14,6 +13,7 @@ use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_queries::typed_substate_layout::{
     ConsensusManagerError, ValidatorRewardAppliedEvent,
 };
+use radix_engine_tests::common::*;
 use rand::prelude::SliceRandom;
 use rand::Rng;
 use rand_chacha;
@@ -22,7 +22,6 @@ use rand_chacha::ChaCha8Rng;
 use scrypto::api::node_modules::*;
 use scrypto_test::prelude::AuthError;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn genesis_epoch_has_correct_initial_validators() {
@@ -3020,8 +3019,11 @@ fn test_tips_and_fee_distribution_single_validator() {
         .build();
 
     // Do some transaction
-    let receipt1 = test_runner.execute_manifest_ignoring_fee(
-        ManifestBuilder::new().drop_auth_zone_proofs().build(),
+    let receipt1 = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .drop_auth_zone_proofs()
+            .build(),
         vec![],
     );
     receipt1.expect_commit_success();
@@ -3084,8 +3086,11 @@ fn test_tips_and_fee_distribution_two_validators() {
         .build();
 
     // Do some transaction
-    let receipt1 = test_runner.execute_manifest_ignoring_fee(
-        ManifestBuilder::new().drop_auth_zone_proofs().build(),
+    let receipt1 = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .drop_auth_zone_proofs()
+            .build(),
         vec![],
     );
     let result1 = receipt1.expect_commit_success();
@@ -3611,8 +3616,11 @@ fn test_tips_and_fee_distribution_when_one_validator_has_zero_stake() {
         .build();
 
     // Do some transaction
-    let receipt1 = test_runner.execute_manifest_ignoring_fee(
-        ManifestBuilder::new().drop_auth_zone_proofs().build(),
+    let receipt1 = test_runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
+            .drop_auth_zone_proofs()
+            .build(),
         vec![],
     );
     let result1 = receipt1.expect_commit_success();

--- a/radix-engine-tests/tests/system/consensus_manager.rs
+++ b/radix-engine-tests/tests/system/consensus_manager.rs
@@ -433,7 +433,7 @@ fn next_round_after_target_duration_does_not_cause_epoch_change_without_min_roun
 #[test]
 fn create_validator_twice() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (public_key, _, account) = test_runner.new_allocated_account();
 
     // Act
@@ -3176,7 +3176,7 @@ fn significant_protocol_updates_are_emitted_in_epoch_change_event() {
     );
     let mut test_runner = TestRunnerBuilder::new()
         .with_custom_genesis(genesis)
-        .without_trace()
+        .without_kernel_trace()
         .build();
 
     let validators_addresses: Vec<ComponentAddress> = validators_keys

--- a/radix-engine-tests/tests/system/core.rs
+++ b/radix-engine-tests/tests/system/core.rs
@@ -327,7 +327,7 @@ fn cant_store_role_assignment() {
 
 #[test]
 fn test_globalize_with_very_deep_own() {
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/system/core.rs
+++ b/radix-engine-tests/tests/system/core.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{CallFrameError, KernelError};
 use radix_engine::kernel::call_frame::{
     CloseSubstateError, CreateNodeError, ProcessSubstateError, TakeNodeError,
@@ -8,9 +7,9 @@ use radix_engine::{
     types::*,
 };
 use radix_engine_interface::blueprints::resource::FromPublicKey;
-use scrypto_test::prelude::{OpenSubstateError, ProcessSubstateKeyError};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
+use scrypto_test::prelude::{OpenSubstateError, ProcessSubstateKeyError};
 
 #[derive(ScryptoSbor, PartialEq, Eq, Debug)]
 struct Compo {

--- a/radix-engine-tests/tests/system/data_validation.rs
+++ b/radix-engine-tests/tests/system/data_validation.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::system::system_type_checker::TypeCheckError;
 use radix_engine::{
     errors::{CallFrameError, KernelError, RuntimeError, SystemError},
@@ -6,8 +5,8 @@ use radix_engine::{
     types::*,
 };
 use radix_engine_interface::blueprints::package::KeyOrValue;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn setup_component(test_runner: &mut DefaultTestRunner) -> ComponentAddress {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("data_validation"));

--- a/radix-engine-tests/tests/system/deep_sbor.rs
+++ b/radix-engine-tests/tests/system/deep_sbor.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 #[ignore = "TODO: investigate how the compiled wasm is producing unreachable"]

--- a/radix-engine-tests/tests/system/error_injection.rs
+++ b/radix-engine-tests/tests/system/error_injection.rs
@@ -38,7 +38,6 @@ fn lock_fee_from_faucet_twice_error_injection() {
     for _ in 0..600 {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .lock_fee_from_faucet()
             .build();
         let receipt = test_runner
             .execute_manifest_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(

--- a/radix-engine-tests/tests/system/error_injection.rs
+++ b/radix-engine-tests/tests/system/error_injection.rs
@@ -62,7 +62,6 @@ fn lock_fee_from_faucet_and_account_error_injection() {
 
     loop {
         let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
             .lock_fee(account, dec!("500"))
             .build();
         let receipt = test_runner

--- a/radix-engine-tests/tests/system/error_injection.rs
+++ b/radix-engine-tests/tests/system/error_injection.rs
@@ -36,9 +36,7 @@ fn lock_fee_from_faucet_twice_error_injection() {
 
     // TODO: Use state from InjectSystemCostingError to tell when we haven't progressed
     for _ in 0..600 {
-        let manifest = ManifestBuilder::new()
-            .lock_fee_from_faucet()
-            .build();
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet().build();
         let receipt = test_runner
             .execute_manifest_with_system::<_, InjectSystemCostingError<'_, NoExtension>>(
                 manifest,

--- a/radix-engine-tests/tests/system/events.rs
+++ b/radix-engine-tests/tests/system/events.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::consensus_manager::{
     ClaimXrdEvent, EpochChangeEvent, RegisterValidatorEvent, RoundChangeEvent, StakeEvent,
     UnregisterValidatorEvent, UnstakeEvent, UpdateAcceptingStakeDelegationStateEvent,
@@ -21,11 +20,11 @@ use radix_engine_interface::blueprints::consensus_manager::{
 };
 use radix_engine_interface::blueprints::package::BlueprintPayloadIdentifier;
 use radix_engine_interface::{burn_roles, metadata, metadata_init, mint_roles, recall_roles};
+use radix_engine_tests::common::*;
 use scrypto::prelude::{AccessRule, FromPublicKey};
 use scrypto::NonFungibleData;
 use scrypto_test::prelude::*;
 use transaction::model::InstructionV1;
-
 
 #[test]
 fn test_events_of_commit_failure() {
@@ -212,7 +211,8 @@ fn scrypto_cant_emit_unregistered_event() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("events"));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "ScryptoEvents",
@@ -222,7 +222,7 @@ fn scrypto_cant_emit_unregistered_event() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_manifest (manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(|e| match e {
@@ -1816,10 +1816,11 @@ fn create_account_events_can_be_looked_up() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .new_account_advanced(OwnerRole::Fixed(AccessRule::AllowAll), None)
         .build();
-    let receipt = test_runner.execute_manifest (manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     {
@@ -1847,7 +1848,8 @@ fn is_decoded_equal<T: ScryptoDecode + PartialEq>(expected: &T, actual: &[u8]) -
 }
 
 fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceAddress {
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_fungible_resource(
             OwnerRole::Fixed(AccessRule::AllowAll),
             false,
@@ -1871,7 +1873,7 @@ fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceA
             None,
         )
         .build();
-    let receipt = test_runner.execute_manifest (manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit(true).new_resource_addresses()[0]
 }
 

--- a/radix-engine-tests/tests/system/events.rs
+++ b/radix-engine-tests/tests/system/events.rs
@@ -9,6 +9,7 @@ use radix_engine::system::attached_modules::metadata::SetMetadataEvent;
 use radix_engine::system::system_type_checker::TypeCheckError;
 use radix_engine::types::blueprints::account::ResourcePreference;
 use radix_engine::types::*;
+use radix_engine_interface::api::node_modules::auth::AuthAddresses;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::api::ModuleId;
@@ -974,15 +975,19 @@ fn consensus_manager_round_update_emits_correct_event() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_validator_transaction(vec![InstructionV1::CallMethod {
-        address: CONSENSUS_MANAGER.into(),
-        method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
-            Round::of(1),
-            0,
-            180000i64,
-        )),
-    }]);
+    let receipt = test_runner.execute_system_transaction(
+        vec![InstructionV1::CallMethod {
+            address: CONSENSUS_MANAGER.into(),
+            method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
+            args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
+                Round::of(1),
+                0,
+                180000i64,
+            )),
+        }],
+        btreeset![AuthAddresses::validator_role()],
+        vec![],
+    );
 
     // Assert
     {
@@ -1031,15 +1036,19 @@ fn consensus_manager_epoch_update_emits_epoch_change_event() {
     test_runner.advance_to_round(Round::of(rounds_per_epoch - 1));
 
     // Act: perform the most usual successful next round
-    let receipt = test_runner.execute_validator_transaction(vec![InstructionV1::CallMethod {
-        address: CONSENSUS_MANAGER.into(),
-        method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
-            Round::of(rounds_per_epoch),
-            0,
-            180000i64,
-        )),
-    }]);
+    let receipt = test_runner.execute_system_transaction(
+        vec![InstructionV1::CallMethod {
+            address: CONSENSUS_MANAGER.into(),
+            method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
+            args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
+                Round::of(rounds_per_epoch),
+                0,
+                180000i64,
+            )),
+        }],
+        btreeset![AuthAddresses::validator_role()],
+        vec![],
+    );
 
     // Assert
     {
@@ -1079,15 +1088,19 @@ fn consensus_manager_epoch_update_emits_xrd_minting_event() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_validator_transaction(vec![InstructionV1::CallMethod {
-        address: CONSENSUS_MANAGER.into(),
-        method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
-        args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
-            Round::of(1),
-            0,
-            180000i64,
-        )),
-    }]);
+    let receipt = test_runner.execute_system_transaction(
+        vec![InstructionV1::CallMethod {
+            address: CONSENSUS_MANAGER.into(),
+            method_name: CONSENSUS_MANAGER_NEXT_ROUND_IDENT.to_string(),
+            args: to_manifest_value_and_unwrap!(&ConsensusManagerNextRoundInput::successful(
+                Round::of(1),
+                0,
+                180000i64,
+            )),
+        }],
+        btreeset![AuthAddresses::validator_role()],
+        vec![],
+    );
 
     // Assert
     let result = receipt.expect_commit_success();

--- a/radix-engine-tests/tests/system/events.rs
+++ b/radix-engine-tests/tests/system/events.rs
@@ -212,7 +212,7 @@ fn scrypto_cant_emit_unregistered_event() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("events"));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             package_address,
             "ScryptoEvents",
@@ -222,7 +222,7 @@ fn scrypto_cant_emit_unregistered_event() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest (manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(|e| match e {
@@ -1816,10 +1816,10 @@ fn create_account_events_can_be_looked_up() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .new_account_advanced(OwnerRole::Fixed(AccessRule::AllowAll), None)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest (manifest, vec![]);
 
     // Assert
     {
@@ -1847,7 +1847,7 @@ fn is_decoded_equal<T: ScryptoDecode + PartialEq>(expected: &T, actual: &[u8]) -
 }
 
 fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceAddress {
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .create_fungible_resource(
             OwnerRole::Fixed(AccessRule::AllowAll),
             false,
@@ -1871,7 +1871,7 @@ fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceA
             None,
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest (manifest, vec![]);
     receipt.expect_commit(true).new_resource_addresses()[0]
 }
 

--- a/radix-engine-tests/tests/system/events.rs
+++ b/radix-engine-tests/tests/system/events.rs
@@ -209,7 +209,7 @@ fn create_proof_emits_correct_events() {
 #[test]
 fn scrypto_cant_emit_unregistered_event() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
@@ -289,7 +289,7 @@ fn scrypto_can_emit_registered_events() {
 #[test]
 fn cant_publish_a_package_with_non_struct_or_enum_event() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     let (code, definition) = PackageLoader::get("events_invalid");
     let manifest = ManifestBuilder::new()
@@ -314,7 +314,7 @@ fn cant_publish_a_package_with_non_struct_or_enum_event() {
 #[test]
 fn local_type_id_with_misleading_name_fails() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     let (code, mut definition) = PackageLoader::get("events");
     let blueprint_setup = definition.blueprints.get_mut("ScryptoEvents").unwrap();
@@ -355,7 +355,7 @@ fn local_type_id_with_misleading_name_fails() {
 #[test]
 fn locking_fee_against_a_vault_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     let manifest = ManifestBuilder::new().lock_fee(FAUCET, 500).build();
 
@@ -388,7 +388,7 @@ fn locking_fee_against_a_vault_emits_correct_events() {
 #[test]
 fn vault_fungible_recall_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
     let recallable_resource_address = test_runner.create_recallable_token(account);
     let vault_id = test_runner.get_component_vaults(account, recallable_resource_address)[0];
@@ -448,7 +448,7 @@ fn vault_fungible_recall_emits_correct_events() {
 #[test]
 fn vault_non_fungible_recall_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
     let (recallable_resource_address, non_fungible_local_id) = {
         let id = NonFungibleLocalId::Integer(IntegerNonFungibleLocalId::new(1));
@@ -543,7 +543,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
 #[test]
 fn resource_manager_new_vault_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
 
     let manifest = ManifestBuilder::new()
@@ -620,7 +620,7 @@ fn resource_manager_new_vault_emits_correct_events() {
 #[test]
 fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -710,7 +710,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
 #[test]
 fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -803,7 +803,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
 #[test]
 fn vault_take_non_fungibles_by_amount_emits_correct_event() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (public_key, _, account) = test_runner.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -1765,7 +1765,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
 #[test]
 fn setting_metadata_emits_correct_events() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let resource_address = create_all_allowed_resource(&mut test_runner);
 
     let manifest = ManifestBuilder::new()
@@ -1813,7 +1813,7 @@ fn setting_metadata_emits_correct_events() {
 #[test]
 fn create_account_events_can_be_looked_up() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -1877,7 +1877,7 @@ fn create_all_allowed_resource(test_runner: &mut DefaultTestRunner) -> ResourceA
 
 #[test]
 fn mint_burn_events_should_match_total_supply_for_fungible_resource() {
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (pk, _, account) = test_runner.new_allocated_account();
 
     // Create
@@ -1973,7 +1973,7 @@ fn mint_burn_events_should_match_total_supply_for_fungible_resource() {
 
 #[test]
 fn mint_burn_events_should_match_total_supply_for_non_fungible_resource() {
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (pk, _, account) = test_runner.new_allocated_account();
 
     // Create

--- a/radix-engine-tests/tests/system/external_bridge.rs
+++ b/radix-engine-tests/tests/system/external_bridge.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 const TARGET_PACKAGE_ADDRESS: [u8; NodeId::LENGTH] = [
     13, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1,

--- a/radix-engine-tests/tests/system/faucet.rs
+++ b/radix-engine-tests/tests/system/faucet.rs
@@ -1,7 +1,6 @@
 use radix_engine::types::*;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn lock_fee_on_empty_faucet_should_give_nice_error() {
     // Arrange

--- a/radix-engine-tests/tests/system/fee.rs
+++ b/radix-engine-tests/tests/system/fee.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::WorktopError;
 use radix_engine::errors::RuntimeError;
 use radix_engine::errors::{ApplicationError, CallFrameError, KernelError};
@@ -6,6 +5,7 @@ use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::transaction::{FeeLocks, TransactionReceipt};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::prelude::PreviewFlags;
 

--- a/radix-engine-tests/tests/system/fee_reserve_states.rs
+++ b/radix-engine-tests/tests/system/fee_reserve_states.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_fee_states() {

--- a/radix-engine-tests/tests/system/identity.rs
+++ b/radix-engine-tests/tests/system/identity.rs
@@ -255,7 +255,7 @@ fn identity_created_with_create_advanced_has_an_empty_owner_badge() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let identity = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(
                 IDENTITY_PACKAGE,
                 IDENTITY_BLUEPRINT,
@@ -266,7 +266,7 @@ fn identity_created_with_create_advanced_has_an_empty_owner_badge() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest (manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };

--- a/radix-engine-tests/tests/system/identity.rs
+++ b/radix-engine-tests/tests/system/identity.rs
@@ -9,7 +9,6 @@ use radix_engine_interface::blueprints::identity::{
 };
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn cannot_securify_in_advanced_mode() {
     // Arrange
@@ -255,7 +254,8 @@ fn identity_created_with_create_advanced_has_an_empty_owner_badge() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let identity = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(
                 IDENTITY_PACKAGE,
                 IDENTITY_BLUEPRINT,
@@ -266,7 +266,7 @@ fn identity_created_with_create_advanced_has_an_empty_owner_badge() {
             )
             .build();
         test_runner
-            .execute_manifest (manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };

--- a/radix-engine-tests/tests/system/instructions.rs
+++ b/radix-engine-tests/tests/system/instructions.rs
@@ -9,7 +9,6 @@ use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto::prelude::{require, require_amount};
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn drop_auth_zone_proofs_should_not_drop_named_proofs() {
     // Arrange

--- a/radix-engine-tests/tests/system/invalid_stored_values.rs
+++ b/radix-engine-tests/tests/system/invalid_stored_values.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::{MovePartitionError, PersistNodeError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn stored_bucket_in_committed_component_should_fail() {

--- a/radix-engine-tests/tests/system/kv_store.rs
+++ b/radix-engine-tests/tests/system/kv_store.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
 use radix_engine::kernel::call_frame::{
     OpenSubstateError, ProcessSubstateError, TakeNodeError, WriteSubstateError,
 };
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_insert_in_child_nodes() {

--- a/radix-engine-tests/tests/system/leaks.rs
+++ b/radix-engine-tests/tests/system/leaks.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::FungibleResourceManagerError;
 use radix_engine::errors::{ApplicationError, KernelError, RuntimeError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn dangling_component_should_fail() {

--- a/radix-engine-tests/tests/system/metadata.rs
+++ b/radix-engine-tests/tests/system/metadata.rs
@@ -1,12 +1,11 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::system::attached_modules::metadata::MetadataError;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::{
     MetadataConversionError::UnexpectedType, MetadataValue,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_get_from_scrypto() {

--- a/radix-engine-tests/tests/system/metadata_component.rs
+++ b/radix-engine-tests/tests/system/metadata_component.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::types::*;
 use radix_engine_queries::typed_substate_layout::{MetadataError, MetadataValidationError};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn cannot_create_metadata_with_invalid_value() {

--- a/radix-engine-tests/tests/system/metadata_identity.rs
+++ b/radix-engine-tests/tests/system/metadata_identity.rs
@@ -4,7 +4,6 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use scrypto_test::prelude::*;
 
-
 fn can_set_identity_metadata_with_owner(is_virtual: bool) {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();

--- a/radix-engine-tests/tests/system/metadata_package.rs
+++ b/radix-engine-tests/tests/system/metadata_package.rs
@@ -1,10 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn cannot_set_package_metadata_with_no_owner() {

--- a/radix-engine-tests/tests/system/metadata_validator.rs
+++ b/radix-engine-tests/tests/system/metadata_validator.rs
@@ -4,7 +4,6 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::metadata::MetadataValue;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn can_set_validator_metadata_with_owner() {
     // Arrange

--- a/radix-engine-tests/tests/system/module.rs
+++ b/radix-engine-tests/tests/system/module.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn mixed_up_modules_causes_type_error() {

--- a/radix-engine-tests/tests/system/package.rs
+++ b/radix-engine-tests/tests/system/package.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::package::*;
 use radix_engine::errors::*;
 use radix_engine::system::system_modules::auth::*;
@@ -7,10 +6,9 @@ use radix_engine::vm::wasm::PrepareError;
 use radix_engine::vm::wasm::*;
 use radix_engine_common::constants::MAX_NUMBER_OF_BLUEPRINT_FIELDS;
 use radix_engine_interface::*;
+use radix_engine_tests::common::*;
 use sbor::basic_well_known_types::*;
 use scrypto_test::prelude::*;
-
-
 
 #[test]
 fn missing_memory_should_cause_error() {

--- a/radix-engine-tests/tests/system/package_schema.rs
+++ b/radix-engine-tests/tests/system/package_schema.rs
@@ -1,6 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 
 use ExpectedResult::{InvalidInput, InvalidOutput, Success};

--- a/radix-engine-tests/tests/system/recallable.rs
+++ b/radix-engine-tests/tests/system/recallable.rs
@@ -1,13 +1,12 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{
     CallFrameError, KernelError, RejectionReason, RuntimeError, SystemModuleError,
 };
 use radix_engine::kernel::call_frame::{CreateFrameError, PassMessageError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto::prelude::FromPublicKey;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn non_existing_vault_should_cause_error() {

--- a/radix-engine-tests/tests/system/reference.rs
+++ b/radix-engine-tests/tests/system/reference.rs
@@ -1,10 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::SystemError;
 use radix_engine::system::system_type_checker::TypeCheckError;
 use radix_engine::{errors::RuntimeError, types::*};
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_add_direct_access_ref_to_stored_substate_external_vault() {
@@ -24,11 +23,12 @@ fn test_add_direct_access_ref_to_stored_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -39,7 +39,8 @@ fn test_add_direct_access_ref_to_stored_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -76,11 +77,12 @@ fn test_add_direct_access_ref_to_heap_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -91,7 +93,8 @@ fn test_add_direct_access_ref_to_heap_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -128,11 +131,12 @@ fn test_add_direct_access_ref_to_kv_store_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -143,7 +147,8 @@ fn test_add_direct_access_ref_to_kv_store_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -175,7 +180,8 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -186,7 +192,7 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -203,7 +209,8 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -235,7 +242,8 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -246,7 +254,7 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -263,7 +271,8 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -295,7 +304,8 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -306,7 +316,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -323,7 +333,8 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -353,7 +364,8 @@ fn test_create_global_node_with_local_ref() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,
@@ -385,11 +397,12 @@ fn test_add_local_ref_to_stored_substate() {
 
     // Instantiate component
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest (
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -400,7 +413,8 @@ fn test_add_local_ref_to_stored_substate() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -434,7 +448,8 @@ fn test_internal_typed_reference() {
 
     // Act
     let receipt = test_runner.execute_manifest(
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,

--- a/radix-engine-tests/tests/system/reference.rs
+++ b/radix-engine-tests/tests/system/reference.rs
@@ -24,11 +24,11 @@ fn test_add_direct_access_ref_to_stored_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -39,7 +39,7 @@ fn test_add_direct_access_ref_to_stored_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -76,11 +76,11 @@ fn test_add_direct_access_ref_to_heap_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -91,7 +91,7 @@ fn test_add_direct_access_ref_to_heap_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -128,11 +128,11 @@ fn test_add_direct_access_ref_to_kv_store_substate_external_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -143,7 +143,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_external_vault() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -175,7 +175,7 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -186,7 +186,7 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -203,7 +203,7 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -235,7 +235,7 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -246,7 +246,7 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -263,7 +263,7 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -295,7 +295,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .withdraw_from_account(account, resource, dec!(1))
             .take_all_from_worktop(resource, "bucket")
             .call_function_with_name_lookup(
@@ -306,7 +306,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
             )
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -323,7 +323,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -353,7 +353,7 @@ fn test_create_global_node_with_local_ref() {
 
     // Call function
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,
@@ -385,11 +385,11 @@ fn test_add_local_ref_to_stored_substate() {
 
     // Instantiate component
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "ReferenceTest", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest (
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -400,7 +400,7 @@ fn test_add_local_ref_to_stored_substate() {
 
     // Call method
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -434,7 +434,7 @@ fn test_internal_typed_reference() {
 
     // Act
     let receipt = test_runner.execute_manifest(
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,

--- a/radix-engine-tests/tests/system/reference.rs
+++ b/radix-engine-tests/tests/system/reference.rs
@@ -40,7 +40,7 @@ fn test_add_direct_access_ref_to_stored_substate_external_vault() {
     // Call method
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -94,7 +94,7 @@ fn test_add_direct_access_ref_to_heap_substate_external_vault() {
     // Call method
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -148,7 +148,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_external_vault() {
     // Call method
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -210,7 +210,7 @@ fn test_add_direct_access_ref_to_stored_substate_internal_vault() {
     // Call function
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -272,7 +272,7 @@ fn test_add_direct_access_ref_to_heap_substate_internal_vault() {
     // Call function
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -334,7 +334,7 @@ fn test_add_direct_access_ref_to_kv_store_substate_internal_vault() {
     // Call function
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -365,7 +365,7 @@ fn test_create_global_node_with_local_ref() {
     // Call function
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,
@@ -414,7 +414,7 @@ fn test_add_local_ref_to_stored_substate() {
     // Call method
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_method(
                 component_address,
@@ -449,7 +449,7 @@ fn test_internal_typed_reference() {
     // Act
     let receipt = test_runner.execute_manifest(
         ManifestBuilder::new()
-            .lock_fee_from_faucet()
+             
             .lock_standard_test_fee(account)
             .call_function(
                 package_address,

--- a/radix-engine-tests/tests/system/remote_generic_args.rs
+++ b/radix-engine-tests/tests/system/remote_generic_args.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_same_package_remote_generic_arg_for_non_fungible_data() {

--- a/radix-engine-tests/tests/system/role_assignment.rs
+++ b/radix-engine-tests/tests/system/role_assignment.rs
@@ -65,7 +65,7 @@ fn can_call_protected_function_with_auth() {
     let (key, _priv, account) = test_runner.new_account(true);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .call_function(
             package_address,
@@ -75,7 +75,7 @@ fn can_call_protected_function_with_auth() {
         )
         .build();
     let receipt = test_runner
-        .execute_manifest_ignoring_fee(manifest, [NonFungibleGlobalId::from_public_key(&key)]);
+        .execute_manifest(manifest, [NonFungibleGlobalId::from_public_key(&key)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -194,18 +194,18 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(manifest, []);
+        let receipt = test_runner.execute_manifest(manifest, []);
         receipt.expect_commit_success();
 
         receipt.expect_commit(true).new_component_addresses()[0]
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "assert_access_rule",
@@ -213,7 +213,7 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
         )
         .build();
 
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, []);
+    let receipt = test_runner.execute_manifest(manifest, []);
 
     // Assert
     receipt.expect_specific_failure(|error: &RuntimeError| {
@@ -232,11 +232,11 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
             .build();
 
-        let receipt = test_runner.execute_manifest_ignoring_fee(
+        let receipt = test_runner.execute_manifest(
             manifest,
             [NonFungibleGlobalId::from_public_key(&public_key)],
         );
@@ -245,7 +245,7 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
         receipt.expect_commit(true).new_component_addresses()[0]
     };
 
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .call_method(
             component_address,
@@ -255,7 +255,7 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_manifest_ignoring_fee(
+    let receipt = test_runner.execute_manifest(
         manifest,
         [NonFungibleGlobalId::from_public_key(&public_key)],
     );
@@ -350,7 +350,7 @@ fn setting_a_role_with_a_long_name_before_attachment_fails() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -385,7 +385,7 @@ fn setting_a_reserved_role_before_attachment_fails() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -420,7 +420,7 @@ fn setting_any_role_in_reserved_space_before_attachment_fails() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -455,7 +455,7 @@ fn setting_a_reserved_role_in_reserved_space_before_attachment_fails() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -494,7 +494,7 @@ fn creation_of_module_with_reserved_roles_before_attachment_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -533,7 +533,7 @@ fn creation_of_module_with_role_names_exceeding_maximum_length_before_attachment
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -565,7 +565,7 @@ fn updating_a_reserved_role_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -582,7 +582,7 @@ fn updating_a_reserved_role_fails() {
         .unwrap();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .set_role(
             component_address,
@@ -614,7 +614,7 @@ fn updating_any_role_on_reserved_space_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -631,7 +631,7 @@ fn updating_any_role_on_reserved_space_fails() {
         .unwrap();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .set_role(
             component_address,
@@ -672,7 +672,7 @@ fn updating_a_role_not_in_the_package_definition_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -689,7 +689,7 @@ fn updating_a_role_not_in_the_package_definition_fails() {
         .unwrap();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .set_role(
             component_address,
@@ -725,7 +725,7 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -742,7 +742,7 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
         .unwrap();
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .set_role(
             component_address,
@@ -777,7 +777,7 @@ fn setting_a_role_with_invalid_utf8_characters_before_attachment_fails() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -816,7 +816,7 @@ fn creation_with_a_role_with_invalid_utf8_characters_before_attachment_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
         .lock_fee_from_faucet()
         .call_function(
             package_address,
@@ -858,7 +858,7 @@ impl MutableRolesTestRunner {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(
                 package_address,
                 Self::BLUEPRINT_NAME,
@@ -866,7 +866,7 @@ impl MutableRolesTestRunner {
                 manifest_args!(roles),
             )
             .build();
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![])
+        test_runner.execute_manifest(manifest, vec![])
     }
 
     pub fn create_component_with_owner(
@@ -876,7 +876,7 @@ impl MutableRolesTestRunner {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
-        let manifest = ManifestBuilder::new()
+        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
             .call_function(
                 package_address,
                 Self::BLUEPRINT_NAME,
@@ -884,7 +884,7 @@ impl MutableRolesTestRunner {
                 manifest_args!(owner_role),
             )
             .build();
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![])
+        test_runner.execute_manifest(manifest, vec![])
     }
 
     pub fn new_with_owner(update_access_rule: AccessRule) -> Self {
@@ -968,11 +968,11 @@ impl MutableRolesTestRunner {
     }
 
     pub fn manifest_builder() -> ManifestBuilder {
-        ManifestBuilder::new()
+         ManifestBuilder::new().lock_fee_from_faucet()
     }
 
     pub fn execute_manifest(&mut self, manifest: TransactionManifestV1) -> TransactionReceipt {
         self.test_runner
-            .execute_manifest_ignoring_fee(manifest, self.initial_proofs.clone())
+            .execute_manifest(manifest, self.initial_proofs.clone())
     }
 }

--- a/radix-engine-tests/tests/system/role_assignment.rs
+++ b/radix-engine-tests/tests/system/role_assignment.rs
@@ -351,7 +351,6 @@ fn setting_a_role_with_a_long_name_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -386,7 +385,6 @@ fn setting_a_reserved_role_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -421,7 +419,6 @@ fn setting_any_role_in_reserved_space_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -456,7 +453,6 @@ fn setting_a_reserved_role_in_reserved_space_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -495,7 +491,6 @@ fn creation_of_module_with_reserved_roles_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -534,7 +529,6 @@ fn creation_of_module_with_role_names_exceeding_maximum_length_before_attachment
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -566,7 +560,6 @@ fn updating_a_reserved_role_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -583,7 +576,6 @@ fn updating_a_reserved_role_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -615,7 +607,6 @@ fn updating_any_role_on_reserved_space_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -632,7 +623,6 @@ fn updating_any_role_on_reserved_space_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::RoleAssignment,
@@ -673,7 +663,6 @@ fn updating_a_role_not_in_the_package_definition_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -690,7 +679,6 @@ fn updating_a_role_not_in_the_package_definition_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -726,7 +714,6 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -743,7 +730,6 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -778,7 +764,6 @@ fn setting_a_role_with_invalid_utf8_characters_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -817,7 +802,6 @@ fn creation_with_a_role_with_invalid_utf8_characters_before_attachment_fails() {
 
     // Act
     let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
-        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",

--- a/radix-engine-tests/tests/system/role_assignment.rs
+++ b/radix-engine-tests/tests/system/role_assignment.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::*;
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::transaction::TransactionReceipt;
@@ -9,10 +8,10 @@ use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
 use radix_engine_interface::rule;
 use radix_engine_queries::typed_substate_layout::*;
+use radix_engine_tests::common::*;
 use scrypto::prelude::FallToOwner;
 use scrypto_test::prelude::InvalidNameError;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_call_public_function() {
@@ -65,7 +64,8 @@ fn can_call_protected_function_with_auth() {
     let (key, _priv, account) = test_runner.new_account(true);
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .call_function(
             package_address,
@@ -74,8 +74,8 @@ fn can_call_protected_function_with_auth() {
             manifest_args!(),
         )
         .build();
-    let receipt = test_runner
-        .execute_manifest(manifest, [NonFungibleGlobalId::from_public_key(&key)]);
+    let receipt =
+        test_runner.execute_manifest(manifest, [NonFungibleGlobalId::from_public_key(&key)]);
 
     // Assert
     receipt.expect_commit_success();
@@ -194,7 +194,8 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
             .build();
 
@@ -205,7 +206,8 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "assert_access_rule",
@@ -232,7 +234,8 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
     let component_address = {
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(package_address, "AssertAccessRule", "new", manifest_args!())
             .build();
 
@@ -245,7 +248,8 @@ fn assert_access_rule_through_component_when_fulfilled_succeeds() {
         receipt.expect_commit(true).new_component_addresses()[0]
     };
 
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .create_proof_from_account_of_amount(account, XRD, dec!(1))
         .call_method(
             component_address,
@@ -350,7 +354,8 @@ fn setting_a_role_with_a_long_name_before_attachment_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -384,7 +389,8 @@ fn setting_a_reserved_role_before_attachment_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -418,7 +424,8 @@ fn setting_any_role_in_reserved_space_before_attachment_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -452,7 +459,8 @@ fn setting_a_reserved_role_in_reserved_space_before_attachment_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -490,7 +498,8 @@ fn creation_of_module_with_reserved_roles_before_attachment_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -528,7 +537,8 @@ fn creation_of_module_with_role_names_exceeding_maximum_length_before_attachment
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -559,7 +569,8 @@ fn updating_a_reserved_role_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -575,7 +586,8 @@ fn updating_a_reserved_role_fails() {
         .unwrap();
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -606,7 +618,8 @@ fn updating_any_role_on_reserved_space_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -622,7 +635,8 @@ fn updating_any_role_on_reserved_space_fails() {
         .unwrap();
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::RoleAssignment,
@@ -662,7 +676,8 @@ fn updating_a_role_not_in_the_package_definition_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -678,7 +693,8 @@ fn updating_a_role_not_in_the_package_definition_fails() {
         .unwrap();
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -713,7 +729,8 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
     let init_roles: IndexMap<ModuleId, RoleAssignmentInit> = indexmap! {};
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -729,7 +746,8 @@ fn updating_a_role_on_package_with_allow_all_method_accessibility_fails() {
         .unwrap();
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .set_role(
             component_address,
             ModuleId::Main,
@@ -763,7 +781,8 @@ fn setting_a_role_with_invalid_utf8_characters_before_attachment_fails() {
     };
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -801,7 +820,8 @@ fn creation_with_a_role_with_invalid_utf8_characters_before_attachment_fails() {
     let set_roles: IndexMap<(ModuleId, String), AccessRule> = indexmap! {};
 
     // Act
-    let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "RoleAssignmentEdgeCases",
@@ -842,7 +862,8 @@ impl MutableRolesTestRunner {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 Self::BLUEPRINT_NAME,
@@ -860,7 +881,8 @@ impl MutableRolesTestRunner {
         let package_address =
             test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 
-        let manifest =  ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(
                 package_address,
                 Self::BLUEPRINT_NAME,
@@ -952,7 +974,7 @@ impl MutableRolesTestRunner {
     }
 
     pub fn manifest_builder() -> ManifestBuilder {
-         ManifestBuilder::new().lock_fee_from_faucet()
+        ManifestBuilder::new().lock_fee_from_faucet()
     }
 
     pub fn execute_manifest(&mut self, manifest: TransactionManifestV1) -> TransactionReceipt {

--- a/radix-engine-tests/tests/system/role_assignment.rs
+++ b/radix-engine-tests/tests/system/role_assignment.rs
@@ -191,7 +191,7 @@ fn component_role_assignment_can_be_mutated_to_non_fungible_resource_through_man
 #[test]
 fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -227,7 +227,7 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
 #[test]
 fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (public_key, _, account) = test_runner.new_account(false);
     let package_address = test_runner.publish_package_simple(PackageLoader::get("role_assignment"));
 

--- a/radix-engine-tests/tests/system/royalty.rs
+++ b/radix-engine-tests/tests/system/royalty.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::package::PackageError;
 use radix_engine::errors::{ApplicationError, RuntimeError, SystemError};
 use radix_engine::system::attached_modules::royalty::ComponentRoyaltyError;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_component_royalty() {

--- a/radix-engine-tests/tests/system/royalty_auth.rs
+++ b/radix-engine-tests/tests/system/royalty_auth.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn package_owner_can_claim_royalty() {

--- a/radix-engine-tests/tests/system/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/system/royalty_edge_cases.rs
@@ -448,7 +448,7 @@ package_interactions_tests! {
 #[test]
 fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (code, mut definition) = CODE_AND_DEF.clone();
 
     for blueprint_definition in definition.blueprints.values_mut() {
@@ -482,7 +482,7 @@ fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
 #[test]
 fn component_and_package_royalties_are_both_applied() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let (code, mut definition) = CODE_AND_DEF.clone();
     let royalty_amount = RoyaltyAmount::Xrd(10.into());
     update_package_royalties(&mut definition, royalty_amount);
@@ -527,7 +527,7 @@ fn component_and_package_royalties_are_both_applied() {
 #[test]
 fn test_component_with_missing_method_royalty() {
     // Arrange
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package_simple(CODE_AND_DEF.clone());
 
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/system/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/system/royalty_edge_cases.rs
@@ -649,7 +649,7 @@ macro_rules! component_instantiation_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
                 let package_address =
                     test_runner.publish_package_simple(CODE_AND_DEF.clone());
 
@@ -695,7 +695,7 @@ macro_rules! component_interaction_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
                 let package_address =
                     test_runner.publish_package_simple(CODE_AND_DEF.clone());
 
@@ -755,7 +755,7 @@ macro_rules! package_publishing_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
                 let (code, mut definition) = CODE_AND_DEF.clone();
 
                 update_package_royalties(&mut definition, royalty_amount);
@@ -803,7 +803,7 @@ macro_rules! package_interactions_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+                let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
                 let (code, mut definition) = CODE_AND_DEF.clone();
 
                 update_package_royalties(&mut definition, royalty_amount);

--- a/radix-engine-tests/tests/system/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/system/royalty_edge_cases.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::*;
 use radix_engine::transaction::*;
 use radix_engine_queries::typed_substate_layout::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 const DECIMAL_MIN: Decimal = Decimal::MIN;
 const DECIMAL_MAX: Decimal = Decimal::MAX;

--- a/radix-engine-tests/tests/system/system.rs
+++ b/radix-engine-tests/tests/system/system.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{ApplicationError, RuntimeError, SystemError, SystemModuleError},
     types::*,
 };
 use radix_engine_queries::typed_substate_layout::{RoleAssignmentError, PACKAGE_BLUEPRINT};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_handle_mismatch() {

--- a/radix-engine-tests/tests/system/system_access_rule.rs
+++ b/radix-engine-tests/tests/system/system_access_rule.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use native_sdk::modules::role_assignment::{RoleAssignment, RoleAssignmentObject};
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
@@ -9,6 +8,7 @@ use radix_engine::vm::{OverridePackageCode, VmApi, VmInvoke};
 use radix_engine_interface::api::{ClientApi, ModuleId};
 use radix_engine_interface::blueprints::package::PackageDefinition;
 use radix_engine_queries::typed_substate_layout::{FunctionAuth, PackageError};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::builder::ManifestBuilder;
 

--- a/radix-engine-tests/tests/system/system_global_address.rs
+++ b/radix-engine-tests/tests/system/system_global_address.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::ResourceNativePackage;
 use radix_engine::errors::{RuntimeError, SystemError};
 use radix_engine::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
@@ -7,6 +6,7 @@ use radix_engine::types::*;
 use radix_engine::vm::{OverridePackageCode, VmApi, VmInvoke};
 use radix_engine_interface::api::{ClientApi, ACTOR_REF_GLOBAL};
 use radix_engine_interface::blueprints::package::{PackageDefinition, RESOURCE_CODE_ID};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use transaction::builder::ManifestBuilder;
 

--- a/radix-engine-tests/tests/system/system_reference.rs
+++ b/radix-engine-tests/tests/system/system_reference.rs
@@ -25,7 +25,7 @@ fn cannot_store_reference_in_non_transient_blueprint() {
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
-            _vm_api: & V,
+            _vm_api: &V,
         ) -> Result<IndexedScryptoValue, RuntimeError>
         where
             Y: ClientApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,

--- a/radix-engine-tests/tests/system/system_role_assignment.rs
+++ b/radix-engine-tests/tests/system/system_role_assignment.rs
@@ -64,6 +64,7 @@ fn cannot_define_more_than_50_roles() {
             }),
         }],
         btreeset!(AuthAddresses::system_role()),
+        vec![],
     );
 
     // Assert
@@ -126,6 +127,7 @@ fn cannot_define_role_name_larger_than_max() {
             }),
         }],
         btreeset!(AuthAddresses::system_role()),
+        vec![],
     );
 
     // Assert

--- a/radix-engine-tests/tests/system/track.rs
+++ b/radix-engine-tests/tests/system/track.rs
@@ -5,7 +5,6 @@ use radix_engine_interface::blueprints::resource::FromPublicKey;
 use radix_engine_queries::typed_substate_layout::VaultError;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn test_lock_fee_and_then_withdraw_failure() {
     // Arrange

--- a/radix-engine-tests/tests/system/transaction_limits.rs
+++ b/radix-engine-tests/tests/system/transaction_limits.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{RuntimeError, SystemModuleError, VmError},
     system::system_modules::limits::TransactionLimitsError,
@@ -6,8 +5,8 @@ use radix_engine::{
     types::*,
     vm::wasm::WasmRuntimeError,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_read_non_existent_entries_from_kv_store_exceeding_limit() {
@@ -272,7 +271,8 @@ fn verify_log_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",
@@ -298,7 +298,8 @@ fn verify_event_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",
@@ -324,7 +325,8 @@ fn verify_panic_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",

--- a/radix-engine-tests/tests/system/transaction_limits.rs
+++ b/radix-engine-tests/tests/system/transaction_limits.rs
@@ -272,7 +272,7 @@ fn verify_log_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",
@@ -280,7 +280,7 @@ fn verify_log_size_limit() {
             manifest_args!(MAX_LOG_SIZE + 1),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     receipt.expect_specific_failure(|e| {
         matches!(
@@ -298,7 +298,7 @@ fn verify_event_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",
@@ -306,7 +306,7 @@ fn verify_event_size_limit() {
             manifest_args!(MAX_EVENT_SIZE + 1),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     receipt.expect_specific_failure(|e| {
         matches!(
@@ -324,7 +324,7 @@ fn verify_panic_size_limit() {
     let package_address =
         test_runner.publish_package_simple(PackageLoader::get("transaction_limits"));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             package_address,
             "TransactionLimitTest",
@@ -332,7 +332,7 @@ fn verify_panic_size_limit() {
             manifest_args!(MAX_PANIC_MESSAGE_SIZE + 1),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     receipt.expect_specific_failure(|e| {
         matches!(

--- a/radix-engine-tests/tests/system/transaction_runtime.rs
+++ b/radix-engine-tests/tests/system/transaction_runtime.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_query_transaction_runtime_info() {

--- a/radix-engine-tests/tests/system/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/system/typed_substate_layout.rs
@@ -172,8 +172,7 @@ fn test_all_scenario_commit_receipts_should_have_substate_changes_which_can_be_t
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt =
-                        test_runner.execute_raw_transaction(  &next.raw_transaction);
+                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_substate_changes_can_be_typed(commit_result);
@@ -209,8 +208,7 @@ fn test_all_scenario_commit_receipts_should_have_events_that_can_be_typed() {
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt =
-                        test_runner.execute_raw_transaction(  &next.raw_transaction);
+                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_events_can_be_typed(commit_result);

--- a/radix-engine-tests/tests/system/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/system/typed_substate_layout.rs
@@ -172,7 +172,7 @@ fn test_all_scenario_commit_receipts_should_have_substate_changes_which_can_be_t
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
+                    let receipt = test_runner.execute_notarized_transaction(&next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_substate_changes_can_be_typed(commit_result);
@@ -208,7 +208,7 @@ fn test_all_scenario_commit_receipts_should_have_events_that_can_be_typed() {
                 .unwrap();
             match next {
                 NextAction::Transaction(next) => {
-                    let receipt = test_runner.execute_raw_transaction(&next.raw_transaction);
+                    let receipt = test_runner.execute_notarized_transaction(&next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_events_can_be_typed(commit_result);

--- a/radix-engine-tests/tests/system/typed_substate_layout.rs
+++ b/radix-engine-tests/tests/system/typed_substate_layout.rs
@@ -173,7 +173,7 @@ fn test_all_scenario_commit_receipts_should_have_substate_changes_which_can_be_t
             match next {
                 NextAction::Transaction(next) => {
                     let receipt =
-                        test_runner.execute_raw_transaction(&network, &next.raw_transaction);
+                        test_runner.execute_raw_transaction(  &next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_substate_changes_can_be_typed(commit_result);
@@ -210,7 +210,7 @@ fn test_all_scenario_commit_receipts_should_have_events_that_can_be_typed() {
             match next {
                 NextAction::Transaction(next) => {
                     let receipt =
-                        test_runner.execute_raw_transaction(&network, &next.raw_transaction);
+                        test_runner.execute_raw_transaction(  &next.raw_transaction);
                     match &receipt.result {
                         TransactionResult::Commit(commit_result) => {
                             assert_receipt_events_can_be_typed(commit_result);

--- a/radix-engine-tests/tests/system/vault.rs
+++ b/radix-engine-tests/tests/system/vault.rs
@@ -670,7 +670,7 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -681,13 +681,13 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -706,14 +706,14 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "take_ids",
@@ -721,7 +721,7 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
         )
         .try_deposit_entire_worktop_or_abort(account, None)
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -735,10 +735,10 @@ fn get_vault_id(
     test_runner: &mut DefaultTestRunner,
     component_address: ComponentAddress,
 ) -> NodeId {
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "vault_id", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success().output(1)
 }
 

--- a/radix-engine-tests/tests/system/vault.rs
+++ b/radix-engine-tests/tests/system/vault.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::VaultError;
 use radix_engine::errors::{
     ApplicationError, CallFrameError, KernelError, RuntimeError, SystemError,
@@ -11,10 +10,10 @@ use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::blueprints::package::KeyOrValue;
 use radix_engine_interface::{metadata, metadata_init};
+use radix_engine_tests::common::*;
 use scrypto::prelude::FromPublicKey;
 use scrypto::NonFungibleData;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_deposit_event_when_creating_vault_with_bucket() {
@@ -670,7 +669,8 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let (_, _, account) = test_runner.new_account(false);
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -687,7 +687,8 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -713,7 +714,8 @@ fn taking_resource_from_non_fungible_vault_should_reduce_the_contained_amount() 
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "take_ids",
@@ -735,7 +737,8 @@ fn get_vault_id(
     test_runner: &mut DefaultTestRunner,
     component_address: ComponentAddress,
 ) -> NodeId {
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "vault_id", manifest_args!())
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);

--- a/radix-engine-tests/tests/system/vault_burn.rs
+++ b/radix-engine-tests/tests/system/vault_burn.rs
@@ -13,7 +13,7 @@ fn package_burn_is_only_callable_within_resource_package() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -24,13 +24,13 @@ fn package_burn_is_only_callable_within_resource_package() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .mint_fungible(resource_address, 10)
         .take_all_from_worktop(resource_address, "bucket")
         .with_name_lookup(|builder, lookup| {
@@ -41,7 +41,7 @@ fn package_burn_is_only_callable_within_resource_package() {
             )
         })
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(is_auth_unauthorized_error);
@@ -53,7 +53,7 @@ fn can_burn_by_amount_from_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -64,13 +64,13 @@ fn can_burn_by_amount_from_fungible_vault() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "to_burn")
             .with_name_lookup(|builder, lookup| {
@@ -83,17 +83,17 @@ fn can_burn_by_amount_from_fungible_vault() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -109,7 +109,7 @@ fn can_burn_by_amount_from_non_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -120,13 +120,13 @@ fn can_burn_by_amount_from_non_fungible_vault() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -145,17 +145,17 @@ fn can_burn_by_amount_from_non_fungible_vault() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -169,7 +169,7 @@ fn can_burn_by_ids_from_non_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -180,13 +180,13 @@ fn can_burn_by_ids_from_non_fungible_vault() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -205,21 +205,21 @@ fn can_burn_by_ids_from_non_fungible_vault() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
             manifest_args!(btreeset![NonFungibleLocalId::integer(1)]),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -238,7 +238,7 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -249,13 +249,13 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -268,18 +268,18 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -298,7 +298,7 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -309,13 +309,13 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -334,18 +334,18 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -362,7 +362,7 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -373,13 +373,13 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -398,14 +398,14 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
@@ -413,7 +413,7 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -432,7 +432,7 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -443,13 +443,13 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -462,17 +462,17 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
+            .execute_manifest(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(is_auth_unauthorized_error);
@@ -491,7 +491,7 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -502,13 +502,13 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -527,17 +527,17 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
+            .execute_manifest(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(is_auth_unauthorized_error);
@@ -554,7 +554,7 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -565,13 +565,13 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -590,21 +590,21 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge])
+            .execute_manifest(manifest, vec![virtual_signature_badge])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
             manifest_args!(btreeset![NonFungibleLocalId::integer(1)]),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(is_auth_unauthorized_error);
@@ -620,7 +620,7 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -631,13 +631,13 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -650,17 +650,17 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -676,7 +676,7 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -687,13 +687,13 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -712,17 +712,17 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -736,7 +736,7 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -747,13 +747,13 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
             )
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -772,21 +772,21 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
             })
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![])
+            .execute_manifest(manifest, vec![])
             .expect_commit_success()
             .new_component_addresses()[0]
     };
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
             manifest_args!(btreeset![NonFungibleLocalId::integer(1)]),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_commit_success();
@@ -804,7 +804,7 @@ fn can_burn_by_amount_from_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -816,13 +816,13 @@ fn can_burn_by_amount_from_fungible_account_vault() {
             .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             account,
             "burn",
@@ -830,7 +830,7 @@ fn can_burn_by_amount_from_fungible_account_vault() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -848,7 +848,7 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -863,17 +863,17 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
             .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(account, "burn", manifest_args!(resource_address, dec!(1)))
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -891,7 +891,7 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new()
+        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -906,13 +906,13 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
             .try_deposit_entire_worktop_or_abort(account, None)
             .build();
         test_runner
-            .execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge.clone()])
+            .execute_manifest(manifest, vec![virtual_signature_badge.clone()])
             .expect_commit_success()
             .new_resource_addresses()[0]
     };
 
     // Act
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(
             account,
             "burn_non_fungibles",
@@ -920,7 +920,7 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
         )
         .build();
     let receipt =
-        test_runner.execute_manifest_ignoring_fee(manifest, vec![virtual_signature_badge]);
+        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -934,10 +934,10 @@ fn get_vault_id(
     test_runner: &mut DefaultTestRunner,
     component_address: ComponentAddress,
 ) -> NodeId {
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_method(component_address, "vault_id", manifest_args!())
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
     receipt.expect_commit_success().output(1)
 }
 

--- a/radix-engine-tests/tests/system/vault_burn.rs
+++ b/radix-engine-tests/tests/system/vault_burn.rs
@@ -1,19 +1,19 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::system::system_modules::auth::AuthError;
 use radix_engine::types::*;
 use radix_engine_interface::api::node_modules::ModuleConfig;
 use radix_engine_interface::{metadata, metadata_init};
+use radix_engine_tests::common::*;
 use scrypto::NonFungibleData;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn package_burn_is_only_callable_within_resource_package() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -30,7 +30,8 @@ fn package_burn_is_only_callable_within_resource_package() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .mint_fungible(resource_address, 10)
         .take_all_from_worktop(resource_address, "bucket")
         .with_name_lookup(|builder, lookup| {
@@ -53,7 +54,8 @@ fn can_burn_by_amount_from_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -70,7 +72,8 @@ fn can_burn_by_amount_from_fungible_vault() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "to_burn")
             .with_name_lookup(|builder, lookup| {
@@ -90,7 +93,8 @@ fn can_burn_by_amount_from_fungible_vault() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -109,7 +113,8 @@ fn can_burn_by_amount_from_non_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -126,7 +131,8 @@ fn can_burn_by_amount_from_non_fungible_vault() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -152,7 +158,8 @@ fn can_burn_by_amount_from_non_fungible_vault() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -169,7 +176,8 @@ fn can_burn_by_ids_from_non_fungible_vault() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -186,7 +194,8 @@ fn can_burn_by_ids_from_non_fungible_vault() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -212,7 +221,8 @@ fn can_burn_by_ids_from_non_fungible_vault() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
@@ -238,7 +248,8 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -255,7 +266,8 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -275,11 +287,11 @@ fn can_burn_by_amount_from_fungible_vault_with_an_access_rule() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -298,7 +310,8 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -315,7 +328,8 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -341,11 +355,11 @@ fn can_burn_by_amount_from_non_fungible_vault_with_an_access_rule() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -362,7 +376,8 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -379,7 +394,8 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -405,15 +421,15 @@ fn can_burn_by_ids_from_non_fungible_vault_with_an_access_rule() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
             manifest_args!(btreeset![NonFungibleLocalId::integer(1)]),
         )
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -432,7 +448,8 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -449,7 +466,8 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -469,7 +487,8 @@ fn cant_burn_by_amount_from_fungible_vault_with_an_access_rule_that_is_not_fulfi
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -491,7 +510,8 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -508,7 +528,8 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -534,7 +555,8 @@ fn cant_burn_by_amount_from_non_fungible_vault_with_an_access_rule_that_is_not_f
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -554,7 +576,8 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -571,7 +594,8 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -597,7 +621,8 @@ fn cant_burn_by_ids_from_non_fungible_vault_with_an_access_rule_that_is_not_fulf
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
@@ -620,7 +645,8 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -637,7 +663,8 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_fungible(resource_address, 100)
             .take_all_from_worktop(resource_address, "bucket")
             .with_name_lookup(|builder, lookup| {
@@ -657,7 +684,8 @@ fn can_burn_by_amount_from_fungible_vault_of_a_locked_down_resource() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!("50")))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -676,7 +704,8 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -693,7 +722,8 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -719,7 +749,8 @@ fn can_burn_by_amount_from_non_fungible_vault_of_a_locked_down_resource() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "burn_amount", manifest_args!(dec!(1)))
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);
@@ -736,7 +767,8 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("vault"));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -753,7 +785,8 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     };
 
     let component_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .mint_non_fungible(
                 resource_address,
                 btreemap!(
@@ -779,7 +812,8 @@ fn can_burn_by_ids_from_non_fungible_vault_of_a_locked_down_resource() {
     let vault_id = get_vault_id(&mut test_runner, component_address);
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             component_address,
             "burn_ids",
@@ -804,7 +838,8 @@ fn can_burn_by_amount_from_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_fungible_resource(
                 OwnerRole::None,
                 true,
@@ -822,15 +857,15 @@ fn can_burn_by_amount_from_fungible_account_vault() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             account,
             "burn",
             manifest_args!(resource_address, dec!("50")),
         )
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -848,7 +883,8 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -869,11 +905,11 @@ fn can_burn_by_amount_from_non_fungible_account_vault() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(account, "burn", manifest_args!(resource_address, dec!(1)))
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -891,7 +927,8 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
     let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
     let virtual_signature_rule = rule!(require(virtual_signature_badge.clone()));
     let resource_address = {
-        let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .create_non_fungible_resource(
                 OwnerRole::None,
                 NonFungibleIdType::Integer,
@@ -912,15 +949,15 @@ fn can_burn_by_ids_from_non_fungible_account_vault() {
     };
 
     // Act
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(
             account,
             "burn_non_fungibles",
             manifest_args!(resource_address, indexset!(NonFungibleLocalId::integer(1))),
         )
         .build();
-    let receipt =
-        test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
+    let receipt = test_runner.execute_manifest(manifest, vec![virtual_signature_badge]);
 
     // Assert
     receipt.expect_commit_success();
@@ -934,7 +971,8 @@ fn get_vault_id(
     test_runner: &mut DefaultTestRunner,
     component_address: ComponentAddress,
 ) -> NodeId {
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_method(component_address, "vault_id", manifest_args!())
         .build();
     let receipt = test_runner.execute_manifest(manifest, vec![]);

--- a/radix-engine-tests/tests/system/vault_freeze.rs
+++ b/radix-engine-tests/tests/system/vault_freeze.rs
@@ -4,7 +4,6 @@ use radix_engine::types::*;
 use scrypto::prelude::FromPublicKey;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn cannot_burn_frozen_burn_fungible_vault() {
     // Arrange

--- a/radix-engine-tests/tests/system/worktop.rs
+++ b/radix-engine-tests/tests/system/worktop.rs
@@ -5,7 +5,6 @@ use radix_engine::types::*;
 use radix_engine_interface::blueprints::resource::FromPublicKey;
 use scrypto_test::prelude::*;
 
-
 #[test]
 fn test_worktop_resource_leak() {
     // Arrange

--- a/radix-engine-tests/tests/vm/cached_wasm_limits.rs
+++ b/radix-engine-tests/tests/vm/cached_wasm_limits.rs
@@ -1,7 +1,6 @@
 use radix_engine::types::*;
 use scrypto_test::prelude::*;
 
-
 /// Long running test which verifies that the Wasm cache is properly evicting entries
 /// Ignored for day-to-day unit testing as it takes a long while to execute
 #[test]

--- a/radix-engine-tests/tests/vm/decimal.rs
+++ b/radix-engine-tests/tests/vm/decimal.rs
@@ -1,6 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine_common::math::*;
 use radix_engine_interface::{dec, pdec};
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 use std::env;
 

--- a/radix-engine-tests/tests/vm/logging.rs
+++ b/radix-engine-tests/tests/vm/logging.rs
@@ -1,18 +1,18 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{ApplicationError, RuntimeError},
     transaction::TransactionReceipt,
     types::*,
 };
 use radix_engine_interface::types::Level;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn call<S: AsRef<str>>(function_name: &str, message: S) -> TransactionReceipt {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("logger"));
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             package_address,
             "Logger",

--- a/radix-engine-tests/tests/vm/logging.rs
+++ b/radix-engine-tests/tests/vm/logging.rs
@@ -12,7 +12,7 @@ fn call<S: AsRef<str>>(function_name: &str, message: S) -> TransactionReceipt {
     let mut test_runner = TestRunnerBuilder::new().build();
     let package_address = test_runner.publish_package_simple(PackageLoader::get("logger"));
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             package_address,
             "Logger",
@@ -20,7 +20,7 @@ fn call<S: AsRef<str>>(function_name: &str, message: S) -> TransactionReceipt {
             manifest_args!(message.as_ref().to_owned()),
         )
         .build();
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     receipt
 }

--- a/radix-engine-tests/tests/vm/logging_limits.rs
+++ b/radix-engine-tests/tests/vm/logging_limits.rs
@@ -5,7 +5,6 @@ use radix_engine::{
 };
 use scrypto_test::prelude::*;
 
-
 fn prepare_code(message_size: usize, iterations: usize) -> Vec<u8> {
     wat2wasm(
         r##"

--- a/radix-engine-tests/tests/vm/logging_limits.rs
+++ b/radix-engine-tests/tests/vm/logging_limits.rs
@@ -68,7 +68,7 @@ fn prepare_code(message_size: usize, iterations: usize) -> Vec<u8> {
 fn test_emit_log(message_size: usize, iterations: usize, expected_err: Option<RuntimeError>) {
     // Arrange
     let code = prepare_code(message_size, iterations);
-    let mut test_runner = TestRunnerBuilder::new().without_trace().build();
+    let mut test_runner = TestRunnerBuilder::new().without_kernel_trace().build();
     let package_address = test_runner.publish_package(
         (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -26,7 +26,8 @@ fn panics_in_native_blueprints_can_be_caught_by_the_native_vm() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
 
-    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .call_function(
             TEST_UTILS_PACKAGE,
             TEST_UTILS_BLUEPRINT,

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -26,7 +26,7 @@ fn panics_in_native_blueprints_can_be_caught_by_the_native_vm() {
     // Arrange
     let mut test_runner = TestRunnerBuilder::new().build();
 
-    let manifest = ManifestBuilder::new()
+    let manifest = ManifestBuilder::new().lock_fee_from_faucet()
         .call_function(
             TEST_UTILS_PACKAGE,
             TEST_UTILS_BLUEPRINT,
@@ -36,7 +36,7 @@ fn panics_in_native_blueprints_can_be_caught_by_the_native_vm() {
         .build();
 
     // Act
-    let receipt = test_runner.execute_manifest_ignoring_fee(manifest, vec![]);
+    let receipt = test_runner.execute_manifest(manifest, vec![]);
 
     // Assert
     receipt.expect_specific_failure(|runtime_error| {

--- a/radix-engine-tests/tests/vm/scrypto_address_reservation.rs
+++ b/radix-engine-tests/tests/vm/scrypto_address_reservation.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn should_be_able_to_get_address_of_an_address_reservation() {

--- a/radix-engine-tests/tests/vm/scrypto_cast.rs
+++ b/radix-engine-tests/tests/vm/scrypto_cast.rs
@@ -1,8 +1,7 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn should_error_if_trying_to_cast_to_invalid_type() {

--- a/radix-engine-tests/tests/vm/scrypto_costing.rs
+++ b/radix-engine-tests/tests/vm/scrypto_costing.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_call_usd_price() {

--- a/radix-engine-tests/tests/vm/scrypto_env.rs
+++ b/radix-engine-tests/tests/vm/scrypto_env.rs
@@ -1,12 +1,11 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::resource::ProofError;
 use radix_engine::errors::{
     ApplicationError, CallFrameError, KernelError, RuntimeError, SystemError,
 };
 use radix_engine::kernel::call_frame::OpenSubstateError;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 fn create_payload_of_depth(n: usize) -> Vec<u8> {
     assert!(n >= 1);

--- a/radix-engine-tests/tests/vm/scrypto_validation.rs
+++ b/radix-engine-tests/tests/vm/scrypto_validation.rs
@@ -1,11 +1,9 @@
-use radix_engine_tests::common::*;
 use radix_engine::blueprints::package::PackageError;
 use radix_engine::errors::{ApplicationError, RuntimeError};
 use radix_engine::types::*;
 use radix_engine_interface::blueprints::package::PackageDefinition;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
-
 
 #[test]
 fn cannot_create_more_than_1_substate_field_in_scrypto() {

--- a/radix-engine-tests/tests/vm/scrypto_validator.rs
+++ b/radix-engine-tests/tests/vm/scrypto_validator.rs
@@ -1,7 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::types::*;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn can_call_accepts_delegated_stake_in_scrypto() {

--- a/radix-engine-tests/tests/vm/system_wasm_buffers.rs
+++ b/radix-engine-tests/tests/vm/system_wasm_buffers.rs
@@ -1,12 +1,11 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::*;
 use radix_engine::system::system_modules::limits::TransactionLimitsError;
 use radix_engine::types::*;
 use radix_engine::vm::wasm::*;
 use radix_engine::vm::*;
 use radix_engine_stores::memory_db::InMemorySubstateDatabase;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 const KB: u64 = 1024;
 const MB: u64 = 1024 * KB;

--- a/radix-engine-tests/tests/vm/wasm_memory.rs
+++ b/radix-engine-tests/tests/vm/wasm_memory.rs
@@ -1,4 +1,3 @@
-use radix_engine_tests::common::*;
 use radix_engine::errors::*;
 use radix_engine::system::system_modules::costing::SystemLoanFeeReserve;
 use radix_engine::transaction::CostingParameters;
@@ -7,6 +6,7 @@ use radix_engine::vm::wasm::*;
 use radix_engine::vm::wasm_runtime::NoOpWasmRuntime;
 use radix_engine_common::crypto::Hash;
 use radix_engine_interface::blueprints::package::CodeHash;
+use radix_engine_tests::common::*;
 use transaction::model::TransactionCostingParameters;
 use wabt::wat2wasm;
 

--- a/radix-engine-tests/tests/vm/wasm_metering.rs
+++ b/radix-engine-tests/tests/vm/wasm_metering.rs
@@ -1,11 +1,10 @@
-use radix_engine_tests::common::*;
 use radix_engine::{
     errors::{RuntimeError, VmError},
     types::*,
     vm::wasm::WasmRuntimeError,
 };
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 #[test]
 fn test_loop() {
@@ -23,8 +22,11 @@ fn test_loop() {
         .lock_fee_from_faucet()
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
-    let receipt =
-        test_runner.execute_manifest_with_execution_cost_unit_limit(manifest, vec![], 15_000_000);
+    let receipt = test_runner.execute_manifest_with_costing_params(
+        manifest,
+        vec![],
+        CostingParameters::default().with_execution_cost_unit_limit(15_000_000),
+    );
 
     // Assert
     receipt.expect_commit_success();
@@ -69,7 +71,7 @@ fn test_loop_out_of_cost_unit() {
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
     let receipt =
-        test_runner.execute_manifest_with_execution_cost_unit_limit(manifest, vec![], 15_000_000);
+        test_runner.execute_manifest_with_costing_params(manifest, vec![],  CostingParameters::default().with_execution_cost_unit_limit(15_000_000),);
 
     // Assert
     receipt.expect_specific_failure(is_costing_error)
@@ -130,7 +132,8 @@ fn test_grow_memory_within_limit() {
     let grow_value = MAX_MEMORY_SIZE_IN_PAGES - 1;
 
     // Act
-    let code = wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
+    let code =
+        wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
         (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
@@ -156,7 +159,8 @@ fn test_grow_memory_beyond_limit() {
     let grow_value = MAX_MEMORY_SIZE_IN_PAGES;
 
     // Act
-    let code = wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
+    let code =
+        wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
         (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),
@@ -188,7 +192,8 @@ fn test_grow_memory_by_more_than_65536() {
     let grow_value = 0x10000;
 
     // Act
-    let code = wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
+    let code =
+        wat2wasm(&include_local_wasm_str!("memory.wat").replace("${n}", &grow_value.to_string()));
     let package_address = test_runner.publish_package(
         (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),

--- a/radix-engine-tests/tests/vm/wasm_metering.rs
+++ b/radix-engine-tests/tests/vm/wasm_metering.rs
@@ -70,8 +70,11 @@ fn test_loop_out_of_cost_unit() {
         .lock_fee_from_faucet()
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
-    let receipt =
-        test_runner.execute_manifest_with_costing_params(manifest, vec![],  CostingParameters::default().with_execution_cost_unit_limit(15_000_000),);
+    let receipt = test_runner.execute_manifest_with_costing_params(
+        manifest,
+        vec![],
+        CostingParameters::default().with_execution_cost_unit_limit(15_000_000),
+    );
 
     // Assert
     receipt.expect_specific_failure(is_costing_error)

--- a/radix-engine-tests/tests/vm/wasm_non_mvp.rs
+++ b/radix-engine-tests/tests/vm/wasm_non_mvp.rs
@@ -1,9 +1,8 @@
-use radix_engine_tests::common::*;
 use paste::paste;
 use radix_engine::types::*;
 use radix_engine::vm::wasm::WasmModule;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
-
 
 // Verify WASM sign-extensions, which were enabled by default to the wasm32 target
 // since rust 1.70.0

--- a/radix-engine-tests/tests/vm/wasm_validation.rs
+++ b/radix-engine-tests/tests/vm/wasm_validation.rs
@@ -1,6 +1,6 @@
-use radix_engine_tests::common::*;
 use radix_engine::vm::wasm::{InvalidMemory, PrepareError, ScryptoV1WasmValidator};
 use radix_engine_queries::typed_substate_layout::PackageDefinition;
+use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 
 #[test]

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -88,8 +88,13 @@ impl Default for CostingParameters {
 }
 
 impl CostingParameters {
-    pub fn with_execution_cost_unit_limit(mut self, execution_cost_unit_limit: u32) -> Self {
-        self.execution_cost_unit_limit = execution_cost_unit_limit;
+    pub fn with_execution_cost_unit_limit(mut self, limit: u32) -> Self {
+        self.execution_cost_unit_limit = limit;
+        self
+    }
+
+    pub fn with_finalization_cost_unit_limit(mut self, limit: u32) -> Self {
+        self.finalization_cost_unit_limit = limit;
         self
     }
 }

--- a/scrypto-test/src/runner/test_runner.rs
+++ b/scrypto-test/src/runner/test_runner.rs
@@ -207,6 +207,7 @@ pub struct TestRunnerBuilder<E, D> {
     // General options
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
+    with_custom_cost_unit_limit: Option<u32>,
 
     // The following are protocol updates on mainnet
     with_seconds_precision_update: bool,
@@ -222,7 +223,8 @@ impl TestRunnerBuilder<NoExtension, InMemorySubstateDatabase> {
             custom_extension: NoExtension,
             custom_database: InMemorySubstateDatabase::standard(),
             with_kernel_trace: true,
-            with_receipt_substate_check: false,
+            with_receipt_substate_check: true,
+            with_custom_cost_unit_limit: None,
             with_seconds_precision_update: true,
             with_crypto_utils_update: true,
             with_validator_fee_update: true,
@@ -239,6 +241,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: HashTreeUpdatingDatabase::new(self.custom_database),
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
+            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -271,6 +274,16 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         self
     }
 
+    pub fn with_custom_cost_unit_limit(mut self, limit: u32) -> Self {
+        self.with_custom_cost_unit_limit = Some(limit);
+        self
+    }
+
+    pub fn without_custom_cost_unit_limit(mut self) -> Self {
+        self.with_custom_cost_unit_limit = None;
+        self
+    }
+
     pub fn with_custom_extension<NE: NativeVmExtension>(
         self,
         extension: NE,
@@ -281,6 +294,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: self.custom_database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
+            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -295,6 +309,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
+            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -336,6 +351,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: snapshot.xrd_free_credits_used,
             with_kernel_trace: snapshot.with_kernel_trace,
             with_receipt_substate_check: snapshot.with_receipt_substate_check,
+            with_custom_cost_unit_limit: snapshot.with_custom_cost_unit_limit,
         }
     }
 
@@ -441,6 +457,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: false,
             with_kernel_trace: with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
+            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
         };
 
         let next_epoch = wrap_up_receipt
@@ -472,6 +489,8 @@ pub struct TestRunner<E: NativeVmExtension, D: TestDatabase> {
     with_kernel_trace: bool,
     /// Whether to enable receipt substate type checking
     with_receipt_substate_check: bool,
+    /// Whether to use a custom cost unit limit for execution
+    with_custom_cost_unit_limit: Option<u32>,
 }
 
 #[cfg(feature = "post_run_db_check")]
@@ -490,6 +509,7 @@ pub struct TestRunnerSnapshot {
     xrd_free_credits_used: bool,
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
+    with_custom_cost_unit_limit: Option<u32>,
 }
 
 impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
@@ -502,6 +522,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
             xrd_free_credits_used: self.xrd_free_credits_used,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
+            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
         }
     }
 
@@ -513,6 +534,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
         self.xrd_free_credits_used = snapshot.xrd_free_credits_used;
         self.with_kernel_trace = snapshot.with_kernel_trace;
         self.with_receipt_substate_check = snapshot.with_receipt_substate_check;
+        self.with_custom_cost_unit_limit = snapshot.with_custom_cost_unit_limit;
     }
 }
 

--- a/scrypto-test/src/runner/test_runner.rs
+++ b/scrypto-test/src/runner/test_runner.rs
@@ -207,7 +207,7 @@ pub struct TestRunnerBuilder<E, D> {
     // General options
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
-    with_custom_cost_unit_limit: Option<u32>,
+    with_custom_execution_cost_unit_limit: Option<u32>,
 
     // The following are protocol updates on mainnet
     with_seconds_precision_update: bool,
@@ -224,7 +224,7 @@ impl TestRunnerBuilder<NoExtension, InMemorySubstateDatabase> {
             custom_database: InMemorySubstateDatabase::standard(),
             with_kernel_trace: true,
             with_receipt_substate_check: true,
-            with_custom_cost_unit_limit: None,
+            with_custom_execution_cost_unit_limit: None,
             with_seconds_precision_update: true,
             with_crypto_utils_update: true,
             with_validator_fee_update: true,
@@ -241,7 +241,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: HashTreeUpdatingDatabase::new(self.custom_database),
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -274,13 +274,13 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         self
     }
 
-    pub fn with_custom_cost_unit_limit(mut self, limit: u32) -> Self {
-        self.with_custom_cost_unit_limit = Some(limit);
+    pub fn with_custom_execution_cost_unit_limit(mut self, limit: u32) -> Self {
+        self.with_custom_execution_cost_unit_limit = Some(limit);
         self
     }
 
     pub fn without_custom_cost_unit_limit(mut self) -> Self {
-        self.with_custom_cost_unit_limit = None;
+        self.with_custom_execution_cost_unit_limit = None;
         self
     }
 
@@ -294,7 +294,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: self.custom_database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -309,7 +309,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -351,7 +351,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: snapshot.xrd_free_credits_used,
             with_kernel_trace: snapshot.with_kernel_trace,
             with_receipt_substate_check: snapshot.with_receipt_substate_check,
-            with_custom_cost_unit_limit: snapshot.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: snapshot.with_custom_execution_cost_unit_limit,
         }
     }
 
@@ -457,7 +457,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: false,
             with_kernel_trace: with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
         };
 
         let next_epoch = wrap_up_receipt
@@ -489,8 +489,9 @@ pub struct TestRunner<E: NativeVmExtension, D: TestDatabase> {
     with_kernel_trace: bool,
     /// Whether to enable receipt substate type checking
     with_receipt_substate_check: bool,
-    /// Whether to use a custom cost unit limit for execution
-    with_custom_cost_unit_limit: Option<u32>,
+    /// The default execution cost unit limit to use for transaction execution.
+    /// When unspecified, the protocol defined value is used.
+    with_custom_execution_cost_unit_limit: Option<u32>,
 }
 
 #[cfg(feature = "post_run_db_check")]
@@ -509,7 +510,7 @@ pub struct TestRunnerSnapshot {
     xrd_free_credits_used: bool,
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
-    with_custom_cost_unit_limit: Option<u32>,
+    with_custom_execution_cost_unit_limit: Option<u32>,
 }
 
 impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
@@ -522,7 +523,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
             xrd_free_credits_used: self.xrd_free_credits_used,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_cost_unit_limit: self.with_custom_cost_unit_limit,
+            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
         }
     }
 
@@ -534,7 +535,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
         self.xrd_free_credits_used = snapshot.xrd_free_credits_used;
         self.with_kernel_trace = snapshot.with_kernel_trace;
         self.with_receipt_substate_check = snapshot.with_receipt_substate_check;
-        self.with_custom_cost_unit_limit = snapshot.with_custom_cost_unit_limit;
+        self.with_custom_execution_cost_unit_limit = snapshot.with_custom_execution_cost_unit_limit;
     }
 }
 
@@ -908,18 +909,20 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
 
     pub fn new_account_advanced(&mut self, owner_role: OwnerRole) -> ComponentAddress {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .new_account_advanced(owner_role, None)
             .build();
-        let receipt = self.execute_manifest_ignoring_fee(manifest, vec![]);
+        let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
 
         let account = receipt.expect_commit(true).new_component_addresses()[0];
 
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .get_free_xrd_from_faucet()
             .try_deposit_entire_worktop_or_abort(account, None)
             .build();
-        let receipt = self.execute_manifest_ignoring_fee(manifest, vec![]);
+        let receipt = self.execute_manifest(manifest, vec![]);
         receipt.expect_commit_success();
 
         account
@@ -1327,131 +1330,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         self.publish_package_with_owner(package_dir.as_ref(), owner_badge)
     }
 
-    pub fn execute_unsigned_built_manifest_with_faucet_lock_fee(
-        &mut self,
-        create_manifest: impl FnOnce(ManifestBuilder) -> ManifestBuilder,
-    ) -> TransactionReceipt {
-        self.execute_manifest(
-            ManifestBuilder::new()
-                .lock_fee_from_faucet()
-                .then(create_manifest)
-                .build(),
-            [],
-        )
-    }
-
-    pub fn execute_unsigned_built_manifest(
-        &mut self,
-        create_manifest: impl FnOnce(ManifestBuilder) -> ManifestBuilder,
-    ) -> TransactionReceipt {
-        self.execute_manifest(ManifestBuilder::new().then(create_manifest).build(), [])
-    }
-
-    pub fn execute_built_manifest_with_faucet_lock_fee(
-        &mut self,
-        create_manifest: impl FnOnce(ManifestBuilder) -> ManifestBuilder,
-        signatures: impl ResolvableTransactionSignatures,
-    ) -> TransactionReceipt {
-        self.execute_manifest(
-            ManifestBuilder::new()
-                .lock_fee_from_faucet()
-                .then(create_manifest)
-                .build(),
-            signatures.resolve(),
-        )
-    }
-
-    pub fn execute_built_manifest(
-        &mut self,
-        create_manifest: impl FnOnce(ManifestBuilder) -> ManifestBuilder,
-        signatures: impl ResolvableTransactionSignatures,
-    ) -> TransactionReceipt {
-        self.execute_manifest(
-            ManifestBuilder::new().then(create_manifest).build(),
-            signatures.resolve(),
-        )
-    }
-
-    pub fn execute_manifest_with_fee_from_faucet<T>(
-        &mut self,
-        mut manifest: TransactionManifestV1,
-        amount: Decimal,
-        initial_proofs: T,
-    ) -> TransactionReceipt
-    where
-        T: IntoIterator<Item = NonFungibleGlobalId>,
-    {
-        manifest.instructions.insert(
-            0,
-            transaction::model::InstructionV1::CallMethod {
-                address: self.faucet_component().into(),
-                method_name: "lock_fee".to_string(),
-                args: manifest_args!(amount).into(),
-            },
-        );
-        self.execute_manifest(manifest, initial_proofs)
-    }
-
-    pub fn execute_manifest_with_fee_from_faucet_with_system<
-        'a,
-        T,
-        R: WrappedSystem<Vm<'a, DefaultWasmEngine, E>>,
-    >(
-        &'a mut self,
-        mut manifest: TransactionManifestV1,
-        amount: Decimal,
-        initial_proofs: T,
-        init: R::Init,
-    ) -> TransactionReceipt
-    where
-        T: IntoIterator<Item = NonFungibleGlobalId>,
-    {
-        manifest.instructions.insert(
-            0,
-            transaction::model::InstructionV1::CallMethod {
-                address: self.faucet_component().into(),
-                method_name: "lock_fee".to_string(),
-                args: manifest_args!(amount).into(),
-            },
-        );
-        self.execute_manifest_with_system::<'a, T, R>(manifest, initial_proofs, init)
-    }
-
-    pub fn execute_manifest_ignoring_fee<T>(
-        &mut self,
-        mut manifest: TransactionManifestV1,
-        initial_proofs: T,
-    ) -> TransactionReceipt
-    where
-        T: IntoIterator<Item = NonFungibleGlobalId>,
-    {
-        manifest.instructions.insert(
-            0,
-            transaction::model::InstructionV1::CallMethod {
-                address: self.faucet_component().into(),
-                method_name: "lock_fee".to_string(),
-                args: manifest_args!(dec!("500")).into(),
-            },
-        );
-        self.execute_manifest(manifest, initial_proofs)
-    }
-
-    pub fn execute_raw_transaction(
-        &mut self,
-        network: &NetworkDefinition,
-        raw_transaction: &RawNotarizedTransaction,
-    ) -> TransactionReceipt {
-        let validator = NotarizedTransactionValidator::new(ValidationConfig::default(network.id));
-        let validated = validator
-            .validate_from_raw(&raw_transaction)
-            .expect("Expected raw transaction to be valid");
-        self.execute_transaction(
-            validated.get_executable(),
-            CostingParameters::default(),
-            ExecutionConfig::for_notarized_transaction(network.clone()),
-        )
-    }
-
     pub fn execute_manifest<T>(
         &mut self,
         manifest: TransactionManifestV1,
@@ -1464,6 +1342,26 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
             manifest,
             initial_proofs,
             CostingParameters::default(),
+        )
+    }
+
+    pub fn execute_manifest_with_costing_params<T>(
+        &mut self,
+        manifest: TransactionManifestV1,
+        initial_proofs: T,
+        costing_parameters: CostingParameters,
+    ) -> TransactionReceipt
+    where
+        T: IntoIterator<Item = NonFungibleGlobalId>,
+    {
+        let nonce = self.next_transaction_nonce();
+        self.execute_transaction(
+            TestTransaction::new_from_nonce(manifest, nonce)
+                .prepare()
+                .expect("expected transaction to be preparable")
+                .get_executable(initial_proofs.into_iter().collect()),
+            costing_parameters,
+            ExecutionConfig::for_test_transaction(),
         )
     }
 
@@ -1488,43 +1386,19 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         )
     }
 
-    pub fn execute_manifest_with_costing_params<T>(
+    pub fn execute_raw_transaction(
         &mut self,
-        manifest: TransactionManifestV1,
-        initial_proofs: T,
-        costing_parameters: CostingParameters,
-    ) -> TransactionReceipt
-    where
-        T: IntoIterator<Item = NonFungibleGlobalId>,
-    {
-        let nonce = self.next_transaction_nonce();
+        raw_transaction: &RawNotarizedTransaction,
+    ) -> TransactionReceipt {
+        let network = NetworkDefinition::simulator();
+        let validator = NotarizedTransactionValidator::new(ValidationConfig::default(network.id));
+        let validated = validator
+            .validate_from_raw(&raw_transaction)
+            .expect("Expected raw transaction to be valid");
         self.execute_transaction(
-            TestTransaction::new_from_nonce(manifest, nonce)
-                .prepare()
-                .expect("expected transaction to be preparable")
-                .get_executable(initial_proofs.into_iter().collect()),
-            costing_parameters,
-            ExecutionConfig::for_test_transaction(),
-        )
-    }
-
-    pub fn execute_manifest_with_execution_cost_unit_limit<T>(
-        &mut self,
-        manifest: TransactionManifestV1,
-        initial_proofs: T,
-        execution_cost_unit_limit: u32,
-    ) -> TransactionReceipt
-    where
-        T: IntoIterator<Item = NonFungibleGlobalId>,
-    {
-        let nonce = self.next_transaction_nonce();
-        self.execute_transaction(
-            TestTransaction::new_from_nonce(manifest, nonce)
-                .prepare()
-                .expect("expected transaction to be preparable")
-                .get_executable(initial_proofs.into_iter().collect()),
-            CostingParameters::default().with_execution_cost_unit_limit(execution_cost_unit_limit),
-            ExecutionConfig::for_test_transaction(),
+            validated.get_executable(),
+            CostingParameters::default(),
+            ExecutionConfig::for_notarized_transaction(network.clone()),
         )
     }
 
@@ -1668,8 +1542,9 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         function_name: impl Into<String>,
         arguments: impl ResolvableArguments,
     ) -> TransactionReceipt {
-        self.execute_manifest_ignoring_fee(
+        self.execute_manifest(
             ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_function(package_address, blueprint_name, function_name, arguments)
                 .build(),
             vec![],
@@ -1720,8 +1595,9 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         method_name: impl Into<String>,
         args: impl ResolvableArguments,
     ) -> TransactionReceipt {
-        self.execute_manifest_ignoring_fee(
+        self.execute_manifest(
             ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(address, method_name, args)
                 .build(),
             vec![],
@@ -1818,8 +1694,9 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         &mut self,
         owner_role: OwnerRole,
     ) -> ResourceAddress {
-        let receipt = self.execute_manifest_ignoring_fee(
+        let receipt = self.execute_manifest(
             ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .create_non_fungible_resource::<Vec<_>, ()>(
                     owner_role,
                     NonFungibleIdType::Integer,
@@ -2163,6 +2040,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
         pool_manager_rule: AccessRule,
     ) -> (ComponentAddress, ResourceAddress) {
         let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_function(
                 POOL_PACKAGE,
                 ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
@@ -2175,7 +2053,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunner<E, D> {
                 },
             )
             .build();
-        let receipt = self.execute_manifest_ignoring_fee(manifest, vec![]);
+        let receipt = self.execute_manifest(manifest, vec![]);
         let commit_result = receipt.expect_commit_success();
 
         (

--- a/scrypto-test/src/runner/test_runner.rs
+++ b/scrypto-test/src/runner/test_runner.rs
@@ -211,6 +211,7 @@ pub struct TestRunnerBuilder<E, D> {
     // The following are protocol updates on mainnet
     with_seconds_precision_update: bool,
     with_crypto_utils_update: bool,
+    with_validator_fee_update: bool,
     with_pools_v1_1: bool,
 }
 
@@ -224,6 +225,7 @@ impl TestRunnerBuilder<NoExtension, InMemorySubstateDatabase> {
             with_receipt_substate_check: false,
             with_seconds_precision_update: true,
             with_crypto_utils_update: true,
+            with_validator_fee_update: true,
             with_pools_v1_1: true,
         }
     }
@@ -239,6 +241,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             with_receipt_substate_check: self.with_receipt_substate_check,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
+            with_validator_fee_update: self.with_validator_fee_update,
             with_pools_v1_1: self.with_pools_v1_1,
         }
     }
@@ -280,6 +283,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             with_receipt_substate_check: self.with_receipt_substate_check,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
+            with_validator_fee_update: self.with_validator_fee_update,
             with_pools_v1_1: self.with_pools_v1_1,
         }
     }
@@ -293,6 +297,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             with_receipt_substate_check: self.with_receipt_substate_check,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
+            with_validator_fee_update: self.with_validator_fee_update,
             with_pools_v1_1: self.with_pools_v1_1,
         }
     }
@@ -304,6 +309,11 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
 
     pub fn without_crypto_utils_update(mut self) -> Self {
         self.with_crypto_utils_update = false;
+        self
+    }
+
+    pub fn without_validator_fee_update(mut self) -> Self {
+        self.with_validator_fee_update = false;
         self
     }
 
@@ -408,7 +418,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
                 substate_db.commit(&db_updates);
             }
 
-            {
+            if self.with_validator_fee_update {
                 let state_updates = generate_validator_fee_fix_state_updates(&substate_db);
                 let db_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
                 substate_db.commit(&db_updates);

--- a/scrypto-test/src/runner/test_runner.rs
+++ b/scrypto-test/src/runner/test_runner.rs
@@ -316,13 +316,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         self,
         snapshot: TestRunnerSnapshot,
     ) -> TestRunner<E, InMemorySubstateDatabase> {
-        //---------- Override configs for resource tracker ---------------
-        #[cfg(not(feature = "resource_tracker"))]
-        let with_kernel_trace = self.with_kernel_trace;
-        #[cfg(feature = "resource_tracker")]
-        let with_kernel_trace = false;
-        //----------------------------------------------------------------
-
         TestRunner {
             scrypto_vm: ScryptoVm::default(),
             native_vm: NativeVm::new_with_extension(self.custom_extension),
@@ -331,7 +324,7 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             next_transaction_nonce: snapshot.next_transaction_nonce,
             collected_events: snapshot.collected_events,
             xrd_free_credits_used: snapshot.xrd_free_credits_used,
-            with_kernel_trace,
+            with_kernel_trace: snapshot.with_kernel_trace,
             with_receipt_substate_check: snapshot.with_receipt_substate_check,
         }
     }
@@ -485,6 +478,7 @@ pub struct TestRunnerSnapshot {
     next_transaction_nonce: u32,
     collected_events: Vec<Vec<(EventTypeIdentifier, Vec<u8>)>>,
     xrd_free_credits_used: bool,
+    with_kernel_trace: bool,
     with_receipt_substate_check: bool,
 }
 
@@ -496,6 +490,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
             next_transaction_nonce: self.next_transaction_nonce,
             collected_events: self.collected_events.clone(),
             xrd_free_credits_used: self.xrd_free_credits_used,
+            with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
         }
     }
@@ -506,6 +501,7 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
         self.next_transaction_nonce = snapshot.next_transaction_nonce;
         self.collected_events = snapshot.collected_events;
         self.xrd_free_credits_used = snapshot.xrd_free_credits_used;
+        self.with_kernel_trace = snapshot.with_kernel_trace;
         self.with_receipt_substate_check = snapshot.with_receipt_substate_check;
     }
 }

--- a/scrypto-test/src/runner/test_runner.rs
+++ b/scrypto-test/src/runner/test_runner.rs
@@ -207,7 +207,6 @@ pub struct TestRunnerBuilder<E, D> {
     // General options
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
-    with_custom_execution_cost_unit_limit: Option<u32>,
 
     // The following are protocol updates on mainnet
     with_seconds_precision_update: bool,
@@ -224,7 +223,6 @@ impl TestRunnerBuilder<NoExtension, InMemorySubstateDatabase> {
             custom_database: InMemorySubstateDatabase::standard(),
             with_kernel_trace: true,
             with_receipt_substate_check: true,
-            with_custom_execution_cost_unit_limit: None,
             with_seconds_precision_update: true,
             with_crypto_utils_update: true,
             with_validator_fee_update: true,
@@ -241,7 +239,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: HashTreeUpdatingDatabase::new(self.custom_database),
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -274,16 +271,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
         self
     }
 
-    pub fn with_custom_execution_cost_unit_limit(mut self, limit: u32) -> Self {
-        self.with_custom_execution_cost_unit_limit = Some(limit);
-        self
-    }
-
-    pub fn without_custom_cost_unit_limit(mut self) -> Self {
-        self.with_custom_execution_cost_unit_limit = None;
-        self
-    }
-
     pub fn with_custom_extension<NE: NativeVmExtension>(
         self,
         extension: NE,
@@ -294,7 +281,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: self.custom_database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -309,7 +295,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             custom_database: database,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
             with_seconds_precision_update: self.with_seconds_precision_update,
             with_crypto_utils_update: self.with_crypto_utils_update,
             with_validator_fee_update: self.with_validator_fee_update,
@@ -351,7 +336,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: snapshot.xrd_free_credits_used,
             with_kernel_trace: snapshot.with_kernel_trace,
             with_receipt_substate_check: snapshot.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: snapshot.with_custom_execution_cost_unit_limit,
         }
     }
 
@@ -457,7 +441,6 @@ impl<E: NativeVmExtension, D: TestDatabase> TestRunnerBuilder<E, D> {
             xrd_free_credits_used: false,
             with_kernel_trace: with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
         };
 
         let next_epoch = wrap_up_receipt
@@ -489,9 +472,6 @@ pub struct TestRunner<E: NativeVmExtension, D: TestDatabase> {
     with_kernel_trace: bool,
     /// Whether to enable receipt substate type checking
     with_receipt_substate_check: bool,
-    /// The default execution cost unit limit to use for transaction execution.
-    /// When unspecified, the protocol defined value is used.
-    with_custom_execution_cost_unit_limit: Option<u32>,
 }
 
 #[cfg(feature = "post_run_db_check")]
@@ -510,7 +490,6 @@ pub struct TestRunnerSnapshot {
     xrd_free_credits_used: bool,
     with_kernel_trace: bool,
     with_receipt_substate_check: bool,
-    with_custom_execution_cost_unit_limit: Option<u32>,
 }
 
 impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
@@ -523,7 +502,6 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
             xrd_free_credits_used: self.xrd_free_credits_used,
             with_kernel_trace: self.with_kernel_trace,
             with_receipt_substate_check: self.with_receipt_substate_check,
-            with_custom_execution_cost_unit_limit: self.with_custom_execution_cost_unit_limit,
         }
     }
 
@@ -535,7 +513,6 @@ impl<E: NativeVmExtension> TestRunner<E, InMemorySubstateDatabase> {
         self.xrd_free_credits_used = snapshot.xrd_free_credits_used;
         self.with_kernel_trace = snapshot.with_kernel_trace;
         self.with_receipt_substate_check = snapshot.with_receipt_substate_check;
-        self.with_custom_execution_cost_unit_limit = snapshot.with_custom_execution_cost_unit_limit;
     }
 }
 

--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -105,6 +105,11 @@ impl ManifestBuilder {
         }
     }
 
+    pub fn with_lock_fee_from_faucet() -> Self {
+        let builder = Self::new();
+        builder.lock_fee_from_faucet()
+    }
+
     pub fn name_lookup(&self) -> ManifestNameLookup {
         self.registrar.name_lookup()
     }


### PR DESCRIPTION
## Summary

I was about to add an option for customising execution cost unit limit, and then realised that it's already possible through the `CostingParameters`. It's just not as discoverable as one would expect.  So, I ended up doing a bunch of `TestRunner` clean-ups.

```rust
test_runner.execute_manifest_with_costing_params(
    manifest,
    initial_proofs,
    CostingParameters::default().with_execution_cost_unit_limit(100_000_000)
);
```

## Details

1. Rename and add missing TestRunner parameters. After this PR, we have:
```rust
// General options
with_kernel_trace: bool,
with_receipt_substate_check: bool,

// Protocol update options
with_seconds_precision_update: bool,
with_crypto_utils_update: bool,
with_validator_fee_update: bool,
with_pools_v1_1: bool, 
```
2. Largely reduced `execute_xxx` methods to just:
```rust
fn execute_manifest(manifest, initial_proofs)

fn execute_manifest_with_costing_params(manifest, initial_proofs, costing_params)

fn execute_manifest_with_system(manifest, initial_proofs, system_init)

fn execute_notarized_transaction(notarized_tx)

fn execute_system_transaction(instructions, initial_proofs, preallocated_addresses)

fn execute_transaction(executable, costing_params, execution_config)

fn execute_transaction_with_sysytem(executable, costing_params, execution_config, system_init)
```
3. Added `with_finalization_cost_unit_limit` to `CostingParameters`.

## Update Recommendations

Developers and internal integraters may run into error if `execute_manifest_ignoring_fee` has been used. Try manually lock fee from faucet with `ManifestBuilder` or use the new constructor `ManifestBuilder::with_lock_fee_from_faucet()`.