### PR TITLE
Add support to just load the build artifacts in `scrypto test` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,13 @@ jobs:
         uses: ./.github/actions/setup-env
       - name: Build and test hello-world
         run: |
-          cargo build --target wasm32-unknown-unknown --release
-          cargo nextest run --release
+          scrypto build
+          scrypto test
         working-directory: examples/hello-world
       - name: Build and test everything
         run: |
-          cargo build --target wasm32-unknown-unknown --release
-          cargo nextest run --release
+          scrypto build
+          scrypto test
         working-directory: examples/everything
       - name: Build no-std
         run: cargo build --target wasm32-unknown-unknown --release
@@ -326,7 +326,7 @@ jobs:
       - name: Run tests
         working-directory: radix-clis
         run: bash ./tests/scrypto_coverage.sh
-        
+
   cargo-check:
     name: Run cargo check
     runs-on: ${{ matrix.os }}
@@ -360,7 +360,7 @@ jobs:
       - uses: RDXWorks-actions/checkout@main
       - name: Cargo Check
         run: |
-          sudo apt-get install libclang-dev -y 
+          sudo apt-get install libclang-dev -y
           curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
           sudo apt-get install git-lfs -y
       - name: Setup environment
@@ -374,4 +374,4 @@ jobs:
             --max-version 50000 \
             --breakpoints 10:91850a10dad5ec6d9a974663e87243b3f3ff8f8b1c0dd74135e8ddd097aa6276,100:8ac9b0caf4daad6f821038f325b215932e90fbabce089ca42bc0330c867aa8f8,1000:6b621e9c7f9674c3d71832aec822b695b0e90010dc6158a18e43fbacf296ef69,500000:7dd4403a757f43f4a885e914b8dc38086fdbaf96082fa90067acf1500075e85d
         working-directory: radix-clis
-  
+

--- a/examples/hello-world/tests/lib.rs
+++ b/examples/hello-world/tests/lib.rs
@@ -11,7 +11,7 @@ fn test_hello() {
     let (public_key, _private_key, account) = ledger.new_allocated_account();
 
     // Publish package
-    let package_address = ledger.compile_and_publish(this_package!());
+    let package_address = ledger.publish_package_simple(this_package_code_and_schema!());
 
     // Test the `instantiate_hello` function.
     let manifest = ManifestBuilder::new()
@@ -52,8 +52,8 @@ fn test_hello() {
 fn test_hello_with_test_environment() -> Result<(), RuntimeError> {
     // Arrange
     let mut env = TestEnvironment::new();
-    let package_address =
-        PackageFactory::compile_and_publish(this_package!(), &mut env, CompileProfile::Fast)?;
+    let (wasm, rpd) = this_package_code_and_schema!();
+    let package_address = PackageFactory::publish_simple(wasm, rpd, &mut env)?;
 
     let mut hello = Hello::instantiate_hello(package_address, &mut env)?;
 

--- a/radix-clis/assets/template/tests/lib.rs
+++ b/radix-clis/assets/template/tests/lib.rs
@@ -11,7 +11,16 @@ fn test_hello() {
     let (public_key, _private_key, account) = ledger.new_allocated_account();
 
     // Publish package
-    let package_address = ledger.compile_and_publish(this_package!());
+    // Package artifacts should be already available if `scrypto` command was used.
+    // Macro `this_package_code_and_schema!()` reads artifacts in runtime.
+    // Alternatively we could get artifacts in compile time (see below), but syntax
+    // checker will complain, until package artifacts are not built (meaning until
+    // first `scrypto build` or `scrypto test` successful invocation)
+    // ```
+    // let wasm = include_code!(".wasm");
+    // let rpd = include_code!(".rpd");
+    // ```
+    let package_address = ledger.publish_package_simple(this_package_code_and_schema!());
 
     // Test the `instantiate_hello` function.
     let manifest = ManifestBuilder::new()
@@ -52,8 +61,9 @@ fn test_hello() {
 fn test_hello_with_test_environment() -> Result<(), RuntimeError> {
     // Arrange
     let mut env = TestEnvironment::new();
-    let package_address = 
-        PackageFactory::compile_and_publish(this_package!(), &mut env, CompileProfile::Fast)?;
+    // Package should be already built if `scrypto` command was used
+    let (wasm, rpd) = this_package_code_and_schema!();
+    let package_address = PackageFactory::publish_simple(wasm, rpd, &mut env)?;
 
     let mut hello = Hello::instantiate_hello(package_address, &mut env)?;
 

--- a/scrypto-test/src/lib.rs
+++ b/scrypto-test/src/lib.rs
@@ -87,6 +87,22 @@ pub mod prelude;
 pub mod sdk;
 pub mod utils;
 
+// TODO: consider setting CARGO_TARGET_DIR by `scrypto` command
+#[cfg(feature = "coverage")]
+#[macro_export]
+macro_rules! target_dir {
+    () => {
+        "coverage"
+    };
+}
+#[cfg(not(feature = "coverage"))]
+#[macro_export]
+macro_rules! target_dir {
+    () => {
+        "target"
+    };
+}
+
 #[macro_export]
 macro_rules! this_package {
     () => {
@@ -106,7 +122,9 @@ macro_rules! package_path {
     ($bin_name: expr, $extension: expr) => {
         concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/target/wasm32-unknown-unknown/release/",
+            "/",
+            target_dir!(),
+            "/wasm32-unknown-unknown/release/",
             $bin_name,
             $extension
         )
@@ -114,7 +132,9 @@ macro_rules! package_path {
     ($package_dir: expr, $bin_name: expr, $extension: expr) => {
         concat!(
             $package_dir,
-            "/target/wasm32-unknown-unknown/release/",
+            "/",
+            target_dir!(),
+            "/wasm32-unknown-unknown/release/",
             $bin_name,
             $extension
         )

--- a/scrypto-test/src/lib.rs
+++ b/scrypto-test/src/lib.rs
@@ -113,28 +113,26 @@ macro_rules! this_package {
 #[macro_export]
 macro_rules! this_package_name {
     () => {
-        env!("CARGO_PKG_NAME")
+        env!("CARGO_PKG_NAME").replace("-", "_")
     };
 }
 
 #[macro_export]
 macro_rules! package_path {
     ($bin_name: expr, $extension: expr) => {
-        concat!(
+        format!(
+            "{}/{}/wasm32-unknown-unknown/release/{}{}",
             env!("CARGO_MANIFEST_DIR"),
-            "/",
             target_dir!(),
-            "/wasm32-unknown-unknown/release/",
             $bin_name,
             $extension
         )
     };
     ($package_dir: expr, $bin_name: expr, $extension: expr) => {
-        concat!(
+        format!(
+            "{}/{}/wasm32-unknown-unknown/release/{}{}",
             $package_dir,
-            "/",
             target_dir!(),
-            "/wasm32-unknown-unknown/release/",
             $bin_name,
             $extension
         )

--- a/scrypto-test/src/prelude.rs
+++ b/scrypto-test/src/prelude.rs
@@ -92,4 +92,7 @@ pub use radix_transactions::prelude::*;
 pub use crate::environment::*;
 pub use crate::ledger_simulator::*;
 pub use crate::sdk::*;
-pub use crate::{include_code, include_schema, this_package};
+pub use crate::{
+    include_code, include_schema, package_path, this_package, this_package_code_and_schema,
+    this_package_name,
+};

--- a/scrypto-test/src/prelude.rs
+++ b/scrypto-test/src/prelude.rs
@@ -93,6 +93,6 @@ pub use crate::environment::*;
 pub use crate::ledger_simulator::*;
 pub use crate::sdk::*;
 pub use crate::{
-    include_code, include_schema, package_path, this_package, this_package_code_and_schema,
-    this_package_name,
+    include_code, include_schema, package_path, target_dir, this_package,
+    this_package_code_and_schema, this_package_name,
 };

--- a/scrypto-test/src/sdk/package.rs
+++ b/scrypto-test/src/sdk/package.rs
@@ -55,6 +55,24 @@ impl PackageFactory {
         })
     }
 
+    pub fn publish_simple<D>(
+        code: Vec<u8>,
+        definition: PackageDefinition,
+        env: &mut TestEnvironment<D>,
+    ) -> Result<PackageAddress, RuntimeError>
+    where
+        D: SubstateDatabase + CommittableSubstateDatabase + 'static,
+    {
+        Self::publish_advanced(
+            OwnerRole::None,
+            definition,
+            code,
+            Default::default(),
+            Default::default(),
+            env,
+        )
+    }
+
     pub fn compile_and_publish<P, D>(
         path: P,
         env: &mut TestEnvironment<D>,
@@ -65,14 +83,7 @@ impl PackageFactory {
         D: SubstateDatabase + CommittableSubstateDatabase + 'static,
     {
         let (wasm, package_definition) = Self::compile(path, compile_profile);
-        Self::publish_advanced(
-            OwnerRole::None,
-            package_definition,
-            wasm,
-            Default::default(),
-            Default::default(),
-            env,
-        )
+        Self::publish_simple(wasm, package_definition, env)
     }
 
     pub fn compile<P>(path: P, compile_profile: CompileProfile) -> (Vec<u8>, PackageDefinition)


### PR DESCRIPTION
## Summary
Refactor `scrypto new-package` template to just load the build artifacts (WASM and package definition), which should be already built.
Also applied the same change to `hello-world`

## Details
There is no need to compile package in `scrypto` unit test. `scrypto` command builds it for us internally, when `scrypto test` or `scrypto coverage` command is invoked.
Moreover compile it in each unit tests, which are running in parallel, might lead to some indeterministic results, because the build artifacts are being shared between unit tests.

NOTE 1!
This PR does not address the problem for the tests, which are already implemented. It only changes the template and provides the reference how such test should look like.
We could possibly fix it internally by adding a build script, but:
- I think it would make a `scrypto` package look too complicated for a common dApp developer. 
- build script does not share the build progress (not sure, maybe it can be reconfigured). If you add a long build time of a `scrypto` package it coud give a feeling that something hung up.

NOTE 2!
With this change we are also loosing some flexibility when using `cargo` command instead of `scrypto`.
eg. such combination will not work properly 
```
# cargo build just '*.wasm' and will not build the '*.rpd' file
cargo build --target wasm32-unknown-unknown --release
# below expects both '*.wasm' and '*.rpd' to be already built
cargo test --release
# cargo nextest run --release
```
I don't think it is a big deal, because a canonical way to work with **Scrypto** should  be using `scrypto` command.

## Testing

## Update Recommendations

### For dApp Developers
dApp developers shall refactor their tests by themselves if they are affected.

