### PR TITLE
Protect scrypto compilation with lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --no-default-features
+            --no-default-features \
             --features compile-blueprints-at-build-time \
             --features alloc \
             -p radix-common \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
+            --features compile-blueprints-at-build-time \
             -p radix-common \
             -p radix-sbor-derive \
             -p radix-engine-interface \
@@ -164,6 +165,7 @@ jobs:
         run: |
           cargo nextest run \
             --release \
+            --features compile-blueprints-at-build-time \
             -p radix-common \
             -p radix-sbor-derive \
             -p radix-engine-interface \
@@ -180,7 +182,9 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --no-default-features --features alloc \
+            --no-default-features
+            --features compile-blueprints-at-build-time \
+            --features alloc \
             -p radix-common \
             -p radix-sbor-derive \
             -p radix-engine-interface \
@@ -197,6 +201,7 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
+            --features compile-blueprints-at-build-time \
             --features wasmer \
             -p radix-common \
             -p radix-sbor-derive \
@@ -326,7 +331,7 @@ jobs:
       - name: Run tests
         working-directory: radix-clis
         run: bash ./tests/scrypto_coverage.sh
-        
+
   cargo-check:
     name: Run cargo check
     runs-on: ${{ matrix.os }}
@@ -360,7 +365,7 @@ jobs:
       - uses: RDXWorks-actions/checkout@main
       - name: Cargo Check
         run: |
-          sudo apt-get install libclang-dev -y 
+          sudo apt-get install libclang-dev -y
           curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
           sudo apt-get install git-lfs -y
       - name: Setup environment
@@ -374,4 +379,4 @@ jobs:
             --max-version 50000 \
             --breakpoints 10:91850a10dad5ec6d9a974663e87243b3f3ff8f8b1c0dd74135e8ddd097aa6276,100:8ac9b0caf4daad6f821038f325b215932e90fbabce089ca42bc0330c867aa8f8,1000:6b621e9c7f9674c3d71832aec822b695b0e90010dc6158a18e43fbacf296ef69,500000:7dd4403a757f43f4a885e914b8dc38086fdbaf96082fa90067acf1500075e85d
         working-directory: radix-clis
-  
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,6 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --features compile-blueprints-at-build-time \
             -p radix-common \
             -p radix-sbor-derive \
             -p radix-engine-interface \
@@ -165,7 +164,6 @@ jobs:
         run: |
           cargo nextest run \
             --release \
-            --features compile-blueprints-at-build-time \
             -p radix-common \
             -p radix-sbor-derive \
             -p radix-engine-interface \
@@ -183,7 +181,6 @@ jobs:
         run: |
           cargo nextest run \
             --no-default-features \
-            --features compile-blueprints-at-build-time \
             --features alloc \
             -p radix-common \
             -p radix-sbor-derive \
@@ -201,7 +198,6 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run \
-            --features compile-blueprints-at-build-time \
             --features wasmer \
             -p radix-common \
             -p radix-sbor-derive \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,8 @@ perfcnt = { version = "0.8.0" }
 plotters = { version = "0.3.4" }
 proc-macro2 = { version = "1.0.38" }
 quote = { version = "1.0.18" }
-radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
+# radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
+radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", branch = "feature/remove_exports", default-features = false,  features = ["ignore_custom_section"]}
 radix-wasmi = {  version = "1.0.0" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ wasmer-compiler-singlepass = { version = "2.2.1" }
 wasmparser = { version = "0.107.0", default-features = false }
 extend = { version = "1.2.0" }
 zeroize = { version = "1.3.0" }
+fslock = { version = "0.2.1" }
 
 # Both the release and test profiles use `panic = "unwind"` to allow certain parts of the Radix
 # Engine to be able to catch panics. As an example, the native-vm has a `catch_unwind` to catch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,3 @@ walrus = { version = "0.12.0", features = ["parallel"] }
 # crashing the engine.
 [profile.release]
 panic = "unwind"
-
-# Optimize for speed for test profile to speed up the tests
-[profile.test]
-opt-level = 3
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,8 @@ fslock = { version = "0.2.1" }
 # crashing the engine.
 [profile.release]
 panic = "unwind"
+
+# Optimize for speed for test profile to speed up the tests
+[profile.test]
+opt-level = 3
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,5 +142,5 @@ panic = "unwind"
 
 # Optimize for speed for test profile to speed up the tests
 [profile.test]
-opt-level = 1
+opt-level = 2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,8 @@ wasmparser = { version = "0.107.0", default-features = false }
 extend = { version = "1.2.0" }
 zeroize = { version = "1.3.0" }
 fslock = { version = "0.2.1" }
+wasm-snip = { version = "0.4.0" }
+walrus = { version = "0.12.0", features = ["parallel"] }
 
 # Both the release and test profiles use `panic = "unwind"` to allow certain parts of the Radix
 # Engine to be able to catch panics. As an example, the native-vm has a `catch_unwind` to catch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ plotters = { version = "0.3.4" }
 proc-macro2 = { version = "1.0.38" }
 quote = { version = "1.0.18" }
 # radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
-radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", branch = "feature/remove_exports", default-features = false,  features = ["ignore_custom_section"]}
+radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", rev = "6832d0e6ec8e2013184a1f0eb01453abc6d63d7b", default-features = false,  features = ["ignore_custom_section"]}
 radix-wasmi = {  version = "1.0.0" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,7 @@ perfcnt = { version = "0.8.0" }
 plotters = { version = "0.3.4" }
 proc-macro2 = { version = "1.0.38" }
 quote = { version = "1.0.18" }
-# radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
-radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", rev = "9341b930330609751c44f70b79703b2feef09b9c", default-features = false,  features = ["ignore_custom_section"]}
+radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
 radix-wasmi = {  version = "1.0.0" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ plotters = { version = "0.3.4" }
 proc-macro2 = { version = "1.0.38" }
 quote = { version = "1.0.18" }
 # radix-wasm-instrument = { version = "1.0.0", default-features = false,  features = ["ignore_custom_section"]}
-radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", rev = "6832d0e6ec8e2013184a1f0eb01453abc6d63d7b", default-features = false,  features = ["ignore_custom_section"]}
+radix-wasm-instrument = { git = "https://github.com/radixdlt/wasm-instrument.git", rev = "9341b930330609751c44f70b79703b2feef09b9c", default-features = false,  features = ["ignore_custom_section"]}
 radix-wasmi = {  version = "1.0.0" }
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,5 +142,5 @@ panic = "unwind"
 
 # Optimize for speed for test profile to speed up the tests
 [profile.test]
-opt-level = 2
+opt-level = 3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,6 @@ wasmparser = { version = "0.107.0", default-features = false }
 extend = { version = "1.2.0" }
 zeroize = { version = "1.3.0" }
 fslock = { version = "0.2.1" }
-wasm-snip = { version = "0.4.0" }
-walrus = { version = "0.12.0", features = ["parallel"] }
 
 # Both the release and test profiles use `panic = "unwind"` to allow certain parts of the Radix
 # Engine to be able to catch panics. As an example, the native-vm has a `catch_unwind` to catch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,3 +139,8 @@ walrus = { version = "0.12.0", features = ["parallel"] }
 # crashing the engine.
 [profile.release]
 panic = "unwind"
+
+# Optimize for speed for test profile to speed up the tests
+[profile.test]
+opt-level = 1
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,5 +142,5 @@ panic = "unwind"
 
 # Optimize for speed for test profile to speed up the tests
 [profile.test]
-opt-level = 3
+opt-level = 1
 

--- a/check_stack_usage.sh
+++ b/check_stack_usage.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PACKAGE=radix-engine-tests
+PACKAGES="-p radix-common -p radix-sbor-derive -p radix-engine-interface -p radix-engine -p radix-engine-tests"
 TARGET=system
 FILE=arguments
 TEST=vector_of_buckets_argument_should_succeed
@@ -24,7 +24,7 @@ function get_stack_usage() {
         stack=$(( $low + ($high - $low) / 2))
         echo checking stack $stack
 
-        if RUST_MIN_STACK=$stack cargo test -p $PACKAGE --test $TARGET $FILE::$TEST -- >$output 2>&1 ; then
+        if RUST_MIN_STACK=$stack cargo test $PACKAGES --test $TARGET $FILE::$TEST -- >$output 2>&1 ; then
             if grep 'stack overflow' $output ; then
                 cat $output
                 echo "unexpected error occurred"

--- a/examples/everything/Cargo.lock
+++ b/examples/everything/Cargo.lock
@@ -408,6 +408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f830c31a9c9fb94e2d27fbc76daf642784ce14eb3910d4719e29b50ccda5d0f0"
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,10 +1216,12 @@ name = "scrypto-compiler"
 version = "1.3.0-dev"
 dependencies = [
  "cargo_toml",
+ "fslock",
  "radix-common",
  "radix-engine",
  "radix-engine-interface",
  "radix-rust",
+ "radix-wasm-instrument",
  "serde_json",
  "wasm-opt",
 ]

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -400,6 +400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f830c31a9c9fb94e2d27fbc76daf642784ce14eb3910d4719e29b50ccda5d0f0"
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,10 +1216,12 @@ name = "scrypto-compiler"
 version = "1.3.0-dev"
 dependencies = [
  "cargo_toml",
+ "fslock",
  "radix-common",
  "radix-engine",
  "radix-engine-interface",
  "radix-rust",
+ "radix-wasm-instrument",
  "serde_json",
  "wasm-opt",
 ]

--- a/radix-clis/Cargo.lock
+++ b/radix-clis/Cargo.lock
@@ -571,6 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,10 +1605,12 @@ name = "scrypto-compiler"
 version = "1.3.0-dev"
 dependencies = [
  "cargo_toml",
+ "fslock",
  "radix-common",
  "radix-engine",
  "radix-engine-interface",
  "radix-rust",
+ "radix-wasm-instrument",
  "serde_json",
  "wasm-opt",
 ]

--- a/radix-engine-tests/build.rs
+++ b/radix-engine-tests/build.rs
@@ -46,6 +46,8 @@ fn main() {
                 "CARGO_ENCODED_RUSTFLAGS".to_owned() => "".to_owned(),
                 "LLVM_PROFILE_FILE".to_owned() => "".to_owned()
             },
+            scrypto_test::prelude::CompileProfile::Fast,
+            false,
         );
         packages.insert(name, (code, definition));
     }

--- a/radix-engine/assets/blueprints/Cargo.lock
+++ b/radix-engine/assets/blueprints/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "radix-blueprint-schema-init"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "bitflags",
  "radix-common",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "radix-common"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "radix-common-derive"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "bitflags",
  "const-sha1",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "radix-rust"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "indexmap",
  "serde",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "radix-sbor-derive"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -535,7 +535,7 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sbor"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "const-sha1",
  "hex",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "const-sha1",
  "itertools",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto-derive"
-version = "1.2.0-dev"
+version = "1.3.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/radix-engine/assets/blueprints/Cargo.lock
+++ b/radix-engine/assets/blueprints/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "radix-blueprint-schema-init"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "bitflags",
  "radix-common",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "radix-common"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "bech32",
  "blake2",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "radix-common-derive"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "bitflags",
  "const-sha1",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "radix-rust"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "indexmap",
  "serde",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "radix-sbor-derive"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -535,7 +535,7 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sbor"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "const-sha1",
  "hex",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "const-sha1",
  "itertools",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "scrypto-derive"
-version = "1.3.0-dev"
+version = "1.2.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -15,8 +15,7 @@ serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
 fslock = { workspace = true }
-wasm-snip = { workspace = true }
-walrus = { workspace = true }
+radix-wasm-instrument = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -17,6 +17,7 @@ cargo_toml = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"
+rayon = { workspace = true }
 
 [lib]
 doctest = false

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
 fslock = { workspace = true }
-highway = { version = "1.1.0" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
 fslock = { workspace = true }
-radix-wasm-instrument = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
 fslock = { workspace = true }
+highway = { version = "1.1.0" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -14,6 +14,7 @@ radix-rust = { workspace = true }
 serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
+fslock = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/Cargo.toml
+++ b/scrypto-compiler/Cargo.toml
@@ -15,6 +15,8 @@ serde_json = { workspace = true }
 wasm-opt = { workspace = true }
 cargo_toml = { workspace = true }
 fslock = { workspace = true }
+wasm-snip = { workspace = true }
+walrus = { workspace = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -768,6 +768,18 @@ impl ScryptoCompiler {
                     }
                 }
             }
+
+            // Unlock if not all packages locked.
+            // We need all packages to be locked at once to make sure
+            // no other thread locked some package in the meantime.
+            if !all_locked {
+                for package_lock in package_locks.iter_mut() {
+                    if package_lock.is_locked() {
+                        package_lock.unlock()?;
+                    }
+                }
+            }
+
             // Give CPU some rest - sleep for 10ms
             std::thread::sleep(std::time::Duration::from_millis(10));
         }

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -49,8 +49,6 @@ pub enum ScryptoCompilerError {
     SchemaDecodeError(DecodeError),
     /// Returned when trying to compile workspace without any scrypto packages.
     NothingToCompile,
-    /// Snip error
-    SnipError(String),
 }
 
 #[derive(Debug, Clone)]
@@ -76,7 +74,7 @@ pub struct ScryptoCompilerInputParams {
     pub custom_options: IndexSet<String>,
     /// If specified optimizes the built wasm using Binaryen's wasm-opt tool.
     /// Default configuration is equivalent to running the following commands in the CLI:
-    /// wasm-opt -0z --strip-debug --strip-dwarf --strip-procedures $some_path $some_path
+    /// wasm-opt -0z --strip-debug --strip-dwarf --strip-producers --dce $some_path $some_path
     pub wasm_optimization: Option<wasm_opt::OptimizationOptions>,
 }
 impl Default for ScryptoCompilerInputParams {

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -737,6 +737,7 @@ impl ScryptoCompiler {
             )
         })?;
 
+        // Collect packages to be locked
         if self.manifests.is_empty() {
             let lock_file_path = self
                 .main_manifest
@@ -757,6 +758,7 @@ impl ScryptoCompiler {
         }
 
         let mut all_locked = false;
+        // Attempt to lock all compiled packages.
         while !all_locked {
             all_locked = true;
             for package_lock in package_locks.iter_mut() {
@@ -766,7 +768,7 @@ impl ScryptoCompiler {
                     }
                 }
             }
-            // sleep for 200ms
+            // Give CPU some rest - sleep for 200ms
             std::thread::sleep(std::time::Duration::from_millis(200));
         }
 
@@ -899,6 +901,11 @@ impl ScryptoCompiler {
             )
         })?;
 
+        // The best would be to directly produce wasm file with schema by overriding Cargo.toml
+        // values from command line.
+        // Possibly it could be done by replacing 'cargo build' with 'cargo rustc' command,
+        // which allows to customize settings on lower level. It is very likely it would implicate
+        // more changes. And we don't want to complicate things more. So lets just rename the file.
         std::fs::rename(
             &manifest_def.target_binary_wasm_path,
             &manifest_def.target_binary_wasm_with_schema_path,

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -1011,7 +1011,9 @@ impl ScryptoCompiler {
         &self,
         manifest_def: &CompilerManifestDefinition,
     ) -> Result<BuildArtifact<Vec<u8>>, ScryptoCompilerError> {
-        self.snip_schema_from_wasm(manifest_def)?;
+        if !self.input_params.features.contains(SCRYPTO_COVERAGE) {
+            self.snip_schema_from_wasm(manifest_def)?;
+        }
 
         self.wasm_optimize(&manifest_def.target_binary_wasm_path.clone())?;
 

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -943,8 +943,11 @@ impl ScryptoCompiler {
         &mut self,
         command: &mut Command,
     ) -> Result<Vec<BuildArtifact<Vec<u8>>>, ScryptoCompilerError> {
-        // self.prepare_command_phase_2(command);
-        // self.cargo_command_call(command)?;
+        // Compile only if coverage enabled
+        if self.input_params.features.contains(SCRYPTO_COVERAGE) {
+            self.prepare_command_phase_2(command);
+            self.cargo_command_call(command)?;
+        }
         // compilation post-processing for all manifests
         if self.manifests.is_empty() {
             // non-workspace compilation

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -1,5 +1,6 @@
 use cargo_toml::Manifest;
 use fslock::{LockFile, ToOsStr};
+use highway::{HighwayHash, HighwayHasher, Key};
 use radix_common::prelude::*;
 use radix_engine::utils::{extract_definition, ExtractSchemaError};
 use radix_engine_interface::{blueprints::package::PackageDefinition, types::Level};
@@ -15,6 +16,32 @@ const MANIFEST_FILE: &str = "Cargo.toml";
 const BUILD_TARGET: &str = "wasm32-unknown-unknown";
 const SCRYPTO_NO_SCHEMA: &str = "scrypto/no-schema";
 const SCRYPTO_COVERAGE: &str = "scrypto/coverage";
+
+#[derive(Debug)]
+struct CacheHash([u8; 16]);
+
+impl CacheHash {
+    fn hash(bytes: &[u8]) -> Self {
+        let key = Key([1, 2, 3, 4]);
+        let mut hasher128 = HighwayHasher::new(key);
+        hasher128.append(bytes);
+        let res128: [u64; 2] = hasher128.finalize128();
+
+        let mut bytes = [0u8; 16];
+
+        bytes[0..8].copy_from_slice(&res128[0].to_le_bytes());
+        bytes[8..16].copy_from_slice(&res128[1].to_le_bytes());
+
+        Self(bytes)
+    }
+}
+
+impl Display for CacheHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hash_string: String = self.0.iter().map(|byte| format!("{:02x}", byte)).collect();
+        write!(f, "{}", hash_string)
+    }
+}
 
 #[derive(Debug)]
 pub enum ScryptoCompilerError {
@@ -944,7 +971,7 @@ impl ScryptoCompiler {
                     Some(String::from("Read WASM file for RPD extract failed.")),
                 )
             })?;
-        let code_hash = hash(&code);
+        let code_hash = CacheHash::hash(&code);
 
         let package_definition =
             extract_definition(&code).map_err(ScryptoCompilerError::SchemaExtractionError)?;
@@ -1004,14 +1031,14 @@ impl ScryptoCompiler {
     fn get_scrypto_cache_paths(
         &self,
         manifest_def: &CompilerManifestDefinition,
-        code_hash: Hash,
+        code_hash: CacheHash,
         create_if_not_exists: bool,
     ) -> Result<(PathBuf, PathBuf), ScryptoCompilerError> {
         // WASM optimizations are optional and might be configured on different ways.
         // They are applied in 2nd compilation, which means one can receive different WASMs
         // for the same WASM files from 1st compilation.
         let options = format!("{:?}{:?}", code_hash, self.input_params.wasm_optimization);
-        let hash_dir = hash(options);
+        let hash_dir = CacheHash::hash(options.as_bytes());
 
         let cache_path = manifest_def
             .target_directory
@@ -1044,7 +1071,7 @@ impl ScryptoCompiler {
     fn store_artifacts_in_cache(
         &self,
         manifest_def: &CompilerManifestDefinition,
-        code_hash: Hash,
+        code_hash: CacheHash,
         artifacts: &BuildArtifacts,
     ) -> Result<(), ScryptoCompilerError> {
         let (rpd_cache_path, wasm_cache_path) =
@@ -1100,7 +1127,7 @@ impl ScryptoCompiler {
                     Some(String::from("Read WASM with schema file failed.")),
                 )
             })?;
-        let code_hash = hash(&code);
+        let code_hash = CacheHash::hash(&code);
 
         let (rpd_cache_path, wasm_cache_path) =
             self.get_scrypto_cache_paths(manifest_def, code_hash, false)?;

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -801,7 +801,7 @@ impl ScryptoCompiler {
         stdout: Option<T>,
         stderr: Option<T>,
     ) -> Result<Vec<BuildArtifacts>, ScryptoCompilerError> {
-        let lock_file = self.lock_packages()?;
+        let package_locks = self.lock_packages()?;
 
         let mut command = Command::new("cargo");
         // Stdio streams used only for 1st phase compilation due to lack of Copy trait.
@@ -819,7 +819,7 @@ impl ScryptoCompiler {
         let mut command = Command::new("cargo");
         let wasms = self.compile_internal_phase_2(&mut command)?;
 
-        self.unlock_packages(lock_file)?;
+        self.unlock_packages(package_locks)?;
 
         Ok(package_definitions
             .iter()

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -768,8 +768,8 @@ impl ScryptoCompiler {
                     }
                 }
             }
-            // Give CPU some rest - sleep for 200ms
-            std::thread::sleep(std::time::Duration::from_millis(200));
+            // Give CPU some rest - sleep for 10ms
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
 
         Ok(package_locks)

--- a/scrypto-compiler/src/lib.rs
+++ b/scrypto-compiler/src/lib.rs
@@ -642,6 +642,15 @@ impl ScryptoCompiler {
     fn lock_compilation(&self) -> Result<LockFile, ScryptoCompilerError> {
         let lock_file_path = self.main_manifest.target_directory.join("scrypto.lock");
 
+        // Create target folder if it doesn't exist
+        std::fs::create_dir_all(&self.main_manifest.target_directory).map_err(|err| {
+            ScryptoCompilerError::IOErrorWithPath(
+                err,
+                self.main_manifest.target_directory.clone(),
+                Some(String::from("Create target folder failed")),
+            )
+        })?;
+
         let path = lock_file_path.to_os_str().map_err(|err| {
             ScryptoCompilerError::IOErrorWithPath(
                 err,

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,6 @@ test_crates_features \
 
 echo "Testing scrypto packages..."
 test_packages \
-    "assets/blueprints/faucet \
     examples/hello-world \
     examples/no-std"
 

--- a/test.sh
+++ b/test.sh
@@ -23,9 +23,7 @@ test_crates_features \
     radix-engine \
     radix-engine-tests \
     radix-transaction-scenarios \
-    radix-transactions" \
-    --features=compile-blueprints-at-build-time
-
+    radix-transactions"
 
 echo "Testing scrypto packages..."
 test_packages \

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,9 @@ test_crates_features \
     radix-engine \
     radix-engine-tests \
     radix-transaction-scenarios \
-    radix-transactions"
+    radix-transactions" \
+    --features=compile-blueprints-at-build-time
+
 
 echo "Testing scrypto packages..."
 test_packages \


### PR DESCRIPTION
## Summary

This change introduces a protection of Scrypto build artifacts with lock file.
This is important when multiple Scrypto compilation processes are invoked in parallel.
Compilation time for multiple compilations increases slightly.

Additionally:
- produce WASM with schema file *_with_schema.wasm
- implemented scrypto compiler cache to skip second compilation if possible
- run RE tests with O1 optimization level. It increases the build time slightly but reduces the test time
- reduced stack usage test duration - it is executed in the same job as `Run Radix Engine tests` but apparently it was rebuilding RE massively instead of reusing build artifacts from the `cargo nextest run`. Discovered that we need to provide exactly the same list of packages in order to benefit from incremental build.

## Testing
Parallel compilation test added.
