### PR TITLE
Faucet blueprint changed magic number to constant

### DIFF
--- a/radix-common/src/constants/mod.rs
+++ b/radix-common/src/constants/mod.rs
@@ -1,6 +1,7 @@
 mod always_visible_nodes;
 mod auth_addresses;
 mod native_addresses;
+mod native_blueprints;
 mod sbor_payload;
 mod transaction_construction;
 mod transaction_execution;
@@ -10,6 +11,7 @@ mod wasm;
 pub use always_visible_nodes::*;
 pub use auth_addresses::*;
 pub use native_addresses::*;
+pub use native_blueprints::*;
 pub use sbor_payload::*;
 pub use transaction_construction::*;
 pub use transaction_execution::*;

--- a/radix-common/src/constants/native_blueprints.rs
+++ b/radix-common/src/constants/native_blueprints.rs
@@ -1,0 +1,4 @@
+// This file contains constants definitions used in native blueprints.
+
+/// XRD amount put on worktop by free() method from Faucet blueprint.
+pub const FAUCET_FREE_AMOUNT: u32 = 10000;

--- a/radix-engine/assets/blueprints/faucet/src/lib.rs
+++ b/radix-engine/assets/blueprints/faucet/src/lib.rs
@@ -1,7 +1,5 @@
 use scrypto::prelude::*;
 
-pub const FAUCET_FREE_AMOUNT: u32 = 10000;
-
 // Faucet - TestNet only
 #[blueprint]
 #[types(Hash, Epoch)]
@@ -39,7 +37,7 @@ mod faucet {
             assert!(self.transactions.get(&transaction_hash).is_none());
             self.transactions.insert(transaction_hash, epoch);
 
-            let amount: Decimal = FAUCET_FREE_AMOUNT.into();
+            let amount: Decimal = 10000.into();
 
             if self.vault.amount() < amount {
                 panic!("The faucet doesn't have funds on this environment. You will need to source XRD another way.")

--- a/radix-engine/assets/blueprints/faucet/src/lib.rs
+++ b/radix-engine/assets/blueprints/faucet/src/lib.rs
@@ -1,5 +1,7 @@
 use scrypto::prelude::*;
 
+pub const FAUCET_FREE_AMOUNT: u32 = 10000;
+
 // Faucet - TestNet only
 #[blueprint]
 #[types(Hash, Epoch)]
@@ -37,7 +39,7 @@ mod faucet {
             assert!(self.transactions.get(&transaction_hash).is_none());
             self.transactions.insert(transaction_hash, epoch);
 
-            let amount: Decimal = 10000.into();
+            let amount: Decimal = FAUCET_FREE_AMOUNT.into();
 
             if self.vault.amount() < amount {
                 panic!("The faucet doesn't have funds on this environment. You will need to source XRD another way.")


### PR DESCRIPTION
## Summary
Changed Faucet blueprint `free` method magic number specifying count of XRD returned to a constant. We need to use that constant in `radix-engine-toolkit` project in `trusted-worktop` feature. Also updated test which uses this magic number in assertions.

This PR re-applies PR: https://github.com/radixdlt/radixdlt-scrypto/pull/1706 which now is missing from `develop`.
