### PR TITLE
Update rust and llvm for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,18 +312,18 @@ jobs:
           shared-key: radix-clis-debug-${{ runner.os }}
           cache-directories: ~/.cargo/registry/src/**/librocksdb-sys-*
           workspaces: radix-clis
-      - name: Install rustc 1.78.0-nightly
+      - name: Install rustc 1.81.0-nightly
         run: |
-          rustup toolchain install nightly-2024-02-08
-          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-02-08
-          rustup default nightly-2024-02-08
+          rustup toolchain install nightly-2024-06-28
+          rustup target add wasm32-unknown-unknown --toolchain nightly-2024-06-28
+          rustup default nightly-2024-06-28
           rustup show
-      - name: Install LLVM 17
+      - name: Install LLVM 18
         run: |
           sudo apt install lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17
+          sudo ./llvm.sh 18
       - name: Run tests
         working-directory: radix-clis
         run: bash ./tests/scrypto_coverage.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ itertools = { version = "0.10.3" }
 lazy_static = { version = "1.4.0" }
 linreg = { version = "0.2.0" }
 lru = { version = "0.8.1", default-features = false }
-minicov = { version = "=0.3.3" }
+minicov = { version = "=0.3.5" }
 moka = { version = "0.9.9", features = ["sync"], default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }


### PR DESCRIPTION
## Summary
- Setup Rust 1.81.0-nightly and LLVM 18 in CI
- Bump `minicov` to 0.3.5

TODO: update documentations before release