### PR TITLE
Fix: change scrypto documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Language for building DeFi apps on Radix.
 
-Documentation: https://docs-babylon.radixdlt.com/main/scrypto/introduction.html
+Documentation: https://docs.radixdlt.com/docs/scrypto-1
 
 
 ## Installation


### PR DESCRIPTION
## Summary
```
INSTRUCTIONS:
Fix: change scrypto documentation link in README
```

## Details
```
INSTRUCTIONS:
Change https://docs-babylon.radixdlt.com/main/scrypto/introduction.html to https://docs.radixdlt.com/docs/scrypto-1
```

