### PR TITLE
Added `DecimalInternal` type

### DIFF
--- a/radix-common/src/math/decimal.rs
+++ b/radix-common/src/math/decimal.rs
@@ -36,7 +36,9 @@ use super::CheckedTruncate;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary, Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Decimal(pub I192);
+pub struct Decimal(pub DecimalInternal);
+
+pub type DecimalInternal = I192;
 
 impl Default for Decimal {
     fn default() -> Self {

--- a/radix-common/src/math/decimal.rs
+++ b/radix-common/src/math/decimal.rs
@@ -36,9 +36,9 @@ use super::CheckedTruncate;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary, Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Decimal(pub DecimalInternal);
+pub struct Decimal(pub InnerDecimal);
 
-pub type DecimalInternal = I192;
+pub type InnerDecimal = I192;
 
 impl Default for Decimal {
     fn default() -> Self {

--- a/radix-common/src/math/precise_decimal.rs
+++ b/radix-common/src/math/precise_decimal.rs
@@ -35,9 +35,9 @@ use crate::*;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PreciseDecimal(pub PreciseDecimalInternal);
+pub struct PreciseDecimal(pub InnerPreciseDecimal);
 
-pub type PreciseDecimalInternal = I256;
+pub type InnerPreciseDecimal = I256;
 
 impl Default for PreciseDecimal {
     fn default() -> Self {

--- a/radix-common/src/math/precise_decimal.rs
+++ b/radix-common/src/math/precise_decimal.rs
@@ -35,7 +35,9 @@ use crate::*;
 /// Unless otherwise specified, all operations will panic if underflow/overflow.
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PreciseDecimal(pub I256);
+pub struct PreciseDecimal(pub PreciseDecimalInternal);
+
+pub type PreciseDecimalInternal = I256;
 
 impl Default for PreciseDecimal {
     fn default() -> Self {


### PR DESCRIPTION
## Summary
Added type alias to `Decimal` and `PreciseDecimal` which is needed by Radix Engine Toolkit to have access to `I192` and `I256` types methods in a generic way (from macro).
This is required for Maya integration to convert between `Decimal` and array of bytes.