### PR TITLE
Added support for seconds precision in `TestEnvironment`

### DIFF
--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -728,7 +728,7 @@ where
 
     /// Gets the current time stamp from the Consensus Manager.
     pub fn get_current_time(&mut self) -> Instant {
-        Runtime::current_time(self, TimePrecision::Minute).unwrap()
+        Runtime::current_time(self, TimePrecision::Second).unwrap()
     }
 
     pub fn set_current_time(&mut self, instant: Instant) {

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -739,17 +739,17 @@ where
             |env| -> Result<(), RuntimeError> {
                 let handle = env.actor_open_field(
                     ACTOR_STATE_SELF,
-                    ConsensusManagerField::ProposerMinuteTimestamp.into(),
+                    ConsensusManagerField::ProposerMilliTimestamp.into(),
                     LockFlags::MUTABLE,
                 )?;
-                let mut proposer_minute_timestamp =
-                    env.field_read_typed::<ConsensusManagerProposerMinuteTimestampFieldPayload>(
+                let mut proposer_milli_timestamp =
+                    env.field_read_typed::<ConsensusManagerProposerMilliTimestampFieldPayload>(
                         handle,
                     )?;
-                proposer_minute_timestamp
+                proposer_milli_timestamp
                     .as_unique_version_mut()
-                    .epoch_minute = (instant.seconds_since_unix_epoch / 60) as i32;
-                env.field_write_typed(handle, &proposer_minute_timestamp)?;
+                    .epoch_milli = instant.seconds_since_unix_epoch * 1000;
+                env.field_write_typed(handle, &proposer_milli_timestamp)?;
                 env.field_close(handle)?;
                 Ok(())
             },

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -746,9 +746,8 @@ where
                     env.field_read_typed::<ConsensusManagerProposerMilliTimestampFieldPayload>(
                         handle,
                     )?;
-                proposer_milli_timestamp
-                    .as_unique_version_mut()
-                    .epoch_milli = instant.seconds_since_unix_epoch * 1000;
+                proposer_milli_timestamp.as_unique_version_mut().epoch_milli =
+                    instant.seconds_since_unix_epoch * 1000;
                 env.field_write_typed(handle, &proposer_milli_timestamp)?;
                 env.field_close(handle)?;
                 Ok(())


### PR DESCRIPTION
## Summary
Updated function `set_current_time()` to use `ProposerMilliTimestamp` calculated from provided seconds.
Updated function `get_current_time()` to use `TimePrecision::Second`.
