### PR TITLE
Added missing `compile_with_env_vars()` function

### DIFF
--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -3,6 +3,7 @@
 pub mod package_loader {
     use radix_common::prelude::*;
     use radix_substate_store_queries::typed_substate_layout::*;
+    use std::path::PathBuf;
 
     const PACKAGES_BINARY: &[u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/compiled_packages.bin"));
@@ -16,7 +17,14 @@ pub mod package_loader {
     pub struct PackageLoader;
     impl PackageLoader {
         pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
-            if let Some(rtn) = PACKAGES.get(name) {
+            // Extract package file name if specified package name contains also a path.
+            let file_name = PathBuf::from(name)
+                .file_name()
+                .unwrap()
+                .to_os_string()
+                .into_string()
+                .unwrap();
+            if let Some(rtn) = PACKAGES.get(&file_name) {
                 rtn.clone()
             } else {
                 panic!("Package \"{}\" not found. Are you sure that this package is: a) in the blueprints folder, b) that this is the same as the package name in the Cargo.toml file?", name)

--- a/scrypto-test/src/ledger_simulator/compile.rs
+++ b/scrypto-test/src/ledger_simulator/compile.rs
@@ -24,20 +24,11 @@ impl Compile {
         let mut compiler_builder = ScryptoCompiler::builder();
         compiler_builder
             .manifest_path(package_dir.as_ref())
-            .env("RUSTFLAGS", EnvironmentVariableAction::Set("".into()))
-            .env(
-                "CARGO_ENCODED_RUSTFLAGS",
-                EnvironmentVariableAction::Set("".into()),
-            )
             .optimize_with_wasm_opt(None)
             .log_level(Level::Trace); // all logs from error to trace
 
         env_vars.iter().for_each(|(name, value)| {
-            if value.is_empty() {
-                compiler_builder.env(name, EnvironmentVariableAction::Unset);
-            } else {
-                compiler_builder.env(name, EnvironmentVariableAction::Set(value.clone()));
-            }
+            compiler_builder.env(name, EnvironmentVariableAction::Set(value.clone()));
         });
 
         #[cfg(feature = "coverage")]


### PR DESCRIPTION
## Summary
Added missing `compile_with_env_vars()` function required for `compile-blueprints-at-build-time` feature in `radix-engine-tests` project.

Also there was an issue when using `compile-blueprints-at-build-time` feature with packages specified to `PackageLoader` in form of path, ex.: `oracle_proxies/oracle_proxy_with_global`. This was fixed in `PackageLoader` by extracting last section from the path.