### PR TITLE
Quickfix: Mapping for `SystemBoot` typed value

### DIFF
--- a/radix-substate-store-queries/src/typed_substate_layout.rs
+++ b/radix-substate-store-queries/src/typed_substate_layout.rs
@@ -471,7 +471,7 @@ fn to_typed_substate_value_internal(
         TypedSubstateKey::BootLoader(boot_loader_key) => {
             let TypedBootLoaderSubstateKey::BootLoaderField(boot_loader_field) = boot_loader_key;
             TypedSubstateValue::BootLoader(match boot_loader_field {
-                BootLoaderField::SystemBoot => BootLoaderSubstateValue::Vm(scrypto_decode(data)?),
+                BootLoaderField::SystemBoot => BootLoaderSubstateValue::System(scrypto_decode(data)?),
                 BootLoaderField::VmBoot => BootLoaderSubstateValue::Vm(scrypto_decode(data)?),
             })
         }

--- a/radix-substate-store-queries/src/typed_substate_layout.rs
+++ b/radix-substate-store-queries/src/typed_substate_layout.rs
@@ -471,7 +471,9 @@ fn to_typed_substate_value_internal(
         TypedSubstateKey::BootLoader(boot_loader_key) => {
             let TypedBootLoaderSubstateKey::BootLoaderField(boot_loader_field) = boot_loader_key;
             TypedSubstateValue::BootLoader(match boot_loader_field {
-                BootLoaderField::SystemBoot => BootLoaderSubstateValue::System(scrypto_decode(data)?),
+                BootLoaderField::SystemBoot => {
+                    BootLoaderSubstateValue::System(scrypto_decode(data)?)
+                }
                 BootLoaderField::VmBoot => BootLoaderSubstateValue::Vm(scrypto_decode(data)?),
             })
         }


### PR DESCRIPTION
## Summary
A quickfix to the other recent quickfix (https://github.com/radixdlt/radixdlt-scrypto/pull/1773).

## Details
A copy-paste error.

## Testing
This is tested on Node's side (which is how it was detected).