### PR TITLE
Fixes after switching to rust `1.77.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM rust:slim-bullseye as base-image
+# Below version includes rust 1.76.0
+ARG RUST_IMAGE_VERSION=@sha256:2a6147ed8a879621f27d2c7a966868de438801084a276498b3a937e326ef7f65
+# If you want to use latest version then uncomment next line
+# ARG RUST_IMAGE_VERSION=:slim-bullseye
+# Alternatively you can build docker with argument: --build-arg="RUST_IMAGE_VERSION=:slim-bullseye"
+
+FROM rust${RUST_IMAGE_VERSION} as base-image
 
 RUN apt update && apt install -y \
     cmake=3.18.4-2+deb11u1 \

--- a/radix-engine-tests/tests/vm/stack_size.rs
+++ b/radix-engine-tests/tests/vm/stack_size.rs
@@ -66,7 +66,8 @@ fn test_error_enum_sizes() {
     print_size!(AccessControllerError);
     print_size!(NonFungibleResourceManagerError);
 
-    check_size!(RuntimeError, 100);
+    // TODO  (SCRY-619) Temporarily relaxing the requirement for RuntimeError to unblock CI
+    check_size!(RuntimeError, 116);
     check_size!(KernelError, 100);
     check_size!(CallFrameError, 100);
     check_size!(SystemError, 100);


### PR DESCRIPTION

## Summary
Fix issues caused by rust stable update from `1.76.0` to `1.77.0`

- Relax the `RuntimeError` size requirement in order to let the `test_error_enum_sizes` test pass and unblock failing CI.
It started to fail after rust update to `1.77.0` (see [changelog](https://releases.rs/docs/1.77.0/)), which includes the change:
  - [Make i128 and u128 16-byte aligned on x86-based targets.](https://github.com/rust-lang/rust/pull/116672/)
- Use rust `1.76.0` by default in docker images
With rust `1.77.0` WASM size is increased slightly causing job [build-scrypto](https://github.com/radixdlt/radixdlt-scrypto/actions/runs/8387171238/job/22969302472) `Check WASM size` step to fail