### PR TITLE
Improve Rust Analyzer performance on `develop`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,20 @@
 {
     "rust-analyzer.linkedProjects": [
+        // Root Workspace & CLIs.
         "Cargo.toml",
         "radix-clis/Cargo.toml",
+        // Various blueprints we have.
+        "examples/everything/Cargo.toml",
+        "examples/hello-world/Cargo.toml",
+        "examples/no-std/Cargo.toml",
+        "radix-clis/tests/blueprints/Cargo.toml",
+        "radix-engine-tests/assets/blueprints/Cargo.toml",
+        "radix-engine/assets/blueprints/Cargo.toml",
+        "radix-transaction-scenarios/assets/blueprints/Cargo.toml",
+        "scrypto-compiler/tests/assets/scenario_1/Cargo.toml",
+        "scrypto-compiler/tests/assets/scenario_2/Cargo.toml",
+        "scrypto-test/assets/blueprints/Cargo.toml",
+        "scrypto-test/tests/blueprints/Cargo.toml",
     ],
     "cSpell.words": [
         "accesscontroller",

--- a/cargo_check.py
+++ b/cargo_check.py
@@ -1,0 +1,87 @@
+"""
+This script finds all of the Cargo.toml files in the script directory, finds their workspace cargo
+manifest, and runs a `cargo check` on the workspace manifest. Essentially this is a check on all of
+the crates we have regardless of what workspace they're in.
+"""
+
+from typing import TypeVar
+import subprocess
+import json
+import os
+
+
+def workspace_path(manifest_path: str) -> str:
+    process: subprocess.Popen = subprocess.Popen(
+        [
+            "cargo",
+            "metadata",
+            "--manifest-path",
+            manifest_path,
+            "--format-version",
+            "1",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout: bytes
+    stderr: bytes
+    stdout, stderr = process.communicate()
+
+    try:
+        return json.loads(stdout)["workspace_root"]
+    except:
+        raise Exception(manifest_path, stdout.decode(), stderr.decode())
+
+
+T = TypeVar("T")
+def unique(l: list[T]) -> list[T]:
+    return list(set(l))
+
+
+def main() -> None:
+    # Find all of the `Cargo.toml` files recursively in the script directory.
+    workspace_manifest_paths: list[str] = sorted(
+        unique(
+            [
+                os.path.join(
+                    workspace_path(os.path.join(dirpath, filename)), "Cargo.toml"
+                )
+                for dirpath, _, filenames in os.walk(
+                    os.path.dirname(os.path.realpath(__file__))
+                )
+                for filename in filenames
+                if filename == "Cargo.toml"
+            ]
+        )
+    )
+
+    # Running cargo check on the manifest.
+    for workspace_manifest_file_path in workspace_manifest_paths:
+        if "dec_macros" in workspace_manifest_file_path:
+            continue
+
+        process: subprocess.Popen = subprocess.Popen(
+            [
+                "cargo",
+                "check",
+                "--all-targets",
+                "--manifest-path",
+                workspace_manifest_file_path,
+            ],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+
+        stderr: bytes
+        _, stderr = process.communicate()
+
+        emoji: str = "❌" if process.returncode != 0 else "✅"
+        print(f"{emoji} {workspace_manifest_file_path}")
+
+        if process.returncode != 0:
+            print(stderr.decode())
+            raise Exception("Check failed on one of the workspaces")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/everything/Cargo.lock
+++ b/examples/everything/Cargo.lock
@@ -391,7 +391,6 @@ dependencies = [
 name = "everything"
 version = "1.2.0-dev"
 dependencies = [
- "sbor",
  "scrypto",
  "scrypto-test",
 ]

--- a/examples/everything/Cargo.toml
+++ b/examples/everything/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../sbor" }
 scrypto = { path = "../../scrypto" }
 
 [dev-dependencies]

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -465,7 +465,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 name = "hello-world"
 version = "1.2.0-dev"
 dependencies = [
- "sbor",
  "scrypto",
  "scrypto-test",
 ]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../sbor" }
 scrypto = { path = "../../scrypto" }
 
 [dev-dependencies]

--- a/radix-clis/assets/template/Cargo.toml_template
+++ b/radix-clis/assets/template/Cargo.toml_template
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = ${sbor}
 scrypto = ${scrypto}
 
 [dev-dependencies]

--- a/radix-clis/tests/blueprints/Cargo.toml
+++ b/radix-clis/tests/blueprints/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../sbor" }
 scrypto = { path = "../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-common/src/lib.rs
+++ b/radix-common/src/lib.rs
@@ -38,9 +38,17 @@ pub use radix_sbor_derive::{
     ScryptoDecode, ScryptoEncode, ScryptoEvent, ScryptoSbor,
 };
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as radix_common;
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
+extern crate self as radix_common;
 
 /// Each module should have its own prelude, which:
 /// * Adds preludes of upstream crates

--- a/radix-common/src/macros.rs
+++ b/radix-common/src/macros.rs
@@ -150,8 +150,8 @@ macro_rules! count {
 #[macro_export]
 macro_rules! scrypto_args {
     ($($args: expr),*) => {{
-        use ::sbor::Encoder;
-        let mut buf = ::sbor::rust::vec::Vec::new();
+        use sbor::Encoder;
+        let mut buf = sbor::rust::vec::Vec::new();
         let mut encoder = $crate::data::scrypto::ScryptoEncoder::new(
             &mut buf,
             $crate::data::scrypto::SCRYPTO_SBOR_V1_MAX_DEPTH,
@@ -175,8 +175,8 @@ macro_rules! scrypto_args {
 #[macro_export]
 macro_rules! manifest_args {
     ($($args: expr),*$(,)?) => {{
-        use ::sbor::Encoder;
-        let mut buf = ::sbor::rust::vec::Vec::new();
+        use sbor::Encoder;
+        let mut buf = sbor::rust::vec::Vec::new();
         let mut encoder = $crate::data::manifest::ManifestEncoder::new(&mut buf, $crate::data::manifest::MANIFEST_SBOR_V1_MAX_DEPTH);
         encoder.write_payload_prefix($crate::data::manifest::MANIFEST_SBOR_V1_PAYLOAD_PREFIX).unwrap();
         encoder.write_value_kind($crate::data::manifest::ManifestValueKind::Tuple).unwrap();

--- a/radix-engine-interface/src/blueprints/locker/invocations.rs
+++ b/radix-engine-interface/src/blueprints/locker/invocations.rs
@@ -4,7 +4,6 @@ use crate::blueprints::macros::*;
 use crate::blueprints::resource::*;
 use radix_common::data::manifest::model::*;
 use radix_common::prelude::*;
-use radix_common::*;
 
 define_type_marker!(Some(LOCKER_PACKAGE), AccountLocker);
 

--- a/radix-engine-interface/src/blueprints/pool/multi_resource_pool/invocations.rs
+++ b/radix-engine-interface/src/blueprints/pool/multi_resource_pool/invocations.rs
@@ -4,7 +4,6 @@ use crate::blueprints::resource::*;
 use radix_common::data::manifest::model::*;
 use radix_common::math::*;
 use radix_common::prelude::*;
-use radix_common::*;
 
 define_type_marker!(Some(POOL_PACKAGE), MultiResourcePool);
 

--- a/radix-engine-interface/src/blueprints/pool/one_resource_pool/invocations.rs
+++ b/radix-engine-interface/src/blueprints/pool/one_resource_pool/invocations.rs
@@ -4,7 +4,6 @@ use crate::blueprints::resource::*;
 use radix_common::data::manifest::model::*;
 use radix_common::math::*;
 use radix_common::prelude::*;
-use radix_common::*;
 
 define_type_marker!(Some(POOL_PACKAGE), OneResourcePool);
 

--- a/radix-engine-interface/src/blueprints/pool/two_resource_pool/invocations.rs
+++ b/radix-engine-interface/src/blueprints/pool/two_resource_pool/invocations.rs
@@ -4,7 +4,6 @@ use crate::blueprints::resource::*;
 use radix_common::data::manifest::model::*;
 use radix_common::math::*;
 use radix_common::prelude::*;
-use radix_common::*;
 
 define_type_marker!(Some(POOL_PACKAGE), TwoResourcePool);
 

--- a/radix-engine-interface/src/lib.rs
+++ b/radix-engine-interface/src/lib.rs
@@ -14,9 +14,17 @@ pub mod macros;
 pub mod object_modules;
 pub mod types;
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as radix_engine_interface;
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
+extern crate self as radix_engine_interface;
 
 /// Each module should have its own prelude, which:
 /// * Adds preludes of upstream crates

--- a/radix-engine-tests/assets/blueprints/address/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/address/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/address_reservation/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/address_reservation/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/allocated_address/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/allocated_address/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/arguments/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/arguments/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/auth_scenarios/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/auth_scenarios/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/balance_changes/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/balance_changes/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/bucket/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/bucket/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/cast/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/cast/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/clock/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/clock/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/component/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/component/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/consensus_manager/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/consensus_manager/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/core/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/core/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/costing/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/costing/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/data_validation/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/data_validation/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/decimal/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/decimal/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0-rc1"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/deep_sbor/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/deep_sbor/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/event-replacement/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/event-replacement/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/events/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/events/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/events_invalid/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/events_invalid/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/execution_trace/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/execution_trace/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/external_blueprint_caller/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/external_blueprint_caller/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/fake_bucket/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/fake_bucket/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/fee/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/fee/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/fee_reserve_states/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/fee_reserve_states/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/kv_store/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/kv_store/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/large_package/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/large_package/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 non_fungible = { path = "../non_fungible" }

--- a/radix-engine-tests/assets/blueprints/leaks/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/leaks/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/local_component/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/local_component/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/local_recursion/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/local_recursion/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/logger/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/logger/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/metadata_component/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/metadata_component/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/module/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/module/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/non_fungible/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/non_fungible/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_generic_proxy_with_global/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_generic_proxy_with_global/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_proxy_with_global/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_proxy_with_global/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_proxy_with_owned/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracle_proxies/oracle_proxy_with_owned/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracles/oracle_v1/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracles/oracle_v1/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracles/oracle_v2/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracles/oracle_v2/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/oracles/oracle_v3/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/oracles/oracle_v3/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/package/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/package/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/package_invalid/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/package_invalid/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/package_schema/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/package_schema/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/package_token/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/package_token/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/proof/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/proof/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/proof_creation/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/proof_creation/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/publish_package/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/publish_package/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/recall/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/recall/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/recursion/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/recursion/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/reentrancy/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/reentrancy/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/reference/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/reference/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/remote_generic_args/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/remote_generic_args/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/resource/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/resource/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/role-assignment-edge-cases/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/role-assignment-edge-cases/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/role_assignment/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/role_assignment/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/royalty-auth/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/royalty-auth/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/royalty-edge-cases/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/royalty-edge-cases/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/royalty/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/royalty/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/scrypto_env/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/scrypto_env/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/static_dependencies/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/static_dependencies/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/static_dependencies2/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/static_dependencies2/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/storage/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/storage/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/stored_external_component/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/stored_external_component/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/stored_resource/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/stored_resource/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/stored_values/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/stored_values/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/system/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/system/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/system_wasm_buffers/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/system_wasm_buffers/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/transaction_limits/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/transaction_limits/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/transaction_runtime/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/transaction_runtime/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/tx_processor_access/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/tx_processor_access/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/validator/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/validator/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/vault/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/vault/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine-tests/assets/blueprints/wasm_non_mvp/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/wasm_non_mvp/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../sbor" }
 scrypto = { path = "../../../../scrypto" }
 
 [dev-dependencies]

--- a/radix-engine/assets/blueprints/Cargo.lock
+++ b/radix-engine/assets/blueprints/Cargo.lock
@@ -26,7 +26,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -39,19 +48,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "bnum"
-version = "0.7.0"
+name = "blst"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "bnum"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 dependencies = [
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "const-sha1"
-version = "0.2.0"
-source = "git+https://github.com/radixdlt/const-sha1#5e9ae2a99e9c76e85aa67f42e4b62e7f7ce8dad4"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-common"
@@ -64,14 +113,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand",
+ "serde",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -81,10 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "faucet"
 version = "1.0.0"
 dependencies = [
- "sbor",
  "scrypto",
 ]
 
@@ -102,21 +201,43 @@ dependencies = [
 name = "genesis-helper"
 version = "1.0.0"
 dependencies = [
- "sbor",
  "scrypto",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
+name = "getrandom"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -129,9 +250,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0-pre"
-source = "git+https://github.com/bluss/indexmap?rev=eedabaca9f84e520eab01325b305c08f3773e66c#eedabaca9f84e520eab01325b305c08f3773e66c"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
+ "equivalent",
  "hashbrown",
  "serde",
 ]
@@ -152,10 +275,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "num-bigint"
@@ -188,10 +326,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -212,64 +372,128 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix-engine-common"
-version = "1.0.0"
+name = "radix-blueprint-schema-init"
+version = "1.2.0-dev"
+dependencies = [
+ "bitflags",
+ "radix-common",
+ "sbor",
+ "serde",
+]
+
+[[package]]
+name = "radix-common"
+version = "1.2.0-dev"
 dependencies = [
  "bech32",
  "blake2",
+ "blst",
  "bnum",
+ "ed25519-dalek",
  "hex",
  "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits",
  "paste",
- "radix-engine-derive",
+ "radix-rust",
+ "radix-sbor-derive",
  "sbor",
+ "secp256k1",
  "serde",
+ "sha3",
  "strum",
- "utils",
+ "zeroize",
 ]
 
 [[package]]
-name = "radix-engine-derive"
-version = "1.0.0"
+name = "radix-common-derive"
+version = "1.2.0-dev"
 dependencies = [
+ "paste",
  "proc-macro2",
  "quote",
- "sbor-derive-common",
- "syn 1.0.93",
+ "radix-common",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "bitflags",
  "const-sha1",
  "hex",
  "lazy_static",
  "paste",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-macros",
+ "radix-blueprint-schema-init",
+ "radix-common",
+ "radix-common-derive",
+ "radix-rust",
  "regex",
  "sbor",
- "scrypto-schema",
+ "serde",
  "serde_json",
  "strum",
- "utils",
 ]
 
 [[package]]
-name = "radix-engine-macros"
-version = "1.0.0"
+name = "radix-rust"
+version = "1.2.0-dev"
 dependencies = [
- "paste",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
+name = "radix-sbor-derive"
+version = "1.2.0-dev"
+dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-common",
- "syn 1.0.93",
+ "sbor-derive-common",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -311,20 +535,20 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sbor"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "const-sha1",
  "hex",
  "lazy_static",
  "paste",
+ "radix-rust",
  "sbor-derive",
  "serde",
- "utils",
 ]
 
 [[package]]
 name = "sbor-derive"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -332,18 +556,18 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "const-sha1",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.93",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "scrypto"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -351,39 +575,46 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "radix-engine-common",
- "radix-engine-derive",
+ "radix-blueprint-schema-init",
+ "radix-common",
  "radix-engine-interface",
+ "radix-rust",
  "sbor",
  "scrypto-derive",
- "scrypto-schema",
  "strum",
- "utils",
 ]
 
 [[package]]
 name = "scrypto-derive"
-version = "1.0.0"
+version = "1.2.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
- "radix-engine-common",
+ "radix-blueprint-schema-init",
+ "radix-common",
  "regex",
  "sbor",
- "scrypto-schema",
  "serde",
  "serde_json",
- "syn 1.0.93",
+ "syn 1.0.109",
 ]
 
 [[package]]
-name = "scrypto-schema"
-version = "1.0.0"
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitflags",
- "radix-engine-common",
- "sbor",
- "serde",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -418,6 +649,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,16 +707,6 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
-source = "git+https://github.com/dtolnay/syn.git?tag=1.0.93#2e505a847174ff8939431c4f5ffb565906590ac2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
@@ -478,6 +728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,21 +749,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "utils"
-version = "1.0.0"
-dependencies = [
- "indexmap",
- "serde",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]

--- a/radix-engine/assets/blueprints/faucet/Cargo.toml
+++ b/radix-engine/assets/blueprints/faucet/Cargo.toml
@@ -4,8 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../sbor" }
-scrypto = { path = "../../../scrypto" }
+scrypto = { path = "../../../../scrypto" }
 
 [lib]
 doctest = false

--- a/radix-engine/assets/blueprints/genesis_helper/Cargo.toml
+++ b/radix-engine/assets/blueprints/genesis_helper/Cargo.toml
@@ -4,8 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../sbor" }
-scrypto = { path = "../../../scrypto" }
+scrypto = { path = "../../../../scrypto" }
 
 [lib]
 doctest = false

--- a/radix-engine/assets/blueprints/genesis_helper/src/lib.rs
+++ b/radix-engine/assets/blueprints/genesis_helper/src/lib.rs
@@ -1,4 +1,3 @@
-use scrypto::api::node_modules::metadata::*;
 use scrypto::prelude::*;
 
 // Important: the types defined here must match those in bootstrap.rs

--- a/radix-engine/src/blueprints/access_controller/package.rs
+++ b/radix-engine/src/blueprints/access_controller/package.rs
@@ -5,7 +5,6 @@ use crate::kernel::kernel_api::KernelNodeApi;
 use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::package::PackageDefinition;
-use radix_engine_interface::*;
 use radix_native_sdk::runtime::Runtime;
 use sbor::rust::prelude::*;
 

--- a/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -11,7 +11,6 @@ use radix_engine_interface::api::{ClientApi, FieldValue, GenericArgs, ACTOR_STAT
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::object_modules::metadata::MetadataInit;
 use radix_engine_interface::object_modules::ModuleConfig;
-use radix_engine_interface::*;
 use radix_native_sdk::component::{globalize_object, globalize_object_with_inner_object_and_event};
 use radix_native_sdk::runtime::Runtime;
 

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -11,7 +11,6 @@ use radix_engine_interface::api::{
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::object_modules::metadata::MetadataInit;
 use radix_engine_interface::object_modules::ModuleConfig;
-use radix_engine_interface::*;
 use radix_native_sdk::component::{globalize_object, globalize_object_with_inner_object_and_event};
 use radix_native_sdk::runtime::Runtime;
 

--- a/radix-engine/src/system/checkers/kernel_db_checker.rs
+++ b/radix-engine/src/system/checkers/kernel_db_checker.rs
@@ -1,6 +1,5 @@
 use crate::internal_prelude::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use radix_substate_store_interface::db_key_mapper::DatabaseKeyMapper;
 use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::ListableSubstateDatabase;

--- a/radix-engine/src/system/checkers/system_db_checker.rs
+++ b/radix-engine/src/system/checkers/system_db_checker.rs
@@ -13,7 +13,6 @@ use radix_engine_interface::blueprints::package::{
     BlueprintDefinition, BlueprintPayloadIdentifier, BlueprintType, KeyOrValue,
 };
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use radix_substate_store_interface::interface::ListableSubstateDatabase;
 use radix_substate_store_interface::interface::SubstateDatabase;
 

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -6,7 +6,6 @@ use radix_common::prelude::{
 use radix_engine_interface::api::{AttachedModuleId, CollectionIndex, ModuleId};
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use radix_substate_store_interface::db_key_mapper::{
     MappedCommittableSubstateDatabase, SubstateKeyContent,
 };

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -8,7 +8,6 @@ use crate::kernel::kernel_callback_api::{
 use crate::system::actor::Actor;
 use crate::system::system_modules::transaction_runtime::Event;
 use crate::track::interface::StoreCommit;
-use radix_engine_interface::*;
 
 #[derive(Debug, IntoStaticStr)]
 pub enum ExecutionCostingEntry<'a> {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -20,7 +20,7 @@ use crate::{
 use radix_engine_interface::api::AttachedModuleId;
 use radix_engine_interface::blueprints::package::BlueprintVersionKey;
 use radix_engine_interface::blueprints::resource::LiquidFungibleResource;
-use radix_engine_interface::{types::NodeId, *};
+use radix_engine_interface::types::NodeId;
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum CostingError {

--- a/radix-engine/src/transaction/state_update_summary.rs
+++ b/radix-engine/src/transaction/state_update_summary.rs
@@ -5,7 +5,6 @@ use crate::track::{NodeStateUpdates, PartitionStateUpdates, StateUpdates};
 use radix_common::data::scrypto::model::*;
 use radix_common::math::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use radix_substate_store_interface::interface::DatabaseUpdate;
 use radix_substate_store_interface::{
     db_key_mapper::SpreadPrefixKeyMapper, interface::SubstateDatabase,

--- a/radix-sbor-derive/src/manifest_categorize.rs
+++ b/radix-sbor-derive/src/manifest_categorize.rs
@@ -27,14 +27,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl ::sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind> for MyStruct {
+                impl sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind> for MyStruct {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind> {
-                        ::sbor::ValueKind::Tuple
+                    fn value_kind() -> sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind> {
+                        sbor::ValueKind::Tuple
                     }
                 }
 
-                impl ::sbor::SborTuple<radix_common::data::manifest::ManifestCustomValueKind> for MyStruct {
+                impl sbor::SborTuple<radix_common::data::manifest::ManifestCustomValueKind> for MyStruct {
                     fn get_length(&self) -> usize {
                         0usize
                     }
@@ -52,16 +52,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<T: Bound> ::sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
+                impl<T: Bound> sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
                     for MyEnum<T>
                 {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind> {
-                        ::sbor::ValueKind::Enum
+                    fn value_kind() -> sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind> {
+                        sbor::ValueKind::Enum
                     }
                 }
 
-                impl<T: Bound> ::sbor::SborEnum<radix_common::data::manifest::ManifestCustomValueKind> for MyEnum<T> {
+                impl<T: Bound> sbor::SborEnum<radix_common::data::manifest::ManifestCustomValueKind> for MyEnum<T> {
                     fn get_discriminator(&self) -> u8 {
                         match self {
                             Self::A { .. } => 0u8,

--- a/radix-sbor-derive/src/manifest_decode.rs
+++ b/radix-sbor-derive/src/manifest_decode.rs
@@ -27,16 +27,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<D: ::sbor::Decoder<radix_common::data::manifest::ManifestCustomValueKind> >
-                    ::sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D> for MyStruct
+                impl<D: sbor::Decoder<radix_common::data::manifest::ManifestCustomValueKind> >
+                    sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D> for MyStruct
                 {
                     #[inline]
                     fn decode_body_with_value_kind(
                         decoder: &mut D,
-                        value_kind: ::sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind>
-                    ) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                        value_kind: sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind>
+                    ) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(0)?;
                         Ok(Self {})
                     }
@@ -56,19 +56,19 @@ mod tests {
             quote! {
                 impl<
                         T: Bound,
-                        D: ::sbor::Decoder<radix_common::data::manifest::ManifestCustomValueKind>
-                    > ::sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D> for MyEnum<T>
+                        D: sbor::Decoder<radix_common::data::manifest::ManifestCustomValueKind>
+                    > sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D> for MyEnum<T>
                 where
-                    T: ::sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D>,
-                    T: ::sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
+                    T: sbor::Decode<radix_common::data::manifest::ManifestCustomValueKind, D>,
+                    T: sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
                 {
                     #[inline]
                     fn decode_body_with_value_kind(
                         decoder: &mut D,
-                        value_kind: ::sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind>
-                    ) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Enum)?;
+                        value_kind: sbor::ValueKind<radix_common::data::manifest::ManifestCustomValueKind>
+                    ) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Enum)?;
                         let discriminator = decoder.read_discriminator()?;
                         #[deny(unreachable_patterns)]
                         match discriminator {
@@ -86,7 +86,7 @@ mod tests {
                                 decoder.read_and_check_size(0)?;
                                 Ok(Self::C)
                             },
-                            _ => Err(::sbor::DecodeError::UnknownDiscriminator(discriminator))
+                            _ => Err(sbor::DecodeError::UnknownDiscriminator(discriminator))
                         }
                     }
                 }

--- a/radix-sbor-derive/src/manifest_encode.rs
+++ b/radix-sbor-derive/src/manifest_encode.rs
@@ -27,16 +27,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<E: ::sbor::Encoder<radix_common::data::manifest::ManifestCustomValueKind> >
-                    ::sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E> for MyStruct
+                impl<E: sbor::Encoder<radix_common::data::manifest::ManifestCustomValueKind> >
+                    sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E> for MyStruct
                 {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
                     }
@@ -56,19 +56,19 @@ mod tests {
             quote! {
                 impl<
                         T: Bound,
-                        E: ::sbor::Encoder<radix_common::data::manifest::ManifestCustomValueKind>
-                    > ::sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E> for MyEnum<T>
+                        E: sbor::Encoder<radix_common::data::manifest::ManifestCustomValueKind>
+                    > sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E> for MyEnum<T>
                 where
-                    T: ::sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E>,
-                    T: ::sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
+                    T: sbor::Encode<radix_common::data::manifest::ManifestCustomValueKind, E>,
+                    T: sbor::Categorize<radix_common::data::manifest::ManifestCustomValueKind>
                 {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Enum)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Enum)
                     }
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         match self {
                             Self::A { named, .. } => {
                                 encoder.write_discriminator(0u8)?;

--- a/radix-sbor-derive/src/scrypto_categorize.rs
+++ b/radix-sbor-derive/src/scrypto_categorize.rs
@@ -27,14 +27,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl ::sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind> for MyStruct {
+                impl sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind> for MyStruct {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind> {
-                        ::sbor::ValueKind::Tuple
+                    fn value_kind() -> sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind> {
+                        sbor::ValueKind::Tuple
                     }
                 }
 
-                impl ::sbor::SborTuple<radix_common::data::scrypto::ScryptoCustomValueKind> for MyStruct {
+                impl sbor::SborTuple<radix_common::data::scrypto::ScryptoCustomValueKind> for MyStruct {
                     fn get_length(&self) -> usize {
                         0usize
                     }
@@ -52,16 +52,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<T: Bound> ::sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
+                impl<T: Bound> sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
                     for MyEnum<T>
                 {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind> {
-                        ::sbor::ValueKind::Enum
+                    fn value_kind() -> sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind> {
+                        sbor::ValueKind::Enum
                     }
                 }
 
-                impl<T: Bound> ::sbor::SborEnum<radix_common::data::scrypto::ScryptoCustomValueKind> for MyEnum<T> {
+                impl<T: Bound> sbor::SborEnum<radix_common::data::scrypto::ScryptoCustomValueKind> for MyEnum<T> {
                     fn get_discriminator(&self) -> u8 {
                         match self {
                             Self::A { .. } => 0u8,

--- a/radix-sbor-derive/src/scrypto_decode.rs
+++ b/radix-sbor-derive/src/scrypto_decode.rs
@@ -27,16 +27,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<D: ::sbor::Decoder<radix_common::data::scrypto::ScryptoCustomValueKind> >
-                    ::sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D> for MyStruct
+                impl<D: sbor::Decoder<radix_common::data::scrypto::ScryptoCustomValueKind> >
+                    sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D> for MyStruct
                 {
                     #[inline]
                     fn decode_body_with_value_kind(
                         decoder: &mut D,
-                        value_kind: ::sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind>
-                    ) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                        value_kind: sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    ) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(0)?;
                         Ok(Self {})
                     }
@@ -56,19 +56,19 @@ mod tests {
             quote! {
                 impl<
                         T: Bound,
-                        D: ::sbor::Decoder<radix_common::data::scrypto::ScryptoCustomValueKind>
-                    > ::sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D> for MyEnum<T>
+                        D: sbor::Decoder<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    > sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D> for MyEnum<T>
                 where
-                    T: ::sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D>,
-                    T: ::sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    T: sbor::Decode<radix_common::data::scrypto::ScryptoCustomValueKind, D>,
+                    T: sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
                 {
                     #[inline]
                     fn decode_body_with_value_kind(
                         decoder: &mut D,
-                        value_kind: ::sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind>
-                    ) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Enum)?;
+                        value_kind: sbor::ValueKind<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    ) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Enum)?;
                         let discriminator = decoder.read_discriminator()?;
                         #[deny(unreachable_patterns)]
                         match discriminator {
@@ -86,7 +86,7 @@ mod tests {
                                 decoder.read_and_check_size(0)?;
                                 Ok(Self::C)
                             },
-                            _ => Err(::sbor::DecodeError::UnknownDiscriminator(discriminator))
+                            _ => Err(sbor::DecodeError::UnknownDiscriminator(discriminator))
                         }
                     }
                 }

--- a/radix-sbor-derive/src/scrypto_describe.rs
+++ b/radix-sbor-derive/src/scrypto_describe.rs
@@ -29,19 +29,19 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl ::sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for MyStruct {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                impl sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for MyStruct {
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "MyStruct",
                         &[],
                         &#code_hash
                     );
-                    fn type_data() -> ::sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_named_fields(
+                    fn type_data() -> sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_named_fields(
                             "MyStruct",
-                            ::sbor::rust::vec![],
+                            sbor::rust::vec![],
                         )
                     }
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {}
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {}
                 }
             },
         );
@@ -56,26 +56,26 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<T> ::sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for Thing<T>
+                impl<T> sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for Thing<T>
                 where
-                    T: ::sbor::Describe<
+                    T: sbor::Describe<
                         radix_common::data::scrypto::ScryptoCustomTypeKind
                     >
                 {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Thing",
                         &[<T>::TYPE_ID,],
                         &#code_hash
                     );
-                    fn type_data() -> ::sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_named_fields(
+                    fn type_data() -> sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_named_fields(
                             "Thing",
-                            ::sbor::rust::vec![
-                                ("field", <T as ::sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind >>::TYPE_ID),
+                            sbor::rust::vec![
+                                ("field", <T as sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind >>::TYPE_ID),
                             ],
                         )
                     }
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {
                         aggregator.add_child_type_and_descendents::<T>();
                     }
                 }
@@ -94,27 +94,27 @@ mod tests {
             output,
             quote! {
                 impl<T: Bound>
-                    ::sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for MyEnum<T>
+                    sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind > for MyEnum<T>
                 where
-                    T: ::sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind >
+                    T: sbor::Describe<radix_common::data::scrypto::ScryptoCustomTypeKind >
                 {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "MyEnum",
                         &[<T>::TYPE_ID,],
                         &#code_hash
                     );
-                    fn type_data() -> ::sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, ::sbor::RustTypeId> {
-                        use ::sbor::rust::borrow::ToOwned;
-                        ::sbor::TypeData::enum_variants(
+                    fn type_data() -> sbor::TypeData<radix_common::data::scrypto::ScryptoCustomTypeKind, sbor::RustTypeId> {
+                        use sbor::rust::borrow::ToOwned;
+                        sbor::TypeData::enum_variants(
                             "MyEnum",
-                            :: sbor :: rust :: prelude :: indexmap ! [
-                                0u8 => :: sbor :: TypeData :: struct_with_named_fields ("A", :: sbor :: rust :: vec ! [("named", < T as :: sbor :: Describe < radix_common::data::scrypto::ScryptoCustomTypeKind >> :: TYPE_ID) ,] ,) ,
-                                1u8 => :: sbor :: TypeData :: struct_with_unnamed_fields ("B", :: sbor :: rust :: vec ! [< String as :: sbor :: Describe < radix_common::data::scrypto::ScryptoCustomTypeKind >> :: TYPE_ID ,] ,) ,
-                                2u8 => :: sbor :: TypeData :: struct_with_unit_fields ("C") ,
+                            sbor :: rust :: prelude :: indexmap ! [
+                                0u8 => sbor :: TypeData :: struct_with_named_fields ("A", sbor :: rust :: vec ! [("named", < T as sbor :: Describe < radix_common::data::scrypto::ScryptoCustomTypeKind >> :: TYPE_ID) ,] ,) ,
+                                1u8 => sbor :: TypeData :: struct_with_unnamed_fields ("B", sbor :: rust :: vec ! [< String as sbor :: Describe < radix_common::data::scrypto::ScryptoCustomTypeKind >> :: TYPE_ID ,] ,) ,
+                                2u8 => sbor :: TypeData :: struct_with_unit_fields ("C") ,
                             ],
                         )
                     }
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<radix_common::data::scrypto::ScryptoCustomTypeKind >) {
                         aggregator.add_child_type_and_descendents::<T>();
                         aggregator.add_child_type_and_descendents::<String>();
                     }

--- a/radix-sbor-derive/src/scrypto_encode.rs
+++ b/radix-sbor-derive/src/scrypto_encode.rs
@@ -27,16 +27,16 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl<E: ::sbor::Encoder<radix_common::data::scrypto::ScryptoCustomValueKind> >
-                    ::sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E> for MyStruct
+                impl<E: sbor::Encoder<radix_common::data::scrypto::ScryptoCustomValueKind> >
+                    sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E> for MyStruct
                 {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
                     }
@@ -56,19 +56,19 @@ mod tests {
             quote! {
                 impl<
                         T: Bound,
-                        E: ::sbor::Encoder<radix_common::data::scrypto::ScryptoCustomValueKind>
-                    > ::sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E> for MyEnum<T>
+                        E: sbor::Encoder<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    > sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E> for MyEnum<T>
                 where
-                    T: ::sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E>,
-                    T: ::sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
+                    T: sbor::Encode<radix_common::data::scrypto::ScryptoCustomValueKind, E>,
+                    T: sbor::Categorize<radix_common::data::scrypto::ScryptoCustomValueKind>
                 {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Enum)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Enum)
                     }
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         match self {
                             Self::A { named, .. } => {
                                 encoder.write_discriminator(0u8)?;

--- a/radix-transaction-scenarios/src/scenarios/account_authorized_depositors.rs
+++ b/radix-transaction-scenarios/src/scenarios/account_authorized_depositors.rs
@@ -1,7 +1,6 @@
 use crate::internal_prelude::*;
 use radix_engine::updates::ProtocolVersion;
 use radix_engine_interface::blueprints::account::*;
-use radix_engine_interface::*;
 
 #[allow(deprecated)]
 pub struct AccountAuthorizedDepositorsScenarioConfig {

--- a/radix-transaction-scenarios/src/scenarios/global_n_owned.rs
+++ b/radix-transaction-scenarios/src/scenarios/global_n_owned.rs
@@ -1,7 +1,6 @@
 use crate::internal_prelude::*;
 use radix_engine::updates::ProtocolVersion;
 use radix_engine_interface::blueprints::package::{PackageDefinition, PACKAGE_BLUEPRINT};
-use radix_engine_interface::*;
 
 #[derive(Default)]
 pub struct GlobalNOwnedScenarioState(Option<(PackageAddress, ComponentAddress)>);

--- a/radix-transaction-scenarios/src/scenarios/kv_store_with_remote_type.rs
+++ b/radix-transaction-scenarios/src/scenarios/kv_store_with_remote_type.rs
@@ -1,7 +1,6 @@
 use crate::internal_prelude::*;
 use radix_engine::updates::ProtocolVersion;
 use radix_engine_interface::blueprints::package::{PackageDefinition, PACKAGE_BLUEPRINT};
-use radix_engine_interface::*;
 
 #[derive(Default)]
 pub struct KVStoreScenarioState(Option<(PackageAddress, ComponentAddress)>);

--- a/radix-transaction-scenarios/src/scenarios/max_transaction.rs
+++ b/radix-transaction-scenarios/src/scenarios/max_transaction.rs
@@ -1,7 +1,6 @@
 use crate::internal_prelude::*;
 use radix_engine::updates::ProtocolVersion;
 use radix_engine_interface::blueprints::package::{PackageDefinition, PACKAGE_BLUEPRINT};
-use radix_engine_interface::*;
 
 #[derive(Default)]
 pub struct MaxTransactionScenarioState(Option<PackageAddress>, Option<ComponentAddress>);

--- a/radix-transactions/src/manifest/decompiler.rs
+++ b/radix-transactions/src/manifest/decompiler.rs
@@ -46,7 +46,6 @@ use radix_engine_interface::object_modules::royalty::{
     COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT, COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT,
     COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
 };
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 use sbor::*;
 

--- a/radix-transactions/src/manifest/generator.rs
+++ b/radix-transactions/src/manifest/generator.rs
@@ -58,7 +58,6 @@ use radix_engine_interface::object_modules::royalty::{
 use radix_engine_interface::types::GlobalAddress;
 use radix_engine_interface::types::InternalAddress;
 use radix_engine_interface::types::ResourceAddress;
-use radix_engine_interface::*;
 use sbor::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/radix-transactions/src/model/v1/instruction.rs
+++ b/radix-transactions/src/model/v1/instruction.rs
@@ -3,7 +3,6 @@ use radix_common::data::manifest::{model::*, ManifestValue};
 use radix_common::data::scrypto::model::*;
 use radix_common::math::Decimal;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::{Decoder, Encoder};
 
 /*

--- a/radix-transactions/src/model/v1/test_transaction.rs
+++ b/radix-transactions/src/model/v1/test_transaction.rs
@@ -3,7 +3,6 @@ use crate::model::*;
 use radix_common::crypto::hash;
 use radix_common::data::manifest::*;
 use radix_common::types::NonFungibleGlobalId;
-use radix_engine_interface::*;
 use std::collections::BTreeSet;
 
 #[derive(ManifestSbor)]

--- a/radix-transactions/src/validation/id_validator.rs
+++ b/radix-transactions/src/validation/id_validator.rs
@@ -7,7 +7,6 @@ use radix_common::data::manifest::*;
 use radix_common::data::scrypto::model::Own;
 use radix_common::prelude::Reference;
 use radix_engine_interface::types::NodeId;
-use radix_engine_interface::*;
 use sbor::rust::collections::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/sbor-derive-common/src/categorize.rs
+++ b/sbor-derive-common/src/categorize.rs
@@ -55,14 +55,14 @@ fn handle_normal_categorize(
             } = process_fields_for_categorize(&s.fields)?;
             let field_count = unskipped_field_names.len();
             quote! {
-                impl #impl_generics ::sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind <#sbor_cvk> {
-                        ::sbor::ValueKind::Tuple
+                    fn value_kind() -> sbor::ValueKind <#sbor_cvk> {
+                        sbor::ValueKind::Tuple
                     }
                 }
 
-                impl #impl_generics ::sbor::SborTuple <#sbor_cvk> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::SborTuple <#sbor_cvk> for #ident #ty_generics #where_clause {
                     fn get_length(&self) -> usize {
                         #field_count
                     }
@@ -113,14 +113,14 @@ fn handle_normal_categorize(
             };
 
             quote! {
-                impl #impl_generics ::sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind <#sbor_cvk> {
-                        ::sbor::ValueKind::Enum
+                    fn value_kind() -> sbor::ValueKind <#sbor_cvk> {
+                        sbor::ValueKind::Enum
                     }
                 }
 
-                impl #impl_generics ::sbor::SborEnum <#sbor_cvk> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::SborEnum <#sbor_cvk> for #ident #ty_generics #where_clause {
                     fn get_discriminator(&self) -> u8 {
                         #discriminator_match
                     }
@@ -166,16 +166,16 @@ fn handle_transparent_categorize(
             let field_name = &unskipped_field_names[0];
 
             let categorize_impl = quote! {
-                impl #impl_generics ::sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Categorize <#sbor_cvk> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind <#sbor_cvk> {
-                        <#field_type as ::sbor::Categorize::<#sbor_cvk>>::value_kind()
+                    fn value_kind() -> sbor::ValueKind <#sbor_cvk> {
+                        <#field_type as sbor::Categorize::<#sbor_cvk>>::value_kind()
                     }
                 }
             };
 
             // Dependent SborTuple impl:
-            // We'd like to just say "where #field_type: ::sbor::SborTuple" - but this doesn't work because of
+            // We'd like to just say "where #field_type: sbor::SborTuple" - but this doesn't work because of
             // https://github.com/rust-lang/rust/issues/48214#issuecomment-1374378038
             // Instead we can use that T: SborTuple => &T: SborTuple to apply a constraint on &T: SborTuple instead
 
@@ -190,30 +190,30 @@ fn handle_transparent_categorize(
 
             let tuple_where_clause = add_where_predicate(
                 where_clause,
-                parse_quote!(for<'b_> &'b_ #field_type: ::sbor::SborTuple <#sbor_cvk>),
+                parse_quote!(for<'b_> &'b_ #field_type: sbor::SborTuple <#sbor_cvk>),
             );
 
             let dependent_sbor_tuple_impl = quote! {
-                impl #impl_generics ::sbor::SborTuple <#sbor_cvk> for #ident #ty_generics #tuple_where_clause {
+                impl #impl_generics sbor::SborTuple <#sbor_cvk> for #ident #ty_generics #tuple_where_clause {
                     fn get_length(&self) -> usize {
-                        <&#field_type as ::sbor::SborTuple <#sbor_cvk>>::get_length(&&self.#field_name)
+                        <&#field_type as sbor::SborTuple <#sbor_cvk>>::get_length(&&self.#field_name)
                     }
                 }
             };
 
             let enum_where_clause = add_where_predicate(
                 where_clause,
-                parse_quote!(for<'b_> &'b_ #field_type: ::sbor::SborEnum <#sbor_cvk>),
+                parse_quote!(for<'b_> &'b_ #field_type: sbor::SborEnum <#sbor_cvk>),
             );
 
             let dependent_sbor_enum_impl = quote! {
-                impl #impl_generics ::sbor::SborEnum <#sbor_cvk> for #ident #ty_generics #enum_where_clause {
+                impl #impl_generics sbor::SborEnum <#sbor_cvk> for #ident #ty_generics #enum_where_clause {
                     fn get_discriminator(&self) -> u8 {
-                        <&#field_type as ::sbor::SborEnum <#sbor_cvk>>::get_discriminator(&&self.#field_name)
+                        <&#field_type as sbor::SborEnum <#sbor_cvk>>::get_discriminator(&&self.#field_name)
                     }
 
                     fn get_length(&self) -> usize {
-                        <&#field_type as ::sbor::SborEnum <#sbor_cvk>>::get_length(&&self.#field_name)
+                        <&#field_type as sbor::SborEnum <#sbor_cvk>>::get_length(&&self.#field_name)
                     }
                 }
             };
@@ -256,14 +256,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test {
+                impl <X: sbor::CustomValueKind> sbor::Categorize<X> for Test {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<X> {
-                        ::sbor::ValueKind::Tuple
+                    fn value_kind() -> sbor::ValueKind<X> {
+                        sbor::ValueKind::Tuple
                     }
                 }
 
-                impl<X: ::sbor::CustomValueKind> ::sbor::SborTuple<X> for Test {
+                impl<X: sbor::CustomValueKind> sbor::SborTuple<X> for Test {
                     fn get_length(&self) -> usize {
                         1usize
                     }
@@ -282,30 +282,30 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test {
+                impl <X: sbor::CustomValueKind> sbor::Categorize<X> for Test {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<X> {
-                        <u32 as ::sbor::Categorize::<X>>::value_kind()
+                    fn value_kind() -> sbor::ValueKind<X> {
+                        <u32 as sbor::Categorize::<X>>::value_kind()
                     }
                 }
 
-                impl<X: ::sbor::CustomValueKind> ::sbor::SborTuple<X> for Test
-                    where for <'b_> &'b_ u32: ::sbor::SborTuple<X>
+                impl<X: sbor::CustomValueKind> sbor::SborTuple<X> for Test
+                    where for <'b_> &'b_ u32: sbor::SborTuple<X>
                 {
                     fn get_length(&self) -> usize {
-                        <&u32 as ::sbor::SborTuple<X>>::get_length(&&self.a)
+                        <&u32 as sbor::SborTuple<X>>::get_length(&&self.a)
                     }
                 }
 
-                impl<X: ::sbor::CustomValueKind> ::sbor::SborEnum<X> for Test
-                    where for <'b_> &'b_ u32: ::sbor::SborEnum<X>
+                impl<X: sbor::CustomValueKind> sbor::SborEnum<X> for Test
+                    where for <'b_> &'b_ u32: sbor::SborEnum<X>
                 {
                     fn get_discriminator(&self) -> u8 {
-                        <&u32 as ::sbor::SborEnum<X>>::get_discriminator(&&self.a)
+                        <&u32 as sbor::SborEnum<X>>::get_discriminator(&&self.a)
                     }
 
                     fn get_length(&self) -> usize {
-                        <&u32 as ::sbor::SborEnum<X>>::get_length(&&self.a)
+                        <&u32 as sbor::SborEnum<X>>::get_length(&&self.a)
                     }
                 }
             },
@@ -320,14 +320,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <A, X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test<A> {
+                impl <A, X: sbor::CustomValueKind> sbor::Categorize<X> for Test<A> {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<X> {
-                        ::sbor::ValueKind::Tuple
+                    fn value_kind() -> sbor::ValueKind<X> {
+                        sbor::ValueKind::Tuple
                     }
                 }
 
-                impl<A, X: ::sbor::CustomValueKind> ::sbor::SborTuple<X> for Test<A> {
+                impl<A, X: sbor::CustomValueKind> sbor::SborTuple<X> for Test<A> {
                     fn get_length(&self) -> usize {
                         1usize
                     }
@@ -344,30 +344,30 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <A: ::sbor::Categorize<X>, X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test<A> {
+                impl <A: sbor::Categorize<X>, X: sbor::CustomValueKind> sbor::Categorize<X> for Test<A> {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<X> {
-                        <A as ::sbor::Categorize::<X>>::value_kind()
+                    fn value_kind() -> sbor::ValueKind<X> {
+                        <A as sbor::Categorize::<X>>::value_kind()
                     }
                 }
 
-                impl<A, X: ::sbor::CustomValueKind> ::sbor::SborTuple<X> for Test<A>
-                    where for <'b_> &'b_ A: ::sbor::SborTuple<X>
+                impl<A, X: sbor::CustomValueKind> sbor::SborTuple<X> for Test<A>
+                    where for <'b_> &'b_ A: sbor::SborTuple<X>
                 {
                     fn get_length(&self) -> usize {
-                        <&A as ::sbor::SborTuple<X>>::get_length(&&self.a)
+                        <&A as sbor::SborTuple<X>>::get_length(&&self.a)
                     }
                 }
 
-                impl<A, X: ::sbor::CustomValueKind> ::sbor::SborEnum<X> for Test<A>
-                    where for <'b_> &'b_ A: ::sbor::SborEnum<X>
+                impl<A, X: sbor::CustomValueKind> sbor::SborEnum<X> for Test<A>
+                    where for <'b_> &'b_ A: sbor::SborEnum<X>
                 {
                     fn get_discriminator(&self) -> u8 {
-                        <&A as ::sbor::SborEnum<X>>::get_discriminator(&&self.a)
+                        <&A as sbor::SborEnum<X>>::get_discriminator(&&self.a)
                     }
 
                     fn get_length(&self) -> usize {
-                        <&A as ::sbor::SborEnum<X>>::get_length(&&self.a)
+                        <&A as sbor::SborEnum<X>>::get_length(&&self.a)
                     }
                 }
             },
@@ -382,14 +382,14 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <X: ::sbor::CustomValueKind> ::sbor::Categorize<X> for Test {
+                impl <X: sbor::CustomValueKind> sbor::Categorize<X> for Test {
                     #[inline]
-                    fn value_kind() -> ::sbor::ValueKind<X> {
-                        ::sbor::ValueKind::Enum
+                    fn value_kind() -> sbor::ValueKind<X> {
+                        sbor::ValueKind::Enum
                     }
                 }
 
-                impl <X: ::sbor::CustomValueKind>  ::sbor::SborEnum<X> for Test {
+                impl <X: sbor::CustomValueKind>  sbor::SborEnum<X> for Test {
                     fn get_discriminator(&self) -> u8 {
                         match self {
                             Self::A => 0u8,

--- a/sbor-derive-common/src/decode.rs
+++ b/sbor-derive-common/src/decode.rs
@@ -96,11 +96,11 @@ pub fn handle_transparent_decode(
             };
 
             quote! {
-                impl #impl_generics ::sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: ::sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        let inner = <#field_type as ::sbor::Decode<#custom_value_kind_generic, #decoder_generic>>::decode_body_with_value_kind(decoder, value_kind)?;
+                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        let inner = <#field_type as sbor::Decode<#custom_value_kind_generic, #decoder_generic>>::decode_body_with_value_kind(decoder, value_kind)?;
                         #decode_content
                     }
                 }
@@ -136,11 +136,11 @@ pub fn handle_normal_decode(
             let decode_fields_content = decode_fields_content(quote! { Self }, &s.fields)?;
 
             quote! {
-                impl #impl_generics ::sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: ::sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         #decode_fields_content
                     }
                 }
@@ -167,16 +167,16 @@ pub fn handle_normal_decode(
             // Note: We use #[deny(unreachable_patterns)] to protect against users
             // defining overlapping consts in their custom #[sbor(discriminator(X))] definitions
             quote! {
-                impl #impl_generics ::sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Decode <#custom_value_kind_generic, #decoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: ::sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Enum)?;
+                    fn decode_body_with_value_kind(decoder: &mut #decoder_generic, value_kind: sbor::ValueKind<#custom_value_kind_generic>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Enum)?;
                         let discriminator = decoder.read_discriminator()?;
                         #[deny(unreachable_patterns)]
                         match discriminator {
                             #(#match_arms,)*
-                            _ => Err(::sbor::DecodeError::UnknownDiscriminator(discriminator))
+                            _ => Err(sbor::DecodeError::UnknownDiscriminator(discriminator))
                         }
                     }
                 }
@@ -259,11 +259,11 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test {
+                impl <D: sbor::Decoder<X>, X: sbor::CustomValueKind > sbor::Decode<X, D> for Test {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: sbor::ValueKind<X>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(1)?;
                         Ok(Self {
                             a: decoder.decode::<u32>()?,
@@ -282,17 +282,17 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <T, D: Clashing, D0: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind> ::sbor::Decode<X, D0> for Test<T, D>
+                impl <T, D: Clashing, D0: sbor::Decoder<X>, X: sbor::CustomValueKind> sbor::Decode<X, D0> for Test<T, D>
                     where
-                        T : ::sbor::Decode<X, D0>,
-                        D : ::sbor::Decode<X, D0>,
-                        T : ::sbor::Categorize<X>,
-                        D : ::sbor::Categorize<X>
+                        T : sbor::Decode<X, D0>,
+                        D : sbor::Decode<X, D0>,
+                        T : sbor::Categorize<X>,
+                        D : sbor::Categorize<X>
                 {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D0, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut D0, value_kind: sbor::ValueKind<X>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(2)?;
                         Ok(Self {
                             a: decoder.decode::<T>()?,
@@ -315,11 +315,11 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <D: ::sbor::Decoder<NoCustomValueKind> > ::sbor::Decode<NoCustomValueKind, D> for Test {
+                impl <D: sbor::Decoder<NoCustomValueKind> > sbor::Decode<NoCustomValueKind, D> for Test {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<NoCustomValueKind>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: sbor::ValueKind<NoCustomValueKind>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(1)?;
                         Ok(Self {
                             a: decoder.decode::<u32>()?,
@@ -338,18 +338,18 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <'a, S, T1, T2, D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test<'a, S, T1, T2>
+                impl <'a, S, T1, T2, D: sbor::Decoder<X>, X: sbor::CustomValueKind > sbor::Decode<X, D> for Test<'a, S, T1, T2>
                 where
-                    S: ::sbor::Decode<X, D>,
-                    T1: ::sbor::Decode<X, D>,
-                    T2: ::sbor::Decode<X, D>,
-                    T1: ::sbor::Categorize<X>,
-                    T2: ::sbor::Categorize<X>
+                    S: sbor::Decode<X, D>,
+                    T1: sbor::Decode<X, D>,
+                    T2: sbor::Decode<X, D>,
+                    T1: sbor::Categorize<X>,
+                    T2: sbor::Categorize<X>
                 {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: sbor::ValueKind<X>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(4)?;
                         Ok(Self {
                             a: decoder.decode::<&'a u32>()?,
@@ -371,11 +371,11 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test {
+                impl <D: sbor::Decoder<X>, X: sbor::CustomValueKind > sbor::Decode<X, D> for Test {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Enum)?;
+                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: sbor::ValueKind<X>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Enum)?;
                         let discriminator = decoder.read_discriminator()?;
                         #[deny(unreachable_patterns)]
                         match discriminator {
@@ -393,7 +393,7 @@ mod tests {
                                     x: decoder.decode::<u8>()?,
                                 })
                             },
-                            _ => Err(::sbor::DecodeError::UnknownDiscriminator(discriminator))
+                            _ => Err(sbor::DecodeError::UnknownDiscriminator(discriminator))
                         }
                     }
                 }
@@ -409,11 +409,11 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <D: ::sbor::Decoder<X>, X: ::sbor::CustomValueKind > ::sbor::Decode<X, D> for Test {
+                impl <D: sbor::Decoder<X>, X: sbor::CustomValueKind > sbor::Decode<X, D> for Test {
                     #[inline]
-                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: ::sbor::ValueKind<X>) -> Result<Self, ::sbor::DecodeError> {
-                        use ::sbor::{self, Decode};
-                        decoder.check_preloaded_value_kind(value_kind, ::sbor::ValueKind::Tuple)?;
+                    fn decode_body_with_value_kind(decoder: &mut D, value_kind: sbor::ValueKind<X>) -> Result<Self, sbor::DecodeError> {
+                        use sbor::{self, Decode};
+                        decoder.check_preloaded_value_kind(value_kind, sbor::ValueKind::Tuple)?;
                         decoder.read_and_check_size(0)?;
                         Ok(Self {
                             a: <u32>::default(),

--- a/sbor-derive-common/src/describe.rs
+++ b/sbor-derive-common/src/describe.rs
@@ -64,10 +64,10 @@ fn handle_transparent_describe(
             let field_type = &unskipped_field_types[0];
 
             let mut type_data_content = quote! {
-                <#field_type as ::sbor::Describe <#custom_type_kind_generic>>::type_data()
+                <#field_type as sbor::Describe <#custom_type_kind_generic>>::type_data()
             };
             let mut type_id = quote! {
-                <#field_type as ::sbor::Describe <#custom_type_kind_generic>>::TYPE_ID
+                <#field_type as sbor::Describe <#custom_type_kind_generic>>::TYPE_ID
             };
 
             // Replace the type name, unless opted out using the "transparent_name" tag
@@ -75,12 +75,12 @@ fn handle_transparent_describe(
                 let type_name = get_sbor_attribute_string_value(&attrs, "type_name")?
                     .unwrap_or(ident.to_string());
                 type_data_content = quote! {
-                    use ::sbor::rust::prelude::*;
+                    use sbor::rust::prelude::*;
                     #type_data_content
                         .with_name(Some(Cow::Borrowed(#type_name)))
                 };
                 type_id = quote! {
-                    ::sbor::RustTypeId::novel_with_code(
+                    sbor::RustTypeId::novel_with_code(
                         #type_name,
                         &[#type_id],
                         &#code_hash
@@ -89,15 +89,15 @@ fn handle_transparent_describe(
             };
 
             quote! {
-                impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
-                    const TYPE_ID: ::sbor::RustTypeId = #type_id;
+                impl #impl_generics sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
+                    const TYPE_ID: sbor::RustTypeId = #type_id;
 
-                    fn type_data() -> ::sbor::TypeData<#custom_type_kind_generic, ::sbor::RustTypeId> {
+                    fn type_data() -> sbor::TypeData<#custom_type_kind_generic, sbor::RustTypeId> {
                         #type_data_content
                     }
 
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<#custom_type_kind_generic>) {
-                        <#field_type as ::sbor::Describe <#custom_type_kind_generic>>::add_all_dependencies(aggregator)
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<#custom_type_kind_generic>) {
+                        <#field_type as sbor::Describe <#custom_type_kind_generic>>::add_all_dependencies(aggregator)
                     }
                 }
             }
@@ -132,7 +132,7 @@ fn handle_normal_describe(
         get_sbor_attribute_string_value(&attrs, "type_name")?.unwrap_or(ident.to_string());
 
     let type_id = quote! {
-        ::sbor::RustTypeId::novel_with_code(
+        sbor::RustTypeId::novel_with_code(
             #type_name,
             // Here we really want to cause distinct types to have distinct hashes, whilst still supporting (most) recursive types.
             // The code hash itself is pretty good for this, but if you allow generic types, it's not enough, as the same code can create
@@ -159,19 +159,19 @@ fn handle_normal_describe(
                 } = process_fields_for_describe(&s.fields)?;
                 let unique_field_types: Vec<_> = get_unique_types(&unskipped_field_types);
                 quote! {
-                    impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
-                        const TYPE_ID: ::sbor::RustTypeId = #type_id;
+                    impl #impl_generics sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
+                        const TYPE_ID: sbor::RustTypeId = #type_id;
 
-                        fn type_data() -> ::sbor::TypeData<#custom_type_kind_generic, ::sbor::RustTypeId> {
-                            ::sbor::TypeData::struct_with_named_fields(
+                        fn type_data() -> sbor::TypeData<#custom_type_kind_generic, sbor::RustTypeId> {
+                            sbor::TypeData::struct_with_named_fields(
                                 #type_name,
-                                ::sbor::rust::vec![
-                                    #((#unskipped_field_name_strings, <#unskipped_field_types as ::sbor::Describe<#custom_type_kind_generic>>::TYPE_ID),)*
+                                sbor::rust::vec![
+                                    #((#unskipped_field_name_strings, <#unskipped_field_types as sbor::Describe<#custom_type_kind_generic>>::TYPE_ID),)*
                                 ],
                             )
                         }
 
-                        fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<#custom_type_kind_generic>) {
+                        fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<#custom_type_kind_generic>) {
                             #(aggregator.add_child_type_and_descendents::<#unique_field_types>();)*
                         }
                     }
@@ -185,19 +185,19 @@ fn handle_normal_describe(
                 let unique_field_types: Vec<_> = get_unique_types(&unskipped_field_types);
 
                 quote! {
-                    impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
-                        const TYPE_ID: ::sbor::RustTypeId = #type_id;
+                    impl #impl_generics sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
+                        const TYPE_ID: sbor::RustTypeId = #type_id;
 
-                        fn type_data() -> ::sbor::TypeData<#custom_type_kind_generic, ::sbor::RustTypeId> {
-                            ::sbor::TypeData::struct_with_unnamed_fields(
+                        fn type_data() -> sbor::TypeData<#custom_type_kind_generic, sbor::RustTypeId> {
+                            sbor::TypeData::struct_with_unnamed_fields(
                                 #type_name,
-                                ::sbor::rust::vec![
-                                    #(<#unskipped_field_types as ::sbor::Describe<#custom_type_kind_generic>>::TYPE_ID,)*
+                                sbor::rust::vec![
+                                    #(<#unskipped_field_types as sbor::Describe<#custom_type_kind_generic>>::TYPE_ID,)*
                                 ],
                             )
                         }
 
-                        fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<#custom_type_kind_generic>) {
+                        fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<#custom_type_kind_generic>) {
                             #(aggregator.add_child_type_and_descendents::<#unique_field_types>();)*
                         }
                     }
@@ -205,11 +205,11 @@ fn handle_normal_describe(
             }
             syn::Fields::Unit => {
                 quote! {
-                    impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
-                        const TYPE_ID: ::sbor::RustTypeId = #type_id;
+                    impl #impl_generics sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
+                        const TYPE_ID: sbor::RustTypeId = #type_id;
 
-                        fn type_data() -> ::sbor::TypeData<#custom_type_kind_generic, ::sbor::RustTypeId> {
-                            ::sbor::TypeData::struct_with_unit_fields(#type_name)
+                        fn type_data() -> sbor::TypeData<#custom_type_kind_generic, sbor::RustTypeId> {
+                            sbor::TypeData::struct_with_unit_fields(#type_name)
                         }
                     }
                 }
@@ -237,27 +237,27 @@ fn handle_normal_describe(
                         Ok(match &v.fields {
                             Fields::Named(FieldsNamed { .. }) => {
                                 quote! {
-                                    ::sbor::TypeData::struct_with_named_fields(
+                                    sbor::TypeData::struct_with_named_fields(
                                         #variant_name,
-                                        ::sbor::rust::vec![
-                                            #((#unskipped_field_name_strings, <#unskipped_field_types as ::sbor::Describe<#custom_type_kind_generic>>::TYPE_ID),)*
+                                        sbor::rust::vec![
+                                            #((#unskipped_field_name_strings, <#unskipped_field_types as sbor::Describe<#custom_type_kind_generic>>::TYPE_ID),)*
                                         ],
                                     )
                                 }
                             }
                             Fields::Unnamed(FieldsUnnamed { .. }) => {
                                 quote! {
-                                    ::sbor::TypeData::struct_with_unnamed_fields(
+                                    sbor::TypeData::struct_with_unnamed_fields(
                                         #variant_name,
-                                        ::sbor::rust::vec![
-                                            #(<#unskipped_field_types as ::sbor::Describe<#custom_type_kind_generic>>::TYPE_ID,)*
+                                        sbor::rust::vec![
+                                            #(<#unskipped_field_types as sbor::Describe<#custom_type_kind_generic>>::TYPE_ID,)*
                                         ],
                                     )
                                 }
                             }
                             Fields::Unit => {
                                 quote! {
-                                    ::sbor::TypeData::struct_with_unit_fields(#variant_name)
+                                    sbor::TypeData::struct_with_unit_fields(#variant_name)
                                 }
                             }
                         })
@@ -268,20 +268,20 @@ fn handle_normal_describe(
             let unique_field_types = get_unique_types(&all_field_types);
 
             quote! {
-                impl #impl_generics ::sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
-                    const TYPE_ID: ::sbor::RustTypeId = #type_id;
+                impl #impl_generics sbor::Describe <#custom_type_kind_generic> for #ident #ty_generics #where_clause {
+                    const TYPE_ID: sbor::RustTypeId = #type_id;
 
-                    fn type_data() -> ::sbor::TypeData<#custom_type_kind_generic, ::sbor::RustTypeId> {
-                        use ::sbor::rust::borrow::ToOwned;
-                        ::sbor::TypeData::enum_variants(
+                    fn type_data() -> sbor::TypeData<#custom_type_kind_generic, sbor::RustTypeId> {
+                        use sbor::rust::borrow::ToOwned;
+                        sbor::TypeData::enum_variants(
                             #type_name,
-                            ::sbor::rust::prelude::indexmap![
+                            sbor::rust::prelude::indexmap![
                                 #(#variant_discriminators => #variant_type_data,)*
                             ],
                         )
                     }
 
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<#custom_type_kind_generic>) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<#custom_type_kind_generic>) {
                         #(aggregator.add_child_type_and_descendents::<#unique_field_types>();)*
                     }
                 }
@@ -315,25 +315,25 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <C: ::sbor::CustomTypeKind<::sbor::RustTypeId> > ::sbor::Describe<C> for Test {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                impl <C: sbor::CustomTypeKind<sbor::RustTypeId> > sbor::Describe<C> for Test {
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Test",
                         &[],
                         &#code_hash
                     );
 
-                    fn type_data() -> ::sbor::TypeData <C, ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_named_fields(
+                    fn type_data() -> sbor::TypeData <C, sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_named_fields(
                             "Test",
-                            ::sbor::rust::vec![
-                                ("a", <u32 as ::sbor::Describe<C>>::TYPE_ID),
-                                ("b", <Vec<u8> as ::sbor::Describe<C>>::TYPE_ID),
-                                ("c", <u32 as ::sbor::Describe<C>>::TYPE_ID),
+                            sbor::rust::vec![
+                                ("a", <u32 as sbor::Describe<C>>::TYPE_ID),
+                                ("b", <Vec<u8> as sbor::Describe<C>>::TYPE_ID),
+                                ("c", <u32 as sbor::Describe<C>>::TYPE_ID),
                             ],
                         )
                     }
 
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<C>) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<C>) {
                         aggregator.add_child_type_and_descendents::<u32>();
                         aggregator.add_child_type_and_descendents::<Vec<u8> >();
                     }
@@ -348,52 +348,52 @@ mod tests {
         let code_hash = get_code_hash_const_array_token_stream(&input);
         let output = handle_describe(
             input,
-            Some("radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>"),
+            Some("radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>"),
         )
         .unwrap();
 
         assert_code_eq(
             output,
             quote! {
-                impl ::sbor::Describe<radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId> >
+                impl sbor::Describe<radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId> >
                     for Test
                 {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Test",
                         &[],
                         &#code_hash
                     );
                     fn type_data() ->
-                        ::sbor::TypeData<
-                            radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>,
-                            ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_named_fields(
+                        sbor::TypeData<
+                            radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>,
+                            sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_named_fields(
                             "Test",
-                            ::sbor::rust::vec![
+                            sbor::rust::vec![
                                 (
                                     "a",
-                                    <u32 as ::sbor::Describe<
-                                        radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>
+                                    <u32 as sbor::Describe<
+                                        radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>
                                     >>::TYPE_ID
                                 ),
                                 (
                                     "b",
-                                    <Vec<u8> as ::sbor::Describe<
-                                        radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>
+                                    <Vec<u8> as sbor::Describe<
+                                        radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>
                                     >>::TYPE_ID
                                 ),
                                 (
                                     "c",
-                                    <u32 as ::sbor::Describe<
-                                        radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>
+                                    <u32 as sbor::Describe<
+                                        radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>
                                     >>::TYPE_ID
                                 ),
                             ],
                         )
                     }
                     fn add_all_dependencies(
-                        aggregator: &mut ::sbor::TypeAggregator<
-                            radix_common::data::ScryptoCustomTypeKind<::sbor::RustTypeId>
+                        aggregator: &mut sbor::TypeAggregator<
+                            radix_common::data::ScryptoCustomTypeKind<sbor::RustTypeId>
                         >
                     ) {
                         aggregator.add_child_type_and_descendents::<u32>();
@@ -413,25 +413,25 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <C: ::sbor::CustomTypeKind<::sbor::RustTypeId> > ::sbor::Describe<C> for Test {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                impl <C: sbor::CustomTypeKind<sbor::RustTypeId> > sbor::Describe<C> for Test {
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Test",
                         &[],
                         &#code_hash
                     );
 
-                    fn type_data() -> ::sbor::TypeData <C, ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_unnamed_fields(
+                    fn type_data() -> sbor::TypeData <C, sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_unnamed_fields(
                             "Test",
-                            ::sbor::rust::vec![
-                                <u32 as ::sbor::Describe<C>>::TYPE_ID,
-                                <Vec<u8> as ::sbor::Describe<C>>::TYPE_ID,
-                                <u32 as ::sbor::Describe<C>>::TYPE_ID,
+                            sbor::rust::vec![
+                                <u32 as sbor::Describe<C>>::TYPE_ID,
+                                <Vec<u8> as sbor::Describe<C>>::TYPE_ID,
+                                <u32 as sbor::Describe<C>>::TYPE_ID,
                             ],
                         )
                     }
 
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<C>) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<C>) {
                         aggregator.add_child_type_and_descendents::<u32>();
                         aggregator.add_child_type_and_descendents::<Vec<u8> >();
                     }
@@ -449,15 +449,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <C: ::sbor::CustomTypeKind<::sbor::RustTypeId> > ::sbor::Describe<C> for Test {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                impl <C: sbor::CustomTypeKind<sbor::RustTypeId> > sbor::Describe<C> for Test {
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Test",
                         &[],
                         &#code_hash
                     );
 
-                    fn type_data() -> ::sbor::TypeData <C, ::sbor::RustTypeId> {
-                        ::sbor::TypeData::struct_with_unit_fields("Test")
+                    fn type_data() -> sbor::TypeData <C, sbor::RustTypeId> {
+                        sbor::TypeData::struct_with_unit_fields("Test")
                     }
                 }
             },
@@ -474,41 +474,41 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <T: SomeTrait, T2, C: ::sbor::CustomTypeKind<::sbor::RustTypeId> > ::sbor::Describe<C> for Test<T, T2>
+                impl <T: SomeTrait, T2, C: sbor::CustomTypeKind<sbor::RustTypeId> > sbor::Describe<C> for Test<T, T2>
                 where
-                    T: ::sbor::Describe<C>,
-                    T2: ::sbor::Describe<C>
+                    T: sbor::Describe<C>,
+                    T2: sbor::Describe<C>
                 {
-                    const TYPE_ID: ::sbor::RustTypeId = ::sbor::RustTypeId::novel_with_code(
+                    const TYPE_ID: sbor::RustTypeId = sbor::RustTypeId::novel_with_code(
                         "Test",
                         &[<T>::TYPE_ID, <T2>::TYPE_ID,],
                         &#code_hash
                     );
 
-                    fn type_data() -> ::sbor::TypeData <C, ::sbor::RustTypeId> {
-                        use ::sbor::rust::borrow::ToOwned;
-                        ::sbor::TypeData::enum_variants(
+                    fn type_data() -> sbor::TypeData <C, sbor::RustTypeId> {
+                        use sbor::rust::borrow::ToOwned;
+                        sbor::TypeData::enum_variants(
                             "Test",
-                            ::sbor::rust::prelude::indexmap![
-                                0u8 => ::sbor::TypeData::struct_with_unit_fields("A"),
-                                1u8 => ::sbor::TypeData::struct_with_unnamed_fields(
+                            sbor::rust::prelude::indexmap![
+                                0u8 => sbor::TypeData::struct_with_unit_fields("A"),
+                                1u8 => sbor::TypeData::struct_with_unnamed_fields(
                                     "B",
-                                    ::sbor::rust::vec![
-                                        <T as ::sbor::Describe<C>>::TYPE_ID,
-                                        <Vec<T2> as ::sbor::Describe<C>>::TYPE_ID,
+                                    sbor::rust::vec![
+                                        <T as sbor::Describe<C>>::TYPE_ID,
+                                        <Vec<T2> as sbor::Describe<C>>::TYPE_ID,
                                     ],
                                 ),
-                                2u8 => ::sbor::TypeData::struct_with_named_fields(
+                                2u8 => sbor::TypeData::struct_with_named_fields(
                                     "C",
-                                    ::sbor::rust::vec![
-                                        ("x", <[u8; 5] as ::sbor::Describe<C>>::TYPE_ID),
+                                    sbor::rust::vec![
+                                        ("x", <[u8; 5] as sbor::Describe<C>>::TYPE_ID),
                                     ],
                                 ),
                             ],
                         )
                     }
 
-                    fn add_all_dependencies(aggregator: &mut ::sbor::TypeAggregator<C>) {
+                    fn add_all_dependencies(aggregator: &mut sbor::TypeAggregator<C>) {
                         aggregator.add_child_type_and_descendents::<T>();
                         aggregator.add_child_type_and_descendents::<Vec<T2> >();
                         aggregator.add_child_type_and_descendents::<[u8; 5]>();

--- a/sbor-derive-common/src/encode.rs
+++ b/sbor-derive-common/src/encode.rs
@@ -58,16 +58,16 @@ pub fn handle_transparent_encode(
             }
             let field_name = &unskipped_field_names[0];
             quote! {
-                impl #impl_generics ::sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         self.#field_name.encode_value_kind(encoder)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         self.#field_name.encode_body(encoder)
                     }
                 }
@@ -106,15 +106,15 @@ pub fn handle_normal_encode(
                 ..
             } = process_fields_for_encode(&s.fields)?;
             quote! {
-                impl #impl_generics ::sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(#unskipped_field_count)?;
                         #(encoder.encode(&self.#unskipped_field_names)?;)*
                         Ok(())
@@ -151,7 +151,7 @@ pub fn handle_normal_encode(
                 quote! {}
             } else {
                 quote! {
-                    use ::sbor::{self, Encode};
+                    use sbor::{self, Encode};
 
                     match self {
                         #(#match_arms)*
@@ -159,14 +159,14 @@ pub fn handle_normal_encode(
                 }
             };
             quote! {
-                impl #impl_generics ::sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
+                impl #impl_generics sbor::Encode <#custom_value_kind_generic, #encoder_generic> for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Enum)
+                    fn encode_value_kind(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Enum)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), ::sbor::EncodeError> {
+                    fn encode_body(&self, encoder: &mut #encoder_generic) -> Result<(), sbor::EncodeError> {
                         #encode_content
                         Ok(())
                     }
@@ -204,15 +204,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E> for Test {
+                impl <E: sbor::Encoder<X>, X: sbor::CustomValueKind > sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(1)?;
                         encoder.encode(&self.a)?;
                         Ok(())
@@ -230,15 +230,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E> for Test {
+                impl <E: sbor::Encoder<X>, X: sbor::CustomValueKind > sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Enum)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Enum)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         match self {
                             Self::A => {
                                 encoder.write_discriminator(0u8)?;
@@ -270,15 +270,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <E: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E> for Test {
+                impl <E: sbor::Encoder<X>, X: sbor::CustomValueKind > sbor::Encode<X, E> for Test {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
                     }
@@ -295,21 +295,21 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <T, E: Clashing, E0: ::sbor::Encoder<X>, X: ::sbor::CustomValueKind > ::sbor::Encode<X, E0> for Test<T, E >
+                impl <T, E: Clashing, E0: sbor::Encoder<X>, X: sbor::CustomValueKind > sbor::Encode<X, E0> for Test<T, E >
                 where
-                    T: ::sbor::Encode<X, E0>,
-                    E: ::sbor::Encode<X, E0>,
-                    T: ::sbor::Categorize<X>,
-                    E: ::sbor::Categorize<X>
+                    T: sbor::Encode<X, E0>,
+                    E: sbor::Encode<X, E0>,
+                    T: sbor::Categorize<X>,
+                    E: sbor::Categorize<X>
                 {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E0) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E0) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E0) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E0) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(2)?;
                         encoder.encode(&self.a)?;
                         encoder.encode(&self.b)?;
@@ -331,15 +331,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <E: ::sbor::Encoder<NoCustomValueKind> > ::sbor::Encode<NoCustomValueKind, E> for Test {
+                impl <E: sbor::Encoder<NoCustomValueKind> > sbor::Encode<NoCustomValueKind, E> for Test {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
                     }
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn test_custom_value_kind_canonical_path() {
         let input = TokenStream::from_str(
-            "#[sbor(custom_value_kind = \"::sbor::basic::NoCustomValueKind\")] struct Test {#[sbor(skip)] a: u32}",
+            "#[sbor(custom_value_kind = \"sbor::basic::NoCustomValueKind\")] struct Test {#[sbor(skip)] a: u32}",
         )
         .unwrap();
         let output = handle_encode(input, None).unwrap();
@@ -359,15 +359,15 @@ mod tests {
         assert_code_eq(
             output,
             quote! {
-                impl <E: ::sbor::Encoder<::sbor::basic::NoCustomValueKind> > ::sbor::Encode<::sbor::basic::NoCustomValueKind, E> for Test {
+                impl <E: sbor::Encoder<sbor::basic::NoCustomValueKind> > sbor::Encode<sbor::basic::NoCustomValueKind, E> for Test {
                     #[inline]
-                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        encoder.write_value_kind(::sbor::ValueKind::Tuple)
+                    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        encoder.write_value_kind(sbor::ValueKind::Tuple)
                     }
 
                     #[inline]
-                    fn encode_body(&self, encoder: &mut E) -> Result<(), ::sbor::EncodeError> {
-                        use ::sbor::{self, Encode};
+                    fn encode_body(&self, encoder: &mut E) -> Result<(), sbor::EncodeError> {
+                        use sbor::{self, Encode};
                         encoder.write_size(0)?;
                         Ok(())
                     }

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -597,9 +597,9 @@ pub fn build_decode_generics<'a>(
                 .push(parse_quote!(#child_type: sbor::Decode<#custom_value_kind_generic, #decoder_generic>));
         }
         for categorize_type in categorize_types {
-            new_where_clause.predicates.push(
-                parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>),
-            );
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>));
         }
         where_clause = Some(new_where_clause);
     }
@@ -663,9 +663,9 @@ pub fn build_encode_generics<'a>(
                 .push(parse_quote!(#child_type: sbor::Encode<#custom_value_kind_generic, #encoder_generic>));
         }
         for categorize_type in categorize_types {
-            new_where_clause.predicates.push(
-                parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>),
-            );
+            new_where_clause
+                .predicates
+                .push(parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>));
         }
         where_clause = Some(new_where_clause);
     }
@@ -728,9 +728,9 @@ pub fn build_describe_generics<'a>(
     }
 
     if need_to_add_ctk_generic {
-        impl_generics.params.push(
-            parse_quote!(#custom_type_kind_generic: sbor::CustomTypeKind<sbor::RustTypeId>),
-        );
+        impl_generics
+            .params
+            .push(parse_quote!(#custom_type_kind_generic: sbor::CustomTypeKind<sbor::RustTypeId>));
     }
 
     let ty_generics: Generics = parse_quote! { #ty_generics };

--- a/sbor-derive-common/src/utils.rs
+++ b/sbor-derive-common/src/utils.rs
@@ -594,11 +594,11 @@ pub fn build_decode_generics<'a>(
         for child_type in child_types {
             new_where_clause
                 .predicates
-                .push(parse_quote!(#child_type: ::sbor::Decode<#custom_value_kind_generic, #decoder_generic>));
+                .push(parse_quote!(#child_type: sbor::Decode<#custom_value_kind_generic, #decoder_generic>));
         }
         for categorize_type in categorize_types {
             new_where_clause.predicates.push(
-                parse_quote!(#categorize_type: ::sbor::Categorize<#custom_value_kind_generic>),
+                parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>),
             );
         }
         where_clause = Some(new_where_clause);
@@ -606,12 +606,12 @@ pub fn build_decode_generics<'a>(
 
     impl_generics
         .params
-        .push(parse_quote!(#decoder_generic: ::sbor::Decoder<#custom_value_kind_generic>));
+        .push(parse_quote!(#decoder_generic: sbor::Decoder<#custom_value_kind_generic>));
 
     if need_to_add_cvk_generic {
         impl_generics
             .params
-            .push(parse_quote!(#custom_value_kind_generic: ::sbor::CustomValueKind));
+            .push(parse_quote!(#custom_value_kind_generic: sbor::CustomValueKind));
     }
 
     Ok((
@@ -660,11 +660,11 @@ pub fn build_encode_generics<'a>(
         for child_type in child_types {
             new_where_clause
                 .predicates
-                .push(parse_quote!(#child_type: ::sbor::Encode<#custom_value_kind_generic, #encoder_generic>));
+                .push(parse_quote!(#child_type: sbor::Encode<#custom_value_kind_generic, #encoder_generic>));
         }
         for categorize_type in categorize_types {
             new_where_clause.predicates.push(
-                parse_quote!(#categorize_type: ::sbor::Categorize<#custom_value_kind_generic>),
+                parse_quote!(#categorize_type: sbor::Categorize<#custom_value_kind_generic>),
             );
         }
         where_clause = Some(new_where_clause);
@@ -672,12 +672,12 @@ pub fn build_encode_generics<'a>(
 
     impl_generics
         .params
-        .push(parse_quote!(#encoder_generic: ::sbor::Encoder<#custom_value_kind_generic>));
+        .push(parse_quote!(#encoder_generic: sbor::Encoder<#custom_value_kind_generic>));
 
     if need_to_add_cvk_generic {
         impl_generics
             .params
-            .push(parse_quote!(#custom_value_kind_generic: ::sbor::CustomValueKind));
+            .push(parse_quote!(#custom_value_kind_generic: sbor::CustomValueKind));
     }
 
     Ok((
@@ -722,14 +722,14 @@ pub fn build_describe_generics<'a>(
         for child_type in child_types.iter() {
             new_where_clause
                 .predicates
-                .push(parse_quote!(#child_type: ::sbor::Describe<#custom_type_kind_generic>));
+                .push(parse_quote!(#child_type: sbor::Describe<#custom_type_kind_generic>));
         }
         where_clause = Some(new_where_clause);
     }
 
     if need_to_add_ctk_generic {
         impl_generics.params.push(
-            parse_quote!(#custom_type_kind_generic: ::sbor::CustomTypeKind<::sbor::RustTypeId>),
+            parse_quote!(#custom_type_kind_generic: sbor::CustomTypeKind<sbor::RustTypeId>),
         );
     }
 
@@ -779,14 +779,14 @@ pub fn build_custom_categorize_generic<'a>(
             };
             type_param
                 .bounds
-                .push(parse_quote!(::sbor::Categorize<#custom_value_kind_generic>));
+                .push(parse_quote!(sbor::Categorize<#custom_value_kind_generic>));
         }
     }
 
     if need_to_add_cvk_generic {
         impl_generics
             .params
-            .push(parse_quote!(#custom_value_kind_generic: ::sbor::CustomValueKind));
+            .push(parse_quote!(#custom_value_kind_generic: sbor::CustomValueKind));
     }
 
     Ok((

--- a/sbor/src/lib.rs
+++ b/sbor/src/lib.rs
@@ -70,8 +70,16 @@ pub use sbor_derive::{
     Describe, Encode, Sbor,
 };
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
 extern crate self as sbor;
 
 // For self-contained macros

--- a/scrypto-compiler/tests/assets/scenario_1/blueprint/Cargo.toml
+++ b/scrypto-compiler/tests/assets/scenario_1/blueprint/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [lib]

--- a/scrypto-compiler/tests/assets/scenario_1/blueprint_2/Cargo.toml
+++ b/scrypto-compiler/tests/assets/scenario_1/blueprint_2/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [lib]

--- a/scrypto-compiler/tests/assets/scenario_1/blueprint_4/Cargo.toml
+++ b/scrypto-compiler/tests/assets/scenario_1/blueprint_4/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../sbor" }
 scrypto = { path = "../../../../../scrypto" }
 
 [lib]

--- a/scrypto-compiler/tests/assets/scenario_1/dir/blueprint_3/Cargo.toml
+++ b/scrypto-compiler/tests/assets/scenario_1/dir/blueprint_3/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.2.0-dev"
 edition = "2021"
 
 [dependencies]
-sbor = { path = "../../../../../../sbor" }
 scrypto = { path = "../../../../../../scrypto" }
 
 [lib]

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -797,9 +797,9 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
             #[no_mangle]
             pub extern "C" fn #schema_ident() -> ::scrypto::engine::wasm_api::Slice {
                 use ::scrypto::radix_blueprint_schema_init::*;
-                use ::sbor::rust::prelude::*;
-                use ::sbor::schema::*;
-                use ::sbor::*;
+                use sbor::rust::prelude::*;
+                use sbor::schema::*;
+                use sbor::*;
 
                 let schema = {
                     let mut aggregator = TypeAggregator::<ScryptoCustomTypeKind>::new();
@@ -944,7 +944,7 @@ pub fn handle_blueprint(input: TokenStream) -> Result<TokenStream> {
     };
 
     let output_test_struct_impls = quote! {
-        impl<D: ::sbor::Decoder<::scrypto::prelude::ScryptoCustomValueKind>>
+        impl<D: sbor::Decoder<::scrypto::prelude::ScryptoCustomValueKind>>
             ::scrypto::prelude::Decode<::scrypto::prelude::ScryptoCustomValueKind, D>
             for #bp_ident
         {
@@ -1350,7 +1350,7 @@ fn generate_dispatcher(bp_ident: &Ident, items: &[ImplItem]) -> Result<Vec<Token
                     quote! {
                         #[no_mangle]
                         pub extern "C" fn #fn_ident(args: ::scrypto::engine::wasm_api::Buffer) -> ::scrypto::engine::wasm_api::Slice {
-                            use ::sbor::rust::ops::{Deref, DerefMut};
+                            use sbor::rust::ops::{Deref, DerefMut};
 
                             // Set up panic hook
                             ::scrypto::set_up_panic_hook();
@@ -1972,7 +1972,7 @@ mod tests {
 
                     #[no_mangle]
                     pub extern "C" fn Test_x(args: ::scrypto::engine::wasm_api::Buffer) -> ::scrypto::engine::wasm_api::Slice {
-                        use ::sbor::rust::ops::{Deref, DerefMut};
+                        use sbor::rust::ops::{Deref, DerefMut};
 
                         // Set up panic hook
                         ::scrypto::set_up_panic_hook();
@@ -1986,7 +1986,7 @@ mod tests {
 
                     #[no_mangle]
                     pub extern "C" fn Test_y(args: ::scrypto::engine::wasm_api::Buffer) -> ::scrypto::engine::wasm_api::Slice {
-                        use ::sbor::rust::ops::{Deref, DerefMut};
+                        use sbor::rust::ops::{Deref, DerefMut};
 
                         // Set up panic hook
                         ::scrypto::set_up_panic_hook();
@@ -2007,9 +2007,9 @@ mod tests {
                     #[no_mangle]
                     pub extern "C" fn Test_schema() -> ::scrypto::engine::wasm_api::Slice {
                         use ::scrypto::radix_blueprint_schema_init::*;
-                        use ::sbor::rust::prelude::*;
-                        use ::sbor::schema::*;
-                        use ::sbor::*;
+                        use sbor::rust::prelude::*;
+                        use sbor::schema::*;
+                        use sbor::*;
 
                         let schema = {
                             let mut aggregator = TypeAggregator::<ScryptoCustomTypeKind>::new();
@@ -2437,7 +2437,7 @@ mod tests {
                     #[derive(Debug, Clone, Copy)]
                     pub struct Test(pub NodeId);
 
-                    impl<D: ::sbor::Decoder<::scrypto::prelude::ScryptoCustomValueKind>>
+                    impl<D: sbor::Decoder<::scrypto::prelude::ScryptoCustomValueKind>>
                         ::scrypto::prelude::Decode<::scrypto::prelude::ScryptoCustomValueKind, D> for Test
                     {
                         #[inline]

--- a/scrypto-test/src/prelude.rs
+++ b/scrypto-test/src/prelude.rs
@@ -79,6 +79,7 @@ pub use radix_native_sdk::resource::*;
 pub use radix_native_sdk::runtime::*;
 
 /* Sbor */
+pub extern crate sbor;
 pub use sbor::prelude::*;
 pub use sbor::*;
 

--- a/scrypto-test/src/sdk/resource/resource_builder.rs
+++ b/scrypto-test/src/sdk/resource/resource_builder.rs
@@ -7,7 +7,6 @@ use radix_engine_interface::object_modules::metadata::MetadataInit;
 use radix_engine_interface::object_modules::role_assignment::RoleDefinition;
 use radix_engine_interface::object_modules::ModuleConfig;
 use radix_engine_interface::prelude::ClientApi;
-use radix_engine_interface::*;
 use sbor::rust::marker::PhantomData;
 use std::fmt::Debug;
 

--- a/scrypto/src/component/package.rs
+++ b/scrypto/src/component/package.rs
@@ -6,7 +6,6 @@ use radix_engine_interface::blueprints::package::{
 };
 use radix_engine_interface::blueprints::resource::Bucket;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 
 pub type Package = Global<PackageStub>;

--- a/scrypto/src/engine/scrypto_env.rs
+++ b/scrypto/src/engine/scrypto_env.rs
@@ -10,7 +10,6 @@ use radix_engine_interface::api::{AttachedModuleId, FieldIndex, LockFlags};
 use radix_engine_interface::types::PackageAddress;
 use radix_engine_interface::types::{BlueprintId, GlobalAddress};
 use radix_engine_interface::types::{Level, NodeId, SubstateHandle};
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 
 pub struct ScryptoVmV1Api;

--- a/scrypto/src/lib.rs
+++ b/scrypto/src/lib.rs
@@ -56,9 +56,17 @@ pub mod types {
 // Re-export blueprint schema init, for use in `#[blueprint]` macro
 pub use radix_blueprint_schema_init;
 
-// This is to make derives work within this crate.
-// See: https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
-pub extern crate self as scrypto;
+// extern crate self as X; in lib.rs allows ::X and X to resolve to this crate inside this crate.
+// This enables procedural macros which output code involving paths to this crate, to work inside
+// this crate. See this link for details:
+// https://users.rust-lang.org/t/how-can-i-use-my-derive-macro-from-the-crate-that-declares-the-trait/60502
+//
+// IMPORTANT:
+// This should never be pub, else `X::X::X::X::...` becomes a valid path in downstream crates,
+// which we've discovered can cause really bad autocomplete times (when combined with other
+// specific imports, generic traits, resolution paths which likely trigger edge cases in
+// Rust Analyzer which get stuck on these infinite possible paths)
+extern crate self as scrypto;
 
 /// Sets up panic hook.
 pub fn set_up_panic_hook() {

--- a/scrypto/src/macros.rs
+++ b/scrypto/src/macros.rs
@@ -10,7 +10,7 @@
 #[macro_export]
 macro_rules! error {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::error(::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::error(::scrypto::prelude::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -32,7 +32,7 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::warn(::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::warn(::scrypto::prelude::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -54,7 +54,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::info(::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::info(::scrypto::prelude::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -76,7 +76,7 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::debug(::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::debug(::scrypto::prelude::sbor::rust::format!($($args),+));
     }};
 }
 
@@ -98,7 +98,7 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     ($($args: expr),+) => {{
-        $crate::runtime::Logger::trace(::sbor::rust::format!($($args),+));
+        $crate::runtime::Logger::trace(::scrypto::prelude::sbor::rust::format!($($args),+));
     }};
 }
 

--- a/scrypto/src/modules/role_assignment.rs
+++ b/scrypto/src/modules/role_assignment.rs
@@ -11,7 +11,6 @@ use radix_engine_interface::blueprints::resource::{
     AccessRule, OwnerRoleEntry, RoleAssignmentInit, RoleKey,
 };
 use radix_engine_interface::object_modules::role_assignment::*;
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 
 pub trait HasRoleAssignment {

--- a/scrypto/src/prelude/mod.rs
+++ b/scrypto/src/prelude/mod.rs
@@ -36,6 +36,7 @@ pub use sbor::{Categorize, Decode, DecodeError, Encode, Sbor};
 
 // Needed for macros
 pub extern crate radix_common;
+pub extern crate sbor;
 
 /// We should always `UncheckedUrl` in Scrypto, as the validation logic is heavy.
 /// Thus, this type alias is added.

--- a/scrypto/src/resource/auth_zone.rs
+++ b/scrypto/src/resource/auth_zone.rs
@@ -3,7 +3,6 @@ use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::collections::IndexSet;
 use scrypto::engine::scrypto_env::ScryptoVmV1Api;
 

--- a/scrypto/src/resource/bucket.rs
+++ b/scrypto/src/resource/bucket.rs
@@ -8,7 +8,6 @@ use radix_common::math::Decimal;
 use radix_common::traits::NonFungibleData;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 use scrypto::engine::scrypto_env::ScryptoVmV1Api;
 

--- a/scrypto/src/resource/non_fungible.rs
+++ b/scrypto/src/resource/non_fungible.rs
@@ -2,7 +2,6 @@ use crate::prelude::ResourceManager;
 use radix_common::data::scrypto::model::*;
 use radix_common::traits::NonFungibleData;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::marker::PhantomData;
 
 /// Represents a non-fungible unit.

--- a/scrypto/src/resource/resource_builder.rs
+++ b/scrypto/src/resource/resource_builder.rs
@@ -15,7 +15,6 @@ use radix_engine_interface::object_modules::metadata::MetadataInit;
 use radix_engine_interface::object_modules::role_assignment::RoleDefinition;
 use radix_engine_interface::object_modules::ModuleConfig;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::prelude::*;
 use sbor::FixedEnumVariant;
 use scrypto::resource::ResourceManager;

--- a/scrypto/src/runtime/local_auth_zone.rs
+++ b/scrypto/src/runtime/local_auth_zone.rs
@@ -3,7 +3,6 @@ use radix_common::math::Decimal;
 use radix_engine_interface::api::ACTOR_REF_AUTH_ZONE;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
-use radix_engine_interface::*;
 use sbor::rust::collections::IndexSet;
 use scrypto::engine::scrypto_env::ScryptoVmV1Api;
 

--- a/scrypto/src/runtime/runtime.rs
+++ b/scrypto/src/runtime/runtime.rs
@@ -19,7 +19,6 @@ use radix_engine_interface::blueprints::resource::{
     AccessRule, AuthZoneAssertAccessRuleInput, AUTH_ZONE_ASSERT_ACCESS_RULE_IDENT,
 };
 use radix_engine_interface::prelude::NON_FUNGIBLE_RESOURCE_MANAGER_BLUEPRINT;
-use radix_engine_interface::*;
 use scrypto::engine::scrypto_env::ScryptoVmV1Api;
 
 /// The transaction runtime.


### PR DESCRIPTION
## Summary

A follow up PR from #1779 that does the following:

* Improves the performance of Rust Analyzer autocomplete by removing the cycles causes by `pub extern crate self as some_name` which lead to paths such as `scrypto::scrypto::scrypto::prelude::*` to be valid.
* Removes the need for the `sbor` crate to be imported by Scrypto packages. The only required dependency now is `scrypto` alone. 

## Update Recommendations

### For dApp Developers

You no longer need the `sbor` dependency and it can be safely removed from your `Cargo.toml` file.