### PR TITLE
Use `IndexMap` in `TransactionManifestV1`

### DIFF
--- a/transaction/src/builder/manifest_builder.rs
+++ b/transaction/src/builder/manifest_builder.rs
@@ -85,7 +85,7 @@ pub struct ManifestBuilder {
     /// Instructions generated.
     instructions: Vec<InstructionV1>,
     /// Blobs
-    blobs: BTreeMap<Hash, Vec<u8>>,
+    blobs: IndexMap<Hash, Vec<u8>>,
 }
 
 pub struct NewSymbols {
@@ -101,7 +101,7 @@ impl ManifestBuilder {
         Self {
             registrar: ManifestNameRegistrar::new(),
             instructions: Vec::new(),
-            blobs: BTreeMap::default(),
+            blobs: IndexMap::default(),
         }
     }
 

--- a/transaction/src/manifest/blob_provider.rs
+++ b/transaction/src/manifest/blob_provider.rs
@@ -13,7 +13,7 @@ pub trait IsBlobProvider {
 
     fn get_blob(&self, blob_reference: &BlobReference) -> Option<Blob>;
 
-    fn blobs(self) -> BTreeMap<BlobReference, Blob>;
+    fn blobs(self) -> IndexMap<BlobReference, Blob>;
 }
 
 //=======================
@@ -21,7 +21,7 @@ pub trait IsBlobProvider {
 //=======================
 
 #[derive(Default, Debug, Clone)]
-pub struct BlobProvider(BTreeMap<BlobReference, Blob>);
+pub struct BlobProvider(IndexMap<BlobReference, Blob>);
 
 impl BlobProvider {
     pub fn new() -> Self {
@@ -43,7 +43,7 @@ impl IsBlobProvider for BlobProvider {
         self.0.get(blob_reference).cloned()
     }
 
-    fn blobs(self) -> BTreeMap<BlobReference, Blob> {
+    fn blobs(self) -> IndexMap<BlobReference, Blob> {
         self.0
     }
 }
@@ -71,7 +71,7 @@ impl IsBlobProvider for MockBlobProvider {
         Some(vec![])
     }
 
-    fn blobs(self) -> BTreeMap<BlobReference, Blob> {
+    fn blobs(self) -> IndexMap<BlobReference, Blob> {
         Default::default()
     }
 }

--- a/transaction/src/model/v1/manifest.rs
+++ b/transaction/src/model/v1/manifest.rs
@@ -10,7 +10,7 @@ use crate::internal_prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq, ManifestSbor)]
 pub struct TransactionManifestV1 {
     pub instructions: Vec<InstructionV1>,
-    pub blobs: BTreeMap<Hash, Vec<u8>>,
+    pub blobs: IndexMap<Hash, Vec<u8>>,
 }
 
 impl TransactionManifestV1 {


### PR DESCRIPTION
## Summary
This is to get rid of `BTreeMap` in order to avoid non-determinism, which was discovered when performing [round-trip test](https://github.com/radixdlt/fuzzer/pull/23). 
