### PR TITLE
Refactoring: Exposing customization methods for `Executable`

### DIFF
--- a/radix-engine-tests/tests/application/common_transformation_costs.rs
+++ b/radix-engine-tests/tests/application/common_transformation_costs.rs
@@ -26,7 +26,7 @@ fn estimate_locking_fee_from_an_account_protected_by_signature() {
         false,
     );
     let receipt1 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(100)),
+        validate_notarized_transaction(&network, &tx1).get_executable().apply_free_credit(dec!(100)),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -43,7 +43,7 @@ fn estimate_locking_fee_from_an_account_protected_by_signature() {
         false,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -83,7 +83,7 @@ fn estimate_locking_fee_from_an_account_protected_by_access_controller() {
         false,
     );
     let receipt1 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(100)),
+        validate_notarized_transaction(&network, &tx1).get_executable().apply_free_credit(dec!(100)),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -107,7 +107,7 @@ fn estimate_locking_fee_from_an_account_protected_by_access_controller() {
         false,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -151,7 +151,7 @@ fn estimate_asserting_worktop_contains_fungible_resource() {
         false,
     );
     let receipt1 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx1).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -173,7 +173,7 @@ fn estimate_asserting_worktop_contains_fungible_resource() {
         false,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -222,7 +222,7 @@ fn estimate_asserting_worktop_contains_non_fungible_resource() {
         false,
     );
     let receipt1 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx1).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -244,7 +244,7 @@ fn estimate_asserting_worktop_contains_non_fungible_resource() {
         false,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -298,7 +298,7 @@ fn estimate_adding_signature() {
         false,
     );
     let receipt1 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx1).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx1).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -314,7 +314,7 @@ fn estimate_adding_signature() {
         false,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );
@@ -374,7 +374,7 @@ fn estimate_notarizing(notary_is_signatory: bool, max: Decimal) {
         notary_is_signatory,
     );
     let receipt2 = ledger.execute_transaction(
-        validate_notarized_transaction(&network, &tx2).get_executable_with_free_credit(dec!(0)),
+        validate_notarized_transaction(&network, &tx2).get_executable(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator())
             .with_cost_breakdown(true),
     );

--- a/radix-engine-tests/tests/blueprints/transaction_tracker.rs
+++ b/radix-engine-tests/tests/blueprints/transaction_tracker.rs
@@ -82,10 +82,8 @@ fn test_transaction_replay_protection() {
 
     // 5. Run the transaction the 3rd time (with epoch range check disabled)
     // Note that in production, this won't be possible.
-    let mut executable = validated.get_executable();
-    executable.skip_epoch_range_check();
     let receipt = ledger.execute_transaction(
-        executable,
+        validated.get_executable().skip_epoch_range_check(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
     );
     receipt.expect_commit_success();

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -121,25 +121,48 @@ impl<'a> Executable<'a> {
         }
     }
 
+    // Consuming builder-like customization methods:
+
+    pub fn overwrite_intent_hash(self, hash: Hash) -> Self {
+        let mut updated_self = self;
+        match &mut updated_self.context.intent_hash {
+            TransactionIntentHash::ToCheck { intent_hash, .. }
+            | TransactionIntentHash::NotToCheck { intent_hash } => {
+                *intent_hash = hash;
+            }
+        }
+        updated_self
+    }
+
+    pub fn skip_epoch_range_check(self) -> Self {
+        let mut updated_self = self;
+        updated_self.context.epoch_range = None;
+        updated_self
+    }
+
+    pub fn apply_free_credit(self, free_credit_in_xrd: Decimal) -> Self {
+        let mut updated_self = self;
+        updated_self.context.costing_parameters.free_credit_in_xrd = free_credit_in_xrd;
+        updated_self
+    }
+
+    pub fn abort_when_loan_repaid(self) -> Self {
+        let mut updated_self = self;
+        updated_self
+            .context
+            .costing_parameters
+            .abort_when_loan_repaid = true;
+        updated_self
+    }
+
+    // Getters:
+
     pub fn intent_hash(&self) -> &TransactionIntentHash {
         &self.context.intent_hash
     }
 
     pub fn epoch_range(&self) -> Option<&EpochRange> {
         self.context.epoch_range.as_ref()
-    }
-
-    pub fn overwrite_intent_hash(&mut self, hash: Hash) {
-        match &mut self.context.intent_hash {
-            TransactionIntentHash::ToCheck { intent_hash, .. }
-            | TransactionIntentHash::NotToCheck { intent_hash } => {
-                *intent_hash = hash;
-            }
-        }
-    }
-
-    pub fn skip_epoch_range_check(&mut self) {
-        self.context.epoch_range = None;
     }
 
     pub fn costing_parameters(&self) -> &TransactionCostingParameters {

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -123,36 +123,29 @@ impl<'a> Executable<'a> {
 
     // Consuming builder-like customization methods:
 
-    pub fn overwrite_intent_hash(self, hash: Hash) -> Self {
-        let mut updated_self = self;
-        match &mut updated_self.context.intent_hash {
+    pub fn overwrite_intent_hash(mut self, hash: Hash) -> Self {
+        match &mut self.context.intent_hash {
             TransactionIntentHash::ToCheck { intent_hash, .. }
             | TransactionIntentHash::NotToCheck { intent_hash } => {
                 *intent_hash = hash;
             }
         }
-        updated_self
+        self
     }
 
-    pub fn skip_epoch_range_check(self) -> Self {
-        let mut updated_self = self;
-        updated_self.context.epoch_range = None;
-        updated_self
+    pub fn skip_epoch_range_check(mut self) -> Self {
+        self.context.epoch_range = None;
+        self
     }
 
-    pub fn apply_free_credit(self, free_credit_in_xrd: Decimal) -> Self {
-        let mut updated_self = self;
-        updated_self.context.costing_parameters.free_credit_in_xrd = free_credit_in_xrd;
-        updated_self
+    pub fn apply_free_credit(mut self, free_credit_in_xrd: Decimal) -> Self {
+        self.context.costing_parameters.free_credit_in_xrd = free_credit_in_xrd;
+        self
     }
 
-    pub fn abort_when_loan_repaid(self) -> Self {
-        let mut updated_self = self;
-        updated_self
-            .context
-            .costing_parameters
-            .abort_when_loan_repaid = true;
-        updated_self
+    pub fn abort_when_loan_repaid(mut self) -> Self {
+        self.context.costing_parameters.abort_when_loan_repaid = true;
+        self
     }
 
     // Getters:

--- a/radix-transactions/src/model/v1/validated_notarized_transaction.rs
+++ b/radix-transactions/src/model/v1/validated_notarized_transaction.rs
@@ -28,10 +28,7 @@ impl HasNotarizedTransactionHash for ValidatedNotarizedTransactionV1 {
 }
 
 impl ValidatedNotarizedTransactionV1 {
-    pub fn get_executable_with_free_credit<'a>(
-        &'a self,
-        free_credit_in_xrd: Decimal,
-    ) -> Executable<'a> {
+    pub fn get_executable<'a>(&'a self) -> Executable<'a> {
         let intent = &self.prepared.signed_intent.intent;
         let header = &intent.header.inner;
         let intent_hash = intent.intent_hash();
@@ -58,15 +55,11 @@ impl ValidatedNotarizedTransactionV1 {
                 },
                 costing_parameters: TransactionCostingParameters {
                     tip_percentage: intent.header.inner.tip_percentage,
-                    free_credit_in_xrd,
+                    free_credit_in_xrd: Decimal::ZERO,
                     abort_when_loan_repaid: false,
                 },
                 pre_allocated_addresses: vec![],
             },
         )
-    }
-
-    pub fn get_executable<'a>(&'a self) -> Executable<'a> {
-        self.get_executable_with_free_credit(Decimal::ZERO)
     }
 }


### PR DESCRIPTION
## Summary
The Node needs to be able to customize the `abort_when_loan_repaid: true` for running a transaction pending in the mempool.
This PR standardizes the way to do this (and similar, already-existing) customizations.

## Testing
A refactoring-only: just the regression tests need to pass.

## Update Recommendations
Only the Node developers need to integrate.
