### PR TITLE
refactor: Remove some type hell with SchemaTypeLinks

### DIFF
--- a/radix-clis/src/scrypto_bindgen/mod.rs
+++ b/radix-clis/src/scrypto_bindgen/mod.rs
@@ -105,7 +105,7 @@ where
     fn resolve_type_kind(
         &self,
         type_identifier: &ScopedTypeId,
-    ) -> Result<SchemaTypeKind<ScryptoCustomSchema>, schema::SchemaError> {
+    ) -> Result<LocalTypeKind<ScryptoCustomSchema>, schema::SchemaError> {
         self.lookup_schema(&type_identifier.0)
             .ok_or(schema::SchemaError::FailedToGetSchemaFromSchemaHash)?
             .as_latest_version()

--- a/radix-common/src/data/manifest/custom_extension.rs
+++ b/radix-common/src/data/manifest/custom_extension.rs
@@ -14,10 +14,7 @@ impl CustomExtension for ManifestCustomExtension {
     fn custom_value_kind_matches_type_kind(
         schema: &Schema<Self::CustomSchema>,
         custom_value_kind: Self::CustomValueKind,
-        type_kind: &TypeKind<
-            <Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
-            LocalTypeId,
-        >,
+        type_kind: &LocalTypeKind<Self::CustomSchema>,
     ) -> bool {
         match custom_value_kind {
             ManifestCustomValueKind::Address => matches!(
@@ -67,7 +64,7 @@ impl CustomExtension for ManifestCustomExtension {
 
     fn custom_type_kind_matches_non_custom_value_kind(
         _: &Schema<Self::CustomSchema>,
-        _: &<Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
+        _: &<Self::CustomSchema as CustomSchema>::CustomLocalTypeKind,
         _: ValueKind<Self::CustomValueKind>,
     ) -> bool {
         // No custom type kinds can match non-custom value kinds

--- a/radix-common/src/data/scrypto/custom_extension.rs
+++ b/radix-common/src/data/scrypto/custom_extension.rs
@@ -13,10 +13,7 @@ impl CustomExtension for ScryptoCustomExtension {
     fn custom_value_kind_matches_type_kind(
         _: &Schema<Self::CustomSchema>,
         custom_value_kind: Self::CustomValueKind,
-        type_kind: &TypeKind<
-            <Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
-            LocalTypeId,
-        >,
+        type_kind: &LocalTypeKind<Self::CustomSchema>,
     ) -> bool {
         match custom_value_kind {
             ScryptoCustomValueKind::Reference => matches!(
@@ -42,7 +39,7 @@ impl CustomExtension for ScryptoCustomExtension {
 
     fn custom_type_kind_matches_non_custom_value_kind(
         _: &Schema<Self::CustomSchema>,
-        _: &<Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
+        _: &<Self::CustomSchema as CustomSchema>::CustomLocalTypeKind,
         _: ValueKind<Self::CustomValueKind>,
     ) -> bool {
         // It's not possible for a custom type kind to match a non-custom value kind

--- a/radix-common/src/data/scrypto/custom_schema.rs
+++ b/radix-common/src/data/scrypto/custom_schema.rs
@@ -9,6 +9,7 @@ pub type ScryptoTypeData<L> = TypeData<ScryptoCustomTypeKind, L>;
 pub type ScryptoLocalTypeData = LocalTypeData<ScryptoCustomSchema>;
 pub type ScryptoAggregatorTypeData = AggregatorTypeData<ScryptoCustomSchema>;
 pub type ScryptoTypeValidation = TypeValidation<ScryptoCustomTypeValidation>;
+pub type ScryptoTypeAggregator = TypeAggregator<ScryptoCustomTypeKind>;
 
 /// A schema for the values that a codec can decode / views as valid
 #[derive(Debug, Clone, PartialEq, Eq, ManifestSbor, ScryptoSbor)]

--- a/radix-common/src/data/scrypto/custom_schema.rs
+++ b/radix-common/src/data/scrypto/custom_schema.rs
@@ -226,6 +226,7 @@ impl CustomSchema for ScryptoCustomSchema {
     type CustomAggregatorTypeKind = ScryptoCustomTypeKind;
     type CustomTypeKindLabel = ScryptoCustomTypeKindLabel;
     type CustomTypeValidation = ScryptoCustomTypeValidation;
+    type DefaultCustomExtension = ScryptoCustomExtension;
 
     fn linearize_type_kind(
         type_kind: Self::CustomLocalTypeKind,

--- a/radix-common/src/data/scrypto/custom_schema.rs
+++ b/radix-common/src/data/scrypto/custom_schema.rs
@@ -1,9 +1,14 @@
 use crate::internal_prelude::*;
 
 pub type ScryptoTypeKind<L> = TypeKind<ScryptoCustomTypeKind, L>;
+pub type ScryptoLocalTypeKind = LocalTypeKind<ScryptoCustomSchema>;
+pub type ScryptoAggregatorTypeKind = AggregatorTypeKind<ScryptoCustomSchema>;
 pub type VersionedScryptoSchema = VersionedSchema<ScryptoCustomSchema>;
 pub type ScryptoSchema = Schema<ScryptoCustomSchema>;
 pub type ScryptoTypeData<L> = TypeData<ScryptoCustomTypeKind, L>;
+pub type ScryptoLocalTypeData = LocalTypeData<ScryptoCustomSchema>;
+pub type ScryptoAggregatorTypeData = AggregatorTypeData<ScryptoCustomSchema>;
+pub type ScryptoTypeValidation = TypeValidation<ScryptoCustomTypeValidation>;
 
 /// A schema for the values that a codec can decode / views as valid
 #[derive(Debug, Clone, PartialEq, Eq, ManifestSbor, ScryptoSbor)]
@@ -217,32 +222,27 @@ lazy_static::lazy_static! {
 }
 
 impl CustomSchema for ScryptoCustomSchema {
-    type CustomTypeKind<L: SchemaTypeLink> = ScryptoCustomTypeKind;
+    type CustomLocalTypeKind = ScryptoCustomTypeKind;
+    type CustomAggregatorTypeKind = ScryptoCustomTypeKind;
     type CustomTypeKindLabel = ScryptoCustomTypeKindLabel;
     type CustomTypeValidation = ScryptoCustomTypeValidation;
 
     fn linearize_type_kind(
-        type_kind: Self::CustomTypeKind<RustTypeId>,
+        type_kind: Self::CustomLocalTypeKind,
         _type_indices: &IndexSet<TypeHash>,
-    ) -> Self::CustomTypeKind<LocalTypeId> {
-        match type_kind {
-            ScryptoCustomTypeKind::Reference => ScryptoCustomTypeKind::Reference,
-            ScryptoCustomTypeKind::Own => ScryptoCustomTypeKind::Own,
-            ScryptoCustomTypeKind::Decimal => ScryptoCustomTypeKind::Decimal,
-            ScryptoCustomTypeKind::PreciseDecimal => ScryptoCustomTypeKind::PreciseDecimal,
-            ScryptoCustomTypeKind::NonFungibleLocalId => ScryptoCustomTypeKind::NonFungibleLocalId,
-        }
+    ) -> Self::CustomAggregatorTypeKind {
+        type_kind
     }
 
     fn resolve_well_known_type(
         well_known_id: WellKnownTypeId,
-    ) -> Option<&'static TypeData<Self::CustomTypeKind<LocalTypeId>, LocalTypeId>> {
+    ) -> Option<&'static LocalTypeData<Self>> {
         resolve_scrypto_well_known_type(well_known_id)
     }
 
     fn validate_custom_type_kind(
         _context: &SchemaContext,
-        type_kind: &Self::CustomTypeKind<LocalTypeId>,
+        type_kind: &Self::CustomLocalTypeKind,
     ) -> Result<(), SchemaValidationError> {
         match type_kind {
             ScryptoCustomTypeKind::Reference
@@ -258,7 +258,7 @@ impl CustomSchema for ScryptoCustomSchema {
 
     fn validate_type_metadata_with_custom_type_kind(
         _: &SchemaContext,
-        type_kind: &Self::CustomTypeKind<LocalTypeId>,
+        type_kind: &Self::CustomLocalTypeKind,
         type_metadata: &TypeMetadata,
     ) -> Result<(), SchemaValidationError> {
         // Even though they all map to the same thing, we keep the explicit match statement so that
@@ -277,7 +277,7 @@ impl CustomSchema for ScryptoCustomSchema {
 
     fn validate_custom_type_validation(
         _context: &SchemaContext,
-        custom_type_kind: &Self::CustomTypeKind<LocalTypeId>,
+        custom_type_kind: &Self::CustomLocalTypeKind,
         custom_type_validation: &Self::CustomTypeValidation,
     ) -> Result<(), SchemaValidationError> {
         match custom_type_kind {

--- a/radix-common/src/data/scrypto/custom_well_known_types.rs
+++ b/radix-common/src/data/scrypto/custom_well_known_types.rs
@@ -572,7 +572,7 @@ create_well_known_lookup!(
 
 pub fn resolve_scrypto_well_known_type(
     well_known_index: WellKnownTypeId,
-) -> Option<&'static TypeData<ScryptoCustomTypeKind, LocalTypeId>> {
+) -> Option<&'static ScryptoLocalTypeData> {
     WELL_KNOWN_LOOKUP
         .get(well_known_index.as_index())
         .and_then(|x| x.as_ref())

--- a/radix-engine-tests/tests/system/schema_sanity_check.rs
+++ b/radix-engine-tests/tests/system/schema_sanity_check.rs
@@ -465,11 +465,11 @@ fn native_blueprints_with_typed_addresses_have_expected_schema() {
 
     assert!(matches!(
         type_kind,
-        TypeKind::<ScryptoCustomTypeKind, LocalTypeId>::Custom(ScryptoCustomTypeKind::Reference)
+        ScryptoLocalTypeKind::Custom(ScryptoCustomTypeKind::Reference)
     ));
     assert!(matches!(
         type_validation,
-        TypeValidation::<ScryptoCustomTypeValidation>::Custom(
+        ScryptoTypeValidation::Custom(
             ScryptoCustomTypeValidation::Reference(ReferenceValidation::IsGlobalTyped(
                 Some(ACCOUNT_PACKAGE),
                 bp_name

--- a/sbor-tests/tests/schema_comparison.rs
+++ b/sbor-tests/tests/schema_comparison.rs
@@ -1,9 +1,6 @@
 use sbor::prelude::*;
 use sbor::schema::*;
-use sbor::BasicValue;
-use sbor::ComparisonSchema;
-use sbor::NoCustomSchema;
-use sbor::NoCustomTypeKind;
+use sbor::{BasicTypeAggregator, BasicValue, ComparisonSchema, NoCustomSchema, NoCustomTypeKind};
 
 //=====================
 // HELPER CODE / TRAITS
@@ -359,14 +356,14 @@ fn equality_removing_length_validation_fails() {
 #[should_panic(expected = "TypeUnreachableFromRootInBaseSchema")]
 fn base_schema_not_covered_by_root_types_fails() {
     let mut base_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
-        aggregator.add_named_root_type_and_descendents::<MyEnum>("enum");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
+        aggregator.add_root_type::<MyEnum>("enum");
         aggregator.generate_named_types_schema()
     };
     let compared_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
         aggregator.generate_named_types_schema()
     };
     // Forget about a root type - this leaves the schema not fully covered.
@@ -379,14 +376,14 @@ fn base_schema_not_covered_by_root_types_fails() {
 #[should_panic(expected = "TypeUnreachableFromRootInComparedSchema")]
 fn compared_schema_not_covered_by_root_types_fails() {
     let base_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
         aggregator.generate_named_types_schema()
     };
     let mut compared_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
-        aggregator.add_named_root_type_and_descendents::<MyEnum>("enum");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
+        aggregator.add_root_type::<MyEnum>("enum");
         aggregator.generate_named_types_schema()
     };
     // Forget about a root type - this leaves the schema not fully covered.
@@ -402,14 +399,14 @@ fn compared_schema_not_covered_by_root_types_fails() {
 #[should_panic(expected = "NamedRootTypeMissingInComparedSchema")]
 fn removed_root_type_fails_comparison() {
     let base_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
-        aggregator.add_named_root_type_and_descendents::<MyEnum>("enum");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
+        aggregator.add_root_type::<MyEnum>("enum");
         aggregator.generate_named_types_schema()
     };
     let compared_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
         aggregator.generate_named_types_schema()
     };
 
@@ -419,14 +416,14 @@ fn removed_root_type_fails_comparison() {
 #[test]
 fn under_extension_added_root_type_succeeds() {
     let base_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
         aggregator.generate_named_types_schema()
     };
     let compared_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
-        aggregator.add_named_root_type_and_descendents::<MyEnum>("enum");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
+        aggregator.add_root_type::<MyEnum>("enum");
         aggregator.generate_named_types_schema()
     };
 
@@ -437,14 +434,14 @@ fn under_extension_added_root_type_succeeds() {
 #[should_panic(expected = "DisallowedNewRootTypeInComparedSchema")]
 fn under_equality_added_root_type_fails() {
     let base_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
         aggregator.generate_named_types_schema()
     };
     let compared_schema = {
-        let mut aggregator = TypeAggregator::<NoCustomTypeKind>::new();
-        aggregator.add_named_root_type_and_descendents::<MyStruct>("struct");
-        aggregator.add_named_root_type_and_descendents::<MyEnum>("enum");
+        let mut aggregator = BasicTypeAggregator::new();
+        aggregator.add_root_type::<MyStruct>("struct");
+        aggregator.add_root_type::<MyEnum>("enum");
         aggregator.generate_named_types_schema()
     };
 

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -205,20 +205,21 @@ lazy_static::lazy_static! {
 pub enum NoCustomSchema {}
 
 impl CustomSchema for NoCustomSchema {
-    type CustomTypeKind<L: SchemaTypeLink> = NoCustomTypeKind;
+    type CustomLocalTypeKind = NoCustomTypeKind;
+    type CustomAggregatorTypeKind = NoCustomTypeKind;
     type CustomTypeKindLabel = NoCustomTypeKindLabel;
     type CustomTypeValidation = NoCustomTypeValidation;
 
     fn linearize_type_kind(
-        _: Self::CustomTypeKind<RustTypeId>,
+        _: Self::CustomAggregatorTypeKind,
         _: &IndexSet<TypeHash>,
-    ) -> Self::CustomTypeKind<LocalTypeId> {
+    ) -> Self::CustomLocalTypeKind {
         unreachable!("No custom type kinds exist")
     }
 
     fn resolve_well_known_type(
         well_known_id: WellKnownTypeId,
-    ) -> Option<&'static TypeData<Self::CustomTypeKind<LocalTypeId>, LocalTypeId>> {
+    ) -> Option<&'static LocalTypeData<Self>> {
         WELL_KNOWN_LOOKUP
             .get(well_known_id.as_index())
             .and_then(|x| x.as_ref())
@@ -226,7 +227,7 @@ impl CustomSchema for NoCustomSchema {
 
     fn validate_custom_type_validation(
         _: &SchemaContext,
-        _: &Self::CustomTypeKind<LocalTypeId>,
+        _: &Self::CustomLocalTypeKind,
         _: &Self::CustomTypeValidation,
     ) -> Result<(), SchemaValidationError> {
         unreachable!("No custom type validation")
@@ -234,14 +235,14 @@ impl CustomSchema for NoCustomSchema {
 
     fn validate_custom_type_kind(
         _: &SchemaContext,
-        _: &Self::CustomTypeKind<LocalTypeId>,
+        _: &Self::CustomLocalTypeKind,
     ) -> Result<(), SchemaValidationError> {
         unreachable!("No custom type kinds exist")
     }
 
     fn validate_type_metadata_with_custom_type_kind(
         _: &SchemaContext,
-        _: &Self::CustomTypeKind<LocalTypeId>,
+        _: &Self::CustomLocalTypeKind,
         _: &TypeMetadata,
     ) -> Result<(), SchemaValidationError> {
         unreachable!("No custom type kinds exist")
@@ -271,17 +272,14 @@ impl CustomExtension for NoCustomExtension {
     fn custom_value_kind_matches_type_kind(
         _: &Schema<Self::CustomSchema>,
         _: Self::CustomValueKind,
-        _: &TypeKind<
-            <Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
-            LocalTypeId,
-        >,
+        _: &TypeKind<<Self::CustomSchema as CustomSchema>::CustomLocalTypeKind, LocalTypeId>,
     ) -> bool {
         unreachable!("No custom value kinds exist")
     }
 
     fn custom_type_kind_matches_non_custom_value_kind(
         _: &Schema<Self::CustomSchema>,
-        _: &<Self::CustomSchema as CustomSchema>::CustomTypeKind<LocalTypeId>,
+        _: &<Self::CustomSchema as CustomSchema>::CustomLocalTypeKind,
         _: ValueKind<Self::CustomValueKind>,
     ) -> bool {
         unreachable!("No custom type kinds exist")
@@ -293,9 +291,13 @@ pub type BasicOwnedRawPayload = RawPayload<'static, NoCustomExtension>;
 pub type BasicRawValue<'a> = RawValue<'a, NoCustomExtension>;
 pub type BasicOwnedRawValue = RawValue<'static, NoCustomExtension>;
 pub type BasicTypeKind<L> = TypeKind<NoCustomTypeKind, L>;
+pub type BasicLocalTypeKind = LocalTypeKind<NoCustomSchema>;
+pub type BasicAggregatorTypeKind = AggregatorTypeKind<NoCustomSchema>;
 pub type BasicSchema = Schema<NoCustomSchema>;
 pub type BasicVersionedSchema = VersionedSchema<NoCustomSchema>;
 pub type BasicTypeData<L> = TypeData<NoCustomTypeKind, L>;
+pub type BasicLocalTypeData = LocalTypeData<NoCustomSchema>;
+pub type BasicAggregatorTypeData = LocalTypeData<NoCustomSchema>;
 
 impl<'a> CustomDisplayContext<'a> for () {
     type CustomExtension = NoCustomExtension;

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -299,6 +299,7 @@ pub type BasicVersionedSchema = VersionedSchema<NoCustomSchema>;
 pub type BasicTypeData<L> = TypeData<NoCustomTypeKind, L>;
 pub type BasicLocalTypeData = LocalTypeData<NoCustomSchema>;
 pub type BasicAggregatorTypeData = LocalTypeData<NoCustomSchema>;
+pub type BasicTypeAggregator = TypeAggregator<NoCustomTypeKind>;
 
 impl<'a> CustomDisplayContext<'a> for () {
     type CustomExtension = NoCustomExtension;

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -209,6 +209,7 @@ impl CustomSchema for NoCustomSchema {
     type CustomAggregatorTypeKind = NoCustomTypeKind;
     type CustomTypeKindLabel = NoCustomTypeKindLabel;
     type CustomTypeValidation = NoCustomTypeValidation;
+    type DefaultCustomExtension = NoCustomExtension;
 
     fn linearize_type_kind(
         _: Self::CustomAggregatorTypeKind,

--- a/sbor/src/payload_validation/payload_validator.rs
+++ b/sbor/src/payload_validation/payload_validator.rs
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     pub fn test_vec_u8_with_min_max() {
-        let t0 = BasicTypeData {
+        let t0 = BasicLocalTypeData {
             kind: BasicTypeKind::Array {
                 element_type: LocalTypeId::SchemaLocalIndex(1),
             },
@@ -455,7 +455,7 @@ mod tests {
                 max: 1.into(),
             }),
         };
-        let t1 = BasicTypeData {
+        let t1 = BasicLocalTypeData {
             kind: BasicTypeKind::U8,
             metadata: TypeMetadata::unnamed(),
             validation: TypeValidation::U8(NumericValidation {

--- a/sbor/src/schema/custom_traits.rs
+++ b/sbor/src/schema/custom_traits.rs
@@ -1,3 +1,5 @@
+use vec_traits::VecSbor;
+
 use crate::rust::prelude::*;
 use crate::traversal::*;
 use crate::*;
@@ -18,18 +20,21 @@ pub trait CustomTypeValidation: Debug + Clone + PartialEq + Eq {
 }
 
 pub trait CustomSchema: Debug + Clone + Copy + PartialEq + Eq + 'static {
-    type CustomTypeValidation: CustomTypeValidation;
+    type CustomTypeValidation: CustomTypeValidation + VecSbor<Self::DefaultCustomExtension>;
     type CustomLocalTypeKind: CustomTypeKind<
-        LocalTypeId,
-        CustomTypeValidation = Self::CustomTypeValidation,
-        CustomTypeKindLabel = Self::CustomTypeKindLabel,
-    >;
+            LocalTypeId,
+            CustomTypeValidation = Self::CustomTypeValidation,
+            CustomTypeKindLabel = Self::CustomTypeKindLabel,
+        > + VecSbor<Self::DefaultCustomExtension>;
     type CustomAggregatorTypeKind: CustomTypeKind<
         RustTypeId,
         CustomTypeValidation = Self::CustomTypeValidation,
         CustomTypeKindLabel = Self::CustomTypeKindLabel,
     >;
     type CustomTypeKindLabel: CustomTypeKindLabel;
+    /// Should only be used for default encoding of a schema, where it's required.
+    /// Typically you should start from a CustomExtension and not use this.
+    type DefaultCustomExtension: CustomExtension<CustomSchema = Self>;
 
     fn linearize_type_kind(
         type_kind: Self::CustomAggregatorTypeKind,

--- a/sbor/src/schema/schema_comparison.rs
+++ b/sbor/src/schema/schema_comparison.rs
@@ -42,7 +42,7 @@ impl SchemaComparisonSettings {
     /// * Types must be structurally identical on their intersection, except new enum variants can be added
     /// * Type metadata (e.g. names) must be identical on their intersection
     /// * Type validation must be equal or strictly weaker in the new schema
-    pub const fn allow_structural_extension() -> Self {
+    pub const fn allow_extension() -> Self {
         Self {
             completeness: SchemaComparisonCompletenessSettings::enforce_type_roots_cover_schema_allow_new_root_types(),
             structure: SchemaComparisonStructureSettings::allow_extension(),
@@ -1617,23 +1617,23 @@ pub struct ComparisonTypeRoot {
     compared_type_id: LocalTypeId,
 }
 
-pub struct NamedSchemaVersions<E: CustomExtension, C: ComparisonSchema<E>> {
+pub struct NamedSchemaVersions<S: CustomSchema, C: ComparisonSchema<S>> {
     ordered_versions: IndexMap<String, C>,
-    extension: PhantomData<E>,
+    custom_schema: PhantomData<S>,
 }
 
-impl<E: CustomExtension, C: ComparisonSchema<E>> NamedSchemaVersions<E, C> {
+impl<S: CustomSchema, C: ComparisonSchema<S>> NamedSchemaVersions<S, C> {
     pub fn new() -> Self {
         Self {
             ordered_versions: Default::default(),
-            extension: Default::default(),
+            custom_schema: Default::default(),
         }
     }
 
     pub fn register_version(
         mut self,
         name: impl AsRef<str>,
-        version: impl IntoSchema<C, E>,
+        version: impl IntoSchema<C, S>,
     ) -> Self {
         self.ordered_versions
             .insert(name.as_ref().to_string(), version.into_schema());
@@ -1645,6 +1645,32 @@ impl<E: CustomExtension, C: ComparisonSchema<E>> NamedSchemaVersions<E, C> {
     }
 }
 
+/// Designed for basic comparisons between two types, e.g. equality checking.
+///
+/// ## Example usage
+/// ```no_run
+/// # use radix_rust::prelude::*;
+/// # use sbor::NoCustomSchema;
+/// # use sbor::SchemaComparison::*;
+/// # type ScryptoCustomSchema = NoCustomSchema;
+/// # struct MyType;
+/// let base = SingleTypeSchema::from("5b....");
+/// let current = SingleTypeSchema::of_type::<MyType>();
+/// assert_single_type_comparison::<ScryptoCustomSchema>(
+///     SchemaComparisonSettings::equality(),
+///     &base,
+///     &current,
+/// );
+/// ```
+pub fn assert_single_type_comparison<S: CustomSchema>(
+    comparison_settings: &SchemaComparisonSettings,
+    base: &SingleTypeSchema<S>,
+    compared: &SingleTypeSchema<S>,
+) {
+    base.compare_with(compared, comparison_settings)
+        .assert_valid("base", "compared");
+}
+
 /// Designed for ensuring a type is only altered in ways which ensure
 /// backwards compatibility in SBOR serialization (i.e. that old payloads
 /// can be deserialized correctly by the latest type).
@@ -1654,8 +1680,8 @@ impl<E: CustomExtension, C: ComparisonSchema<E>> NamedSchemaVersions<E, C> {
 /// * Checks that each schema is consistent with the previous schema - but
 ///   can be an extension (e.g. enums can have new variants)
 ///
-/// The indexmap should be a map from a version name to a hex-encoded
-/// basic-sbor-encoded `SingleTypeSchema` (with a single type).
+/// The version registry is be a map from a version name to some encoding
+/// of a `SingleTypeSchema` - including as-is, or hex-encoded sbor-encoded.
 /// The version name is only used for a more useful message on error.
 ///
 /// ## Example usage
@@ -1666,11 +1692,10 @@ impl<E: CustomExtension, C: ComparisonSchema<E>> NamedSchemaVersions<E, C> {
 /// # type ScryptoCustomSchema = NoCustomSchema;
 /// # struct MyType;
 /// assert_type_backwards_compatibility::<ScryptoCustomSchema, MyType>(
-///     SchemaComparisonSettings::allow_structural_extension(),
-///     indexmap! {
-///         "babylon_launch" => "5b...",
-///         "bottlenose" => "5b...",
-///     }
+///     |v| {
+///         v.register_version("babylon_launch", "5b...")
+///          .register_version("bottlenose", "5b...")
+///     },
 /// );
 /// ```
 /// ## Setup
@@ -1679,36 +1704,59 @@ impl<E: CustomExtension, C: ComparisonSchema<E>> NamedSchemaVersions<E, C> {
 ///
 /// ```
 pub fn assert_type_backwards_compatibility<
-    E: CustomExtension,
-    T: Describe<<E::CustomSchema as CustomSchema>::CustomAggregatorTypeKind>,
+    S: CustomSchema,
+    T: Describe<S::CustomAggregatorTypeKind>,
 >(
     versions_builder: impl FnOnce(
-        NamedSchemaVersions<E, SingleTypeSchema<E::CustomSchema>>,
-    ) -> NamedSchemaVersions<E, SingleTypeSchema<E::CustomSchema>>,
-) where
-    SingleTypeSchema<E::CustomSchema>: ComparisonSchema<E>,
-{
-    assert_type_compatibility::<E, T>(
-        &SchemaComparisonSettings::allow_structural_extension(),
+        NamedSchemaVersions<S, SingleTypeSchema<S>>,
+    ) -> NamedSchemaVersions<S, SingleTypeSchema<S>>,
+) {
+    assert_type_compatibility::<S, T>(
+        &SchemaComparisonSettings::allow_extension(),
         versions_builder,
     )
 }
 
-pub fn assert_type_compatibility<
-    E: CustomExtension,
-    T: Describe<<E::CustomSchema as CustomSchema>::CustomAggregatorTypeKind>,
->(
+/// Designed for ensuring a type is only altered in ways which ensure
+/// backwards compatibility in SBOR serialization (i.e. that old payloads
+/// can be deserialized correctly by the latest type).
+///
+/// This function:
+/// * Checks that the type's current schema is equal to the latest version
+/// * Checks that each schema is consistent with the previous schema - but
+///   can be an extension (e.g. enums can have new variants)
+///
+/// The version registry is be a map from a version name to some encoding
+/// of a `SingleTypeSchema` - including as-is, or hex-encoded sbor-encoded.
+/// The version name is only used for a more useful message on error.
+///
+/// ## Example usage
+/// ```no_run
+/// # use radix_rust::prelude::*;
+/// # use sbor::NoCustomSchema;
+/// # use sbor::SchemaComparison::*;
+/// # type ScryptoCustomSchema = NoCustomSchema;
+/// # struct MyType;
+/// assert_type_compatibility::<ScryptoCustomSchema, MyType>(
+///     SchemaComparisonSettings::allow_extension(),
+///     |v| {
+///         v.register_version("babylon_launch", "5b...")
+///          .register_version("bottlenose", "5b...")
+///     },
+/// );
+/// ```
+/// ## Setup
+/// To generate the encoded schema, just run the method with an empty `indexmap!`
+/// and the assertion will include the encoded schemas, for copying into the assertion.
+///
+/// ```
+pub fn assert_type_compatibility<S: CustomSchema, T: Describe<S::CustomAggregatorTypeKind>>(
     comparison_settings: &SchemaComparisonSettings,
     versions_builder: impl FnOnce(
-        NamedSchemaVersions<E, SingleTypeSchema<E::CustomSchema>>,
-    ) -> NamedSchemaVersions<E, SingleTypeSchema<E::CustomSchema>>,
-) where
-    SingleTypeSchema<E::CustomSchema>: ComparisonSchema<E>,
-{
-    let current = {
-        let (type_id, schema) = generate_full_schema_from_single_type::<T, E::CustomSchema>();
-        SingleTypeSchema { schema, type_id }
-    };
+        NamedSchemaVersions<S, SingleTypeSchema<S>>,
+    ) -> NamedSchemaVersions<S, SingleTypeSchema<S>>,
+) {
+    let current = generate_single_type_schema::<T, S>();
     assert_schema_compatibility(
         comparison_settings,
         &current,
@@ -1716,15 +1764,35 @@ pub fn assert_type_compatibility<
     )
 }
 
-pub fn assert_type_collection_backwards_compatibility<E: CustomExtension>(
+pub fn assert_type_collection_comparison<S: CustomSchema>(
     comparison_settings: &SchemaComparisonSettings,
-    current: NamedTypesSchema<E::CustomSchema>,
+    base: &NamedTypesSchema<S>,
+    compared: &NamedTypesSchema<S>,
+) {
+    base.compare_with(compared, comparison_settings)
+        .assert_valid("base", "compared");
+}
+
+pub fn assert_type_collection_backwards_compatibility<S: CustomSchema>(
+    current: NamedTypesSchema<S>,
     versions_builder: impl FnOnce(
-        NamedSchemaVersions<E, NamedTypesSchema<E::CustomSchema>>,
-    ) -> NamedSchemaVersions<E, NamedTypesSchema<E::CustomSchema>>,
-) where
-    NamedTypesSchema<E::CustomSchema>: ComparisonSchema<E>,
-{
+        NamedSchemaVersions<S, NamedTypesSchema<S>>,
+    ) -> NamedSchemaVersions<S, NamedTypesSchema<S>>,
+) {
+    assert_type_collection_compatibility(
+        &SchemaComparisonSettings::allow_extension(),
+        current,
+        versions_builder,
+    )
+}
+
+pub fn assert_type_collection_compatibility<S: CustomSchema>(
+    comparison_settings: &SchemaComparisonSettings,
+    current: NamedTypesSchema<S>,
+    versions_builder: impl FnOnce(
+        NamedSchemaVersions<S, NamedTypesSchema<S>>,
+    ) -> NamedSchemaVersions<S, NamedTypesSchema<S>>,
+) {
     assert_schema_compatibility(
         comparison_settings,
         &current,
@@ -1732,10 +1800,10 @@ pub fn assert_type_collection_backwards_compatibility<E: CustomExtension>(
     )
 }
 
-fn assert_schema_compatibility<E: CustomExtension, C: ComparisonSchema<E>>(
+fn assert_schema_compatibility<S: CustomSchema, C: ComparisonSchema<S>>(
     schema_comparison_settings: &SchemaComparisonSettings,
     current: &C,
-    named_versions: &NamedSchemaVersions<E, C>,
+    named_versions: &NamedSchemaVersions<S, C>,
 ) {
     let named_versions = named_versions.get_versions();
 
@@ -1759,7 +1827,7 @@ fn assert_schema_compatibility<E: CustomExtension, C: ComparisonSchema<E>>(
 
     if let Some(error_message) = result.error_message(latest_version_name, "current") {
         let mut error = String::new();
-        writeln!(&mut error, "The most recent named version ({latest_version_name}) DOES NOT MATCH the current version.").unwrap();
+        writeln!(&mut error, "The most recent named version ({latest_version_name}) DOES NOT PASS CHECKS, likely because it is not equal to the current version.").unwrap();
         writeln!(&mut error).unwrap();
         write!(&mut error, "{error_message}").unwrap();
         writeln!(&mut error).unwrap();
@@ -1805,21 +1873,21 @@ impl<S: CustomSchema> SingleTypeSchema<S> {
         Self { schema, type_id }
     }
 
-    pub fn from<T: Describe<S::CustomAggregatorTypeKind> + ?Sized>() -> Self {
+    pub fn from<T: IntoSchema<Self, S>>(from: &T) -> Self {
+        from.into_schema()
+    }
+
+    pub fn for_type<T: Describe<S::CustomAggregatorTypeKind> + ?Sized>() -> Self {
         generate_single_type_schema::<T, S>()
     }
 }
 
-impl<E: CustomExtension> ComparisonSchema<E> for SingleTypeSchema<E::CustomSchema>
-where
-    <E::CustomSchema as CustomSchema>::CustomLocalTypeKind: VecSbor<E>,
-    <E::CustomSchema as CustomSchema>::CustomTypeValidation: VecSbor<E>,
-{
+impl<S: CustomSchema> ComparisonSchema<S> for SingleTypeSchema<S> {
     fn compare_with<'s>(
         &'s self,
         compared: &'s Self,
         settings: &SchemaComparisonSettings,
-    ) -> SchemaComparisonResult<'s, E::CustomSchema> {
+    ) -> SchemaComparisonResult<'s, S> {
         SchemaComparisonKernel::new(
             &self.schema.as_unique_version(),
             &compared.schema.as_unique_version(),
@@ -1833,10 +1901,7 @@ where
     }
 }
 
-impl<E: CustomExtension> IntoSchema<Self, E> for SingleTypeSchema<E::CustomSchema>
-where
-    Self: ComparisonSchema<E>,
-{
+impl<S: CustomSchema> IntoSchema<Self, S> for SingleTypeSchema<S> {
     fn into_schema(&self) -> Self {
         self.clone()
     }
@@ -1859,21 +1924,21 @@ impl<S: CustomSchema> NamedTypesSchema<S> {
         Self { schema, type_ids }
     }
 
-    pub fn from(aggregator: TypeAggregator<S::CustomAggregatorTypeKind>) -> Self {
+    pub fn from<T: IntoSchema<Self, S>>(from: &T) -> Self {
+        from.into_schema()
+    }
+
+    pub fn from_aggregator(aggregator: TypeAggregator<S::CustomAggregatorTypeKind>) -> Self {
         aggregator.generate_named_types_schema::<S>()
     }
 }
 
-impl<E: CustomExtension> ComparisonSchema<E> for NamedTypesSchema<E::CustomSchema>
-where
-    <E::CustomSchema as CustomSchema>::CustomLocalTypeKind: VecSbor<E>,
-    <E::CustomSchema as CustomSchema>::CustomTypeValidation: VecSbor<E>,
-{
+impl<S: CustomSchema> ComparisonSchema<S> for NamedTypesSchema<S> {
     fn compare_with<'s>(
         &'s self,
         compared: &'s Self,
         settings: &SchemaComparisonSettings,
-    ) -> SchemaComparisonResult<'s, E::CustomSchema> {
+    ) -> SchemaComparisonResult<'s, S> {
         SchemaComparisonKernel::new(
             &self.schema.as_unique_version(),
             &compared.schema.as_unique_version(),
@@ -1883,19 +1948,16 @@ where
     }
 }
 
-impl<E: CustomExtension> IntoSchema<Self, E> for NamedTypesSchema<E::CustomSchema>
-where
-    Self: ComparisonSchema<E>,
-{
+impl<S: CustomSchema> IntoSchema<Self, S> for NamedTypesSchema<S> {
     fn into_schema(&self) -> Self {
         self.clone()
     }
 }
 
 // Marker trait
-pub trait ComparisonSchema<E: CustomExtension>: Clone + VecSbor<E> {
+pub trait ComparisonSchema<S: CustomSchema>: Clone + VecSbor<S::DefaultCustomExtension> {
     fn encode_to_bytes(&self) -> Vec<u8> {
-        vec_encode::<E, Self>(self, BASIC_SBOR_V1_MAX_DEPTH).unwrap()
+        vec_encode::<S::DefaultCustomExtension, Self>(self, BASIC_SBOR_V1_MAX_DEPTH).unwrap()
     }
 
     fn encode_to_hex(&self) -> String {
@@ -1903,7 +1965,7 @@ pub trait ComparisonSchema<E: CustomExtension>: Clone + VecSbor<E> {
     }
 
     fn decode_from_bytes(bytes: &[u8]) -> Self {
-        vec_decode::<E, Self>(bytes, BASIC_SBOR_V1_MAX_DEPTH).unwrap()
+        vec_decode::<S::DefaultCustomExtension, Self>(bytes, BASIC_SBOR_V1_MAX_DEPTH).unwrap()
     }
 
     fn decode_from_hex(hex: &str) -> Self {
@@ -1914,40 +1976,40 @@ pub trait ComparisonSchema<E: CustomExtension>: Clone + VecSbor<E> {
         &'s self,
         compared: &'s Self,
         settings: &SchemaComparisonSettings,
-    ) -> SchemaComparisonResult<'s, E::CustomSchema>;
+    ) -> SchemaComparisonResult<'s, S>;
 }
 
-pub trait IntoSchema<C: ComparisonSchema<E>, E: CustomExtension> {
+pub trait IntoSchema<C: ComparisonSchema<S>, S: CustomSchema> {
     fn into_schema(&self) -> C;
 }
 
-impl<'a, C: ComparisonSchema<E>, E: CustomExtension, T: IntoSchema<C, E> + ?Sized> IntoSchema<C, E>
+impl<'a, C: ComparisonSchema<S>, S: CustomSchema, T: IntoSchema<C, S> + ?Sized> IntoSchema<C, S>
     for &'a T
 {
     fn into_schema(&self) -> C {
-        <T as IntoSchema<C, E>>::into_schema(*self)
+        <T as IntoSchema<C, S>>::into_schema(*self)
     }
 }
 
-impl<C: ComparisonSchema<E>, E: CustomExtension> IntoSchema<C, E> for [u8] {
+impl<C: ComparisonSchema<S>, S: CustomSchema> IntoSchema<C, S> for [u8] {
     fn into_schema(&self) -> C {
         C::decode_from_bytes(self)
     }
 }
 
-impl<C: ComparisonSchema<E>, E: CustomExtension> IntoSchema<C, E> for Vec<u8> {
+impl<C: ComparisonSchema<S>, S: CustomSchema> IntoSchema<C, S> for Vec<u8> {
     fn into_schema(&self) -> C {
         C::decode_from_bytes(self)
     }
 }
 
-impl<C: ComparisonSchema<E>, E: CustomExtension> IntoSchema<C, E> for String {
+impl<C: ComparisonSchema<S>, S: CustomSchema> IntoSchema<C, S> for String {
     fn into_schema(&self) -> C {
         C::decode_from_hex(self)
     }
 }
 
-impl<C: ComparisonSchema<E>, E: CustomExtension> IntoSchema<C, E> for str {
+impl<C: ComparisonSchema<S>, S: CustomSchema> IntoSchema<C, S> for str {
     fn into_schema(&self) -> C {
         C::decode_from_hex(self)
     }

--- a/sbor/src/schema/schema_validation/mod.rs
+++ b/sbor/src/schema/schema_validation/mod.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use crate::rust::prelude::*;
 
-    fn create_schema(type_data: Vec<TypeData<NoCustomTypeKind, LocalTypeId>>) -> BasicSchema {
+    fn create_schema(type_data: Vec<BasicLocalTypeData>) -> BasicSchema {
         let mut type_kinds = vec![];
         let mut type_metadata = vec![];
         let mut type_validations = vec![];

--- a/sbor/src/schema/schema_validation/type_kind_validation.rs
+++ b/sbor/src/schema/schema_validation/type_kind_validation.rs
@@ -5,7 +5,7 @@ pub const MAX_NUMBER_OF_FIELDS: usize = 1024;
 
 pub fn validate_type_kind<'a, S: CustomSchema>(
     context: &SchemaContext,
-    type_kind: &SchemaTypeKind<S>,
+    type_kind: &LocalTypeKind<S>,
 ) -> Result<(), SchemaValidationError> {
     match type_kind {
         TypeKind::Any

--- a/sbor/src/schema/schema_validation/type_metadata_validation.rs
+++ b/sbor/src/schema/schema_validation/type_metadata_validation.rs
@@ -4,7 +4,7 @@ use crate::schema::*;
 
 pub fn validate_type_metadata_with_type_kind<'a, S: CustomSchema>(
     context: &SchemaContext,
-    type_kind: &SchemaTypeKind<S>,
+    type_kind: &LocalTypeKind<S>,
     type_metadata: &TypeMetadata,
 ) -> Result<(), SchemaValidationError> {
     match type_kind {

--- a/sbor/src/schema/schema_validation/type_validation_validation.rs
+++ b/sbor/src/schema/schema_validation/type_validation_validation.rs
@@ -3,7 +3,7 @@ use crate::schema::*;
 
 pub fn validate_custom_type_validation<'a, S: CustomSchema>(
     context: &SchemaContext,
-    type_kind: &SchemaTypeKind<S>,
+    type_kind: &LocalTypeKind<S>,
     type_validation: &TypeValidation<S::CustomTypeValidation>,
 ) -> Result<(), SchemaValidationError> {
     // It's always possible to opt into no additional validation.

--- a/sbor/src/schema/type_aggregator.rs
+++ b/sbor/src/schema/type_aggregator.rs
@@ -163,7 +163,7 @@ impl<C: CustomTypeKind<RustTypeId>> TypeAggregator<C> {
     ///
     /// This is only intended for use when adding root types to schemas,
     /// /and should not be called from inside Describe macros.
-    pub fn add_named_root_type_and_descendents<T: Describe<C> + ?Sized>(
+    pub fn add_root_type<T: Describe<C> + ?Sized>(
         &mut self,
         name: impl Into<String>,
     ) -> LocalTypeId {

--- a/sbor/src/schema/type_data/mod.rs
+++ b/sbor/src/schema/type_data/mod.rs
@@ -9,6 +9,10 @@ pub use type_kind::*;
 pub use type_metadata::*;
 pub use type_validation::*;
 
+pub type LocalTypeData<S> = TypeData<<S as CustomSchema>::CustomLocalTypeKind, LocalTypeId>;
+pub type AggregatorTypeData<S> =
+    TypeData<<S as CustomSchema>::CustomAggregatorTypeKind, RustTypeId>;
+
 /// Combines all data about a Type:
 /// * `kind` - The type's [`TypeKind`] - this is essentially the definition of the structure of the type,
 ///   and includes the type's `ValueKind` as well as the [`TypeKind`] of any child types.

--- a/sbor/src/schema/type_data/type_kind.rs
+++ b/sbor/src/schema/type_data/type_kind.rs
@@ -2,9 +2,13 @@ use super::*;
 use crate::rust::collections::IndexMap;
 use crate::rust::vec::Vec;
 
+pub type LocalTypeKind<S> = TypeKind<<S as CustomSchema>::CustomLocalTypeKind, LocalTypeId>;
+pub type AggregatorTypeKind<S> =
+    TypeKind<<S as CustomSchema>::CustomAggregatorTypeKind, RustTypeId>;
+
 /// A schema for the values that a codec can decode / views as valid
 #[derive(Debug, Clone, PartialEq, Eq, Sbor)]
-#[sbor(child_types = "T,L", categorize_types = "L")]
+#[sbor(child_types = "T, L", categorize_types = "L")]
 pub enum TypeKind<T: CustomTypeKind<L>, L: SchemaTypeLink> {
     Any,
 

--- a/sbor/src/schema/type_link.rs
+++ b/sbor/src/schema/type_link.rs
@@ -7,6 +7,9 @@ use sbor::*;
 /// - [`LocalTypeId`]: A link in the context of a schema (a well known id, or a local type index)
 pub trait SchemaTypeLink: Debug + Clone + PartialEq + Eq + From<WellKnownTypeId> {}
 
+/// A newer alias for `RustTypeId`.
+pub type AggregatorTypeId = RustTypeId;
+
 /// This is a compile-time identifier for a given type, used by the type aggregator
 /// to uniquely identify a type.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Sbor)]

--- a/sbor/src/traversal/typed/typed_traverser.rs
+++ b/sbor/src/traversal/typed/typed_traverser.rs
@@ -522,7 +522,7 @@ impl<'s, E: CustomExtension> TypedTraverserState<'s, E> {
 fn value_kind_matches_type_kind<E: CustomExtension>(
     schema: &Schema<E::CustomSchema>,
     value_kind: ValueKind<E::CustomValueKind>,
-    type_kind: &SchemaTypeKind<E::CustomSchema>,
+    type_kind: &LocalTypeKind<E::CustomSchema>,
 ) -> bool {
     if matches!(type_kind, TypeKind::Any) {
         return true;

--- a/sbor/src/vec_traits.rs
+++ b/sbor/src/vec_traits.rs
@@ -30,7 +30,7 @@ pub trait VecSbor<E: CustomExtension>:
     Categorize<E::CustomValueKind>
     + VecEncode<E::CustomValueKind>
     + VecDecode<E::CustomValueKind>
-    + Describe<<E::CustomSchema as CustomSchema>::CustomTypeKind<RustTypeId>>
+    + Describe<<E::CustomSchema as CustomSchema>::CustomAggregatorTypeKind>
 {
 }
 
@@ -39,6 +39,6 @@ where
     T: Categorize<E::CustomValueKind>,
     T: VecEncode<E::CustomValueKind>,
     T: VecDecode<E::CustomValueKind>,
-    T: Describe<<E::CustomSchema as CustomSchema>::CustomTypeKind<RustTypeId>>,
+    T: Describe<<E::CustomSchema as CustomSchema>::CustomAggregatorTypeKind>,
 {
 }

--- a/scrypto-bindgen/src/schema.rs
+++ b/scrypto-bindgen/src/schema.rs
@@ -10,7 +10,7 @@ pub trait PackageSchemaResolver {
     fn resolve_type_kind(
         &self,
         type_identifier: &ScopedTypeId,
-    ) -> Result<SchemaTypeKind<ScryptoCustomSchema>, SchemaError>;
+    ) -> Result<LocalTypeKind<ScryptoCustomSchema>, SchemaError>;
 
     fn resolve_type_metadata(
         &self,


### PR DESCRIPTION
## Summary
Minor refactor to improve the type hell when dealing with schemas.


### Part A
Builds on top of #1836 (will need merging after)

Notably it:
* Swaps `CustomSchema::CustomTypeKind<L>` for explicit `CustomSchema::CustomLocalTypeKind` and `CustomSchema::AggregatorLocalTypeKind` which simplifies a lot
* Introduces some aliases to make using these types much less boilerplatey
```rust
pub type LocalTypeKind<S> = TypeKind<<S as CustomSchema>::CustomLocalTypeKind, LocalTypeId>;
pub type AggregatorTypeKind<S> =
    TypeKind<<S as CustomSchema>::CustomAggregatorTypeKind, RustTypeId>;

pub type LocalTypeData<S> = TypeData<<S as CustomSchema>::CustomLocalTypeKind, LocalTypeId>;
pub type AggregatorTypeData<S> =
    TypeData<<S as CustomSchema>::CustomAggregatorTypeKind, RustTypeId>;
```

### Part B
Adds a `CustomSchema::DefaultCustomExtension` which we can use for encoding/decoding the schemas, which allows us to remove lots of really ugly/confusing bounds around the specific extension which we use for schema comparison, allowing us to just talk in terms of `CustomSchema` - because the schemas now know how to encode/decode themselves against the default extension.

 The default extension for `ScryptoCustomSchema` is now `ScryptoExtension` (chosen over `ManifestExtension` for sanity).

## Update Recommendations
If you get a compile error, change:
* `CustomSchema::CustomTypeKind<LocalTypeId>` to `CustomSchema::CustomLocalTypeKind`
* `CustomSchema::CustomTypeKind<RustTypeId>` to `CustomSchema::AggregatorLocalTypeKind` 
