### PR TITLE
Quickfix: Add missed `SystemBoot` typed field + mapping

### DIFF
--- a/radix-engine-interface/src/types/node_layout.rs
+++ b/radix-engine-interface/src/types/node_layout.rs
@@ -16,7 +16,8 @@ pub const BOOT_LOADER_PARTITION: PartitionNumber = PartitionNumber(32u8);
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Sbor, PartialEq, Eq, Hash, PartialOrd, Ord, FromRepr)]
 pub enum BootLoaderField {
-    Vm = 2u8,
+    SystemBoot = 1,
+    VmBoot = 2,
 }
 
 pub const TYPE_INFO_FIELD_PARTITION: PartitionNumber = PartitionNumber(0u8);

--- a/radix-substate-store-queries/src/typed_substate_layout.rs
+++ b/radix-substate-store-queries/src/typed_substate_layout.rs
@@ -27,6 +27,7 @@ use radix_engine::blueprints::pool::v1::substates::two_resource_pool::{
 pub use radix_engine::blueprints::resource::*;
 pub use radix_engine::object_modules::role_assignment::*;
 pub use radix_engine::object_modules::royalty::*;
+use radix_engine::system::system_callback::SystemBoot;
 use radix_engine::system::system_substates::FieldSubstate;
 use radix_engine::system::system_substates::KeyValueEntrySubstate;
 pub use radix_engine::system::type_info::*;
@@ -390,6 +391,7 @@ pub enum TypedSubstateValue {
 
 #[derive(Debug)]
 pub enum BootLoaderSubstateValue {
+    System(SystemBoot),
     Vm(VmBoot),
 }
 
@@ -467,10 +469,10 @@ fn to_typed_substate_value_internal(
 ) -> Result<TypedSubstateValue, DecodeError> {
     let substate_value = match substate_key {
         TypedSubstateKey::BootLoader(boot_loader_key) => {
-            TypedSubstateValue::BootLoader(match boot_loader_key {
-                TypedBootLoaderSubstateKey::BootLoaderField(BootLoaderField::Vm) => {
-                    BootLoaderSubstateValue::Vm(scrypto_decode(data)?)
-                }
+            let TypedBootLoaderSubstateKey::BootLoaderField(boot_loader_field) = boot_loader_key;
+            TypedSubstateValue::BootLoader(match boot_loader_field {
+                BootLoaderField::SystemBoot => BootLoaderSubstateValue::Vm(scrypto_decode(data)?),
+                BootLoaderField::VmBoot => BootLoaderSubstateValue::Vm(scrypto_decode(data)?),
             })
         }
         TypedSubstateKey::TypeInfo(type_info_key) => {


### PR DESCRIPTION
## Summary
A trivial line with mapping needed by Node.
Probably missed at https://github.com/radixdlt/radixdlt-scrypto/pull/1763.

## Testing
Node's int-tests fail without it, and hopefully will pass with it.