### PR TITLE
Implement `as_fungible()` and `as_non_fungible()` methods only Generic types.

### DIFF
--- a/radix-engine-tests/assets/blueprints/non_fungible/src/big_vault.rs
+++ b/radix-engine-tests/assets/blueprints/non_fungible/src/big_vault.rs
@@ -40,7 +40,7 @@ mod big_vault {
         }
 
         pub fn non_fungibles(&mut self, count: u32) -> IndexSet<NonFungibleLocalId> {
-            self.vault.as_non_fungible().non_fungible_local_ids(count)
+            self.vault.non_fungible_local_ids(count)
         }
     }
 }

--- a/radix-engine-tests/assets/blueprints/non_fungible/src/non_fungible_test.rs
+++ b/radix-engine-tests/assets/blueprints/non_fungible/src/non_fungible_test.rs
@@ -69,10 +69,10 @@ mod non_fungible_test {
 
         pub fn update_nft(mint_badge: FungibleBucket, proof: NonFungibleProof) -> Bucket {
             let proof = proof.skip_checking();
-            mint_badge.as_fungible().authorize_with_amount(dec!(1), || {
+            mint_badge.authorize_with_amount(dec!(1), || {
                 let resource_manager = proof.resource_manager();
                 resource_manager.update_non_fungible_data(
-                    &proof.as_non_fungible().non_fungible_local_id(),
+                    &proof.non_fungible_local_id(),
                     "available",
                     true,
                 )
@@ -398,7 +398,7 @@ mod non_fungible_test {
         }
 
         pub fn take_non_fungible_and_put_bucket() -> NonFungibleBucket {
-            let mut bucket = Self::create_non_fungible_fixed().as_non_fungible();
+            let mut bucket = Self::create_non_fungible_fixed();
             assert_eq!(bucket.amount(), 3.into());
 
             let non_fungible = bucket.take_non_fungible(&NonFungibleLocalId::integer(1));
@@ -416,7 +416,7 @@ mod non_fungible_test {
             let mut non_fungibles = index_set_new();
             non_fungibles.insert(NonFungibleLocalId::integer(1));
 
-            let non_fungible = bucket.as_non_fungible().take_non_fungibles(&non_fungibles);
+            let non_fungible = bucket.take_non_fungibles(&non_fungibles);
             assert_eq!(bucket.amount(), 2.into());
             assert_eq!(non_fungible.amount(), 1.into());
 
@@ -444,13 +444,11 @@ mod non_fungible_test {
             let mut bucket = Self::create_non_fungible_fixed();
             let non_fungible_bucket = bucket.take(1);
             assert_eq!(
-                non_fungible_bucket
-                    .as_non_fungible()
-                    .non_fungible_local_ids(),
+                non_fungible_bucket.non_fungible_local_ids(),
                 IndexSet::from([NonFungibleLocalId::integer(1)])
             );
             assert_eq!(
-                bucket.as_non_fungible().non_fungible_local_ids(),
+                bucket.non_fungible_local_ids(),
                 IndexSet::from([
                     NonFungibleLocalId::integer(2),
                     NonFungibleLocalId::integer(3)
@@ -463,13 +461,11 @@ mod non_fungible_test {
             let mut bucket = Self::create_non_fungible_fixed();
             let non_fungible_bucket = bucket.take(1);
             assert_eq!(
-                non_fungible_bucket
-                    .as_non_fungible()
-                    .non_fungible_local_id(),
+                non_fungible_bucket.non_fungible_local_id(),
                 NonFungibleLocalId::integer(1)
             );
             assert_eq!(
-                bucket.as_non_fungible().non_fungible_local_id(),
+                bucket.non_fungible_local_id(),
                 NonFungibleLocalId::integer(2)
             );
             (bucket, non_fungible_bucket)
@@ -479,13 +475,11 @@ mod non_fungible_test {
             let mut vault = NonFungibleVault::with_bucket(Self::create_non_fungible_fixed());
             let non_fungible_bucket = vault.take(1);
             assert_eq!(
-                non_fungible_bucket
-                    .as_non_fungible()
-                    .non_fungible_local_ids(),
+                non_fungible_bucket.non_fungible_local_ids(),
                 IndexSet::from([NonFungibleLocalId::integer(1)])
             );
             assert_eq!(
-                vault.as_non_fungible().non_fungible_local_ids(100),
+                vault.non_fungible_local_ids(100),
                 IndexSet::from([
                     NonFungibleLocalId::integer(2),
                     NonFungibleLocalId::integer(3)
@@ -532,13 +526,11 @@ mod non_fungible_test {
             let mut vault = NonFungibleVault::with_bucket(Self::create_non_fungible_fixed());
             let non_fungible_bucket = vault.take(1);
             assert_eq!(
-                non_fungible_bucket
-                    .as_non_fungible()
-                    .non_fungible_local_id(),
+                non_fungible_bucket.non_fungible_local_id(),
                 NonFungibleLocalId::integer(1)
             );
             assert_eq!(
-                vault.as_non_fungible().non_fungible_local_id(),
+                vault.non_fungible_local_id(),
                 NonFungibleLocalId::integer(2)
             );
 
@@ -556,19 +548,18 @@ mod non_fungible_test {
 
             // read singleton bucket
             let singleton = bucket.take(1);
-            let _: Sandwich = singleton.as_non_fungible().non_fungible().data();
+            let _: Sandwich = singleton.non_fungible().data();
 
             // read singleton vault
             let mut vault = NonFungibleVault::with_bucket(singleton);
-            let _: Sandwich = vault.as_non_fungible().non_fungible().data();
+            let _: Sandwich = vault.non_fungible().data();
 
             // read singleton proof
             let proof = vault
-                .as_non_fungible()
                 .create_proof_of_non_fungibles(&indexset!(NonFungibleLocalId::integer(1)))
                 .skip_checking();
             assert_eq!(proof.resource_address(), vault.resource_address());
-            let _: Sandwich = proof.as_non_fungible().non_fungible().data();
+            let _: Sandwich = proof.non_fungible().data();
             proof.drop();
 
             // clean up

--- a/radix-engine-tests/assets/blueprints/proof/src/vault_proof.rs
+++ b/radix-engine-tests/assets/blueprints/proof/src/vault_proof.rs
@@ -54,10 +54,7 @@ mod vault_proof {
                 self.vault.as_non_fungible().non_fungible_local_ids(100),
                 non_fungible_local_ids
             );
-            assert_eq!(
-                proof.as_non_fungible().non_fungible_local_ids(),
-                proof_non_fungible_local_ids
-            );
+            assert_eq!(proof.non_fungible_local_ids(), proof_non_fungible_local_ids);
             assert_eq!(clone.non_fungible_local_ids(), proof_non_fungible_local_ids);
 
             clone.drop();
@@ -137,7 +134,7 @@ mod vault_proof {
                         )
                         .skip_checking();
                         assert_eq!(proof.resource_address(), self.vault.resource_address());
-                        assert_eq!(proof.as_non_fungible().non_fungible_local_ids(), ids);
+                        assert_eq!(proof.non_fungible_local_ids(), ids);
                         proof.drop();
                     })
                 });

--- a/radix-engine-tests/assets/blueprints/resource/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/resource/src/lib.rs
@@ -181,9 +181,7 @@ mod resource_test {
                 burner_updater => rule!(deny_all);
             })
             .create_with_no_initial_supply();
-            let tokens = badge
-                .as_fungible()
-                .authorize_with_amount(dec!(1), || resource_manager.mint(amount));
+            let tokens = badge.authorize_with_amount(dec!(1), || resource_manager.mint(amount));
             (badge.into(), tokens.into(), resource_manager)
         }
 
@@ -485,9 +483,8 @@ mod resource_types {
         }
 
         pub fn produce_fungible_things() -> (FungibleBucket, FungibleProof, FungibleVault) {
-            let mut bucket = ResourceBuilder::new_fungible(OwnerRole::None)
-                .mint_initial_supply(100)
-                .as_fungible();
+            let mut bucket =
+                ResourceBuilder::new_fungible(OwnerRole::None).mint_initial_supply(100);
             let proof = bucket.create_proof_of_amount(dec!(1));
             let vault = FungibleVault::with_bucket(bucket.take(5));
 
@@ -529,8 +526,7 @@ mod resource_types {
                                 available: true,
                             },
                         ),
-                    ])
-                    .as_non_fungible();
+                    ]);
             let proof =
                 bucket.create_proof_of_non_fungibles(&indexset!(NonFungibleLocalId::integer(0)));
             let vault = NonFungibleVault::with_bucket(bucket.take(1));

--- a/scrypto/src/resource/proof.rs
+++ b/scrypto/src/resource/proof.rs
@@ -64,7 +64,9 @@ pub trait ScryptoProof {
     fn clone(&self) -> Self;
 
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O;
+}
 
+pub trait ScryptoGenericProof {
     fn as_fungible(&self) -> CheckedFungibleProof;
 
     fn as_non_fungible(&self) -> CheckedNonFungibleProof;
@@ -343,7 +345,9 @@ impl ScryptoProof for CheckedProof {
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
         self.0.authorize(f)
     }
+}
 
+impl ScryptoGenericProof for CheckedProof {
     fn as_fungible(&self) -> CheckedFungibleProof {
         assert!(
             self.resource_address()
@@ -351,7 +355,7 @@ impl ScryptoProof for CheckedProof {
                 .is_global_fungible_resource_manager(),
             "Not a fungible proof"
         );
-        CheckedFungibleProof(CheckedProof(Proof(self.0 .0)))
+        CheckedFungibleProof(Self(Proof(self.0 .0)))
     }
 
     fn as_non_fungible(&self) -> CheckedNonFungibleProof {
@@ -361,7 +365,7 @@ impl ScryptoProof for CheckedProof {
                 .is_global_non_fungible_resource_manager(),
             "Not a non-fungible proof"
         );
-        CheckedNonFungibleProof(CheckedProof(Proof(self.0 .0)))
+        CheckedNonFungibleProof(Self(Proof(self.0 .0)))
     }
 }
 
@@ -398,14 +402,6 @@ impl ScryptoProof for CheckedFungibleProof {
 
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
         self.0.authorize(f)
-    }
-
-    fn as_fungible(&self) -> CheckedFungibleProof {
-        self.0.as_fungible()
-    }
-
-    fn as_non_fungible(&self) -> CheckedNonFungibleProof {
-        self.0.as_non_fungible()
     }
 }
 
@@ -444,14 +440,6 @@ impl ScryptoProof for CheckedNonFungibleProof {
 
     fn authorize<F: FnOnce() -> O, O>(&self, f: F) -> O {
         self.0.authorize(f)
-    }
-
-    fn as_fungible(&self) -> CheckedFungibleProof {
-        self.0.as_fungible()
-    }
-
-    fn as_non_fungible(&self) -> CheckedNonFungibleProof {
-        self.0.as_non_fungible()
     }
 }
 


### PR DESCRIPTION
## Summary

Implement `as_fungible()` and `as_non_fungible()` methods only Generic types.

## Details
In https://github.com/radixdlt/radixdlt-scrypto/pull/1782 these methods were implemented for all three types:
- generic
- fungible
- non-fungible

It allowed to create such combinations as below:
```
let vault = FungibleVault::with_bucket(some_bucket).as_non_fungible();  
```
It is not possible to get `NonFungibleVault` from `FungibleVault`.

## Testing
Tests were updated accordingly.
