### PR TITLE
Bugfix: Associate JMT leaves created due to "tree restructuring" with their unchanged Substates

### DIFF
--- a/substate-store-impls/src/hash_tree/substate_tier.rs
+++ b/substate-store-impls/src/hash_tree/substate_tier.rs
@@ -212,33 +212,25 @@ impl<'s, S: ReadableTreeStore + WriteableTreeStore> SubstateTier<'s, S> {
     ) {
         for (key, node) in tree_update_batch.node_batch.iter().flatten() {
             // We promised to associate Substate values; but not all newly-created nodes are leaves:
-            if let Node::Leaf(leaf_node) = &node {
-                let sort_key = Self::to_typed_key(leaf_node.leaf_key().clone());
-                let substate_value = match substate_updates {
-                    PartitionDatabaseUpdates::Delta { substate_updates } => substate_updates
-                        .get(&sort_key)
-                        .map(|update| match update {
-                            DatabaseUpdate::Set(value) => AssociatedSubstateValue::Upserted(value),
-                            DatabaseUpdate::Delete => {
-                                panic!("a new tree leaf must represent a Substate upsert")
-                            }
-                        })
-                        .unwrap_or(AssociatedSubstateValue::Unchanged),
-                    PartitionDatabaseUpdates::Reset {
-                        new_substate_values,
-                    } => AssociatedSubstateValue::Upserted(
-                        new_substate_values.get(&sort_key).expect(
-                            "a new tree leaf after partition reset must represent a new Substate",
-                        ),
-                    ),
-                };
-                self.base_store.associate_substate(
-                    &self.stored_node_key(&key),
-                    &self.partition_key,
-                    &sort_key,
-                    substate_value,
-                );
-            }
+            let Node::Leaf(leaf_node) = &node else {
+                continue;
+            };
+            let sort_key = Self::to_typed_key(leaf_node.leaf_key().clone());
+            let substate_value = substate_updates
+                .get_substate_change(&sort_key)
+                .map(|change| match change {
+                    SubstateChange::Upsert(value) => AssociatedSubstateValue::Upserted(value),
+                    SubstateChange::Delete => {
+                        panic!("deletes are not represented by new tree leafs")
+                    }
+                })
+                .unwrap_or_else(|| AssociatedSubstateValue::Unchanged);
+            self.base_store.associate_substate(
+                &self.stored_node_key(&key),
+                &self.partition_key,
+                &sort_key,
+                substate_value,
+            );
         }
     }
 }

--- a/substate-store-impls/src/hash_tree/test.rs
+++ b/substate-store-impls/src/hash_tree/test.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 use radix_engine_common::crypto::{hash, Hash};
 use radix_engine_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use sbor::prelude::indexmap::indexmap;
-use std::cell::RefCell;
 use std::ops::Deref;
 use substate_store_interface::interface::*;
 use utils::prelude::*;
@@ -227,7 +226,7 @@ fn physical_nodes_of_tiered_jmt_have_expected_keys_and_contents() {
 
 #[test]
 fn substate_values_get_associated_with_substate_tier_leaves() {
-    let mut tester = HashTreeTester::new(SubstateValueAssociationStore::default());
+    let mut tester = HashTreeTester::new(TypedInMemoryTreeStore::new().storing_associated_substates());
     tester.put_substate_changes(vec![
         change_exact(vec![123, 12, 1], 8, vec![6, 6, 1], Some(vec![4])),
         change_exact(vec![123, 12, 1], 8, vec![6, 6, 2], Some(vec![])),
@@ -253,6 +252,45 @@ fn substate_values_get_associated_with_substate_tier_leaves() {
             // A very incomplete node key, representing Substate-Tier root: (since it is the only Substate within its partition)
             StoredTreeNodeKey::new(1, NibblePath::new_even(vec![220, 3, TSEP, 99, TSEP])) => (
                 (partition_key(vec![220, 3], 99), DbSortKey(vec![253])), vec![7; 66]
+            ),
+        )
+    );
+}
+
+#[test]
+#[ignore = "TODO(wip): handle the restructuring!"]
+fn substate_values_get_re_associated_after_tree_restructuring() {
+    let mut tester = HashTreeTester::new(TypedInMemoryTreeStore::new().storing_associated_substates());
+    // Let's start with the same set-up as in the base `substate_values_get_associated_with_substate_tier_leaves` test:
+    tester.put_substate_changes(vec![
+        change_exact(vec![123, 12, 1], 8, vec![6, 6, 1], Some(vec![4])),
+        change_exact(vec![123, 12, 1], 8, vec![6, 6, 2], Some(vec![])),
+        change_exact(vec![123, 12, 1], 8, vec![6, 7, 5, 9], Some(vec![1, 2])),
+        change_exact(vec![220, 3], 99, vec![253], Some(vec![7; 66])),
+    ]);
+
+    // For clearer assert, let's disregard the substates associated in this step:
+    tester.tree_store.associated_substates.borrow_mut().clear();
+
+    // Now inserting this "sibling" substate forces rewrite of the leaf associated with sort key `vec![6, 7, 5, 9]`:
+    tester.put_substate_changes(vec![change_exact(
+        vec![123, 12, 1],
+        8,
+        vec![6, 7, 5, 4],
+        Some(vec![3]),
+    )]);
+
+    let associated_substates = tester.tree_store.associated_substates.borrow();
+    assert_eq!(
+        associated_substates.deref(),
+        &hashmap!(
+            // The newly-inserted substate:
+            StoredTreeNodeKey::new(2, NibblePath::new_even(vec![123, 12, 1, TSEP, 8, TSEP, 6, 7, 5, 4])) => (
+                (partition_key(vec![123, 12, 1], 8), DbSortKey(vec![6, 7, 5, 4])), vec![3]
+            ),
+            // Its previously-existing sibling, whose tree node had to be re-inserted due to restructuring:
+            StoredTreeNodeKey::new(2, NibblePath::new_even(vec![123, 12, 1, TSEP, 8, TSEP, 6, 7, 5, 9])) => (
+                (partition_key(vec![123, 12, 1], 8), DbSortKey(vec![6, 7, 5, 9])), vec![1, 2]
             ),
         )
     );
@@ -967,43 +1005,5 @@ impl HashTreeTester<TypedInMemoryTreeStore> {
             )
             .bytes(),
         )
-    }
-}
-
-/// A degenerate, test [`TreeStore`] which only stores associated Substate values.
-#[derive(Debug, Default)]
-struct SubstateValueAssociationStore {
-    associated_substates: RefCell<HashMap<StoredTreeNodeKey, (DbSubstateKey, DbSubstateValue)>>,
-}
-
-impl ReadableTreeStore for SubstateValueAssociationStore {
-    fn get_node(&self, _key: &StoredTreeNodeKey) -> Option<TreeNode> {
-        None
-    }
-}
-
-impl WriteableTreeStore for SubstateValueAssociationStore {
-    fn insert_node(&self, _key: StoredTreeNodeKey, _node: TreeNode) {
-        // deliberately empty
-    }
-
-    fn associate_substate(
-        &self,
-        state_tree_leaf_key: &StoredTreeNodeKey,
-        partition_key: &DbPartitionKey,
-        sort_key: &DbSortKey,
-        substate_value: &DbSubstateValue,
-    ) {
-        self.associated_substates.borrow_mut().insert(
-            state_tree_leaf_key.clone(),
-            (
-                (partition_key.clone(), sort_key.clone()),
-                substate_value.clone(),
-            ),
-        );
-    }
-
-    fn record_stale_tree_part(&self, _part: StaleTreePart) {
-        // deliberately empty
     }
 }

--- a/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -35,13 +35,12 @@ impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
         self.diff.new_nodes.borrow_mut().push((key, node));
     }
 
-    #[allow(unused_variables)]
     fn associate_substate(
         &self,
-        state_tree_leaf_key: &StoredTreeNodeKey,
-        partition_key: &DbPartitionKey,
-        sort_key: &DbSortKey,
-        substate_value: AssociatedSubstateValue,
+        _state_tree_leaf_key: &StoredTreeNodeKey,
+        _partition_key: &DbPartitionKey,
+        _sort_key: &DbSortKey,
+        _substate_value: AssociatedSubstateValue,
     ) {
         // intentionally empty
     }

--- a/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
+++ b/substate-store-impls/src/rocks_db_with_merkle_tree/state_tree.rs
@@ -41,7 +41,7 @@ impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
         state_tree_leaf_key: &StoredTreeNodeKey,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
-        substate_value: &DbSubstateValue,
+        substate_value: AssociatedSubstateValue,
     ) {
         // intentionally empty
     }

--- a/substate-store-interface/src/interface.rs
+++ b/substate-store-interface/src/interface.rs
@@ -65,6 +65,37 @@ pub enum PartitionDatabaseUpdates {
     },
 }
 
+impl PartitionDatabaseUpdates {
+    /// Returns an effective change applied to the given Substate by this Partition update.
+    /// May return [`None`] only if the Substate was unaffected.
+    ///
+    /// This method is useful for index-updating logic which does not care about the nature of the
+    /// Partition update (i.e. delta vs reset).
+    pub fn get_substate_change(&self, sort_key: &DbSortKey) -> Option<SubstateChange> {
+        match self {
+            Self::Delta { substate_updates } => {
+                substate_updates.get(sort_key).map(|update| match update {
+                    DatabaseUpdate::Set(value) => SubstateChange::Upsert(value),
+                    DatabaseUpdate::Delete => SubstateChange::Delete,
+                })
+            }
+            Self::Reset {
+                new_substate_values,
+            } => new_substate_values
+                .get(sort_key)
+                .map(|value| SubstateChange::Upsert(value))
+                .or_else(|| Some(SubstateChange::Delete)),
+        }
+    }
+}
+
+/// A change applied to a Substate - see [`PartitionDatabaseUpdates::get_substate_change`].
+/// Technically, this is a 1:1 counterpart of [`DatabaseUpdate`], but operating on references.
+pub enum SubstateChange<'v> {
+    Upsert(&'v DbSubstateValue),
+    Delete,
+}
+
 impl Default for PartitionDatabaseUpdates {
     fn default() -> Self {
         Self::Delta {

--- a/substate-store-interface/src/interface.rs
+++ b/substate-store-interface/src/interface.rs
@@ -65,31 +65,6 @@ pub enum PartitionDatabaseUpdates {
     },
 }
 
-impl PartitionDatabaseUpdates {
-    /// Returns an effective new Substate value *upserted* under the given `sort_key` (i.e. after
-    /// hypothetically applying this Partition update).
-    /// Please note that this method only cares about upserts - i.e. returns [`None`] either if the
-    /// substate was unaffected, or if it was deleted by this update.
-    ///
-    /// This method is useful for index-updating logic which does not care about the nature of the
-    /// Partition update (i.e. delta vs reset).
-    pub fn get_upserted_value(&self, sort_key: &DbSortKey) -> Option<&DbSubstateValue> {
-        match self {
-            Self::Delta { substate_updates } => {
-                substate_updates
-                    .get(sort_key)
-                    .and_then(|update| match update {
-                        DatabaseUpdate::Set(value) => Some(value),
-                        DatabaseUpdate::Delete => None,
-                    })
-            }
-            Self::Reset {
-                new_substate_values,
-            } => new_substate_values.get(sort_key),
-        }
-    }
-}
-
 impl Default for PartitionDatabaseUpdates {
     fn default() -> Self {
         Self::Delta {


### PR DESCRIPTION
## Summary
This fixes a bug found in the impl of https://github.com/radixdlt/radixdlt-scrypto/pull/1728:
It turns out that Node needs to be notified about JMT leaves created during tree restructuring. Previous implementation was deliberately skipping them.

## Testing
Added a unit test for precisely this behavior (which fails before the fix: see the first commit).
Added another unit test to cover partition resets (which luckily always worked fine, but is just a related area with some bug potential).

## Update Recommendations
Only internal Node devs need to adjust to some small API change.
