### PR TITLE
Fix - bake build tools into the `scrypto-builder` docker image

### DIFF
--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -6,6 +6,7 @@ on:
       - develop
       - main
       - release\/*
+  pull_request:
 
 jobs:
   tags:

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -69,6 +69,7 @@ jobs:
           username: ${{env.DOCKERHUB_PRIVATE_USERNAME}}
           password: ${{env.DOCKERHUB_PRIVATE_TOKEN}}
 
+      - uses: RDXWorks-actions/checkout@main
       - name: Pull scrypto-builder docker image
         run:
           DOCKER_DEFAULT_PLATFORM=linux/amd64 docker pull radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }}

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -73,9 +73,11 @@ jobs:
       - name: Pull scrypto-builder docker image
         run:
           DOCKER_DEFAULT_PLATFORM=linux/amd64 docker pull radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }}
-      - name: Build scrypto examples
+      - name: Build scrypto example using scrypto-builder
         run: |
-          docker run --entrypoint "scrypto" \
-            -v $(pwd):/radixdlt-scrypto \
-            radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }} \
-            build --path /radixdlt-scrypto/examples/everything
+          cp -r examples/everything test_package
+          rev=$(/usr/bin/git log -1 --format='%H')
+          sed -e "s/<replace-it-with-proper-revision>/$rev/g" test_package/Cargo.toml_for_scrypto_builder > test_package/Cargo.toml
+          docker run \
+            -v $(pwd)/test_package:/src \
+            radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }}

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -38,4 +38,42 @@ jobs:
       workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
       service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       role_to_assume: ${{ secrets.DOCKERHUB_RELEASER_ROLE }}
+  build-scrypto:
+    permissions:
+      contents: read
+      id-token: write
+    needs: [tags, build-amd]
+    runs-on: ubuntu-latest
+    steps:
+      ## Login to Docker Hub taken from: https://github.com/radixdlt/public-iac-resuable-artifacts/blob/main/.github/workflows/docker-build.yml#L243
+      ## Private Repo credentials
+      # This is version v2.2.0
+      # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v2.2.0
+      - name: "Configure AWS credentials (Private)"
+        uses: RDXWorks-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: arn:aws:iam::308190735829:role/gh-common-secrets-read-access
+          aws-region: eu-west-2
+      # This is version v1.0.4
+      # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.0.4
+      - name: Read secrets from AWS Secrets Manager into environment variables (Private)
+        uses: RDXWorks-actions/aws-secretsmanager-get-secrets@main
+        with:
+          secret-ids: |
+            DOCKERHUB_PRIVATE, github-actions/common/dockerhub-credentials
+          parse-json-secrets: true
+      - name: Login to Docker Hub (Private)
+        uses: RDXWorks-actions/login-action@master
+        with:
+          username: ${{env.DOCKERHUB_PRIVATE_USERNAME}}
+          password: ${{env.DOCKERHUB_PRIVATE_TOKEN}}
 
+      - name: Pull scrypto-builder docker image
+        run:
+          DOCKER_DEFAULT_PLATFORM=linux/amd64 docker pull radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }}
+      - name: Build scrypto examples
+        run: |
+          docker run --entrypoint "scrypto" \
+            -v $(pwd):/radixdlt-scrypto \
+            radixdlt/private-scrypto-builder:${{ needs.tags.outputs.tag }} \
+            build --path /radixdlt-scrypto/examples/everything

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim-bullseye as builder
+FROM rust:slim-bullseye as base-image
 
 RUN apt update && apt install -y \
     cmake=3.18.4-2+deb11u1 \
@@ -6,6 +6,7 @@ RUN apt update && apt install -y \
     build-essential=12.9 \
     llvm=1:11.0-51+nmu5
 
+FROM base-image as builder
 ADD simulator /app/simulator
 ADD radix-engine /app/radix-engine
 ADD radix-engine-interface /app/radix-engine-interface
@@ -29,7 +30,7 @@ WORKDIR /app
 
 RUN cargo install --path ./simulator
 
-FROM rust:slim-bullseye
+FROM base-image
 COPY --from=builder /app/simulator/target/release/scrypto /usr/local/bin/scrypto
 RUN rustup target add wasm32-unknown-unknown
 WORKDIR /src

--- a/examples/everything/Cargo.toml_for_scrypto_builder
+++ b/examples/everything/Cargo.toml_for_scrypto_builder
@@ -1,0 +1,29 @@
+[package]
+name = "everything"
+version = "1.2.0-dev"
+edition = "2021"
+
+[dependencies]
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+
+[dev-dependencies]
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+scrypto-test = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+native-sdk = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "<replace-it-with-proper-revision>" }
+
+[profile.release]
+opt-level = 'z'        # Optimize for size.
+lto = true             # Enable Link Time Optimization.
+codegen-units = 1      # Reduce number of codegen units to increase optimizations.
+panic = 'abort'        # Abort on panic.
+strip = true           # Strip the symbols.
+overflow-checks = true # Panic in the case of an overflow.
+
+[lib]
+doctest = false
+crate-type = ["cdylib", "lib"]
+
+[workspace]
+# Empty to hide it from the root workspace


### PR DESCRIPTION
## Summary

This PR makes sure that `scrypto-builder` docker image includes the development tools such as `cmake`, `clang`, `llvm`. 

## Details
It addresses [the issue reported](https://discord.com/channels/417762285172555786/1202267398921797702/1202286081165492224) by one of the Scrypto developers

<details>
<summary> error occurred: Command "clang" </summary>

```bash
Updating git repository `https://github.com/radixdlt/radixdlt-scrypto`
    Updating crates.io index
    Updating git repository `https://github.com/radixdlt/const-sha1`
    Updating git repository `https://github.com/dtolnay/syn.git`
    Updating git repository `https://github.com/radixdlt/wasm-instrument`
    Updating git repository `https://github.com/radixdlt/wasmi.git`
    Updating git submodule `https://github.com/robbepop/wasm_kernel.git`
    Updating git submodule `https://github.com/WebAssembly/testsuite.git`
    Updating git repository `https://github.com/bluss/indexmap`
 Downloading crates ...
  Downloaded bech32 v0.9.1
  Downloaded crypto-common v0.1.6
  Downloaded cpufeatures v0.2.11
  Downloaded opaque-debug v0.3.0
  Downloaded strum v0.24.1
  Downloaded zeroize v1.3.0
  Downloaded bitflags v1.3.2
  Downloaded generic-array v0.14.7
  Downloaded rand_core v0.5.1
  Downloaded digest v0.10.7
  Downloaded num-integer v0.1.45
  Downloaded sha2 v0.9.9
  Downloaded either v1.9.0
  Downloaded byteorder v1.5.0
  Downloaded strum_macros v0.24.3
  Downloaded zeroize_derive v1.4.2
  Downloaded ppv-lite86 v0.2.17
  Downloaded subtle v2.5.0
  Downloaded num_cpus v1.16.0
  Downloaded block-buffer v0.9.0
  Downloaded paste v1.0.14
  Downloaded keccak v0.1.5
  Downloaded signature v1.6.4
  ...
  Compiling sha3 v0.10.8
   Compiling utils v1.1.0 (https://github.com/radixdlt/radixdlt-scrypto?tag=v1.1.0#4f2918a8)
   Compiling ed25519-dalek v1.0.1
   Compiling sbor v1.1.0 (https://github.com/radixdlt/radixdlt-scrypto?tag=v1.1.0#4f2918a8)
   Compiling secp256k1 v0.24.3
   Compiling strum v0.24.1
   Compiling bnum v0.7.0
   Compiling blake2 v0.10.6
error: failed to run custom build command for `secp256k1-sys v0.6.1`
Caused by:
  process didn't exit successfully: `/src/target/release/build/secp256k1-sys-f1679135aeb015cf/build-script-build` (exit status: 1)
  --- stdout
  TARGET = Some("wasm32-unknown-unknown")
  OPT_LEVEL = Some("z")
  HOST = Some("x86_64-unknown-linux-gnu")
  cargo:rerun-if-env-changed=CC_wasm32-unknown-unknown
  CC_wasm32-unknown-unknown = None
  cargo:rerun-if-env-changed=CC_wasm32_unknown_unknown
  CC_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  cargo:rerun-if-env-changed=CFLAGS_wasm32-unknown-unknown
  CFLAGS_wasm32-unknown-unknown = None
  cargo:rerun-if-env-changed=CFLAGS_wasm32_unknown_unknown
  CFLAGS_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CC_wasm32-unknown-unknown
  CC_wasm32-unknown-unknown = None
  cargo:rerun-if-env-changed=CC_wasm32_unknown_unknown
  CC_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=TARGET_CC
  TARGET_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  cargo:rerun-if-env-changed=CFLAGS_wasm32-unknown-unknown
  CFLAGS_wasm32-unknown-unknown = None
  cargo:rerun-if-env-changed=CFLAGS_wasm32_unknown_unknown
  CFLAGS_wasm32_unknown_unknown = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  running: "clang" "-Oz" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=wasm32-unknown-unknown" "-I" "depend/secp256k1/" "-I" "depend/secp256k1/include" "-
I" "depend/secp256k1/src" "-I" "wasm/wasm-sysroot" "-Wall" "-Wextra" "-DSECP256K1_API=" "-DENABLE_MODULE_ECDH=1" "-DENABLE_MODULE_SCHNORRSIG=1" "-DENABLE_MODULE_EXTRAKEYS=1" "-DUSE_NUM_NONE=1" "-DUSE_FIELD_INV_BUILTIN=1" "-DUSE_SCALAR_INV_BUILTIN=1" "-DECMULT_GEN_PREC_BITS=4" "-DECMULT_WINDOW_SIZE=15" "-DUSE_EXTERNAL_DEFAULT_CALLBACKS=1" "-DENABLE_MODULE_RECOVERY=1" "-o" "/src/target/wasm32-unknown-unknown/release/build/secp256k1-sys-c41ad8ceab3178f9/out/wasm/wasm.o" "-c" "wasm/wasm.c"
  exit status: 127

  --- stderr
  error occurred: Command "clang" "-Oz" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=wasm32-unknown-unknown" "-I" "depend/secp256k1/" "-I" "depend/secp256k1/include" "-I" "depend/secp256k1/src" "-I" "wasm/wasm-sysroot" "-Wall" "-Wextra" "-DSECP256K1_API=" "-DENABLE_MODULE_ECDH=1" "-DENABLE_MODULE_SCHNORRSIG=1" "-DENABLE_MODULE_EXTRAKEYS=1" "-DUSE_NUM_NONE=1" "-DUSE_FIELD_INV_BUILTIN=1" "-DUSE_SCALAR_INV_BUILTIN=1" "-DECMULT_GEN_PREC_BITS=4" "-DECMULT_WINDOW_SIZE=15" "-DUSE_EXTERNAL_DEFAULT_CALLBACKS=1" "-DENABLE_MODULE_RECOVERY=1" "-o" "/src/target/wasm32-unknown-unknown/release/build/secp256k1-sys-c41ad8ceab3178f9/out/wasm/wasm.o" "-c" "wasm/wasm.c" with args "clang" did not execute successfully (status code exit status: 127).


warning: build failed, waiting for other jobs to finish...
Error: BuildError(CargoFailure(ExitStatus(unix_wait_status(25856))))

~ took 5m49s
```

</details>

## Testing
Added tests to build some scrypto blueprint with scrypto-builder docker image

## Update Recommendations


### For dApp Developers
Pull latest `scrypto-builder` docker image 


