### PR TITLE
[DRAFT] `declare_native_blueprint_state` extensions

### DIFF
--- a/radix-engine/src/blueprints/models/feature_set.rs
+++ b/radix-engine/src/blueprints/models/feature_set.rs
@@ -22,6 +22,140 @@ pub trait HasFeatures: Debug {
     }
 }
 
+/// For feature checks against a non-inner object
+#[derive(Debug)]
+pub enum FeatureChecks<TOwn: HasFeatures> {
+    None,
+    RequireAllSubstates,
+    ForFeatures { own_features: TOwn },
+}
+
+impl<T: HasFeatures> From<T> for FeatureChecks<T> {
+    fn from(value: T) -> Self {
+        FeatureChecks::ForFeatures {
+            own_features: value,
+        }
+    }
+}
+
+impl<TOwn: HasFeatures> FeatureChecks<TOwn> {
+    pub fn assert_valid(
+        &self,
+        substate_name: &'static str,
+        condition: &Condition,
+        is_present: bool,
+    ) -> Result<(), RuntimeError> {
+        let is_valid = match self {
+            FeatureChecks::None => Ok(()),
+            FeatureChecks::RequireAllSubstates => {
+                if is_present {
+                    Ok(())
+                } else {
+                    Err(format!("Required all substates to be present, but {} was not present", substate_name))
+                }
+            },
+            FeatureChecks::ForFeatures { own_features } => {
+                match condition {
+                    Condition::Always => {
+                        if is_present {
+                            Ok(())
+                        } else {
+                            Err(format!("Substate condition for {} required it to be always present, but it was not", substate_name))
+                        }
+                    }
+                    Condition::IfFeature(feature) => {
+                        let feature_enabled = own_features.feature_names_str().contains(&feature.as_str());
+                        if feature_enabled && !is_present {
+                            Err(format!("Substate condition for {} required it to be present when the feature {} was enabled, but it was absent", substate_name, feature))
+                        } else if !feature_enabled && is_present {
+                            Err(format!("Substate condition for {} required it to be absent when the feature {} was disabled, but it was present", substate_name, feature))
+                        } else {
+                            Ok(())
+                        }
+                    },
+                    Condition::IfOuterFeature(_) => {
+                        Err(format!("Substate condition for {} required an outer object feature, but the blueprint does not have an outer blueprint defined", substate_name))
+                    }
+                }
+            },
+        };
+        is_valid.map_err(|error_message| {
+            RuntimeError::SystemError(SystemError::InvalidNativeSubstatesForFeature(error_message))
+        })
+    }
+}
+
+/// For feature checks against an inner object
+pub enum InnerObjectFeatureChecks<TOwn, TOuter> {
+    None,
+    RequireAllSubstates,
+    ForFeatures {
+        own_features: TOwn,
+        outer_object_features: TOuter,
+    },
+}
+
+impl<TOwn: HasFeatures, TOuter: HasFeatures> InnerObjectFeatureChecks<TOwn, TOuter> {
+    pub fn assert_valid(
+        &self,
+        substate_name: &'static str,
+        condition: &Condition,
+        is_present: bool,
+    ) -> Result<(), RuntimeError> {
+        let is_valid = match self {
+            Self::None => Ok(()),
+            Self::RequireAllSubstates => {
+                if is_present {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "Required all substates to be present, but {} was not present",
+                        substate_name
+                    ))
+                }
+            }
+            Self::ForFeatures {
+                own_features,
+                outer_object_features,
+            } => match condition {
+                Condition::Always => {
+                    if is_present {
+                        Ok(())
+                    } else {
+                        Err(format!("Substate condition for {} required it to be always present, but it was not", substate_name))
+                    }
+                }
+                Condition::IfFeature(feature) => {
+                    let feature_enabled =
+                        own_features.feature_names_str().contains(&feature.as_str());
+                    if feature_enabled && !is_present {
+                        Err(format!("Substate condition for {} required it to be present when the feature {} was enabled, but it was absent", substate_name, feature))
+                    } else if !feature_enabled && is_present {
+                        Err(format!("Substate condition for {} required it to be absent when the feature {} was disabled, but it was present", substate_name, feature))
+                    } else {
+                        Ok(())
+                    }
+                }
+                Condition::IfOuterFeature(feature) => {
+                    let feature_enabled = outer_object_features
+                        .feature_names_str()
+                        .contains(&feature.as_str());
+                    if feature_enabled && !is_present {
+                        Err(format!("Substate condition for {} required it to be present when the outer object feature {} was enabled, but it was absent", substate_name, feature))
+                    } else if !feature_enabled && is_present {
+                        Err(format!("Substate condition for {} required it to be absent when the outer object feature {} was disabled, but it was present", substate_name, feature))
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+        };
+        is_valid.map_err(|error_message| {
+            RuntimeError::SystemError(SystemError::InvalidNativeSubstatesForFeature(error_message))
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -242,6 +242,7 @@ pub enum SystemError {
     CreateObjectError(Box<CreateObjectError>),
     InvalidGenericArgs,
     InvalidFeature(String),
+    InvalidNativeSubstatesForFeature(String),
     AssertAccessRuleFailed,
     BlueprintDoesNotExist(CanonicalBlueprintId),
     AuthTemplateDoesNotExist(CanonicalBlueprintId),


### PR DESCRIPTION
## Summary
DRAFT PR.

Replaces / rebases the key parts of #1318 - some of this still needs to go (e.g. the partition stuff).

Still to come:
* Implement Typed API, MutableTypedField etc
* Trial `XStateInit`, and the typed API in new native blueprints
* ... and when we next create a V2 of a native blueprint, consider moving it across to the nicer APIs.

## Details
```
INSTRUCTIONS:
Provide further details about the changes, or how they fit into the roadmap.
You can delete this section if it's not useful.
```

## Testing
```
INSTRUCTIONS:
Further details about the tests you've added or manually performed.
You can delete this section if it's not useful.
```

## Update Recommendations
```
INSTRUCTIONS:
This section is to provide recommendations to consumers of this repo about how they
should handle breaking changes, or integrate new features. The two key stakeholder
groups are dApp Developers and Internal Integrators, and there are separate sections
for each.

In order to allow us to compile aggregated update instructions across PRs, please tag the PR
with 0+ of the relevant labels:
* scrypto-lib - Any change to the scrypto library
* sbor - Any breaking change to SBOR encoding/decoding
* manifest - Any change to manifest display, compilation/decompilation
* transaction - Any change which affects the compiled manifest, or transaction semantics
* substate - Any change to substates, the state model, or what's stored in the DB
* native-blueprint-interface - Any change to the interface of native blueprints
* files-moved - Any change to where engine types have moved, which will require
  internal integrators to update their imports

If you have a breaking change which doesn't fix into a category above, then tag it with
the closest label, and discuss in slack/discord.

If your PR contains no breaking changes or new features or hasn't been tagged, this whole
section can be deleted.
```

### For dApp Developers
```
INSTRUCTIONS:
Migration recommendations for a dApp developer to update their dApp/integrations
due to to the change/s in this PR.

These will be aggregated by the Developer Ecosystem team and included in the next Scrypto migration guide
(eg https://docs-babylon.radixdlt.com/main/scrypto/release_notes/migrating_from_0.7_to_0.8.html )
```

### For Internal Integrators
```
INSTRUCTIONS:
Instructions to any internal integrations (eg Node, Toolkit, Gateway, Ledger App) for how the changes may affect
them and recommendations for how they should update to support this change.
```
