### PR TITLE
Refactor: add `ProtocolUpdateBatchGenerator.batch_count()`

### DIFF
--- a/radix-engine-tests/tests/flash/crypto_utils.rs
+++ b/radix-engine-tests/tests/flash/crypto_utils.rs
@@ -32,15 +32,12 @@ fn run_flash_test(flash_substates: bool, expect_success: bool) {
         let anemone_protocol_update_batch_generator = AnemoneSettings::all_disabled()
             .enable(|item| &mut item.vm_boot_to_enable_bls128_and_keccak256)
             .create_batch_generator();
-        let mut i = 0;
-        while let Some(batch) =
-            anemone_protocol_update_batch_generator.generate_batch(ledger.substate_db(), i)
-        {
-            i += 1;
+        for batch_index in 0..anemone_protocol_update_batch_generator.batch_count() {
+            let batch = anemone_protocol_update_batch_generator
+                .generate_batch(ledger.substate_db(), batch_index);
             for ProtocolUpdateTransactionDetails::FlashV1Transaction(
                 FlashProtocolUpdateTransactionDetails { state_updates, .. },
-            ) in batch.transactions
-            {
+            ) in batch.transactions {
                 ledger
                     .substate_db_mut()
                     .commit(&state_updates.create_database_updates::<SpreadPrefixKeyMapper>())

--- a/radix-engine-tests/tests/flash/pools.rs
+++ b/radix-engine-tests/tests/flash/pools.rs
@@ -69,15 +69,12 @@ fn database_is_consistent_before_and_after_protocol_update() {
         let anemone_protocol_update_batch_generator = AnemoneSettings::all_disabled()
             .enable(|item| &mut item.pools_update)
             .create_batch_generator();
-        let mut i = 0;
-        while let Some(batch) =
-            anemone_protocol_update_batch_generator.generate_batch(ledger.substate_db(), i)
-        {
-            i += 1;
+        for batch_index in 0..anemone_protocol_update_batch_generator.batch_count() {
+            let batch = anemone_protocol_update_batch_generator
+                .generate_batch(ledger.substate_db(), batch_index);
             for ProtocolUpdateTransactionDetails::FlashV1Transaction(
                 FlashProtocolUpdateTransactionDetails { state_updates, .. },
-            ) in batch.transactions
-            {
+            ) in batch.transactions {
                 ledger
                     .substate_db_mut()
                     .commit(&state_updates.create_database_updates::<SpreadPrefixKeyMapper>())
@@ -210,15 +207,12 @@ fn single_sided_contributions_to_two_resource_pool_are_only_allowed_after_protoc
         let anemone_protocol_update_batch_generator = AnemoneSettings::all_disabled()
             .enable(|item| &mut item.pools_update)
             .create_batch_generator();
-        let mut i = 0;
-        while let Some(batch) =
-            anemone_protocol_update_batch_generator.generate_batch(ledger.substate_db(), i)
-        {
-            i += 1;
+        for batch_index in 0..anemone_protocol_update_batch_generator.batch_count() {
+            let batch = anemone_protocol_update_batch_generator
+                .generate_batch(ledger.substate_db(), batch_index);
             for ProtocolUpdateTransactionDetails::FlashV1Transaction(
                 FlashProtocolUpdateTransactionDetails { state_updates, .. },
-            ) in batch.transactions
-            {
+            ) in batch.transactions {
                 ledger
                     .substate_db_mut()
                     .commit(&state_updates.create_database_updates::<SpreadPrefixKeyMapper>())
@@ -377,15 +371,12 @@ fn single_sided_contributions_to_multi_resource_pool_are_only_allowed_after_prot
         let anemone_protocol_update_batch_generator = AnemoneSettings::all_disabled()
             .enable(|item| &mut item.pools_update)
             .create_batch_generator();
-        let mut i = 0;
-        while let Some(batch) =
-            anemone_protocol_update_batch_generator.generate_batch(ledger.substate_db(), i)
-        {
-            i += 1;
+        for batch_index in 0..anemone_protocol_update_batch_generator.batch_count() {
+            let batch = anemone_protocol_update_batch_generator
+                .generate_batch(ledger.substate_db(), batch_index);
             for ProtocolUpdateTransactionDetails::FlashV1Transaction(
                 FlashProtocolUpdateTransactionDetails { state_updates, .. },
-            ) in batch.transactions
-            {
+            ) in batch.transactions {
                 ledger
                     .substate_db_mut()
                     .commit(&state_updates.create_database_updates::<SpreadPrefixKeyMapper>())

--- a/radix-engine-tests/tests/flash/seconds_precision.rs
+++ b/radix-engine-tests/tests/flash/seconds_precision.rs
@@ -41,15 +41,12 @@ fn run_flash_test(flash_substates: bool, expect_success: bool) {
         let anemone_protocol_update_batch_generator = AnemoneSettings::all_disabled()
             .enable(|item| &mut item.seconds_precision)
             .create_batch_generator();
-        let mut i = 0;
-        while let Some(batch) =
-            anemone_protocol_update_batch_generator.generate_batch(ledger.substate_db(), i)
-        {
-            i += 1;
+        for batch_index in 0..anemone_protocol_update_batch_generator.batch_count() {
+            let batch = anemone_protocol_update_batch_generator
+                .generate_batch(ledger.substate_db(), batch_index);
             for ProtocolUpdateTransactionDetails::FlashV1Transaction(
                 FlashProtocolUpdateTransactionDetails { state_updates, .. },
-            ) in batch.transactions
-            {
+            ) in batch.transactions {
                 ledger
                     .substate_db_mut()
                     .commit(&state_updates.create_database_updates::<SpreadPrefixKeyMapper>())

--- a/radix-engine/src/updates/anemone.rs
+++ b/radix-engine/src/updates/anemone.rs
@@ -63,12 +63,16 @@ impl ProtocolUpdateBatchGenerator for AnemoneBatchGenerator {
         &self,
         store: &dyn SubstateDatabase,
         batch_index: u32,
-    ) -> Option<ProtocolUpdateBatch> {
-        match batch_index {
-            // Just a single batch for Anemone, perhaps in future updates we should have separate batches for each update?
-            0 => Some(generate_principal_batch(store, &self.settings)),
-            _ => None,
+    ) -> ProtocolUpdateBatch {
+        if batch_index != 0 {
+            panic!("batch index out of range")
         }
+        // Just a single batch for Anemone, perhaps in future updates we should have separate batches for each update?
+        generate_principal_batch(store, &self.settings)
+    }
+
+    fn batch_count(&self) -> u32 {
+        1
     }
 }
 

--- a/radix-engine/src/updates/bottlenose.rs
+++ b/radix-engine/src/updates/bottlenose.rs
@@ -108,12 +108,16 @@ impl ProtocolUpdateBatchGenerator for BottlenoseBatchGenerator {
         &self,
         store: &dyn SubstateDatabase,
         batch_index: u32,
-    ) -> Option<ProtocolUpdateBatch> {
-        match batch_index {
-            // Just a single batch for Bottlenose, perhaps in future updates we should have separate batches for each update?
-            0 => Some(generate_principal_batch(store, &self.settings)),
-            _ => None,
+    ) -> ProtocolUpdateBatch {
+        if batch_index != 0 {
+            panic!("batch index out of range")
         }
+        // Just a single batch for Bottlenose, perhaps in future updates we should have separate batches for each update?
+        generate_principal_batch(store, &self.settings)
+    }
+
+    fn batch_count(&self) -> u32 {
+        1
     }
 }
 

--- a/radix-engine/src/updates/mod.rs
+++ b/radix-engine/src/updates/mod.rs
@@ -115,18 +115,20 @@ impl<T: DefaultForNetwork + UpdateSettingMarker> UpdateSetting<T> {
 /// This must be stateless, to allow the update to be resumed.
 pub trait ProtocolUpdateBatchGenerator: ProtocolUpdateBatchGeneratorDynClone {
     /// Generate a batch of transactions to be committed atomically with a proof.
-    /// Return None if it's the last batch.
+    /// *Panics* if the given batch index is outside the range (see [`Self::batch_count()`]).
     ///
-    /// It should be assumed that the SubstateDatabase has *committed all previous batches*, this
-    /// ensures that the update is deterministically continuable if the node shuts down mid update.
+    /// It should be assumed that the [`SubstateDatabase`] has *committed all previous batches*.
+    /// This ensures that the update is deterministically continuable if the Node shuts down
+    /// mid-update.
     ///
-    /// This is the interface currently needed by the node, to allow the update to be resumed.
-    /// This update isn't great, we could/should probably improve this in future.
-    fn generate_batch(
-        &self,
-        store: &dyn SubstateDatabase,
-        batch_index: u32,
-    ) -> Option<ProtocolUpdateBatch>;
+    /// TODO(potential API improvement): This is the interface currently needed by the Node, to
+    /// allow the update to be resumed; it is not great, and we could improve this in future.
+    fn generate_batch(&self, store: &dyn SubstateDatabase, batch_index: u32)
+        -> ProtocolUpdateBatch;
+
+    /// Returns the number of contained batches.
+    /// The [`Self::generate_batch()`] expects indices in range `[0, self.batch_count() - 1]`.
+    fn batch_count(&self) -> u32;
 }
 
 pub trait ProtocolUpdateBatchGeneratorDynClone {


### PR DESCRIPTION
## Summary

This is needed for better integration with "post-protocol-update Scenarios" on the Node's side.

## Details

Node wants to execute transaction batches for configured Scenarios after transaction batches of a specific Protocol Update.
The progress across these batches has to survive Node's restarts.
To achieve it, the Node re-uses the same `batch_index` (in the underlying persistence), and thus it needs a way of distinguishing which indices belong to Protocol Update itself, and which represent the post-PU scenarios.
The easiest way is to declare how many batches each PU contains, and it also seems to have no downsides (i.e. doesn't reduce flexibility, since the batch generator was always closer to a random-access than to an iterator, despite its API shape).

## Testing
Adjusted some test set-up code.
The behavior itself should not change.

## Update Recommendations
Only the Node developers have to integrate at Bottlenose branch.