### PR TITLE
Fixed `validate_resource_specifier()` function

### DIFF
--- a/scrypto-test/src/sdk/resource/bucket_factory.rs
+++ b/scrypto-test/src/sdk/resource/bucket_factory.rs
@@ -173,7 +173,7 @@ impl BucketFactory {
                     let mut iter = non_fungibles
                         .keys()
                         .map(|id| id.id_type())
-                        .collect::<HashSet<NonFungibleIdType>>()
+                        .collect::<IndexSet<NonFungibleIdType>>()
                         .into_iter();
                     let Some(id_type) = iter.next() else {
                         return Ok(true);

--- a/scrypto-test/src/sdk/resource/bucket_factory.rs
+++ b/scrypto-test/src/sdk/resource/bucket_factory.rs
@@ -170,7 +170,11 @@ impl BucketFactory {
                 // 1. All of one type.
                 // 2. This one type is the type of the non-fungible local ids.
                 let id_type = {
-                    let mut iter = non_fungibles.keys().map(|id| id.id_type());
+                    let mut iter = non_fungibles
+                        .keys()
+                        .map(|id| id.id_type())
+                        .collect::<HashSet<NonFungibleIdType>>()
+                        .into_iter();
                     let Some(id_type) = iter.next() else {
                         return Ok(true);
                     };
@@ -194,5 +198,56 @@ impl BucketFactory {
             _ => return Ok(false),
         }
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_validate_resource_specifier_method() {
+        // Arrange
+        let mut env = TestEnvironment::new();
+        let bucket = ResourceBuilder::new_integer_non_fungible::<()>(OwnerRole::None)
+            .mint_initial_supply([], &mut env)
+            .unwrap();
+
+        let items = indexmap!(
+            NonFungibleLocalId::integer(1u64) => SborValue::U8 { value: 1 },
+            NonFungibleLocalId::integer(2u64) => SborValue::U8 { value: 2 },
+        );
+
+        let resource =
+            FactoryResourceSpecifier::Ids(bucket.resource_address(&mut env).unwrap(), items);
+
+        // Act
+        let result = BucketFactory::validate_resource_specifier(&resource, &mut env).unwrap();
+
+        // Assert
+        assert!(result);
+    }
+
+    #[test]
+    fn verify_validate_resource_specifier_method_should_fail() {
+        // Arrange
+        let mut env = TestEnvironment::new();
+        let bucket = ResourceBuilder::new_integer_non_fungible::<()>(OwnerRole::None)
+            .mint_initial_supply([], &mut env)
+            .unwrap();
+
+        let items = indexmap!(
+            NonFungibleLocalId::integer(1u64) => SborValue::U8 { value: 1 },
+            NonFungibleLocalId::string("value").unwrap() => SborValue::U8 { value: 2 },
+        );
+
+        let resource =
+            FactoryResourceSpecifier::Ids(bucket.resource_address(&mut env).unwrap(), items);
+
+        // Act
+        let result = BucketFactory::validate_resource_specifier(&resource, &mut env).unwrap();
+
+        // Assert
+        assert!(!result);
     }
 }


### PR DESCRIPTION
## Summary
`validate_resource_specifier()` function returns wrong result for proper input data: non fungible resource with at least two ids.

## Testing
Added two test to verify `validate_resource_specifier()` function, on current develop 1st test: `verify_validate_resource_specifier_method()` is failing, but should succeed.
