### PR TITLE
Fix CI - pin `minicov`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ itertools = { version = "0.10.3" }
 lazy_static = { version = "1.4.0" }
 linreg = { version = "0.2.0" }
 lru = { version = "0.8.1", default-features = false }
-minicov = { version = "0.3" }
+minicov = { version = "=0.3.3" }
 moka = { version = "0.9.9", features = ["sync"], default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }


### PR DESCRIPTION
## Summary
Fix CI coverage tests - pin `minicov` to `0.3.3` 