### PR TITLE
Fix scrypto coverage CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,10 +320,17 @@ jobs:
           rustup show
       - name: Install LLVM 18
         run: |
-          sudo apt install lsb-release wget software-properties-common gnupg
+          sudo apt-get install -y lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 18
+          # llvm.sh does not explicitly install llvm-18, which is needed here.
+          # It shall be installed as a dependency, but it was observed that
+          # it is not always installed. Reason unknown, might be related to below, which was also observed:
+          #  The following packages have unmet dependencies:
+          #   libllvm18 : Breaks: llvm-18-dev (< 1:18.1.8-4) but 1:18.1.8~++20240717051017+3b5b5c1ec4a3-1~exp1~20240717171122.141 is to be installed
+          # So, just in case, try to install them here.
+          sudo apt-get install -y llvm-18
       - name: Run tests
         working-directory: radix-clis
         run: bash ./tests/scrypto_coverage.sh


### PR DESCRIPTION
## Summary
Assure LLVM 18 tools are installed for for CI scrypto coverage test.

