### PR TITLE
Update metadata tests to use compiled assets

### DIFF
--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -78,19 +78,6 @@ pub mod path_macros {
     }
 
     #[macro_export]
-    macro_rules! path_workspace_blueprint {
-        ($package: expr, $name: expr) => {
-            concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../",
-                $package,
-                "/assets/blueprints/",
-                $name
-            )
-        };
-    }
-
-    #[macro_export]
     macro_rules! path_workspace_transaction_examples {
         ($name: expr) => {
             concat!(
@@ -126,7 +113,6 @@ pub mod path_macros {
     pub use crate::include_workspace_asset_bytes;
     pub use crate::include_workspace_transaction_examples_str;
     pub use crate::path_local_blueprint;
-    pub use crate::path_workspace_blueprint;
     pub use crate::path_workspace_transaction_examples;
 }
 

--- a/radix-engine-tests/tests/system/metadata.rs
+++ b/radix-engine-tests/tests/system/metadata.rs
@@ -7,14 +7,24 @@ use radix_engine_interface::object_modules::metadata::{
 use radix_engine_tests::common::*;
 use scrypto_test::prelude::*;
 
+fn publish_metadata_package(
+    ledger: &mut LedgerSimulator<NoExtension, InMemorySubstateDatabase>,
+) -> PackageAddress {
+    let code =
+        include_workspace_asset_bytes!("radix-transaction-scenarios", "metadata.wasm").to_vec();
+    let package_def = manifest_decode::<PackageDefinition>(include_workspace_asset_bytes!(
+        "radix-transaction-scenarios",
+        "metadata.rpd"
+    ))
+    .unwrap();
+    ledger.publish_package_simple((code, package_def))
+}
+
 #[test]
 fn can_get_from_scrypto() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -48,10 +58,7 @@ fn can_get_from_scrypto() {
 fn can_set_from_scrypto() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "MetadataTest", "new", manifest_args!())
@@ -78,10 +85,7 @@ fn can_set_from_scrypto() {
 fn cannot_initialize_metadata_if_key_too_long() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
 
     // Act
     let key = "a".repeat(MAX_METADATA_KEY_STRING_LEN + 1);
@@ -111,10 +115,7 @@ fn cannot_initialize_metadata_if_key_too_long() {
 fn cannot_set_metadata_if_key_too_long() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "MetadataTest", "new", manifest_args!())
@@ -148,10 +149,7 @@ fn cannot_set_metadata_if_key_too_long() {
 fn cannot_initialize_metadata_if_value_too_long() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
 
     // Act
     let value = "a".repeat(MAX_METADATA_VALUE_SBOR_LEN + 1);
@@ -181,10 +179,7 @@ fn cannot_initialize_metadata_if_value_too_long() {
 fn cannot_set_metadata_if_value_too_long() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "MetadataTest", "new", manifest_args!())
@@ -218,10 +213,7 @@ fn cannot_set_metadata_if_value_too_long() {
 fn cannot_set_metadata_if_initialized_empty_locked() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let package_address = ledger.compile_and_publish(path_workspace_blueprint!(
-        "radix-transaction-scenarios",
-        "metadata"
-    ));
+    let package_address = publish_metadata_package(&mut ledger);
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
         .call_function(package_address, "MetadataTest", "new", manifest_args!())


### PR DESCRIPTION
## Summary

CI is failing when the metadata tests try to compile scenario assets. Example: https://github.com/radixdlt/radixdlt-scrypto/actions/runs/8932039773/job/24535207622?pr=1794

This PR resolves the CI issue by loading the compiled artifacts. 

We may consider bumping the dependency of the source blueprints in future.
