### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Documentation: https://docs.radixdlt.com/docs/scrypto-1
      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
      ```
    - Linux:
-     - Make sure a C++ compiler, LLVM and cmake is installed:
+     - Make sure a C++ compiler, LLVM, cmake and clang is installed:
      ```bash
      sudo apt install build-essential llvm cmake clang
      ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Documentation: https://docs.radixdlt.com/docs/scrypto-1
    - Linux:
      - Make sure a C++ compiler, LLVM and cmake is installed:
      ```bash
-     sudo apt install build-essential llvm cmake
+     sudo apt install build-essential llvm cmake clang
      ```
      - Install the Rust compiler:
      ```bash


### PR DESCRIPTION
## Summary
Linux installation steps has missing `clang` dependency. 

## Details
I was following the installation steps on clean Ubuntu mantic, jammy and focal, Scrypto is failing to compile because of `librocksdb-sys` compilation fail due to missing `clang`.
