### PR TITLE
Add Substate key to accompany the Substate value associated with a JMT leaf

### DIFF
--- a/substate-store-impls/src/hash_tree/substate_tier.rs
+++ b/substate-store-impls/src/hash_tree/substate_tier.rs
@@ -190,7 +190,7 @@ impl<'s, S: ReadableTreeStore + WriteableTreeStore> SubstateTier<'s, S> {
 
         let tier_update_batch = self.generate_tier_update_batch(next_version, leaf_updates);
         self.apply_tier_update_batch(&tier_update_batch);
-        self.associate_substate_values(updates, &tier_update_batch.tree_update_batch);
+        self.associate_substates(updates, &tier_update_batch.tree_update_batch);
 
         tier_update_batch.new_root_hash
     }
@@ -205,7 +205,7 @@ impl<'s, S: ReadableTreeStore + WriteableTreeStore> SubstateTier<'s, S> {
         (value_hash, new_leaf_payload)
     }
 
-    fn associate_substate_values(
+    fn associate_substates(
         &self,
         substate_updates: &PartitionDatabaseUpdates,
         tree_update_batch: &TreeUpdateBatch<Version>,

--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -983,10 +983,16 @@ impl WriteableTreeStore for SubstateValueAssociationStore {
         // deliberately empty
     }
 
-    fn associate_substate_value(&self, key: &StoredTreeNodeKey, substate_value: &DbSubstateValue) {
+    fn associate_substate(
+        &self,
+        state_tree_leaf_key: &StoredTreeNodeKey,
+        _partition_key: &DbPartitionKey,
+        _sort_key: &DbSortKey,
+        substate_value: &DbSubstateValue,
+    ) {
         self.associated_substate_values
             .borrow_mut()
-            .insert(key.clone(), substate_value.clone());
+            .insert(state_tree_leaf_key.clone(), substate_value.clone());
     }
 
     fn record_stale_tree_part(&self, _part: StaleTreePart) {

--- a/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -2,7 +2,9 @@ use crate::hash_tree::put_at_next_version;
 use crate::hash_tree::tree_store::*;
 use radix_engine_common::prelude::Hash;
 use std::cell::RefCell;
-use substate_store_interface::interface::{DatabaseUpdates, DbSubstateValue};
+use substate_store_interface::interface::{
+    DatabaseUpdates, DbPartitionKey, DbSortKey, DbSubstateValue,
+};
 
 struct CollectingTreeStore<'s, S> {
     readable_delegate: &'s S,
@@ -33,10 +35,12 @@ impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
         self.diff.new_nodes.borrow_mut().push((key, node));
     }
 
-    fn associate_substate_value(
+    fn associate_substate(
         &self,
-        _key: &StoredTreeNodeKey,
-        _substate_value: &DbSubstateValue,
+        state_tree_leaf_key: &StoredTreeNodeKey,
+        partition_key: &DbPartitionKey,
+        sort_key: &DbSortKey,
+        substate_value: &DbSubstateValue,
     ) {
         // intentionally empty
     }

--- a/substate-store-interface/src/interface.rs
+++ b/substate-store-interface/src/interface.rs
@@ -65,6 +65,31 @@ pub enum PartitionDatabaseUpdates {
     },
 }
 
+impl PartitionDatabaseUpdates {
+    /// Returns an effective new Substate value *upserted* under the given `sort_key` (i.e. after
+    /// hypothetically applying this Partition update).
+    /// Please note that this method only cares about upserts - i.e. returns [`None`] either if the
+    /// substate was unaffected, or if it was deleted by this update.
+    ///
+    /// This method is useful for index-updating logic which does not care about the nature of the
+    /// Partition update (i.e. delta vs reset).
+    pub fn get_upserted_value(&self, sort_key: &DbSortKey) -> Option<&DbSubstateValue> {
+        match self {
+            Self::Delta { substate_updates } => {
+                substate_updates
+                    .get(sort_key)
+                    .and_then(|update| match update {
+                        DatabaseUpdate::Set(value) => Some(value),
+                        DatabaseUpdate::Delete => None,
+                    })
+            }
+            Self::Reset {
+                new_substate_values,
+            } => new_substate_values.get(sort_key),
+        }
+    }
+}
+
 impl Default for PartitionDatabaseUpdates {
     fn default() -> Self {
         Self::Delta {


### PR DESCRIPTION
## Summary
This is a minor follow-up to https://github.com/radixdlt/radixdlt-scrypto/pull/1728 (i.e. a tweak to impl of https://radixdlt.atlassian.net/browse/LZ-20).
It turns out that Node may optimize its historical state feature impl when it knows the associated Substates key (apart from value).

## Details
We are not sure we will use the Substate key right away, but it is very cheap to just pass it there and thus we prefer to have it available.

Apart from the feature, I squeezed in a slight simplification of the "associate substates" logic (i.e. avoiding some rewrites by reading directly from `&PartitionDatabaseUpdates`).

## Testing
Adjusted the unit test.

## Update Recommendations
Only Node is supposed to integrate and this will be a trivial API adjustment.
