### PR TITLE
LZ-20: support storing actual historical substate values within JMT's leaves

### DIFF
--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -521,7 +521,12 @@ impl<S: TreeStore> HashTreeTester<S> {
     fn apply_database_updates(&mut self, database_updates: &DatabaseUpdates) -> Hash {
         let next_version = self.current_version.unwrap_or(0) + 1;
         let current_version = self.current_version.replace(next_version);
-        put_at_next_version(&mut self.tree_store, current_version, database_updates)
+        put_at_next_version(
+            &mut self.tree_store,
+            current_version,
+            database_updates,
+            false,
+        )
     }
 
     fn index_to_delta_maps(

--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -291,8 +291,7 @@ fn does_not_store_substate_values_when_not_requested() {
     tester.put_substate_changes(vec![
         change_exact(vec![1, 3, 3, 7], 99, vec![253], Some(vec![66; 10203040])),
         change_exact(vec![1, 3, 3, 7], 99, vec![66], Some(vec![])),
-        change_exact(vec![123, 12, 1, 0], 88, vec![6, 6, 6], Some(vec![7]),
-        ),
+        change_exact(vec![123, 12, 1, 0], 88, vec![6, 6, 6], Some(vec![7])),
     ]);
 
     let substate_tier_values = tester

--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -2,7 +2,7 @@ use super::types::{Nibble, NibblePath, Version, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use crate::hash_tree::jellyfish::JellyfishMerkleTree;
 use crate::hash_tree::tree_store::{
     SerializedInMemoryTreeStore, StaleTreePart, TreeChildEntry, TreeInternalNode, TreeLeafNode,
-    TreeNode, TreeStore, TypedInMemoryTreeStore,
+    TreeNode, TreeStore, TypedInMemoryTreeStore, ValueTreeLeafNode,
 };
 use crate::hash_tree::types::{LeafKey, NodeKey};
 use crate::hash_tree::{put_at_next_version, NestedTreeStore};
@@ -354,10 +354,11 @@ fn records_stale_subtree_root_key_when_partition_removed() {
 fn sbor_uses_custom_direct_codecs_for_nibbles() {
     let nibbles = nibbles("a1a2a3");
     let direct_bytes = nibbles.bytes().to_vec();
-    let node = TreeNode::Leaf(TreeLeafNode {
+    let node = TreeNode::Leaf(ValueTreeLeafNode {
         key_suffix: nibbles,
         value_hash: Hash([7; 32]),
         last_hash_change_version: 1337,
+        value: None,
     });
     let encoded = scrypto_encode(&node).unwrap();
     assert!(encoded
@@ -385,10 +386,11 @@ fn sbor_decodes_what_was_encoded() {
                 },
             ],
         }),
-        TreeNode::Leaf(TreeLeafNode {
+        TreeNode::Leaf(ValueTreeLeafNode {
             key_suffix: nibbles("abc"),
             value_hash: Hash([7; 32]),
             last_hash_change_version: 1337,
+            value: Some(vec![13, 37]),
         }),
         TreeNode::Null,
     ];

--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -1,8 +1,8 @@
 use super::types::{Nibble, NibblePath, Version, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use crate::hash_tree::jellyfish::JellyfishMerkleTree;
 use crate::hash_tree::tree_store::{
-    SerializedInMemoryTreeStore, StaleTreePart, TreeChildEntry, TreeInternalNode, TreeLeafNode,
-    TreeNode, TreeStore, TypedInMemoryTreeStore, ValueTreeLeafNode,
+    SerializedInMemoryTreeStore, StaleTreePart, TreeChildEntry, TreeInternalNode, TreeNode,
+    TreeStore, TypedInMemoryTreeStore, ValueTreeLeafNode,
 };
 use crate::hash_tree::types::{LeafKey, NodeKey};
 use crate::hash_tree::{put_at_next_version, NestedTreeStore};

--- a/substate-store-impls/src/hash_tree/tree_store.rs
+++ b/substate-store-impls/src/hash_tree/tree_store.rs
@@ -86,7 +86,7 @@ pub struct TreeLeafNode {
     pub last_hash_change_version: Version,
 }
 
-/// Leaf node.
+/// A leaf node capable of storing a Substate value.
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Sbor)]
 pub struct ValueTreeLeafNode {
     /// All the remaining nibbles in the _hashed_ payload's key.
@@ -95,7 +95,7 @@ pub struct ValueTreeLeafNode {
     pub value_hash: Hash,
     /// A version at which the [`value_hash`] has most recently changed.
     pub last_hash_change_version: Version,
-    /// TODO(wip): doc
+    /// An actual Substate value - only present for Substate Tier leaves, when the JMT is configured to store values.
     pub value: Option<DbSubstateValue>,
 }
 

--- a/substate-store-impls/src/hash_tree_support.rs
+++ b/substate-store-impls/src/hash_tree_support.rs
@@ -41,6 +41,7 @@ impl<D> HashTreeUpdatingDatabase<D> {
             &mut self.tree_store,
             Some(self.current_version).filter(|version| *version > 0),
             db_updates,
+            false,
         );
         self.current_version += 1;
     }

--- a/substate-store-impls/src/rocks_db_with_merkle_tree/mod.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/mod.rs
@@ -1,5 +1,5 @@
 use crate::hash_tree::tree_store::{
-    encode_key, NodeKey, ReadableTreeStore, StaleTreePart, TreeNode, TreeNodeV1, VersionedTreeNode,
+    encode_key, NodeKey, ReadableTreeStore, StaleTreePart, TreeNode, VersionedTreeNode,
 };
 use itertools::Itertools;
 use radix_engine_common::constants::MAX_SUBSTATE_KEY_SIZE;
@@ -258,7 +258,7 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
                                     .unwrap();
                                 let value: VersionedTreeNode = scrypto_decode(&bytes).unwrap();
                                 match value.into_latest() {
-                                    TreeNodeV1::Internal(x) => {
+                                    TreeNode::Internal(x) => {
                                         for child in x.children {
                                             queue.push_back(
                                                 node_key.gen_child_node_key(
@@ -268,8 +268,8 @@ impl CommittableSubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
                                             )
                                         }
                                     }
-                                    TreeNodeV1::Leaf(_) => {}
-                                    TreeNodeV1::Null => {}
+                                    TreeNode::Leaf(_) => {}
+                                    TreeNode::Null => {}
                                 }
                             }
                         }

--- a/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -65,6 +65,7 @@ pub fn compute_state_tree_update<S: ReadableTreeStore>(
         &mut collector,
         Some(parent_state_version).filter(|v| *v > 0),
         database_updates,
+        false,
     );
     (collector.into_diff(), root_hash)
 }


### PR DESCRIPTION
## Summary
Addresses https://radixdlt.atlassian.net/browse/LZ-20.

## Details
More motivation and discussion at https://rdxworks.slack.com/archives/C01M90Y2448/p1709044014451889?thread_ts=1708525744.178989&cid=C01M90Y2448

## Testing
Just unit tests added. This code is not used by Engine directly. Higher-level tests covering this will be added in Node.

## Update Recommendations
No update required from dApp Developers.
Node developers will have to migrate from `TreeLeafNode` to `ValueTreeLeafNode`, and drive the `store_values` boolean flag.
