### PR TITLE
Fixed scrypto coverage command with path argument

### DIFF
--- a/radix-clis/src/scrypto/cmd_coverage.rs
+++ b/radix-clis/src/scrypto/cmd_coverage.rs
@@ -148,7 +148,10 @@ impl Coverage {
         fs::create_dir_all(&data_path).unwrap();
 
         // Set enviromental variable COVERAGE_DIRECTORY
-        env::set_var("COVERAGE_DIRECTORY", data_path.to_str().unwrap());
+        env::set_var(
+            "COVERAGE_DIRECTORY",
+            fs::canonicalize(&data_path).unwrap().to_str().unwrap(),
+        );
 
         // Run tests
         test_package(path, self.arguments.clone(), true)


### PR DESCRIPTION
## Summary
When `--path` argument was specified to `scrypto coverage` command the `COVERAGE_DIRECTORY` passed to test was misaligned with current directory set during tests execution. It is enough to just change `COVERAGE_DIRECTORY` path to absolute path instead of relative.