### PR TITLE
tweak: The JSON `variant_id` is now a u8, in line with Gateway typings

### DIFF
--- a/sbor/src/representations/serde_serialization/serde_serializer.rs
+++ b/sbor/src/representations/serde_serialization/serde_serializer.rs
@@ -925,7 +925,7 @@ mod tests {
                             "key": {
                                 "kind": "Enum",
                                 "type_name": "TestEnum",
-                                "variant_id": "0",
+                                "variant_id": 0,
                                 "variant_name": "UnitVariant",
                                 "fields": []
                             },
@@ -956,7 +956,7 @@ mod tests {
                             "key": {
                                 "kind": "Enum",
                                 "type_name": "TestEnum",
-                                "variant_id": "1",
+                                "variant_id": 1,
                                 "variant_name": "SingleFieldVariant",
                                 "fields": [
                                     {
@@ -993,7 +993,7 @@ mod tests {
                             "key": {
                                 "kind": "Enum",
                                 "type_name": "TestEnum",
-                                "variant_id": "2",
+                                "variant_id": 2,
                                 "variant_name": "DoubleStructVariant",
                                 "fields": [
                                     {
@@ -1066,14 +1066,14 @@ mod tests {
                 {
                     "kind": "Enum",
                     "type_name": "TestEnum",
-                    "variant_id": "0",
+                    "variant_id": 0,
                     "variant_name": "UnitVariant",
                     "fields": []
                 },
                 {
                     "kind": "Enum",
                     "type_name": "TestEnum",
-                    "variant_id": "1",
+                    "variant_id": 1,
                     "variant_name": "SingleFieldVariant",
                     "fields": [
                         {
@@ -1086,7 +1086,7 @@ mod tests {
                 {
                     "kind": "Enum",
                     "type_name": "TestEnum",
-                    "variant_id": "2",
+                    "variant_id": 2,
                     "variant_name": "DoubleStructVariant",
                     "fields": [
                         {
@@ -1149,12 +1149,12 @@ mod tests {
                     "fields": [
                         {
                             "kind": "Enum",
-                            "variant_id": "32",
+                            "variant_id": 32,
                             "fields": []
                         },
                         {
                             "kind": "Enum",
-                            "variant_id": "21",
+                            "variant_id": 21,
                             "fields": [
                                 {
                                     "kind": "I32",

--- a/sbor/src/representations/serde_serialization/value_map_aggregator.rs
+++ b/sbor/src/representations/serde_serialization/value_map_aggregator.rs
@@ -13,6 +13,7 @@ pub enum SerializableType<'a, 't, 'de, 's1, 's2, E: SerializableCustomExtension>
     I16(i16),
     I32(i32),
     U8(u8),
+    U8AsInteger(u8),
     U16(u16),
     U32(u32),
     SerializableFields(SerializableFields<'t, 'de, 's1, 's2, E>),
@@ -38,6 +39,7 @@ impl<'a, 'a2, 't, 'de, 's1, 's2, E: SerializableCustomExtension>
                 Self::I16(i) => serializer.serialize_str(&i.to_string()),
                 Self::I32(i) => serializer.serialize_str(&i.to_string()),
                 Self::U8(u) => serializer.serialize_str(&u.to_string()),
+                Self::U8AsInteger(u) => serializer.serialize_u8(*u),
                 Self::U16(u) => serializer.serialize_str(&u.to_string()),
                 Self::U32(u) => serializer.serialize_str(&u.to_string()),
                 Self::SerializableFields(s) => s.contextual_serialize(serializer, context),
@@ -52,6 +54,7 @@ impl<'a, 'a2, 't, 'de, 's1, 's2, E: SerializableCustomExtension>
                 Self::I16(i) => serializer.serialize_i16(*i),
                 Self::I32(i) => serializer.serialize_i32(*i),
                 Self::U8(u) => serializer.serialize_u8(*u),
+                Self::U8AsInteger(u) => serializer.serialize_u8(*u),
                 Self::U16(u) => serializer.serialize_u16(*u),
                 Self::U32(u) => serializer.serialize_u32(*u),
                 Self::SerializableFields(s) => s.contextual_serialize(serializer, context),
@@ -210,7 +213,7 @@ impl<'a, 'a2, 't, 'de, 's, 's1, 's2, E: SerializableCustomExtension>
 
     pub fn add_enum_variant_details(&mut self, variant_id: u8, variant_name: Option<&'a str>) {
         self.fields
-            .push(("variant_id", SerializableType::U8(variant_id)));
+            .push(("variant_id", SerializableType::U8AsInteger(variant_id)));
         variant_name.map(|variant_name| {
             self.fields
                 .push(("variant_name", SerializableType::Str(variant_name)))


### PR DESCRIPTION
## Summary

https://radixdlt.atlassian.net/browse/SCRY-632

It turns out the Gateway typing for `ProgrammaticScryptoSborValueEnum` was:
```yml
    ProgrammaticScryptoSborValueEnum:
      allOf:
        - $ref: "#/components/schemas/ProgrammaticScryptoSborValue"
        - type: object
          required:
            - variant_id
            - fields
          properties:
            variant_id:
              type: integer
              minimum: 0
              maximum: 255
            variant_name:
              type: string
            fields:
              type: array
              items:
                $ref: "#/components/schemas/ProgrammaticScryptoSborValue"
```
And indeed Gateway was returning `variant_id` as a JSON number for its non-state responses. Core API was returning it as a string though, and it has been untyped in the Gateway API.

As the Gateway sees the most integrations, I think it needs to win here and force the underlying spec/impl to change to u8, and the Core API along with it. (Personally I think I also prefer `variant_id` being a JSON number anyway).

## Testing
Updated existing tests

## Update Recommendations
### For dApp Developers
Anyone using programmatic SBOR JSON should be aware of this inconsistency, and that it's being fixed.

### For Internal Integrators
We should record to add to the node's release notes.
