### PR TITLE
get_resource_total_supply method for testrunner

### DIFF
--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -872,7 +872,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
         reader.read_typed_kv_entry(kv_store_id.as_node_id(), key)
     }
 
-    pub fn get_resource_total_supply(&self, resource: ResourceAddress) -> Decimal {
+    pub fn get_fungible_resource_total_supply(&self, resource: ResourceAddress) -> Decimal {
         let total_supply = self
             .substate_db()
             .get_mapped::<SpreadPrefixKeyMapper, FungibleResourceManagerTotalSupplyFieldSubstate>(

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -872,6 +872,20 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
         reader.read_typed_kv_entry(kv_store_id.as_node_id(), key)
     }
 
+    pub fn get_resource_total_supply(&self, resource: ResourceAddress) -> Decimal {
+        let total_supply = self
+            .substate_db()
+            .get_mapped::<SpreadPrefixKeyMapper, FungibleResourceManagerTotalSupplyFieldSubstate>(
+                &resource.as_node_id(),
+                MAIN_BASE_PARTITION,
+                &FungibleResourceManagerField::TotalSupply.into(),
+            )
+            .unwrap()
+            .into_payload()
+            .into_latest();
+        total_supply
+    }
+
     pub fn load_account_from_faucet(&mut self, account_address: ComponentAddress) {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()


### PR DESCRIPTION
## Summary
New convenient method of LedgerSimulator (TestRunner) for getting resource total supply during tests.

## Details
Tested. Code stolen from here.
https://github.com/radixdlt/radixdlt-scrypto/blob/develop/radix-engine-tests/tests/system/bootstrap.rs#L272





