### PR TITLE
Scrypto compiler default options for tests

### DIFF
--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -52,7 +52,8 @@ fn test_hello() {
 fn test_hello_with_test_environment() -> Result<(), RuntimeError> {
     // Arrange
     let mut env = TestEnvironment::new();
-    let package_address = PackageFactory::compile_and_publish(this_package!(), &mut env)?;
+    let package_address =
+        PackageFactory::compile_and_publish(this_package!(), &mut env, CompileProfile::Fast)?;
 
     let mut hello = Hello::instantiate_hello(package_address, &mut env)?;
 

--- a/radix-clis/assets/template/tests/lib.rs
+++ b/radix-clis/assets/template/tests/lib.rs
@@ -52,7 +52,8 @@ fn test_hello() {
 fn test_hello_with_test_environment() -> Result<(), RuntimeError> {
     // Arrange
     let mut env = TestEnvironment::new();
-    let package_address = PackageFactory::compile_and_publish(this_package!(), &mut env)?;
+    let package_address = 
+        PackageFactory::compile_and_publish(this_package!(), &mut env, CompileProfile::Fast)?;
 
     let mut hello = Hello::instantiate_hello(package_address, &mut env)?;
 

--- a/radix-clis/src/scrypto/cmd_coverage.rs
+++ b/radix-clis/src/scrypto/cmd_coverage.rs
@@ -106,18 +106,8 @@ impl Coverage {
 
         // Build package
         let path = self.path.clone().unwrap_or(current_dir().unwrap());
-        let build_artifacts = build_package(
-            &path,
-            true,
-            Level::Trace,
-            true,
-            &[(
-                "CARGO_ENCODED_RUSTFLAGS".to_owned(),
-                "-Clto=off\x1f-Cinstrument-coverage\x1f-Zno-profiler-runtime\x1f--emit=llvm-ir"
-                    .to_owned(),
-            )],
-        )
-        .map_err(Error::BuildError)?;
+        let build_artifacts =
+            build_package(&path, true, Level::Trace, true, &[]).map_err(Error::BuildError)?;
         if build_artifacts.len() > 1 {
             return Err(Error::BuildError(BuildError::WorkspaceNotSupported).into());
         }

--- a/radix-clis/src/scrypto/cmd_coverage.rs
+++ b/radix-clis/src/scrypto/cmd_coverage.rs
@@ -106,8 +106,18 @@ impl Coverage {
 
         // Build package
         let path = self.path.clone().unwrap_or(current_dir().unwrap());
-        let build_artifacts =
-            build_package(&path, true, Level::Trace, true, &[]).map_err(Error::BuildError)?;
+        let build_artifacts = build_package(
+            &path,
+            true,
+            Level::Trace,
+            true,
+            &[(
+                "CARGO_ENCODED_RUSTFLAGS".to_owned(),
+                "-Clto=off\x1f-Cinstrument-coverage\x1f-Zno-profiler-runtime\x1f--emit=llvm-ir"
+                    .to_owned(),
+            )],
+        )
+        .map_err(Error::BuildError)?;
         if build_artifacts.len() > 1 {
             return Err(Error::BuildError(BuildError::WorkspaceNotSupported).into());
         }

--- a/radix-clis/src/utils/cargo.rs
+++ b/radix-clis/src/utils/cargo.rs
@@ -64,6 +64,10 @@ pub fn build_package<P: AsRef<Path>>(
     }
     if coverage {
         compiler_builder.coverage();
+
+        let mut target_path = PathBuf::from(base_path.as_ref());
+        target_path.push("coverage");
+        compiler_builder.target_directory(target_path);
     }
     env.iter().for_each(|(name, value)| {
         compiler_builder.env(name, EnvironmentVariableAction::Set(value.clone()));

--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -38,6 +38,7 @@ pub mod package_loader {
 pub mod package_loader {
     use radix_common::prelude::*;
     use radix_substate_store_queries::typed_substate_layout::*;
+    use scrypto_test::ledger_simulator::CompileProfile;
     use std::path::PathBuf;
 
     pub struct PackageLoader;
@@ -45,7 +46,13 @@ pub mod package_loader {
         pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
             let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
             let package_dir = manifest_dir.join("assets").join("blueprints").join(name);
-            scrypto_test::prelude::Compile::compile(package_dir)
+            scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::FastWithTraceLogs)
+        }
+
+        pub fn get_using_default_compiler_options(name: &str) -> (Vec<u8>, PackageDefinition) {
+            let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
+            let package_dir = manifest_dir.join("assets").join("blueprints").join(name);
+            scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::Default)
         }
     }
 }

--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -30,10 +30,6 @@ pub mod package_loader {
                 panic!("Package \"{}\" not found. Are you sure that this package is: a) in the blueprints folder, b) that this is the same as the package name in the Cargo.toml file?", name)
             }
         }
-
-        pub fn get_using_standard_compiler_profile(name: &str) -> (Vec<u8>, PackageDefinition) {
-            panic!("Package \"{}\" already compiled. Cannot use specific compiler profile in compile-blueprints-at-build-time mode.", name)
-        }
     }
 }
 
@@ -48,20 +44,9 @@ pub mod package_loader {
     pub struct PackageLoader;
     impl PackageLoader {
         pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
-            Self::get_internal(name, CompileProfile::FastWithTraceLogs)
-        }
-
-        pub fn get_using_standard_compiler_profile(name: &str) -> (Vec<u8>, PackageDefinition) {
-            Self::get_internal(name, CompileProfile::Standard)
-        }
-
-        fn get_internal(
-            name: &str,
-            compile_profile: CompileProfile,
-        ) -> (Vec<u8>, PackageDefinition) {
             let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
             let package_dir = manifest_dir.join("assets").join("blueprints").join(name);
-            scrypto_test::prelude::Compile::compile(package_dir, compile_profile)
+            scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::FastWithTraceLogs)
         }
     }
 }

--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -30,6 +30,10 @@ pub mod package_loader {
                 panic!("Package \"{}\" not found. Are you sure that this package is: a) in the blueprints folder, b) that this is the same as the package name in the Cargo.toml file?", name)
             }
         }
+
+        pub fn get_using_standard_compiler_profile(name: &str) -> (Vec<u8>, PackageDefinition) {
+            panic!("Package \"{}\" already compiled. Cannot use specific compiler profile in compile-blueprints-at-build-time mode.", name)
+        }
     }
 }
 
@@ -47,8 +51,8 @@ pub mod package_loader {
             Self::get_internal(name, CompileProfile::FastWithTraceLogs)
         }
 
-        pub fn get_using_default_compiler_options(name: &str) -> (Vec<u8>, PackageDefinition) {
-            Self::get_internal(name, CompileProfile::Default)
+        pub fn get_using_standard_compiler_profile(name: &str) -> (Vec<u8>, PackageDefinition) {
+            Self::get_internal(name, CompileProfile::Standard)
         }
 
         fn get_internal(

--- a/radix-engine-tests/src/common.rs
+++ b/radix-engine-tests/src/common.rs
@@ -44,15 +44,20 @@ pub mod package_loader {
     pub struct PackageLoader;
     impl PackageLoader {
         pub fn get(name: &str) -> (Vec<u8>, PackageDefinition) {
-            let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
-            let package_dir = manifest_dir.join("assets").join("blueprints").join(name);
-            scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::FastWithTraceLogs)
+            Self::get_internal(name, CompileProfile::FastWithTraceLogs)
         }
 
         pub fn get_using_default_compiler_options(name: &str) -> (Vec<u8>, PackageDefinition) {
+            Self::get_internal(name, CompileProfile::Default)
+        }
+
+        fn get_internal(
+            name: &str,
+            compile_profile: CompileProfile,
+        ) -> (Vec<u8>, PackageDefinition) {
             let manifest_dir = PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
             let package_dir = manifest_dir.join("assets").join("blueprints").join(name);
-            scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::Default)
+            scrypto_test::prelude::Compile::compile(package_dir, compile_profile)
         }
     }
 }

--- a/radix-engine-tests/tests/flash/crypto_utils.rs
+++ b/radix-engine-tests/tests/flash/crypto_utils.rs
@@ -89,8 +89,11 @@ fn run_flash_test_test_environment(enable_bls: bool, expect_success: bool) {
         .build();
 
     // Act
-    let result =
-        PackageFactory::compile_and_publish(path_local_blueprint!("crypto_scrypto"), &mut test_env);
+    let result = PackageFactory::compile_and_publish(
+        path_local_blueprint!("crypto_scrypto"),
+        &mut test_env,
+        CompileProfile::Fast,
+    );
 
     // Assert
     if expect_success {

--- a/radix-engine-tests/tests/vm/system_wasm_buffers.rs
+++ b/radix-engine-tests/tests/vm/system_wasm_buffers.rs
@@ -14,7 +14,10 @@ fn get_ledger() -> (
     LedgerSimulator<NoExtension, InMemorySubstateDatabase>,
     ComponentAddress,
 ) {
-    let (code, definition) = Compile::compile(path_local_blueprint!("system_wasm_buffers"));
+    let (code, definition) = Compile::compile(
+        path_local_blueprint!("system_wasm_buffers"),
+        CompileProfile::FastWithTraceLogs,
+    );
 
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -201,15 +201,15 @@ pub struct BuildArtifact<T> {
 }
 
 #[derive(Debug, Clone)]
-struct CompilerManifestDefinition {
+pub struct CompilerManifestDefinition {
     /// Path to Cargo.toml file.
-    manifest_path: PathBuf,
+    pub manifest_path: PathBuf,
     /// Path to directory where compilation artifacts are stored.
-    target_directory: PathBuf,
+    pub target_directory: PathBuf,
     /// Path to target binary WASM file.
-    target_binary_wasm_path: PathBuf,
+    pub target_binary_wasm_path: PathBuf,
     /// Path to target binary RPD file.
-    target_binary_rpd_path: PathBuf,
+    pub target_binary_rpd_path: PathBuf,
 }
 
 /// Programmatic implementation of Scrypto compiler which is a wrapper around rust cargo tool.
@@ -770,6 +770,11 @@ impl ScryptoCompiler {
             .success()
             .then_some(())
             .ok_or(ScryptoCompilerError::CargoBuildFailure(status))
+    }
+
+    /// Returns information about the main manifest
+    pub fn get_main_manifest_definition(&self) -> CompilerManifestDefinition {
+        self.main_manifest.clone()
     }
 }
 

--- a/scrypto-test/Cargo.toml
+++ b/scrypto-test/Cargo.toml
@@ -41,6 +41,8 @@ resource_tracker = ["radix-engine/resource_tracker", "radix-common/resource_trac
 rocksdb = ["radix-substate-store-impls/rocksdb"]
 post_run_db_check = []
 
+coverage = ["radix-common/coverage", "radix-engine/coverage"]
+
 [lib]
 doctest = false
 bench = false

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -1238,7 +1238,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
     }
 
     pub fn compile<P: AsRef<Path>>(&mut self, package_dir: P) -> (Vec<u8>, PackageDefinition) {
-        Compile::compile(package_dir)
+        Compile::compile(package_dir, CompileProfile::FastWithTraceLogs)
     }
 
     // Doesn't need to be here - kept for backward compatibility
@@ -2614,7 +2614,9 @@ impl From<(Vec<u8>, PackageDefinition)> for PackagePublishingSource {
 impl PackagePublishingSource {
     pub fn code_and_definition(self) -> (Vec<u8>, PackageDefinition) {
         match self {
-            Self::CompileAndPublishFromSource(path) => Compile::compile(path),
+            Self::CompileAndPublishFromSource(path) => {
+                Compile::compile(path, CompileProfile::FastWithTraceLogs)
+            }
             Self::PublishExisting(code, definition) => (code, definition),
         }
     }

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -1238,7 +1238,15 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
     }
 
     pub fn compile<P: AsRef<Path>>(&mut self, package_dir: P) -> (Vec<u8>, PackageDefinition) {
-        Compile::compile(package_dir, CompileProfile::FastWithTraceLogs)
+        self.compile_with_option(package_dir, CompileProfile::FastWithTraceLogs)
+    }
+
+    pub fn compile_with_option<P: AsRef<Path>>(
+        &mut self,
+        package_dir: P,
+        compile_profile: CompileProfile,
+    ) -> (Vec<u8>, PackageDefinition) {
+        Compile::compile(package_dir, compile_profile)
     }
 
     // Doesn't need to be here - kept for backward compatibility
@@ -2577,31 +2585,31 @@ pub fn assert_receipt_events_can_be_typed(commit_result: &CommitResult) {
 }
 
 pub enum PackagePublishingSource {
-    CompileAndPublishFromSource(PathBuf),
+    CompileAndPublishFromSource(PathBuf, CompileProfile),
     PublishExisting(Vec<u8>, PackageDefinition),
 }
 
 impl From<String> for PackagePublishingSource {
     fn from(value: String) -> Self {
-        Self::CompileAndPublishFromSource(value.into())
+        Self::CompileAndPublishFromSource(value.into(), CompileProfile::FastWithTraceLogs)
     }
 }
 
 impl<'g> From<&'g str> for PackagePublishingSource {
     fn from(value: &'g str) -> Self {
-        Self::CompileAndPublishFromSource(value.into())
+        Self::CompileAndPublishFromSource(value.into(), CompileProfile::FastWithTraceLogs)
     }
 }
 
 impl From<PathBuf> for PackagePublishingSource {
     fn from(value: PathBuf) -> Self {
-        Self::CompileAndPublishFromSource(value)
+        Self::CompileAndPublishFromSource(value, CompileProfile::FastWithTraceLogs)
     }
 }
 
 impl<'g> From<&'g Path> for PackagePublishingSource {
     fn from(value: &'g Path) -> Self {
-        Self::CompileAndPublishFromSource(value.into())
+        Self::CompileAndPublishFromSource(value.into(), CompileProfile::FastWithTraceLogs)
     }
 }
 
@@ -2614,9 +2622,7 @@ impl From<(Vec<u8>, PackageDefinition)> for PackagePublishingSource {
 impl PackagePublishingSource {
     pub fn code_and_definition(self) -> (Vec<u8>, PackageDefinition) {
         match self {
-            Self::CompileAndPublishFromSource(path) => {
-                Compile::compile(path, CompileProfile::FastWithTraceLogs)
-            }
+            Self::CompileAndPublishFromSource(path, profile) => Compile::compile(path, profile),
             Self::PublishExisting(code, definition) => (code, definition),
         }
     }

--- a/scrypto-test/tests/tuple_return.rs
+++ b/scrypto-test/tests/tuple_return.rs
@@ -8,6 +8,7 @@ fn tuple_returns_work_with_scrypto_test() {
     let package_address = PackageFactory::compile_and_publish(
         concat!(env!("CARGO_MANIFEST_DIR"), "/tests/blueprints/tuple-return"),
         &mut env,
+        CompileProfile::Fast,
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
Added `CompilerProfile` to `LedgerSimulator`.

## Details
Adding new `scrypto-compiler` crate introduced divergence between default `scrypto build` command compilation options and compilation options used by `LedgerSimulator` and `SDK` in `scrypto-test` project. This PR provides option for the users of `LedgerSimulator` to choose if they want to use standard `scrypto build` compilation options or faster compilation options (WASM optimizations are disabled in that case).
Also refactored `PackageFactory` to use same compiler object as `LedgerSimulator`.

## Testing
Added new tests which verifies if blueprint compiled using `scrypto build` and `LedgerSimulator` with Standard compilation options are binary same. Also added other validation tests.

