### PR TITLE
LZ-20: Implement JMT associating Substate-Tier leaves with Substate values

### DIFF
--- a/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -4,7 +4,7 @@ use crate::hash_tree::tree_store::{
 };
 use radix_engine_common::prelude::Hash;
 use std::cell::RefCell;
-use substate_store_interface::interface::DatabaseUpdates;
+use substate_store_interface::interface::{DatabaseUpdates, DbSubstateValue};
 
 struct CollectingTreeStore<'s, S> {
     readable_delegate: &'s S,
@@ -33,6 +33,10 @@ impl<'s, S: ReadableTreeStore> ReadableTreeStore for CollectingTreeStore<'s, S> 
 impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
     fn insert_node(&self, key: NodeKey, node: TreeNode) {
         self.diff.new_nodes.borrow_mut().push((key, node));
+    }
+
+    fn associate_substate_value(&self, _key: &NodeKey, _substate_value: &DbSubstateValue) {
+        // intentionally empty
     }
 
     fn record_stale_tree_part(&self, part: StaleTreePart) {


### PR DESCRIPTION
## Summary
This PR accomplishes what https://github.com/radixdlt/radixdlt-scrypto/pull/1726 tried, but using another approach
Addresses https://radixdlt.atlassian.net/browse/LZ-20.

## Details
It uses the new approach described as **Variant D)** at https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3313532929/RNP-15+-+Historical+State#Rolling-the-history.

Summarizing: JMT now "notifies" the `TreeStore` about `&DbSubstateValue`s associated with JMT-native `NodeKey`s. The Node's implementation of `TreeStore` will store this in a separate table.

## Testing
Unit test included; Integration tests to be added on Node's side.

## Update Recommendations
No update needed, except for Node developers wanting to use this new capability.
