### PR TITLE
Added scrypto coverage test to CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
         working-directory: radix-clis
   
   scrypto-coverage-tests:
-    name: Run Scrypto coverage tests
+    name: Run CLI tests (scrypto coverage)
     runs-on: ubuntu-16-cores-selfhosted
     steps:
       - uses: RDXWorks-actions/checkout@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,35 @@ jobs:
         run: bash ./tests/scrypto.sh
         working-directory: radix-clis
 
+  radix-clis-scrypto-coverage:
+    name: Run CLI tests (scrypto coverage)
+    runs-on: ubuntu-16-cores-selfhosted
+    steps:
+      - uses: RDXWorks-actions/checkout@main
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+      - uses: radixdlt/rust-cache@allow_registry_src_caching
+        with:
+          prefix-key: ""
+          shared-key: radix-clis-debug-${{ runner.os }}
+          cache-directories: ~/.cargo/registry/src/**/librocksdb-sys-*
+          workspaces: radix-clis
+      - name: Install rustc 1.78.0-nightly
+        run: |
+          rustup toolchain install nightly-2024-02-08
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-02-08
+          rustup default nightly-2024-02-08
+          rustup show
+      - name: Install LLVM 17
+        run: |
+          sudo apt install lsb-release wget software-properties-common gnupg
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+      - name: Run tests
+        working-directory: radix-clis
+        run: bash ./tests/scrypto_coverage.sh
+        
   cargo-check:
     name: Run cargo check
     runs-on: ${{ matrix.os }}
@@ -312,7 +341,7 @@ jobs:
         run: cargo check --all
 
   cargo-check-post-run-db-check:
-    name: Run cargo check
+    name: Run cargo check with post run db check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -346,31 +375,3 @@ jobs:
             --breakpoints 10:91850a10dad5ec6d9a974663e87243b3f3ff8f8b1c0dd74135e8ddd097aa6276,100:8ac9b0caf4daad6f821038f325b215932e90fbabce089ca42bc0330c867aa8f8,1000:6b621e9c7f9674c3d71832aec822b695b0e90010dc6158a18e43fbacf296ef69,500000:7dd4403a757f43f4a885e914b8dc38086fdbaf96082fa90067acf1500075e85d
         working-directory: radix-clis
   
-  scrypto-coverage-tests:
-    name: Run CLI tests (scrypto coverage)
-    runs-on: ubuntu-16-cores-selfhosted
-    steps:
-      - uses: RDXWorks-actions/checkout@main
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-      - uses: radixdlt/rust-cache@allow_registry_src_caching
-        with:
-          prefix-key: ""
-          shared-key: radix-clis-debug-${{ runner.os }}
-          cache-directories: ~/.cargo/registry/src/**/librocksdb-sys-*
-          workspaces: radix-clis
-      - name: Install rustc 1.78.0-nightly
-        run: |
-          rustup toolchain install nightly-2024-02-08
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-02-08
-          rustup default nightly-2024-02-08
-          rustup show
-      - name: Install LLVM 17
-        run: |
-          sudo apt install lsb-release wget software-properties-common gnupg
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 17
-      - name: Run tests
-        working-directory: radix-clis
-        run: bash ./tests/scrypto_coverage.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,3 +345,32 @@ jobs:
             --max-version 50000 \
             --breakpoints 10:91850a10dad5ec6d9a974663e87243b3f3ff8f8b1c0dd74135e8ddd097aa6276,100:8ac9b0caf4daad6f821038f325b215932e90fbabce089ca42bc0330c867aa8f8,1000:6b621e9c7f9674c3d71832aec822b695b0e90010dc6158a18e43fbacf296ef69,500000:7dd4403a757f43f4a885e914b8dc38086fdbaf96082fa90067acf1500075e85d
         working-directory: radix-clis
+  
+  scrypto-coverage-tests:
+    name: Run Scrypto coverage tests
+    runs-on: ubuntu-16-cores-selfhosted
+    steps:
+      - uses: RDXWorks-actions/checkout@main
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+      - uses: radixdlt/rust-cache@allow_registry_src_caching
+        with:
+          prefix-key: ""
+          shared-key: radix-clis-debug-${{ runner.os }}
+          cache-directories: ~/.cargo/registry/src/**/librocksdb-sys-*
+          workspaces: radix-clis
+      - name: Install rustc 1.78.0-nightly
+        run: |
+          rustup toolchain install nightly-2024-02-08
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-02-08
+          rustup default nightly-2024-02-08
+          rustup show
+      - name: Install LLVM 17
+        run: |
+          sudo apt install lsb-release wget software-properties-common gnupg
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+      - name: Run tests
+        working-directory: radix-clis
+        run: bash ./tests/scrypto_coverage.sh


### PR DESCRIPTION
## Summary
Added execution of CLI test: `scrypto_coverage.sh` to CI workflow.
Successful new job run: https://github.com/radixdlt/radixdlt-scrypto/actions/runs/9127710496/job/25098580548?pr=1817
This PR requires changes done in [fix/scrypt-coverage-with-path](https://github.com/radixdlt/radixdlt-scrypto/tree/fix/scrypt-coverage-with-path) branch - PR https://github.com/radixdlt/radixdlt-scrypto/pull/1816.