### PR TITLE
Improve Rust Analyzer's performance on the main branch

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -37,4 +37,3 @@ runs:
       # see: https://github.com/actions/runner-images/blob/macOS-12/20240105.3/images/macos/macos-12-Readme.md
       run: echo "$(brew --prefix llvm@15)/bin" >> $GITHUB_PATH
       shell: bash
-

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust toolchain
       uses: RDXWorks-actions/toolchain@master
       with:
-        toolchain: stable
+        toolchain: 1.77.2
         default: true
         target: wasm32-unknown-unknown
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -10,6 +10,7 @@ runs:
         toolchain: 1.77.2
         default: true
         target: wasm32-unknown-unknown
+        components: rustfmt
 
     - name: Install nextest
       uses: RDXWorks-actions/install-action@nextest

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,10 +7,9 @@ runs:
     - name: Install Rust toolchain
       uses: RDXWorks-actions/toolchain@master
       with:
-        toolchain: 1.70.0
+        toolchain: stable
         default: true
         target: wasm32-unknown-unknown
-        components: rustfmt
 
     - name: Install nextest
       uses: RDXWorks-actions/install-action@nextest

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust toolchain
       uses: RDXWorks-actions/toolchain@master
       with:
-        toolchain: 1.77.2
+        toolchain: 1.70.0
         default: true
         target: wasm32-unknown-unknown
         components: rustfmt

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,10 @@ jobs:
   benchmark:
     name: Run bench
     runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,11 +11,9 @@ concurrency:
 jobs:
   benchmark:
     name: Run bench
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
-
+    runs-on: ubuntu-16-cores-selfhosted
     permissions:
       pull-requests: write
-
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [gh-runner-scrypto-ubuntu-jammy-16-cores]
+        os: [ubuntu-16-cores-selfhosted]
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -143,7 +143,7 @@ jobs:
 
   radix-engine:
     name: Run Radix Engine tests
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+    runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -165,7 +165,7 @@ jobs:
     # - overflow-checks
     # which are false for release variant
     name: Run Radix Engine tests (release)
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+    runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -182,7 +182,7 @@ jobs:
 
   radix-engine-no-std:
     name: Run Radix Engine tests (no_std)
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+    runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -199,7 +199,7 @@ jobs:
 
   radix-engine-wasmer:
     name: Run Radix Engine tests (wasmer)
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+    runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -261,7 +261,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [gh-runner-scrypto-ubuntu-jammy-16-cores, windows-latest-16-cores]
+        os: [ubuntu-16-cores-selfhosted, windows-16-cores-selfhosted]
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -287,7 +287,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [gh-runner-scrypto-ubuntu-jammy-16-cores, windows-latest-16-cores, macos-latest]
+        os: [ubuntu-16-cores-selfhosted, windows-16-cores-selfhosted, macos-latest]
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -307,7 +307,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [gh-runner-scrypto-ubuntu-jammy-16-cores]
+        os: [ubuntu-16-cores-selfhosted]
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -320,7 +320,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [gh-runner-scrypto-ubuntu-jammy-16-cores]
+        os: [ubuntu-16-cores-selfhosted]
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Setup environment
@@ -330,7 +330,7 @@ jobs:
 
   determinism-test:
     name: Run determinism test
-    runs-on: gh-runner-scrypto-ubuntu-jammy-16-cores
+    runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main
       - name: Cargo Check

--- a/.github/workflows/publish-scrypto-builder.yml
+++ b/.github/workflows/publish-scrypto-builder.yml
@@ -16,7 +16,7 @@ jobs:
   build-amd:
     uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
-      runs_on: gh-runner-scrypto-ubuntu-jammy-16-cores
+      runs_on: ubuntu-16-cores-selfhosted
       environment: "release"
       image_registry: "docker.io"
       image_organization: "radixdlt"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Language for building DeFi apps on Radix.
 
-Documentation: https://docs-babylon.radixdlt.com/main/scrypto/introduction.html
+Documentation: https://docs.radixdlt.com/docs/scrypto-1
 
 
 ## Installation

--- a/radix-engine-common/src/lib.rs
+++ b/radix-engine-common/src/lib.rs
@@ -38,7 +38,7 @@ pub use radix_engine_derive::{
 
 // This is to make derives work within this crate.
 // See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as radix_engine_common;
+extern crate self as radix_engine_common;
 
 /// Each module should have its own prelude, which:
 /// * Adds preludes of upstream crates

--- a/radix-engine-common/src/lib.rs
+++ b/radix-engine-common/src/lib.rs
@@ -36,8 +36,16 @@ pub use radix_engine_derive::{
     ScryptoDecode, ScryptoEncode, ScryptoEvent, ScryptoSbor,
 };
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
 extern crate self as radix_engine_common;
 
 /// Each module should have its own prelude, which:

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -29,8 +29,16 @@ pub use radix_engine_common::*;
 pub extern crate sbor;
 pub use sbor::{Categorize, Decode, Encode, Sbor};
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
 extern crate self as radix_engine_interface;
 
 /// Each module should have its own prelude, which:

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -31,7 +31,7 @@ pub use sbor::{Categorize, Decode, Encode, Sbor};
 
 // This is to make derives work within this crate.
 // See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as radix_engine_interface;
+extern crate self as radix_engine_interface;
 
 /// Each module should have its own prelude, which:
 /// * Adds preludes of upstream crates

--- a/radix-engine-tests/tests/vm/stack_size.rs
+++ b/radix-engine-tests/tests/vm/stack_size.rs
@@ -66,7 +66,7 @@ fn test_error_enum_sizes() {
     print_size!(AccessControllerError);
     print_size!(NonFungibleResourceManagerError);
 
-    check_size!(RuntimeError, 100);
+    check_size!(RuntimeError, 116);
     check_size!(KernelError, 100);
     check_size!(CallFrameError, 100);
     check_size!(SystemError, 100);

--- a/sbor/src/lib.rs
+++ b/sbor/src/lib.rs
@@ -70,8 +70,16 @@ pub use sbor_derive::{
     Describe, Encode, Sbor,
 };
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
 extern crate self as sbor;
 
 // For self-contained macros

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -47,7 +47,7 @@ pub use radix_engine_interface::{
 
 // This is to make derives work within this crate.
 // See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as scrypto;
+extern crate self as scrypto;
 
 /// Sets up panic hook.
 pub fn set_up_panic_hook() {

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -45,8 +45,16 @@ pub use radix_engine_interface::{
     address, api, blueprints, constants, crypto, data, math, network, schema, time, types,
 };
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
 extern crate self as scrypto;
 
 /// Sets up panic hook.


### PR DESCRIPTION
## Summary

This PR improves Rust analyzer's performance on the main branch by getting rid of a cyclic path that we had in our crates where things like `scrypto::scrypto::scrypto::scrypto::scrypto::prelude::*` were valid paths.