### PR TITLE
Fix CALL_DIRECT_VAULT_METHOD compilation

### DIFF
--- a/transaction/examples/call/call_method.rtm
+++ b/transaction/examples/call/call_method.rtm
@@ -20,3 +20,8 @@ CALL_ROLE_ASSIGNMENT_METHOD
     "get"
     Enum<0u8>()
     "hello";
+
+CALL_DIRECT_VAULT_METHOD
+    Address("${vault_address}")
+    "unknown"
+    123u8;

--- a/transaction/src/manifest/ast.rs
+++ b/transaction/src/manifest/ast.rs
@@ -131,6 +131,12 @@ pub enum Instruction {
         args: Vec<Value>,
     },
 
+    CallDirectVaultMethod {
+        address: Value,
+        method_name: Value,
+        args: Vec<Value>,
+    },
+
     DropNamedProofs,
 
     DropAllProofs,

--- a/transaction/src/manifest/e2e.rs
+++ b/transaction/src/manifest/e2e.rs
@@ -390,6 +390,11 @@ CALL_ROLE_ASSIGNMENT_METHOD
     Enum<0u8>()
     "hello"
 ;
+CALL_DIRECT_VAULT_METHOD
+    Address("${vault_address}")
+    "unknown"
+    123u8
+;
 "##,
             ),
         );

--- a/transaction/src/manifest/parser.rs
+++ b/transaction/src/manifest/parser.rs
@@ -58,6 +58,7 @@ pub enum InstructionIdent {
     CallRoyaltyMethod,
     CallMetadataMethod,
     CallRoleAssignmentMethod,
+    CallDirectVaultMethod,
     DropNamedProofs,
     DropAllProofs,
     AllocateGlobalAddress,
@@ -152,6 +153,7 @@ impl InstructionIdent {
             "CALL_ROYALTY_METHOD" => InstructionIdent::CallRoyaltyMethod,
             "CALL_METADATA_METHOD" => InstructionIdent::CallMetadataMethod,
             "CALL_ROLE_ASSIGNMENT_METHOD" => InstructionIdent::CallRoleAssignmentMethod,
+            "CALL_DIRECT_VAULT_METHOD" => InstructionIdent::CallDirectVaultMethod,
 
             "DROP_NAMED_PROOFS" => InstructionIdent::DropNamedProofs,
             "DROP_ALL_PROOFS" => InstructionIdent::DropAllProofs,
@@ -601,6 +603,11 @@ impl Parser {
                 args: self.parse_values_till_semicolon()?,
             },
             InstructionIdent::CallRoleAssignmentMethod => Instruction::CallRoleAssignmentMethod {
+                address: self.parse_value()?,
+                method_name: self.parse_value()?,
+                args: self.parse_values_till_semicolon()?,
+            },
+            InstructionIdent::CallDirectVaultMethod => Instruction::CallDirectVaultMethod {
                 address: self.parse_value()?,
                 method_name: self.parse_value()?,
                 args: self.parse_values_till_semicolon()?,


### PR DESCRIPTION
## Summary

`CALL_DIRECT_VAULT_METHOD` is generated by decompiler but not supported by the compiler. This PR fixes the mismatch.

## Testing

New tests added.
