### PR TITLE
refactor: Prefer parameter bounds over where clause

### DIFF
--- a/examples/everything/Cargo.lock
+++ b/examples/everything/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.12",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,16 +32,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -110,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +241,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +298,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -308,6 +422,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +489,25 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "env_filter"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6dc8c8ff84895b051f07a0e65f975cf225131742531338752abfb324e4449ff"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06676b12debf7bba6903559720abca942d3a66b8acb88815fd2c7c6537e9ade1"
+dependencies = [
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -472,12 +619,21 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -520,6 +676,46 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "inferno"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap 2.2.6",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -604,6 +800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +848,27 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -699,7 +928,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -786,6 +1015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +1086,7 @@ dependencies = [
  "colored",
  "const-sha1",
  "hex",
+ "inferno",
  "lazy_static",
  "moka",
  "num-traits",
@@ -862,11 +1101,12 @@ dependencies = [
  "radix-substate-store-interface",
  "radix-transactions",
  "radix-wasm-instrument",
- "radix-wasmi",
  "sbor",
  "serde_json",
  "strum",
  "syn 1.0.109",
+ "tempfile",
+ "wasmi",
  "wasmparser 0.107.0",
 ]
 
@@ -1003,24 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix-wasmi"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bf4a0498ed223122e726f9360e9889c2bb6eb6898069f4b6f9960b067a742d"
-dependencies = [
- "radix-wasmi-arena",
- "spin",
- "wasmi_core",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "radix-wasmi-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a03d7e7816ade40c6ecedff7515198906d644527771bd8fb5a335094353a15a"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1316,15 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rgb"
+version = "0.8.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1390,6 +1621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1658,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1563,6 +1817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,10 +1932,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmi_core"
-version = "0.8.0"
+name = "wasmi"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21fc8d8dafc2df566ebcba7d48a2df7b37386d6afa64237cdf9415c8d7d98ec"
+checksum = "dbaac6e702fa7b52258e5ac90d6e20a40afb37a1fbe7c645d0903ee42c5f85f4"
+dependencies = [
+ "arrayvec",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff59e30e550a509cc689ec638e5042be4d78ec9f6dd8a71fd02ee28776a74fd"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.3",
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e10c674add0f92f47bf8ad57c55ee3ac1762a0d9baf07535e27e22b758a916"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -1706,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.91.0"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -1893,6 +2181,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.12",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,16 +32,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -110,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +241,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +298,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -308,6 +422,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +489,25 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "env_filter"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6dc8c8ff84895b051f07a0e65f975cf225131742531338752abfb324e4449ff"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06676b12debf7bba6903559720abca942d3a66b8acb88815fd2c7c6537e9ade1"
+dependencies = [
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -464,12 +611,21 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
@@ -520,6 +676,46 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "inferno"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
+dependencies = [
+ "ahash",
+ "clap",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "env_logger",
+ "indexmap 2.2.6",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -604,6 +800,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +848,27 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -699,7 +928,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -786,6 +1015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +1086,7 @@ dependencies = [
  "colored",
  "const-sha1",
  "hex",
+ "inferno",
  "lazy_static",
  "moka",
  "num-traits",
@@ -862,11 +1101,12 @@ dependencies = [
  "radix-substate-store-interface",
  "radix-transactions",
  "radix-wasm-instrument",
- "radix-wasmi",
  "sbor",
  "serde_json",
  "strum",
  "syn 1.0.109",
+ "tempfile",
+ "wasmi",
  "wasmparser 0.107.0",
 ]
 
@@ -1003,24 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix-wasmi"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bf4a0498ed223122e726f9360e9889c2bb6eb6898069f4b6f9960b067a742d"
-dependencies = [
- "radix-wasmi-arena",
- "spin",
- "wasmi_core",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "radix-wasmi-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a03d7e7816ade40c6ecedff7515198906d644527771bd8fb5a335094353a15a"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1316,15 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "rgb"
+version = "0.8.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade4539f42266ded9e755c605bdddf546242b2c961b03b06a7375260788a0523"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1221,7 +1452,6 @@ dependencies = [
  "radix-engine",
  "radix-engine-interface",
  "radix-rust",
- "radix-wasm-instrument",
  "serde_json",
  "wasm-opt",
 ]
@@ -1391,6 +1621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,7 +1658,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1564,6 +1817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,10 +1932,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmi_core"
-version = "0.8.0"
+name = "wasmi"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21fc8d8dafc2df566ebcba7d48a2df7b37386d6afa64237cdf9415c8d7d98ec"
+checksum = "dbaac6e702fa7b52258e5ac90d6e20a40afb37a1fbe7c645d0903ee42c5f85f4"
+dependencies = [
+ "arrayvec",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff59e30e550a509cc689ec638e5042be4d78ec9f6dd8a71fd02ee28776a74fd"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.3",
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e10c674add0f92f47bf8ad57c55ee3ac1762a0d9baf07535e27e22b758a916"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -1707,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.91.0"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -1894,6 +2181,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/radix-clis/Cargo.lock
+++ b/radix-clis/Cargo.lock
@@ -779,6 +779,9 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1083,6 +1086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1119,17 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1394,12 +1414,12 @@ dependencies = [
  "radix-substate-store-interface",
  "radix-transactions",
  "radix-wasm-instrument",
- "radix-wasmi",
  "sbor",
  "serde_json",
  "strum",
  "syn 1.0.109",
  "tempfile",
+ "wasmi",
  "wasmparser 0.107.0",
 ]
 
@@ -1534,24 +1554,6 @@ dependencies = [
  "wasmparser 0.107.0",
  "wasmprinter",
 ]
-
-[[package]]
-name = "radix-wasmi"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bf4a0498ed223122e726f9360e9889c2bb6eb6898069f4b6f9960b067a742d"
-dependencies = [
- "radix-wasmi-arena",
- "spin",
- "wasmi_core",
- "wasmparser-nostd",
-]
-
-[[package]]
-name = "radix-wasmi-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a03d7e7816ade40c6ecedff7515198906d644527771bd8fb5a335094353a15a"
 
 [[package]]
 name = "rand"
@@ -1965,6 +1967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,10 +2341,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmi_core"
-version = "0.8.0"
+name = "wasmi"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21fc8d8dafc2df566ebcba7d48a2df7b37386d6afa64237cdf9415c8d7d98ec"
+checksum = "dbaac6e702fa7b52258e5ac90d6e20a40afb37a1fbe7c645d0903ee42c5f85f4"
+dependencies = [
+ "arrayvec",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff59e30e550a509cc689ec638e5042be4d78ec9f6dd8a71fd02ee28776a74fd"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.3",
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e10c674add0f92f47bf8ad57c55ee3ac1762a0d9baf07535e27e22b758a916"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2362,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.91.0"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]

--- a/radix-engine-interface/src/api/actor_api.rs
+++ b/radix-engine-interface/src/api/actor_api.rs
@@ -4,7 +4,6 @@ use crate::internal_prelude::*;
 use crate::types::*;
 use bitflags::bitflags;
 use radix_engine_interface::api::{ActorStateHandle, LockFlags};
-use sbor::rust::fmt::Debug;
 use sbor::rust::string::String;
 use sbor::rust::vec::Vec;
 
@@ -17,7 +16,7 @@ bitflags! {
 }
 
 /// Api which exposes methods in the context of the actor
-pub trait SystemActorApi<E: Debug> {
+pub trait SystemActorApi<E> {
     /// Retrieve the current blueprint id
     fn actor_get_blueprint_id(&mut self) -> Result<BlueprintId, E>;
 

--- a/radix-engine-interface/src/api/actor_key_value_entry_api.rs
+++ b/radix-engine-interface/src/api/actor_key_value_entry_api.rs
@@ -1,10 +1,9 @@
 use radix_common::data::scrypto::{scrypto_decode, ScryptoDecode};
 use radix_engine_interface::api::key_value_entry_api::KeyValueEntryHandle;
 use radix_engine_interface::api::{ActorStateHandle, CollectionIndex, LockFlags};
-use sbor::rust::fmt::Debug;
 use sbor::rust::vec::Vec;
 
-pub trait SystemActorKeyValueEntryApi<E: Debug> {
+pub trait SystemActorKeyValueEntryApi<E> {
     /// Returns a handle for a specified key value entry in a collection. If an invalid collection
     /// index or key is passed an error is returned.
     fn actor_open_key_value_entry(

--- a/radix-engine-interface/src/api/mod.rs
+++ b/radix-engine-interface/src/api/mod.rs
@@ -40,10 +40,14 @@ pub const ACTOR_REF_AUTH_ZONE: ActorRefHandle = 8u32;
 pub type FieldIndex = u8;
 pub type CollectionIndex = u8;
 
+use radix_common::prelude::*;
+
+pub trait SystemApiError: fmt::Debug + ScryptoCategorize + ScryptoDecode {}
+
 /// Interface of the system, for blueprints and object modules.
 ///
 /// For WASM blueprints, only a subset of the API is exposed at the moment.
-pub trait SystemApi<E: sbor::rust::fmt::Debug>:
+pub trait SystemApi<E: SystemApiError>:
     SystemActorApi<E>
     + SystemActorKeyValueEntryApi<E>
     + SystemObjectApi<E>

--- a/radix-engine-monkey-tests/src/resource.rs
+++ b/radix-engine-monkey-tests/src/resource.rs
@@ -33,17 +33,16 @@ pub const CUSTOM_PACKAGE_CODE_ID: u64 = 1024;
 #[derive(Clone)]
 pub struct ResourceTestInvoke;
 impl VmInvoke for ResourceTestInvoke {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             "call_vault" => {
                 let handle = api

--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -81,16 +81,13 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(Self)
     }
 
-    fn start<Y>(
+    fn start<Y: KernelApi<Self>>(
         _: &mut Y,
         _: &[u8],
         _: &Vec<PreAllocatedAddress>,
         _: &IndexSet<Reference>,
         _: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         unreachable!()
     }
 
@@ -119,52 +116,52 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn on_create_node<Y>(_api: &mut Y, _event: CreateNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_create_node<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: CreateNodeEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_drop_node<Y>(_api: &mut Y, _event: DropNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_drop_node<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: DropNodeEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_move_module<Y>(_api: &mut Y, _event: MoveModuleEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_move_module<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: MoveModuleEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_open_substate<Y>(_api: &mut Y, _event: OpenSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_open_substate<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: OpenSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_close_substate<Y>(_api: &mut Y, _event: CloseSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_close_substate<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: CloseSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_read_substate<Y>(_api: &mut Y, _event: ReadSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_read_substate<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: ReadSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_write_substate<Y>(_api: &mut Y, _event: WriteSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_write_substate<Y: KernelInternalApi<Self>>(
+        _api: &mut Y,
+        _event: WriteSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
@@ -191,58 +188,49 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn before_invoke<Y>(
+    fn before_invoke<Y: KernelApi<Self>>(
         _invocation: &KernelInvocation<Self::CallFrameData>,
         _api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn after_invoke<Y>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn after_invoke<Y: KernelApi<Self>>(
+        _output: &IndexedScryptoValue,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_start<Y>(_api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_finish<Y>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_finish<Y: KernelApi<Self>>(
+        _message: &CallFrameMessage,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_allocate_node_id<Y>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_allocate_node_id<Y: KernelApi<Self>>(
+        _entity_type: EntityType,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn invoke_upstream<Y>(
+    fn invoke_upstream<Y: KernelApi<Self>>(
         args: &IndexedScryptoValue,
         _api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         Ok(args.clone())
     }
 
-    fn auto_drop<Y>(_nodes: Vec<NodeId>, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn auto_drop<Y: KernelApi<Self>>(
+        _nodes: Vec<NodeId>,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
@@ -255,22 +243,19 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn on_substate_lock_fault<Y>(
+    fn on_substate_lock_fault<Y: KernelApi<Self>>(
         _node_id: NodeId,
         _partition_num: PartitionNumber,
         _offset: &SubstateKey,
         _api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<bool, RuntimeError> {
         Ok(false)
     }
 
-    fn on_drop_node_mut<Y>(_node_id: &NodeId, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_drop_node_mut<Y: KernelApi<Self>>(
+        _node_id: &NodeId,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 }

--- a/radix-engine-tests/src/pool_stubs.rs
+++ b/radix-engine-tests/src/pool_stubs.rs
@@ -64,17 +64,14 @@ impl Clone for Cloneable<Bucket> {
 pub struct OneResourcePool(NodeId);
 
 impl OneResourcePool {
-    pub fn instantiate<Y>(
+    pub fn instantiate<Y: SystemApi<RuntimeError>>(
         resource_address: ResourceAddress,
         owner_role: OwnerRole,
         pool_manager_rule: AccessRule,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<Self, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_function::<_, _, OneResourcePoolInstantiateOutput>(
+    ) -> Result<Self, RuntimeError> {
+        typed_call_function::<OneResourcePoolInstantiateOutput>(
             POOL_PACKAGE,
             ONE_RESOURCE_POOL_BLUEPRINT_IDENT,
             ONE_RESOURCE_POOL_INSTANTIATE_IDENT,
@@ -89,11 +86,12 @@ impl OneResourcePool {
         .map(|rtn| Self(rtn.0.into_node_id()))
     }
 
-    pub fn contribute<Y>(&mut self, bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, OneResourcePoolContributeOutput>(
+    pub fn contribute<Y: SystemApi<RuntimeError>>(
+        &mut self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
+        typed_call_method::<OneResourcePoolContributeOutput>(
             &self.0,
             ONE_RESOURCE_POOL_CONTRIBUTE_IDENT,
             &OneResourcePoolContributeInput { bucket },
@@ -101,11 +99,12 @@ impl OneResourcePool {
         )
     }
 
-    pub fn protected_deposit<Y>(&mut self, bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, OneResourcePoolProtectedDepositOutput>(
+    pub fn protected_deposit<Y: SystemApi<RuntimeError>>(
+        &mut self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        typed_call_method::<OneResourcePoolProtectedDepositOutput>(
             &self.0,
             ONE_RESOURCE_POOL_PROTECTED_DEPOSIT_IDENT,
             &OneResourcePoolProtectedDepositInput { bucket },
@@ -113,16 +112,13 @@ impl OneResourcePool {
         )
     }
 
-    pub fn protected_withdraw<Y>(
+    pub fn protected_withdraw<Y: SystemApi<RuntimeError>>(
         &mut self,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, OneResourcePoolProtectedWithdrawOutput>(
+    ) -> Result<Bucket, RuntimeError> {
+        typed_call_method::<OneResourcePoolProtectedWithdrawOutput>(
             &self.0,
             ONE_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
             &OneResourcePoolProtectedWithdrawInput {
@@ -133,14 +129,11 @@ impl OneResourcePool {
         )
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         &self,
         amount_of_pool_units: Decimal,
         api: &mut Y,
-    ) -> Result<OneResourcePoolGetRedemptionValueOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolGetRedemptionValueOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             ONE_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,
@@ -151,14 +144,11 @@ impl OneResourcePool {
         )
     }
 
-    pub fn redeem<Y>(
+    pub fn redeem<Y: SystemApi<RuntimeError>>(
         &mut self,
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<OneResourcePoolRedeemOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolRedeemOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             ONE_RESOURCE_POOL_REDEEM_IDENT,
@@ -171,17 +161,14 @@ impl OneResourcePool {
 pub struct TwoResourcePool(NodeId);
 
 impl TwoResourcePool {
-    pub fn instantiate<Y>(
+    pub fn instantiate<Y: SystemApi<RuntimeError>>(
         resource_addresses: (ResourceAddress, ResourceAddress),
         owner_role: OwnerRole,
         pool_manager_rule: AccessRule,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<Self, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_function::<_, _, TwoResourcePoolInstantiateOutput>(
+    ) -> Result<Self, RuntimeError> {
+        typed_call_function::<TwoResourcePoolInstantiateOutput>(
             POOL_PACKAGE,
             TWO_RESOURCE_POOL_BLUEPRINT_IDENT,
             TWO_RESOURCE_POOL_INSTANTIATE_IDENT,
@@ -196,14 +183,11 @@ impl TwoResourcePool {
         .map(|rtn| Self(rtn.0.into_node_id()))
     }
 
-    pub fn contribute<Y>(
+    pub fn contribute<Y: SystemApi<RuntimeError>>(
         &mut self,
         buckets: (Bucket, Bucket),
         api: &mut Y,
-    ) -> Result<TwoResourcePoolContributeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<TwoResourcePoolContributeOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             TWO_RESOURCE_POOL_CONTRIBUTE_IDENT,
@@ -212,14 +196,11 @@ impl TwoResourcePool {
         )
     }
 
-    pub fn protected_deposit<Y>(
+    pub fn protected_deposit<Y: SystemApi<RuntimeError>>(
         &mut self,
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<TwoResourcePoolProtectedDepositOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<TwoResourcePoolProtectedDepositOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             TWO_RESOURCE_POOL_PROTECTED_DEPOSIT_IDENT,
@@ -228,17 +209,14 @@ impl TwoResourcePool {
         )
     }
 
-    pub fn protected_withdraw<Y>(
+    pub fn protected_withdraw<Y: SystemApi<RuntimeError>>(
         &mut self,
         resource_address: ResourceAddress,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, TwoResourcePoolProtectedWithdrawOutput>(
+    ) -> Result<Bucket, RuntimeError> {
+        typed_call_method::<TwoResourcePoolProtectedWithdrawOutput>(
             &self.0,
             TWO_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
             &TwoResourcePoolProtectedWithdrawInput {
@@ -250,14 +228,11 @@ impl TwoResourcePool {
         )
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         &self,
         amount_of_pool_units: Decimal,
         api: &mut Y,
-    ) -> Result<TwoResourcePoolGetRedemptionValueOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<TwoResourcePoolGetRedemptionValueOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             TWO_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,
@@ -268,14 +243,11 @@ impl TwoResourcePool {
         )
     }
 
-    pub fn redeem<Y>(
+    pub fn redeem<Y: SystemApi<RuntimeError>>(
         &mut self,
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<TwoResourcePoolRedeemOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<TwoResourcePoolRedeemOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             TWO_RESOURCE_POOL_REDEEM_IDENT,
@@ -288,17 +260,14 @@ impl TwoResourcePool {
 pub struct MultiResourcePool<const N: usize>(NodeId);
 
 impl<const N: usize> MultiResourcePool<N> {
-    pub fn instantiate<Y>(
+    pub fn instantiate<Y: SystemApi<RuntimeError>>(
         resource_addresses: [ResourceAddress; N],
         owner_role: OwnerRole,
         pool_manager_rule: AccessRule,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<Self, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_function::<_, _, MultiResourcePoolInstantiateOutput>(
+    ) -> Result<Self, RuntimeError> {
+        typed_call_function::<MultiResourcePoolInstantiateOutput>(
             POOL_PACKAGE,
             MULTI_RESOURCE_POOL_BLUEPRINT_IDENT,
             MULTI_RESOURCE_POOL_INSTANTIATE_IDENT,
@@ -313,14 +282,11 @@ impl<const N: usize> MultiResourcePool<N> {
         .map(|rtn| Self(rtn.0.into_node_id()))
     }
 
-    pub fn contribute<Y>(
+    pub fn contribute<Y: SystemApi<RuntimeError>>(
         &mut self,
         buckets: [Bucket; N],
         api: &mut Y,
-    ) -> Result<MultiResourcePoolContributeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolContributeOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             MULTI_RESOURCE_POOL_CONTRIBUTE_IDENT,
@@ -331,14 +297,11 @@ impl<const N: usize> MultiResourcePool<N> {
         )
     }
 
-    pub fn protected_deposit<Y>(
+    pub fn protected_deposit<Y: SystemApi<RuntimeError>>(
         &mut self,
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolProtectedDepositOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolProtectedDepositOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             MULTI_RESOURCE_POOL_PROTECTED_DEPOSIT_IDENT,
@@ -347,17 +310,14 @@ impl<const N: usize> MultiResourcePool<N> {
         )
     }
 
-    pub fn protected_withdraw<Y>(
+    pub fn protected_withdraw<Y: SystemApi<RuntimeError>>(
         &mut self,
         resource_address: ResourceAddress,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, MultiResourcePoolProtectedWithdrawOutput>(
+    ) -> Result<Bucket, RuntimeError> {
+        typed_call_method::<MultiResourcePoolProtectedWithdrawOutput>(
             &self.0,
             MULTI_RESOURCE_POOL_PROTECTED_WITHDRAW_IDENT,
             &MultiResourcePoolProtectedWithdrawInput {
@@ -369,14 +329,11 @@ impl<const N: usize> MultiResourcePool<N> {
         )
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         &self,
         amount_of_pool_units: Decimal,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolGetRedemptionValueOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolGetRedemptionValueOutput, RuntimeError> {
         typed_call_method(
             &self.0,
             MULTI_RESOURCE_POOL_GET_REDEMPTION_VALUE_IDENT,
@@ -387,11 +344,12 @@ impl<const N: usize> MultiResourcePool<N> {
         )
     }
 
-    pub fn redeem<Y>(&mut self, bucket: Bucket, api: &mut Y) -> Result<[Bucket; N], RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
-        typed_call_method::<_, _, MultiResourcePoolRedeemOutput>(
+    pub fn redeem<Y: SystemApi<RuntimeError>>(
+        &mut self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<[Bucket; N], RuntimeError> {
+        typed_call_method::<MultiResourcePoolRedeemOutput>(
             &self.0,
             MULTI_RESOURCE_POOL_REDEEM_IDENT,
             &MultiResourcePoolRedeemInput { bucket },
@@ -401,38 +359,28 @@ impl<const N: usize> MultiResourcePool<N> {
     }
 }
 
-fn typed_call_function<Y, I, O>(
+fn typed_call_function<O: ScryptoDecode>(
     package_address: PackageAddress,
     blueprint_name: &str,
     function_name: &str,
-    input: I,
-    api: &mut Y,
-) -> Result<O, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-    I: ScryptoEncode,
-    O: ScryptoDecode,
-{
+    input: impl ScryptoEncode,
+    api: &mut impl SystemApi<RuntimeError>,
+) -> Result<O, RuntimeError> {
     api.call_function(
         package_address,
         blueprint_name,
         function_name,
         scrypto_encode(&input).unwrap(),
     )
-    .map(|rtn| scrypto_decode::<O>(&rtn).unwrap())
+    .map(|rtn| scrypto_decode(&rtn).unwrap())
 }
 
-fn typed_call_method<Y, I, O>(
+fn typed_call_method<O: ScryptoDecode>(
     address: &NodeId,
     method_name: &str,
-    input: I,
-    api: &mut Y,
-) -> Result<O, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-    I: ScryptoEncode,
-    O: ScryptoDecode,
-{
+    input: impl ScryptoEncode,
+    api: &mut impl SystemApi<RuntimeError>,
+) -> Result<O, RuntimeError> {
     api.call_method(address, method_name, scrypto_encode(&input).unwrap())
-        .map(|rtn| scrypto_decode::<O>(&rtn).unwrap())
+        .map(|rtn| scrypto_decode(&rtn).unwrap())
 }

--- a/radix-engine-tests/tests/blueprints/access_controller_big_vault.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller_big_vault.rs
@@ -68,17 +68,16 @@ const CUSTOM_PACKAGE_CODE_ID: u64 = 1024;
 #[derive(Clone)]
 struct TestInvoke;
 impl VmInvoke for TestInvoke {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             "new" => {
                 let size: (usize,) = input.as_typed().unwrap();

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -59,7 +59,11 @@ impl KernelCallbackObject for TestCallbackObject {
     type ExecutionOutput = ();
     type Receipt = TestReceipt;
 
-    fn init<S: BootStore + CommitableSubstateStore>(_store: &mut S, _executable: &Executable, _init_input: Self::Init) -> Result<Self, RejectionReason> {
+    fn init<S: BootStore + CommitableSubstateStore>(
+        _store: &mut S,
+        _executable: &Executable,
+        _init_input: Self::Init,
+    ) -> Result<Self, RejectionReason> {
         Ok(Self)
     }
 
@@ -67,16 +71,13 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(StableReferenceType::Global)
     }
 
-    fn start<Y>(
+    fn start<Y: KernelApi<Self>>(
         _api: &mut Y,
         _manifest_encoded_instructions: &[u8],
         _pre_allocated_addresses: &Vec<PreAllocatedAddress>,
         _references: &IndexSet<Reference>,
         _blobs: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         unreachable!()
     }
 
@@ -92,52 +93,31 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn on_create_node<Y>(_api: &mut Y, _event: CreateNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_create_node<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: CreateNodeEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_drop_node<Y>(_api: &mut Y, _event: DropNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_drop_node<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: DropNodeEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_move_module<Y>(_api: &mut Y, _event: MoveModuleEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_move_module<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: MoveModuleEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_open_substate<Y>(_api: &mut Y, _event: OpenSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_open_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: OpenSubstateEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_close_substate<Y>(_api: &mut Y, _event: CloseSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_close_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: CloseSubstateEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_read_substate<Y>(_api: &mut Y, _event: ReadSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_read_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: ReadSubstateEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_write_substate<Y>(_api: &mut Y, _event: WriteSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_write_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: WriteSubstateEvent) -> Result<(), RuntimeError> {
         Ok(())
     }
 
@@ -164,58 +144,37 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn before_invoke<Y>(
+    fn before_invoke<Y: KernelApi<Self>>(
         _invocation: &KernelInvocation<Self::CallFrameData>,
         _api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn after_invoke<Y>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn after_invoke<Y: KernelApi<Self>>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_start<Y>(_api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_finish<Y>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_finish<Y: KernelApi<Self>>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_allocate_node_id<Y>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_allocate_node_id<Y: KernelApi<Self>>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn invoke_upstream<Y>(
+    fn invoke_upstream<Y: KernelApi<Self>>(
         args: &IndexedScryptoValue,
         _api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         Ok(args.clone())
     }
 
-    fn auto_drop<Y>(_nodes: Vec<NodeId>, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn auto_drop<Y: KernelApi<Self>>(_nodes: Vec<NodeId>, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
@@ -228,22 +187,16 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn on_substate_lock_fault<Y>(
+    fn on_substate_lock_fault<Y: KernelApi<Self>>(
         _node_id: NodeId,
         _partition_num: PartitionNumber,
         _offset: &SubstateKey,
         _api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<bool, RuntimeError> {
         Ok(false)
     }
 
-    fn on_drop_node_mut<Y>(_node_id: &NodeId, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_drop_node_mut<Y: KernelApi<Self>>(_node_id: &NodeId, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 }

--- a/radix-engine-tests/tests/system/auth_zone.rs
+++ b/radix-engine-tests/tests/system/auth_zone.rs
@@ -16,17 +16,16 @@ fn should_not_be_able_to_move_auth_zone() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let auth_zone_id = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE).unwrap();

--- a/radix-engine-tests/tests/system/system_access_rule.rs
+++ b/radix-engine-tests/tests/system/system_access_rule.rs
@@ -234,17 +234,16 @@ fn creating_an_access_rule_which_is_beyond_the_depth_limit_should_error<F>(
     #[derive(Clone)]
     struct TestInvoke(AccessRuleCreation, AccessRule);
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "create_access_rule" => match self.0 {
                     AccessRuleCreation::OwnerCreation => {

--- a/radix-engine-tests/tests/system/system_actor_collection.rs
+++ b/radix-engine-tests/tests/system/system_actor_collection.rs
@@ -19,17 +19,16 @@ fn opening_read_only_key_value_entry_should_not_create_substates() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let _handle = api.actor_open_key_value_entry(

--- a/radix-engine-tests/tests/system/system_actor_field.rs
+++ b/radix-engine-tests/tests/system/system_actor_field.rs
@@ -20,17 +20,16 @@ fn opening_non_existent_outer_object_fields_should_not_panic() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     api.actor_open_field(ACTOR_STATE_OUTER_OBJECT, 0u8, LockFlags::read_only())?;

--- a/radix-engine-tests/tests/system/system_call_method.rs
+++ b/radix-engine-tests/tests/system/system_call_method.rs
@@ -17,17 +17,16 @@ fn call_method_with_owned_actor_should_fail() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "new" => {
                     let node_id = api.new_simple_object(BLUEPRINT_NAME, indexmap!())?;

--- a/radix-engine-tests/tests/system/system_errors.rs
+++ b/radix-engine-tests/tests/system/system_errors.rs
@@ -16,17 +16,16 @@ const CUSTOM_PACKAGE_CODE_ID: u64 = 1024;
 #[derive(Clone)]
 struct TestInvoke;
 impl VmInvoke for TestInvoke {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         _input: &IndexedScryptoValue,
         api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             "invalid_state_handle" => {
                 api.actor_open_field(2u32, 0u8, LockFlags::read_only())?;

--- a/radix-engine-tests/tests/system/system_genesis_packages.rs
+++ b/radix-engine-tests/tests/system/system_genesis_packages.rs
@@ -20,17 +20,16 @@ fn claiming_royalties_on_native_packages_should_be_unauthorized() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     api.call_method(

--- a/radix-engine-tests/tests/system/system_global_address.rs
+++ b/radix-engine-tests/tests/system/system_global_address.rs
@@ -20,17 +20,16 @@ fn global_address_access_from_frame_owned_object_should_not_succeed() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let node_id = api.new_simple_object(BLUEPRINT_NAME, indexmap!())?;
@@ -98,17 +97,16 @@ fn global_address_access_from_direct_access_methods_should_fail_even_with_borrow
     #[derive(Clone)]
     struct ResourceOverride(HashSet<String>);
     impl VmInvoke for ResourceOverride {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             if self.0.contains(export_name) {
                 api.actor_get_node_id(ACTOR_REF_GLOBAL)
                     .expect_err("Direct method calls should never have global address");

--- a/radix-engine-tests/tests/system/system_kv_store.rs
+++ b/radix-engine-tests/tests/system/system_kv_store.rs
@@ -15,17 +15,16 @@ const CUSTOM_PACKAGE_CODE_ID: u64 = 1024;
 #[derive(Clone)]
 struct TestInvoke;
 impl VmInvoke for TestInvoke {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         _input: &IndexedScryptoValue,
         api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             "test" => {
                 let kv_store = api.key_value_store_new(

--- a/radix-engine-tests/tests/system/system_lock_fee.rs
+++ b/radix-engine-tests/tests/system/system_lock_fee.rs
@@ -20,17 +20,16 @@ fn cannot_lock_fee_on_new_global_vault() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "lock_fee" => {
                     let handle =

--- a/radix-engine-tests/tests/system/system_module_methods.rs
+++ b/radix-engine-tests/tests/system/system_module_methods.rs
@@ -24,17 +24,16 @@ fn should_not_be_able_to_call_royalty_methods(resource: bool) {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             _export_name: &str,
             input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             let node_id = input.references()[0];
             let _ = api.call_module_method(
                 &node_id,
@@ -108,17 +107,16 @@ fn should_not_be_able_to_call_metadata_methods_on_frame_owned_object() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let node_id = api.new_simple_object(BLUEPRINT_NAME, indexmap![])?;
@@ -180,17 +178,16 @@ fn should_not_be_able_to_call_metadata_methods_on_child_object(globalized_parent
         globalized_parent: bool,
     }
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let child = api.new_simple_object(

--- a/radix-engine-tests/tests/system/system_reference.rs
+++ b/radix-engine-tests/tests/system/system_reference.rs
@@ -20,17 +20,16 @@ fn cannot_store_reference_in_non_transient_blueprint() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "new" => {
                     let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
@@ -83,17 +82,16 @@ fn cannot_write_reference_in_non_transient_blueprint() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "new" => {
                     let node_id = api
@@ -149,17 +147,16 @@ fn cannot_write_reference_in_kv_store() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "kv_store" => {
                     let kv_store = api.key_value_store_new(

--- a/radix-engine-tests/tests/system/system_role_assignment.rs
+++ b/radix-engine-tests/tests/system/system_role_assignment.rs
@@ -24,17 +24,16 @@ fn cannot_define_more_than_50_roles() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             _export_name: &str,
             _input: &IndexedScryptoValue,
             _api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             Ok(IndexedScryptoValue::from_typed(&()))
         }
     }
@@ -86,17 +85,16 @@ fn cannot_define_role_name_larger_than_max() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             _export_name: &str,
             _input: &IndexedScryptoValue,
             _api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             Ok(IndexedScryptoValue::from_typed(&()))
         }
     }
@@ -149,17 +147,16 @@ fn cannot_setup_more_than_50_roles() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let mut data = index_map_new();
@@ -220,17 +217,16 @@ fn cannot_set_role_before_attachment() {
     #[derive(Clone)]
     struct TestInvoke;
     impl VmInvoke for TestInvoke {
-        fn invoke<Y, V>(
+        fn invoke<
+            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+            V: VmApi,
+        >(
             &mut self,
             export_name: &str,
             _input: &IndexedScryptoValue,
             api: &mut Y,
             _vm_api: &V,
-        ) -> Result<IndexedScryptoValue, RuntimeError>
-        where
-            Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-            V: VmApi,
-        {
+        ) -> Result<IndexedScryptoValue, RuntimeError> {
             match export_name {
                 "test" => {
                     let role_assignment =

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -240,17 +240,16 @@ impl NativeVmExtension for NonStringPanicExtension {
 pub struct NonStringPanicExtensionInstance;
 
 impl VmInvoke for NonStringPanicExtensionInstance {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         _: &str,
         _: &IndexedScryptoValue,
         _: &mut Y,
         _: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         // A panic with a non-string type. Making sure that our panic infrastructure can catch those
         // panics too even if it can't make any useful messages out of them.
         std::panic::panic_any(1234);

--- a/radix-engine/src/blueprints/access_controller/v1/blueprint.rs
+++ b/radix-engine/src/blueprints/access_controller/v1/blueprint.rs
@@ -16,14 +16,11 @@ use sbor::rust::prelude::*;
 pub struct AccessControllerV1Blueprint;
 
 impl AccessControllerV1Blueprint {
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         dispatch! {
             IDENT,
             export_name,
@@ -54,7 +51,7 @@ impl AccessControllerV1Blueprint {
         }
     }
 
-    pub fn create<Y>(
+    pub fn create<Y: SystemApi<RuntimeError>>(
         AccessControllerCreateInput {
             controlled_asset,
             rule_set,
@@ -62,10 +59,7 @@ impl AccessControllerV1Blueprint {
             address_reservation,
         }: AccessControllerCreateInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCreateOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCreateOutput, RuntimeError> {
         // Allocating the address of the access controller - this will be needed for the metadata
         // and access rules of the recovery badge
         let (address_reservation, address) = {
@@ -184,26 +178,20 @@ impl AccessControllerV1Blueprint {
         Ok(Global::new(ComponentAddress::try_from(address).unwrap()))
     }
 
-    pub fn create_proof<Y>(
+    pub fn create_proof<Y: SystemApi<RuntimeError>>(
         _: AccessControllerCreateProofInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCreateProofOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCreateProofOutput, RuntimeError> {
         transition(api, AccessControllerCreateProofStateMachineInput)
     }
 
-    pub fn initiate_recovery_as_primary<Y>(
+    pub fn initiate_recovery_as_primary<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateRecoveryAsPrimaryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerInitiateRecoveryAsPrimaryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateRecoveryAsPrimaryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateRecoveryAsPrimaryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -227,16 +215,13 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn initiate_recovery_as_recovery<Y>(
+    pub fn initiate_recovery_as_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateRecoveryAsRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerInitiateRecoveryAsRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateRecoveryAsRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateRecoveryAsRecoveryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -260,13 +245,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn initiate_badge_withdraw_attempt_as_primary<Y>(
+    pub fn initiate_badge_withdraw_attempt_as_primary<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput { .. }: AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput,
@@ -282,13 +264,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn initiate_badge_withdraw_attempt_as_recovery<Y>(
+    pub fn initiate_badge_withdraw_attempt_as_recovery<Y: SystemApi<RuntimeError>>(
         _: AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput,
@@ -304,16 +283,13 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_primary_role_recovery_proposal<Y>(
+    pub fn quick_confirm_primary_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -340,16 +316,13 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_recovery_role_recovery_proposal<Y>(
+    pub fn quick_confirm_recovery_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -376,12 +349,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_primary_role_badge_withdraw_attempt<Y>(
+    pub fn quick_confirm_primary_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         _: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
     ) -> Result<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
     {
         let bucket = transition_mut(
             api,
@@ -401,12 +372,10 @@ impl AccessControllerV1Blueprint {
         Ok(bucket)
     }
 
-    pub fn quick_confirm_recovery_role_badge_withdraw_attempt<Y>(
+    pub fn quick_confirm_recovery_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         _: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
     ) -> Result<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
     {
         let bucket = transition_mut(
             api,
@@ -426,16 +395,13 @@ impl AccessControllerV1Blueprint {
         Ok(bucket)
     }
 
-    pub fn timed_confirm_recovery<Y>(
+    pub fn timed_confirm_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerTimedConfirmRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerTimedConfirmRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerTimedConfirmRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerTimedConfirmRecoveryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -463,13 +429,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn cancel_primary_role_recovery_proposal<Y>(
+    pub fn cancel_primary_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelPrimaryRoleRecoveryProposalInput { .. }: AccessControllerCancelPrimaryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelPrimaryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelPrimaryRoleRecoveryProposalOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput,
@@ -485,13 +448,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn cancel_recovery_role_recovery_proposal<Y>(
+    pub fn cancel_recovery_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelRecoveryRoleRecoveryProposalInput { .. }: AccessControllerCancelRecoveryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelRecoveryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelRecoveryRoleRecoveryProposalOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelRecoveryRoleRecoveryProposalStateMachineInput,
@@ -507,13 +467,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn cancel_primary_role_badge_withdraw_attempt<Y>(
+    pub fn cancel_primary_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput { .. }: AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
@@ -529,13 +486,10 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn cancel_recovery_role_badge_withdraw_attempt<Y>(
+    pub fn cancel_recovery_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput { .. }: AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
@@ -551,42 +505,33 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn lock_primary_role<Y>(
+    pub fn lock_primary_role<Y: SystemApi<RuntimeError>>(
         AccessControllerLockPrimaryRoleInput { .. }: AccessControllerLockPrimaryRoleInput,
         api: &mut Y,
-    ) -> Result<AccessControllerLockPrimaryRoleOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerLockPrimaryRoleOutput, RuntimeError> {
         transition_mut(api, AccessControllerLockPrimaryRoleStateMachineInput)?;
         Runtime::emit_event(api, LockPrimaryRoleEvent {})?;
 
         Ok(())
     }
 
-    pub fn unlock_primary_role<Y>(
+    pub fn unlock_primary_role<Y: SystemApi<RuntimeError>>(
         _: AccessControllerUnlockPrimaryRoleInput,
         api: &mut Y,
-    ) -> Result<AccessControllerUnlockPrimaryRoleOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerUnlockPrimaryRoleOutput, RuntimeError> {
         transition_mut(api, AccessControllerUnlockPrimaryRoleStateMachineInput)?;
         Runtime::emit_event(api, UnlockPrimaryRoleEvent {})?;
 
         Ok(())
     }
 
-    pub fn stop_timed_recovery<Y>(
+    pub fn stop_timed_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerStopTimedRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerStopTimedRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerStopTimedRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerStopTimedRecoveryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerStopTimedRecoveryStateMachineInput {
@@ -601,15 +546,12 @@ impl AccessControllerV1Blueprint {
         Ok(())
     }
 
-    pub fn mint_recovery_badges<Y>(
+    pub fn mint_recovery_badges<Y: SystemApi<RuntimeError>>(
         AccessControllerMintRecoveryBadgesInput {
             non_fungible_local_ids,
         }: AccessControllerMintRecoveryBadgesInput,
         api: &mut Y,
-    ) -> Result<AccessControllerMintRecoveryBadgesOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerMintRecoveryBadgesOutput, RuntimeError> {
         let resource_address = {
             let handle = api.actor_open_field(
                 ACTOR_STATE_SELF,
@@ -672,12 +614,11 @@ fn init_roles_from_rule_set(rule_set: RuleSet) -> RoleAssignmentInit {
     }
 }
 
-fn transition<Y, I>(
+fn transition<Y: SystemApi<RuntimeError>, I>(
     api: &mut Y,
     input: I,
 ) -> Result<<AccessControllerV1Substate as Transition<I>>::Output, RuntimeError>
 where
-    Y: SystemApi<RuntimeError>,
     AccessControllerV1Substate: Transition<I>,
 {
     let handle = api.actor_open_field(
@@ -698,12 +639,11 @@ where
     Ok(rtn)
 }
 
-fn transition_mut<Y, I>(
+fn transition_mut<Y: SystemApi<RuntimeError>, I>(
     api: &mut Y,
     input: I,
 ) -> Result<<AccessControllerV1Substate as TransitionMut<I>>::Output, RuntimeError>
 where
-    Y: SystemApi<RuntimeError>,
     AccessControllerV1Substate: TransitionMut<I>,
 {
     let handle = api.actor_open_field(
@@ -731,14 +671,11 @@ where
     Ok(rtn)
 }
 
-fn update_role_assignment<Y>(
+fn update_role_assignment<Y: SystemApi<RuntimeError>>(
     api: &mut Y,
     receiver: &NodeId,
     rule_set: RuleSet,
-) -> Result<(), RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<(), RuntimeError> {
     let attached = AttachedRoleAssignment(*receiver);
     attached.set_role(
         ModuleId::Main,

--- a/radix-engine/src/blueprints/access_controller/v1/package.rs
+++ b/radix-engine/src/blueprints/access_controller/v1/package.rs
@@ -331,14 +331,11 @@ impl AccessControllerV1NativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         AccessControllerV1Blueprint::invoke_export(export_name, input, api)
     }
 }

--- a/radix-engine/src/blueprints/access_controller/v1/state_machine.rs
+++ b/radix-engine/src/blueprints/access_controller/v1/state_machine.rs
@@ -17,9 +17,11 @@ use sbor::rust::boxed::Box;
 pub(super) trait Transition<I> {
     type Output;
 
-    fn transition<Y>(&self, api: &mut Y, input: I) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>;
+    fn transition<Y: SystemApi<RuntimeError>>(
+        &self,
+        api: &mut Y,
+        input: I,
+    ) -> Result<Self::Output, RuntimeError>;
 }
 
 /// A trait which defines the interface for an access controller transition for a given trigger or
@@ -27,9 +29,11 @@ pub(super) trait Transition<I> {
 pub(super) trait TransitionMut<I> {
     type Output;
 
-    fn transition_mut<Y>(&mut self, api: &mut Y, input: I) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>;
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
+        &mut self,
+        api: &mut Y,
+        input: I,
+    ) -> Result<Self::Output, RuntimeError>;
 }
 
 //=================================================
@@ -49,14 +53,11 @@ pub(super) struct AccessControllerCreateProofStateMachineInput;
 impl Transition<AccessControllerCreateProofStateMachineInput> for AccessControllerV1Substate {
     type Output = Proof;
 
-    fn transition<Y>(
+    fn transition<Y: SystemApi<RuntimeError>>(
         &self,
         api: &mut Y,
         _input: AccessControllerCreateProofStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Proofs can only be created when the primary role is unlocked - regardless of any pending
         // recovery or withdraw attempts.
         match self.state {
@@ -88,14 +89,11 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsPrimaryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerInitiateRecoveryAsPrimaryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -130,14 +128,11 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsRecoveryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         input: AccessControllerInitiateRecoveryAsRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -147,7 +142,7 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsRecoveryStateMachineInput>
                 _,
             ) => match self.timed_recovery_delay_in_minutes {
                 Some(delay_in_minutes) => {
-                    let current_time = Runtime::current_time(api, TimePrecision::Minute)?;
+                    let current_time = Runtime::current_time(TimePrecision::Minute, api)?;
                     let timed_recovery_allowed_after = current_time
                         .add_minutes(delay_in_minutes as i64)
                         .map_or(access_controller_runtime_error!(TimeOverflow), |instant| {
@@ -187,14 +182,11 @@ impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMac
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -226,14 +218,11 @@ impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMa
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -265,14 +254,11 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalStateM
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerQuickConfirmPrimaryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, PrimaryRoleRecoveryAttemptState::RecoveryAttempt(ref proposal), _, _, _) => {
                 let proposal = proposal.clone();
@@ -304,14 +290,11 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalState
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerQuickConfirmRecoveryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -350,14 +333,11 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptSt
 {
     type Output = Bucket;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         _input: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, _, PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt, _, _) => {
                 // Transition back to the initial state of the state machine
@@ -382,14 +362,11 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptS
 {
     type Output = Bucket;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         _input: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, _, _, _, RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt) => {
                 // Transition back to the initial state of the state machine
@@ -416,14 +393,11 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         input: AccessControllerTimedConfirmRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Timed confirm recovery can only be performed by the recovery role (this is checked
         // through access rules on the invocation itself) and can be performed in recovery mode
         // regardless of whether primary is locked or unlocked.
@@ -446,10 +420,10 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
                 validate_recovery_proposal(&proposal, &input.proposal_to_confirm)?;
 
                 let recovery_time_has_elapsed = Runtime::compare_against_current_time(
-                    api,
                     *timed_recovery_allowed_after,
                     TimePrecision::Minute,
                     TimeComparisonOperator::Gte,
+                    api,
                 )?;
 
                 // If the timed recovery delay has elapsed, then we transition into normal
@@ -474,14 +448,11 @@ impl TransitionMut<AccessControllerCancelPrimaryRoleRecoveryProposalStateMachine
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -508,14 +479,11 @@ impl TransitionMut<AccessControllerCancelRecoveryRoleRecoveryProposalStateMachin
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelRecoveryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -542,14 +510,11 @@ impl TransitionMut<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMac
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A badge withdraw attempt can only be canceled when it exists regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -576,14 +541,11 @@ impl TransitionMut<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMa
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A badge withdraw attempt can only be canceled when it exists regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -610,14 +572,11 @@ impl TransitionMut<AccessControllerLockPrimaryRoleStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerLockPrimaryRoleStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Primary can only be locked when it's unlocked
         match self.state {
             (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Unlocked, ..) => {
@@ -636,14 +595,11 @@ impl TransitionMut<AccessControllerUnlockPrimaryRoleStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerUnlockPrimaryRoleStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Primary can only be unlocked when it's locked
         match self.state {
             (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Locked, ..) => {
@@ -664,14 +620,11 @@ impl TransitionMut<AccessControllerStopTimedRecoveryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerStopTimedRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // We can only stop the timed recovery timer if we're in recovery mode. It doesn't matter
         // if primary is locked or unlocked
         match self.state {

--- a/radix-engine/src/blueprints/access_controller/v2/blueprint.rs
+++ b/radix-engine/src/blueprints/access_controller/v2/blueprint.rs
@@ -17,14 +17,11 @@ use sbor::rust::prelude::*;
 pub struct AccessControllerV2Blueprint;
 
 impl AccessControllerV2Blueprint {
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         dispatch! {
             IDENT,
             export_name,
@@ -60,7 +57,7 @@ impl AccessControllerV2Blueprint {
         }
     }
 
-    pub fn create<Y>(
+    pub fn create<Y: SystemApi<RuntimeError>>(
         AccessControllerCreateInput {
             controlled_asset,
             rule_set,
@@ -68,10 +65,7 @@ impl AccessControllerV2Blueprint {
             address_reservation,
         }: AccessControllerCreateInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCreateOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCreateOutput, RuntimeError> {
         // Allocating the address of the access controller - this will be needed for the metadata
         // and access rules of the recovery badge
         let (address_reservation, address) = {
@@ -192,26 +186,20 @@ impl AccessControllerV2Blueprint {
         Ok(Global::new(ComponentAddress::try_from(address).unwrap()))
     }
 
-    pub fn create_proof<Y>(
+    pub fn create_proof<Y: SystemApi<RuntimeError>>(
         _: AccessControllerCreateProofInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCreateProofOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCreateProofOutput, RuntimeError> {
         transition(api, AccessControllerCreateProofStateMachineInput)
     }
 
-    pub fn initiate_recovery_as_primary<Y>(
+    pub fn initiate_recovery_as_primary<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateRecoveryAsPrimaryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerInitiateRecoveryAsPrimaryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateRecoveryAsPrimaryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateRecoveryAsPrimaryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -235,16 +223,13 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn initiate_recovery_as_recovery<Y>(
+    pub fn initiate_recovery_as_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateRecoveryAsRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerInitiateRecoveryAsRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateRecoveryAsRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateRecoveryAsRecoveryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -268,13 +253,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn initiate_badge_withdraw_attempt_as_primary<Y>(
+    pub fn initiate_badge_withdraw_attempt_as_primary<Y: SystemApi<RuntimeError>>(
         AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput { .. }: AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput,
@@ -290,13 +272,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn initiate_badge_withdraw_attempt_as_recovery<Y>(
+    pub fn initiate_badge_withdraw_attempt_as_recovery<Y: SystemApi<RuntimeError>>(
         _: AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput,
@@ -312,16 +291,13 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_primary_role_recovery_proposal<Y>(
+    pub fn quick_confirm_primary_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerQuickConfirmPrimaryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -348,16 +324,13 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_recovery_role_recovery_proposal<Y>(
+    pub fn quick_confirm_recovery_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerQuickConfirmRecoveryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -384,12 +357,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn quick_confirm_primary_role_badge_withdraw_attempt<Y>(
+    pub fn quick_confirm_primary_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         _: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
     ) -> Result<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
     {
         let bucket = transition_mut(
             api,
@@ -409,12 +380,10 @@ impl AccessControllerV2Blueprint {
         Ok(bucket)
     }
 
-    pub fn quick_confirm_recovery_role_badge_withdraw_attempt<Y>(
+    pub fn quick_confirm_recovery_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         _: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
     ) -> Result<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
     {
         let bucket = transition_mut(
             api,
@@ -434,16 +403,13 @@ impl AccessControllerV2Blueprint {
         Ok(bucket)
     }
 
-    pub fn timed_confirm_recovery<Y>(
+    pub fn timed_confirm_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerTimedConfirmRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerTimedConfirmRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerTimedConfirmRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerTimedConfirmRecoveryOutput, RuntimeError> {
         let proposal = RecoveryProposal {
             rule_set,
             timed_recovery_delay_in_minutes,
@@ -471,13 +437,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn cancel_primary_role_recovery_proposal<Y>(
+    pub fn cancel_primary_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelPrimaryRoleRecoveryProposalInput { .. }: AccessControllerCancelPrimaryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelPrimaryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelPrimaryRoleRecoveryProposalOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput,
@@ -493,13 +456,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn cancel_recovery_role_recovery_proposal<Y>(
+    pub fn cancel_recovery_role_recovery_proposal<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelRecoveryRoleRecoveryProposalInput { .. }: AccessControllerCancelRecoveryRoleRecoveryProposalInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelRecoveryRoleRecoveryProposalOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelRecoveryRoleRecoveryProposalOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelRecoveryRoleRecoveryProposalStateMachineInput,
@@ -515,13 +475,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn cancel_primary_role_badge_withdraw_attempt<Y>(
+    pub fn cancel_primary_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput { .. }: AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
@@ -537,13 +494,10 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn cancel_recovery_role_badge_withdraw_attempt<Y>(
+    pub fn cancel_recovery_role_badge_withdraw_attempt<Y: SystemApi<RuntimeError>>(
         AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput { .. }: AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptInput,
         api: &mut Y,
-    ) -> Result<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
@@ -559,42 +513,33 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn lock_primary_role<Y>(
+    pub fn lock_primary_role<Y: SystemApi<RuntimeError>>(
         AccessControllerLockPrimaryRoleInput { .. }: AccessControllerLockPrimaryRoleInput,
         api: &mut Y,
-    ) -> Result<AccessControllerLockPrimaryRoleOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerLockPrimaryRoleOutput, RuntimeError> {
         transition_mut(api, AccessControllerLockPrimaryRoleStateMachineInput)?;
         Runtime::emit_event(api, LockPrimaryRoleEvent {})?;
 
         Ok(())
     }
 
-    pub fn unlock_primary_role<Y>(
+    pub fn unlock_primary_role<Y: SystemApi<RuntimeError>>(
         _: AccessControllerUnlockPrimaryRoleInput,
         api: &mut Y,
-    ) -> Result<AccessControllerUnlockPrimaryRoleOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerUnlockPrimaryRoleOutput, RuntimeError> {
         transition_mut(api, AccessControllerUnlockPrimaryRoleStateMachineInput)?;
         Runtime::emit_event(api, UnlockPrimaryRoleEvent {})?;
 
         Ok(())
     }
 
-    pub fn stop_timed_recovery<Y>(
+    pub fn stop_timed_recovery<Y: SystemApi<RuntimeError>>(
         AccessControllerStopTimedRecoveryInput {
             rule_set,
             timed_recovery_delay_in_minutes,
         }: AccessControllerStopTimedRecoveryInput,
         api: &mut Y,
-    ) -> Result<AccessControllerStopTimedRecoveryOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerStopTimedRecoveryOutput, RuntimeError> {
         transition_mut(
             api,
             AccessControllerStopTimedRecoveryStateMachineInput {
@@ -609,15 +554,12 @@ impl AccessControllerV2Blueprint {
         Ok(())
     }
 
-    pub fn mint_recovery_badges<Y>(
+    pub fn mint_recovery_badges<Y: SystemApi<RuntimeError>>(
         AccessControllerMintRecoveryBadgesInput {
             non_fungible_local_ids,
         }: AccessControllerMintRecoveryBadgesInput,
         api: &mut Y,
-    ) -> Result<AccessControllerMintRecoveryBadgesOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerMintRecoveryBadgesOutput, RuntimeError> {
         Self::with_state(api, |state, api| {
             api.call_method(
                 state.recovery_badge.as_node_id(),
@@ -639,13 +581,10 @@ impl AccessControllerV2Blueprint {
         })
     }
 
-    pub fn lock_recovery_fee<Y>(
+    pub fn lock_recovery_fee<Y: SystemApi<RuntimeError>>(
         AccessControllerLockRecoveryFeeInput { amount }: AccessControllerLockRecoveryFeeInput,
         api: &mut Y,
-    ) -> Result<AccessControllerLockRecoveryFeeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerLockRecoveryFeeOutput, RuntimeError> {
         Self::with_state_mut(api, |state, api| {
             let vault = state
                 .xrd_fee_vault
@@ -655,13 +594,10 @@ impl AccessControllerV2Blueprint {
         })
     }
 
-    pub fn withdraw_recovery_fee<Y>(
+    pub fn withdraw_recovery_fee<Y: SystemApi<RuntimeError>>(
         AccessControllerWithdrawRecoveryFeeInput { amount }: AccessControllerWithdrawRecoveryFeeInput,
         api: &mut Y,
-    ) -> Result<AccessControllerWithdrawRecoveryFeeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerWithdrawRecoveryFeeOutput, RuntimeError> {
         Runtime::emit_event(api, WithdrawRecoveryXrdEvent { amount })?;
 
         Self::with_state_mut(api, |state, api| {
@@ -673,13 +609,10 @@ impl AccessControllerV2Blueprint {
         })
     }
 
-    pub fn contribute_recovery_fee<Y>(
+    pub fn contribute_recovery_fee<Y: SystemApi<RuntimeError>>(
         AccessControllerContributeRecoveryFeeInput { bucket }: AccessControllerContributeRecoveryFeeInput,
         api: &mut Y,
-    ) -> Result<AccessControllerContributeRecoveryFeeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccessControllerContributeRecoveryFeeOutput, RuntimeError> {
         bucket
             .amount(api)
             .and_then(|amount| Runtime::emit_event(api, DepositRecoveryXrdEvent { amount }))?;
@@ -698,11 +631,10 @@ impl AccessControllerV2Blueprint {
 
     /// This method is used to read the access controller state and perform any lazy updating
     /// required.
-    fn with_state<Y, F, O>(api: &mut Y, callback: F) -> Result<O, RuntimeError>
-    where
-        F: FnOnce(&mut AccessControllerV2Substate, &mut Y) -> Result<O, RuntimeError>,
-        Y: SystemApi<RuntimeError>,
-    {
+    fn with_state<Y: SystemApi<RuntimeError>, O>(
+        api: &mut Y,
+        callback: impl FnOnce(&mut AccessControllerV2Substate, &mut Y) -> Result<O, RuntimeError>,
+    ) -> Result<O, RuntimeError> {
         // Get a read lock over the access-controller field.
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -762,11 +694,10 @@ impl AccessControllerV2Blueprint {
 
     /// This method is used to read the access controller state and perform any lazy updating
     /// required.
-    fn with_state_mut<Y, F, O>(api: &mut Y, callback: F) -> Result<O, RuntimeError>
-    where
-        F: FnOnce(&mut AccessControllerV2Substate, &mut Y) -> Result<O, RuntimeError>,
-        Y: SystemApi<RuntimeError>,
-    {
+    fn with_state_mut<Y: SystemApi<RuntimeError>, O>(
+        api: &mut Y,
+        callback: impl FnOnce(&mut AccessControllerV2Substate, &mut Y) -> Result<O, RuntimeError>,
+    ) -> Result<O, RuntimeError> {
         // Get a write lock over the access-controller field.
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -838,36 +769,31 @@ fn init_roles_from_rule_set(rule_set: RuleSet) -> RoleAssignmentInit {
     }
 }
 
-fn transition<Y, I>(
+fn transition<Y: SystemApi<RuntimeError>, I>(
     api: &mut Y,
     input: I,
 ) -> Result<<AccessControllerV2Substate as Transition<I>>::Output, RuntimeError>
 where
-    Y: SystemApi<RuntimeError>,
     AccessControllerV2Substate: Transition<I>,
 {
     AccessControllerV2Blueprint::with_state(api, |state, api| state.transition(api, input))
 }
 
-fn transition_mut<Y, I>(
+fn transition_mut<Y: SystemApi<RuntimeError>, I>(
     api: &mut Y,
     input: I,
 ) -> Result<<AccessControllerV2Substate as TransitionMut<I>>::Output, RuntimeError>
 where
-    Y: SystemApi<RuntimeError>,
     AccessControllerV2Substate: TransitionMut<I>,
 {
     AccessControllerV2Blueprint::with_state_mut(api, |state, api| state.transition_mut(api, input))
 }
 
-fn update_role_assignment<Y>(
+fn update_role_assignment<Y: SystemApi<RuntimeError>>(
     api: &mut Y,
     receiver: &NodeId,
     rule_set: RuleSet,
-) -> Result<(), RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<(), RuntimeError> {
     let attached = AttachedRoleAssignment(*receiver);
     attached.set_role(
         ModuleId::Main,

--- a/radix-engine/src/blueprints/access_controller/v2/package.rs
+++ b/radix-engine/src/blueprints/access_controller/v2/package.rs
@@ -388,14 +388,11 @@ impl AccessControllerV2NativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         AccessControllerV2Blueprint::invoke_export(export_name, input, api)
     }
 }

--- a/radix-engine/src/blueprints/access_controller/v2/state_machine.rs
+++ b/radix-engine/src/blueprints/access_controller/v2/state_machine.rs
@@ -17,9 +17,11 @@ use sbor::rust::boxed::Box;
 pub(super) trait Transition<I> {
     type Output;
 
-    fn transition<Y>(&self, api: &mut Y, input: I) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>;
+    fn transition<Y: SystemApi<RuntimeError>>(
+        &self,
+        api: &mut Y,
+        input: I,
+    ) -> Result<Self::Output, RuntimeError>;
 }
 
 /// A trait which defines the interface for an access controller transition for a given trigger or
@@ -27,9 +29,11 @@ pub(super) trait Transition<I> {
 pub(super) trait TransitionMut<I> {
     type Output;
 
-    fn transition_mut<Y>(&mut self, api: &mut Y, input: I) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>;
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
+        &mut self,
+        api: &mut Y,
+        input: I,
+    ) -> Result<Self::Output, RuntimeError>;
 }
 
 //=================================================
@@ -49,14 +53,11 @@ pub(super) struct AccessControllerCreateProofStateMachineInput;
 impl Transition<AccessControllerCreateProofStateMachineInput> for AccessControllerV2Substate {
     type Output = Proof;
 
-    fn transition<Y>(
+    fn transition<Y: SystemApi<RuntimeError>>(
         &self,
         api: &mut Y,
         _input: AccessControllerCreateProofStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Proofs can only be created when the primary role is unlocked - regardless of any pending
         // recovery or withdraw attempts.
         match self.state {
@@ -88,14 +89,11 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsPrimaryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerInitiateRecoveryAsPrimaryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -130,14 +128,11 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsRecoveryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         input: AccessControllerInitiateRecoveryAsRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -147,7 +142,7 @@ impl TransitionMut<AccessControllerInitiateRecoveryAsRecoveryStateMachineInput>
                 _,
             ) => match self.timed_recovery_delay_in_minutes {
                 Some(delay_in_minutes) => {
-                    let current_time = Runtime::current_time(api, TimePrecision::Minute)?;
+                    let current_time = Runtime::current_time(TimePrecision::Minute, api)?;
                     let timed_recovery_allowed_after = current_time
                         .add_minutes(delay_in_minutes as i64)
                         .map_or(access_controller_runtime_error!(TimeOverflow), |instant| {
@@ -187,14 +182,11 @@ impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMac
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerInitiateBadgeWithdrawAttemptAsPrimaryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -226,14 +218,11 @@ impl TransitionMut<AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMa
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerInitiateBadgeWithdrawAttemptAsRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -265,14 +254,11 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleRecoveryProposalStateM
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerQuickConfirmPrimaryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, PrimaryRoleRecoveryAttemptState::RecoveryAttempt(ref proposal), _, _, _) => {
                 let proposal = proposal.clone();
@@ -304,14 +290,11 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleRecoveryProposalState
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerQuickConfirmRecoveryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (
                 _,
@@ -350,14 +333,11 @@ impl TransitionMut<AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptSt
 {
     type Output = Bucket;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         _input: AccessControllerQuickConfirmPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, _, PrimaryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt, _, _) => {
                 // Transition back to the initial state of the state machine
@@ -382,14 +362,11 @@ impl TransitionMut<AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptS
 {
     type Output = Bucket;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         _input: AccessControllerQuickConfirmRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         match self.state {
             (_, _, _, _, RecoveryRoleBadgeWithdrawAttemptState::BadgeWithdrawAttempt) => {
                 // Transition back to the initial state of the state machine
@@ -416,14 +393,11 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
 {
     type Output = RecoveryProposal;
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         api: &mut Y,
         input: AccessControllerTimedConfirmRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Timed confirm recovery can only be performed by the recovery role (this is checked
         // through access rules on the invocation itself) and can be performed in recovery mode
         // regardless of whether primary is locked or unlocked.
@@ -446,10 +420,10 @@ impl TransitionMut<AccessControllerTimedConfirmRecoveryStateMachineInput>
                 validate_recovery_proposal(&proposal, &input.proposal_to_confirm)?;
 
                 let recovery_time_has_elapsed = Runtime::compare_against_current_time(
-                    api,
                     *timed_recovery_allowed_after,
                     TimePrecision::Minute,
                     TimeComparisonOperator::Gte,
+                    api,
                 )?;
 
                 // If the timed recovery delay has elapsed, then we transition into normal
@@ -474,14 +448,11 @@ impl TransitionMut<AccessControllerCancelPrimaryRoleRecoveryProposalStateMachine
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelPrimaryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -508,14 +479,11 @@ impl TransitionMut<AccessControllerCancelRecoveryRoleRecoveryProposalStateMachin
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelRecoveryRoleRecoveryProposalStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A recovery attempt can only be canceled when we're in recovery mode regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -542,14 +510,11 @@ impl TransitionMut<AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMac
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelPrimaryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A badge withdraw attempt can only be canceled when it exists regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -576,14 +541,11 @@ impl TransitionMut<AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMa
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerCancelRecoveryRoleBadgeWithdrawAttemptStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // A badge withdraw attempt can only be canceled when it exists regardless of whether
         // primary is locked or unlocked
         match self.state {
@@ -610,14 +572,11 @@ impl TransitionMut<AccessControllerLockPrimaryRoleStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerLockPrimaryRoleStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Primary can only be locked when it's unlocked
         match self.state {
             (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Unlocked, ..) => {
@@ -636,14 +595,11 @@ impl TransitionMut<AccessControllerUnlockPrimaryRoleStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         _input: AccessControllerUnlockPrimaryRoleStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // Primary can only be unlocked when it's locked
         match self.state {
             (ref mut primary_role_locking_state @ PrimaryRoleLockingState::Locked, ..) => {
@@ -664,14 +620,11 @@ impl TransitionMut<AccessControllerStopTimedRecoveryStateMachineInput>
 {
     type Output = ();
 
-    fn transition_mut<Y>(
+    fn transition_mut<Y: SystemApi<RuntimeError>>(
         &mut self,
         _api: &mut Y,
         input: AccessControllerStopTimedRecoveryStateMachineInput,
-    ) -> Result<Self::Output, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Self::Output, RuntimeError> {
         // We can only stop the timed recovery timer if we're in recovery mode. It doesn't matter
         // if primary is locked or unlocked
         match self.state {

--- a/radix-engine/src/blueprints/account/package.rs
+++ b/radix-engine/src/blueprints/account/package.rs
@@ -20,14 +20,11 @@ impl AccountNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             ACCOUNT_ON_VIRTUALIZE_EXPORT_NAME => {
                 let input: OnVirtualizeInput = input.as_typed().map_err(|e| {

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -503,7 +503,7 @@ impl ConsensusManagerBlueprint {
         }
     }
 
-    pub(crate) fn create<Y>(
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(
         validator_token_address_reservation: GlobalAddressReservation,
         consensus_manager_address_reservation: GlobalAddressReservation,
         genesis_epoch: Epoch,
@@ -511,10 +511,7 @@ impl ConsensusManagerBlueprint {
         initial_time_milli: i64,
         initial_current_leader: Option<ValidatorIndex>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if initial_config.max_validators > ValidatorIndex::MAX as u32 {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::ConsensusManagerError(
@@ -533,7 +530,7 @@ impl ConsensusManagerBlueprint {
             let consensus_manager_address =
                 api.get_reservation_address(consensus_manager_address_reservation.0.as_node_id())?;
 
-            ResourceManager::new_non_fungible::<ValidatorOwnerBadgeData, Y, RuntimeError, _>(
+            ResourceManager::new_non_fungible::<ValidatorOwnerBadgeData, _, _, _>(
                 OwnerRole::Fixed(rule!(require(global_caller(consensus_manager_address)))),
                 NonFungibleIdType::Bytes,
                 true,
@@ -630,10 +627,9 @@ impl ConsensusManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn get_current_epoch<Y>(api: &mut Y) -> Result<Epoch, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_current_epoch<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Epoch, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ConsensusManagerField::State.into(),
@@ -647,10 +643,7 @@ impl ConsensusManagerBlueprint {
         Ok(consensus_manager.epoch)
     }
 
-    pub(crate) fn start<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn start<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         let config_substate = {
             let config_handle = api.actor_open_field(
                 ACTOR_STATE_SELF,
@@ -702,13 +695,10 @@ impl ConsensusManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn get_current_time_v1<Y>(
+    pub(crate) fn get_current_time_v1<Y: SystemApi<RuntimeError>>(
         precision: TimePrecisionV1,
         api: &mut Y,
-    ) -> Result<Instant, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Instant, RuntimeError> {
         match precision {
             TimePrecisionV1::Minute => {
                 let handle = api.actor_open_field(
@@ -730,13 +720,10 @@ impl ConsensusManagerBlueprint {
         }
     }
 
-    pub(crate) fn get_current_time_v2<Y>(
+    pub(crate) fn get_current_time_v2<Y: SystemApi<RuntimeError>>(
         precision: TimePrecisionV2,
         api: &mut Y,
-    ) -> Result<Instant, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Instant, RuntimeError> {
         match precision {
             TimePrecisionV2::Minute => {
                 let handle = api.actor_open_field(
@@ -773,15 +760,12 @@ impl ConsensusManagerBlueprint {
         }
     }
 
-    pub(crate) fn compare_current_time_v1<Y>(
+    pub(crate) fn compare_current_time_v1<Y: SystemApi<RuntimeError>>(
         other_arbitrary_precision_instant: Instant,
         precision: TimePrecisionV1,
         operator: TimeComparisonOperator,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         match precision {
             TimePrecisionV1::Minute => {
                 let other_epoch_minute = other_arbitrary_precision_instant
@@ -822,15 +806,12 @@ impl ConsensusManagerBlueprint {
         }
     }
 
-    pub(crate) fn compare_current_time_v2<Y>(
+    pub(crate) fn compare_current_time_v2<Y: SystemApi<RuntimeError>>(
         other_arbitrary_precision_instant: Instant,
         precision: TimePrecisionV2,
         operator: TimeComparisonOperator,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         match precision {
             TimePrecisionV2::Minute => {
                 let other_epoch_minute = other_arbitrary_precision_instant
@@ -904,15 +885,12 @@ impl ConsensusManagerBlueprint {
         i32::try_from(epoch_milli / MILLIS_IN_MINUTE).ok() // safe until A.D. 5700
     }
 
-    pub(crate) fn next_round<Y>(
+    pub(crate) fn next_round<Y: SystemApi<RuntimeError>>(
         round: Round,
         proposer_timestamp_milli: i64,
         proposal_history: LeaderProposalHistory,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         Self::check_non_decreasing_and_update_timestamps(proposer_timestamp_milli, api)?;
 
         let config_handle = api.actor_open_field(
@@ -988,10 +966,9 @@ impl ConsensusManagerBlueprint {
         Ok(())
     }
 
-    fn get_validator_xrd_cost<Y>(api: &mut Y) -> Result<Option<Decimal>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn get_validator_xrd_cost<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Option<Decimal>, RuntimeError> {
         let manager_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ConsensusManagerField::State.field_index(),
@@ -1031,15 +1008,12 @@ impl ConsensusManagerBlueprint {
         Ok(validator_creation_xrd_cost)
     }
 
-    pub(crate) fn create_validator<Y>(
+    pub(crate) fn create_validator<Y: SystemApi<RuntimeError>>(
         key: Secp256k1PublicKey,
         fee_factor: Decimal,
         xrd_payment: Bucket,
         api: &mut Y,
-    ) -> Result<(ComponentAddress, Bucket, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(ComponentAddress, Bucket, Bucket), RuntimeError> {
         if !xrd_payment.resource_address(api)?.eq(&XRD) {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::ConsensusManagerError(ConsensusManagerError::NotXrd),
@@ -1058,13 +1032,10 @@ impl ConsensusManagerBlueprint {
         Ok((validator_address, owner_token_bucket, xrd_payment))
     }
 
-    fn check_non_decreasing_and_update_timestamps<Y>(
+    fn check_non_decreasing_and_update_timestamps<Y: SystemApi<RuntimeError>>(
         current_time_ms: i64,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ConsensusManagerField::ProposerMilliTimestamp.into(),
@@ -1123,14 +1094,11 @@ impl ConsensusManagerBlueprint {
         Ok(())
     }
 
-    fn update_proposal_statistics<Y>(
+    fn update_proposal_statistics<Y: SystemApi<RuntimeError>>(
         progressed_rounds: u64,
         proposal_history: LeaderProposalHistory,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if proposal_history.gap_round_leaders.len() as u64 != progressed_rounds - 1 {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::ConsensusManagerError(
@@ -1170,14 +1138,11 @@ impl ConsensusManagerBlueprint {
         Ok(())
     }
 
-    fn epoch_change<Y>(
+    fn epoch_change<Y: SystemApi<RuntimeError>>(
         next_epoch: Epoch,
         config: &ConsensusManagerConfig,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         // Read previous validator set
         let validator_set_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -1355,17 +1320,14 @@ impl ConsensusManagerBlueprint {
 
     /// Emits a configured XRD amount ([`ConsensusManagerConfigSubstate.total_emission_xrd_per_epoch`])
     /// and distributes it across the given validator set, according to their stake.
-    fn apply_validator_emissions_and_rewards<Y>(
+    fn apply_validator_emissions_and_rewards<Y: SystemApi<RuntimeError>>(
         validator_set: ActiveValidatorSet,
         validator_statistics: Vec<ProposalStatistic>,
         config: &ConsensusManagerConfig,
         validator_rewards: &mut ValidatorRewardsSubstate,
         epoch: Epoch, // the concluded epoch, for event creation
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let mut stake_sum_xrd = Decimal::ZERO;
 
         let mut validator_infos: IndexMap<ValidatorIndex, ValidatorInfo> = index_map_new();

--- a/radix-engine/src/blueprints/consensus_manager/package.rs
+++ b/radix-engine/src/blueprints/consensus_manager/package.rs
@@ -19,14 +19,11 @@ impl ConsensusManagerNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             CONSENSUS_MANAGER_CREATE_IDENT => {
                 let input: ConsensusManagerCreateInput = input.as_typed().map_err(|e| {
@@ -278,14 +275,11 @@ impl ConsensusManagerNativePackage {
 pub struct ConsensusManagerSecondsPrecisionNativeCode;
 
 impl ConsensusManagerSecondsPrecisionNativeCode {
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             CONSENSUS_MANAGER_GET_CURRENT_TIME_IDENT => {
                 let input: ConsensusManagerGetCurrentTimeInputV2 =

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -546,42 +546,33 @@ impl ValidatorBlueprint {
         }
     }
 
-    pub fn register<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn register<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         Self::register_update(true, api)
     }
 
-    pub fn unregister<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unregister<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         Self::register_update(false, api)
     }
 
-    pub fn stake_as_owner<Y>(xrd_bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn stake_as_owner<Y: SystemApi<RuntimeError>>(
+        xrd_bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::stake_internal(xrd_bucket, true, api)
     }
 
-    pub fn stake<Y>(xrd_bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn stake<Y: SystemApi<RuntimeError>>(
+        xrd_bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::stake_internal(xrd_bucket, false, api)
     }
 
-    fn stake_internal<Y>(
+    fn stake_internal<Y: SystemApi<RuntimeError>>(
         xrd_bucket: Bucket,
         is_owner: bool,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.field_index(),
@@ -643,10 +634,10 @@ impl ValidatorBlueprint {
         Ok(stake_unit_bucket)
     }
 
-    pub fn unstake<Y>(stake_unit_bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unstake<Y: SystemApi<RuntimeError>>(
+        stake_unit_bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         let stake_unit_bucket_amount = stake_unit_bucket.amount(api)?;
 
         let handle = api.actor_open_field(
@@ -738,13 +729,10 @@ impl ValidatorBlueprint {
         Ok(unstake_bucket)
     }
 
-    pub fn signal_protocol_update_readiness<Y>(
+    pub fn signal_protocol_update_readiness<Y: SystemApi<RuntimeError>>(
         protocol_version_name: String,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if protocol_version_name.len() != VALIDATOR_PROTOCOL_VERSION_NAME_LEN {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::ValidatorError(
@@ -781,10 +769,9 @@ impl ValidatorBlueprint {
         Ok(())
     }
 
-    pub fn get_protocol_update_readiness<Y>(api: &mut Y) -> Result<Option<String>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn get_protocol_update_readiness<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Option<String>, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::ProtocolUpdateReadinessSignal.into(),
@@ -798,10 +785,10 @@ impl ValidatorBlueprint {
         Ok(signal.protocol_version_name)
     }
 
-    fn register_update<Y>(new_registered: bool, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn register_update<Y: SystemApi<RuntimeError>>(
+        new_registered: bool,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.field_index(),
@@ -839,15 +826,12 @@ impl ValidatorBlueprint {
         return Ok(());
     }
 
-    fn index_update<Y>(
+    fn index_update<Y: SystemApi<RuntimeError>>(
         validator: &ValidatorSubstate,
         new_registered: bool,
         new_stake_amount: Decimal,
         api: &mut Y,
-    ) -> Result<Option<SortedKey>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Option<SortedKey>, RuntimeError> {
         let validator_address: ComponentAddress =
             ComponentAddress::new_or_panic(api.actor_get_node_id(ACTOR_REF_GLOBAL)?.into());
         let new_sorted_key =
@@ -884,10 +868,10 @@ impl ValidatorBlueprint {
         Ok(new_sorted_key)
     }
 
-    pub fn claim_xrd<Y>(bucket: Bucket, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn claim_xrd<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.field_index(),
@@ -950,10 +934,10 @@ impl ValidatorBlueprint {
         Ok(claimed_bucket)
     }
 
-    pub fn update_key<Y>(key: Secp256k1PublicKey, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn update_key<Y: SystemApi<RuntimeError>>(
+        key: Secp256k1PublicKey,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -984,10 +968,10 @@ impl ValidatorBlueprint {
         Ok(())
     }
 
-    pub fn update_fee<Y>(new_fee_factor: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn update_fee<Y: SystemApi<RuntimeError>>(
+        new_fee_factor: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         // check if new fee is valid
         check_validator_fee_factor(new_fee_factor)?;
 
@@ -1055,10 +1039,9 @@ impl ValidatorBlueprint {
         Ok(())
     }
 
-    pub fn accepts_delegated_stake<Y>(api: &mut Y) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn accepts_delegated_stake<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<bool, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -1073,10 +1056,9 @@ impl ValidatorBlueprint {
         Ok(substate.accepts_delegated_stake)
     }
 
-    pub fn total_stake_xrd_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn total_stake_xrd_amount<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -1093,10 +1075,9 @@ impl ValidatorBlueprint {
         Ok(stake_amount)
     }
 
-    pub fn total_stake_unit_supply<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn total_stake_unit_supply<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -1113,13 +1094,10 @@ impl ValidatorBlueprint {
         Ok(total_stake_unit_supply)
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         amount_of_stake_units: Decimal,
         api: &mut Y,
-    ) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Decimal, RuntimeError> {
         if amount_of_stake_units.is_negative() || amount_of_stake_units.is_zero() {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::ValidatorError(ValidatorError::InvalidGetRedemptionAmount),
@@ -1152,13 +1130,10 @@ impl ValidatorBlueprint {
         Ok(redemption_value)
     }
 
-    pub fn update_accept_delegated_stake<Y>(
+    pub fn update_accept_delegated_stake<Y: SystemApi<RuntimeError>>(
         accept_delegated_stake: bool,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -1187,13 +1162,10 @@ impl ValidatorBlueprint {
     /// Locks the given stake units in an internal "delayed withdrawal" vault (which is the owner's
     /// way of showing their commitment to running this validator in an orderly fashion - see
     /// [`ValidatorSubstate.locked_owner_stake_unit_vault_id`]).
-    pub fn lock_owner_stake_units<Y>(
+    pub fn lock_owner_stake_units<Y: SystemApi<RuntimeError>>(
         stake_unit_bucket: Bucket,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.into(),
@@ -1213,13 +1185,10 @@ impl ValidatorBlueprint {
     /// The requested amount of stake units (if available) will be ready for withdrawal after the
     /// network-configured [`ConsensusManagerConfigSubstate.num_owner_stake_units_unlock_epochs`] via a
     /// call to [`finish_unlock_owner_stake_units()`].
-    pub fn start_unlock_owner_stake_units<Y>(
+    pub fn start_unlock_owner_stake_units<Y: SystemApi<RuntimeError>>(
         requested_stake_unit_amount: Decimal,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         // read the current epoch (needed for a drive-by "finish unlocking" of available withdrawals)
         let consensus_manager_handle = api.actor_open_field(
             ACTOR_STATE_OUTER_OBJECT,
@@ -1294,10 +1263,9 @@ impl ValidatorBlueprint {
     /// Finishes the process of unlocking the owner's stake units by withdrawing *all* the pending
     /// amounts which have reached their target epoch and thus are already available (potentially
     /// none).
-    pub fn finish_unlock_owner_stake_units<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn finish_unlock_owner_stake_units<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         // read the current epoch
         let consensus_manager_handle = api.actor_open_field(
             ACTOR_STATE_OUTER_OBJECT,
@@ -1377,16 +1345,13 @@ impl ValidatorBlueprint {
     /// value of all its stake units.
     /// Note: the validator's proposal statistics passed to this method are used only for creating
     /// an event (i.e. they are only informational and they do not drive any logic at this point).
-    pub fn apply_emission<Y>(
+    pub fn apply_emission<Y: SystemApi<RuntimeError>>(
         xrd_bucket: Bucket,
         concluded_epoch: Epoch,
         proposals_made: u64,
         proposals_missed: u64,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         // begin the read+modify+write of the validator substate...
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -1474,14 +1439,11 @@ impl ValidatorBlueprint {
         Ok(())
     }
 
-    pub fn apply_reward<Y>(
+    pub fn apply_reward<Y: SystemApi<RuntimeError>>(
         xrd_bucket: Bucket,
         concluded_epoch: Epoch,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         // begin the read+modify+write of the validator substate...
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -1554,10 +1516,10 @@ impl ValidatorBlueprint {
         }
     }
 
-    fn update_validator<Y>(update: UpdateSecondaryIndex, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn update_validator<Y: SystemApi<RuntimeError>>(
+        update: UpdateSecondaryIndex,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         match update {
             UpdateSecondaryIndex::Create {
                 index_key,
@@ -1725,13 +1687,10 @@ impl SecurifiedRoleAssignment for SecurifiedValidator {
 pub(crate) struct ValidatorCreator;
 
 impl ValidatorCreator {
-    fn create_stake_unit_resource<Y>(
+    fn create_stake_unit_resource<Y: SystemApi<RuntimeError>>(
         validator_address: GlobalAddress,
         api: &mut Y,
-    ) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<ResourceAddress, RuntimeError> {
         let stake_unit_resman = ResourceManager::new_fungible(
             OwnerRole::Fixed(rule!(require(global_caller(validator_address)))),
             true,
@@ -1761,13 +1720,10 @@ impl ValidatorCreator {
         Ok(stake_unit_resman.0)
     }
 
-    fn create_claim_nft<Y>(
+    fn create_claim_nft<Y: SystemApi<RuntimeError>>(
         validator_address: GlobalAddress,
         api: &mut Y,
-    ) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<ResourceAddress, RuntimeError> {
         let unstake_resman = ResourceManager::new_non_fungible::<UnstakeData, Y, RuntimeError, _>(
             OwnerRole::Fixed(rule!(require(global_caller(validator_address)))),
             NonFungibleIdType::RUID,
@@ -1797,15 +1753,12 @@ impl ValidatorCreator {
         Ok(unstake_resman.0)
     }
 
-    pub fn create<Y>(
+    pub fn create<Y: SystemApi<RuntimeError>>(
         key: Secp256k1PublicKey,
         is_registered: bool,
         fee_factor: Decimal,
         api: &mut Y,
-    ) -> Result<(ComponentAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(ComponentAddress, Bucket), RuntimeError> {
         // check if validator fee is valid
         check_validator_fee_factor(fee_factor)?;
 

--- a/radix-engine/src/blueprints/identity/package.rs
+++ b/radix-engine/src/blueprints/identity/package.rs
@@ -124,14 +124,11 @@ impl IdentityNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             IDENTITY_CREATE_ADVANCED_IDENT => {
                 let input: IdentityCreateAdvancedInput = input.as_typed().map_err(|e| {
@@ -191,13 +188,10 @@ impl PresecurifiedRoleAssignment for SecurifiedIdentity {}
 pub struct IdentityBlueprint;
 
 impl IdentityBlueprint {
-    pub fn create_advanced<Y>(
+    pub fn create_advanced<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         api: &mut Y,
-    ) -> Result<GlobalAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<GlobalAddress, RuntimeError> {
         let role_assignment = SecurifiedIdentity::create_advanced(owner_role, api)?;
 
         let (node_id, modules) = Self::create_object(
@@ -212,10 +206,9 @@ impl IdentityBlueprint {
         Ok(address)
     }
 
-    pub fn create<Y>(api: &mut Y) -> Result<(GlobalAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn create<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<(GlobalAddress, Bucket), RuntimeError> {
         let (address_reservation, address) = api.allocate_global_address(BlueprintId {
             package_address: IDENTITY_PACKAGE,
             blueprint_name: IDENTITY_BLUEPRINT.to_string(),
@@ -241,13 +234,10 @@ impl IdentityBlueprint {
         Ok((address, bucket))
     }
 
-    pub fn on_virtualize<Y>(
+    pub fn on_virtualize<Y: SystemApi<RuntimeError>>(
         input: OnVirtualizeInput,
         api: &mut Y,
-    ) -> Result<OnVirtualizeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OnVirtualizeOutput, RuntimeError> {
         match input.variant_id {
             IDENTITY_CREATE_PREALLOCATED_SECP256K1_ID => {
                 let public_key_hash = PublicKeyHash::Secp256k1(Secp256k1PublicKeyHash(input.rid));
@@ -263,14 +253,11 @@ impl IdentityBlueprint {
         }
     }
 
-    fn create_virtual<Y>(
+    fn create_virtual<Y: SystemApi<RuntimeError>>(
         public_key_hash: PublicKeyHash,
         address_reservation: GlobalAddressReservation,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let owner_badge = {
             let bytes = public_key_hash.get_hash_bytes();
             let entity_type = match public_key_hash {
@@ -310,10 +297,7 @@ impl IdentityBlueprint {
         Ok(())
     }
 
-    fn securify<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn securify<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Bucket, RuntimeError> {
         let receiver = Runtime::get_node_id(api)?;
         let owner_badge_data = IdentityOwnerBadgeData {
             name: "Identity Owner Badge".into(),
@@ -327,14 +311,11 @@ impl IdentityBlueprint {
         )
     }
 
-    fn create_object<Y>(
+    fn create_object<Y: SystemApi<RuntimeError>>(
         role_assignment: RoleAssignment,
         metadata_init: MetadataInit,
         api: &mut Y,
-    ) -> Result<(NodeId, IndexMap<AttachedModuleId, Own>), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(NodeId, IndexMap<AttachedModuleId, Own>), RuntimeError> {
         let metadata = Metadata::create_with_data(metadata_init, api)?;
         let royalty = ComponentRoyalty::create(ComponentRoyaltyConfig::default(), api)?;
 

--- a/radix-engine/src/blueprints/locker/blueprint.rs
+++ b/radix-engine/src/blueprints/locker/blueprint.rs
@@ -93,14 +93,11 @@ impl AccountLockerBlueprint {
         }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         dispatch! {
             EXPORT_NAME,
             export_name,
@@ -122,7 +119,7 @@ impl AccountLockerBlueprint {
         }
     }
 
-    fn instantiate<Y>(
+    fn instantiate<Y: SystemApi<RuntimeError>>(
         AccountLockerInstantiateInput {
             owner_role,
             storer_role,
@@ -132,10 +129,7 @@ impl AccountLockerBlueprint {
             address_reservation,
         }: AccountLockerInstantiateInput,
         api: &mut Y,
-    ) -> Result<AccountLockerInstantiateOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerInstantiateOutput, RuntimeError> {
         Self::instantiate_internal(
             owner_role,
             storer_role,
@@ -150,13 +144,10 @@ impl AccountLockerBlueprint {
         )
     }
 
-    fn instantiate_simple<Y>(
+    fn instantiate_simple<Y: SystemApi<RuntimeError>>(
         AccountLockerInstantiateSimpleInput { allow_recover }: AccountLockerInstantiateSimpleInput,
         api: &mut Y,
-    ) -> Result<AccountLockerInstantiateSimpleOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerInstantiateSimpleOutput, RuntimeError> {
         // Two address reservations are needed. One for the badge and another for the account locker
         // that we're instantiating.
         let (locker_reservation, locker_address) = api.allocate_global_address(BlueprintId {
@@ -216,7 +207,7 @@ impl AccountLockerBlueprint {
         .map(|rtn| (rtn, badge))
     }
 
-    fn instantiate_internal<Y>(
+    fn instantiate_internal<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         storer_role: AccessRule,
         storer_updater_role: AccessRule,
@@ -225,10 +216,7 @@ impl AccountLockerBlueprint {
         metadata_init: MetadataInit,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<Global<AccountLockerMarker>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Global<AccountLockerMarker>, RuntimeError> {
         // Main module
         let object_id = api.new_simple_object(ACCOUNT_LOCKER_BLUEPRINT, indexmap! {})?;
 
@@ -260,17 +248,14 @@ impl AccountLockerBlueprint {
         Ok(Global::new(component_address))
     }
 
-    fn store<Y>(
+    fn store<Y: SystemApi<RuntimeError>>(
         AccountLockerStoreInput {
             claimant,
             bucket,
             try_direct_send,
         }: AccountLockerStoreInput,
         api: &mut Y,
-    ) -> Result<AccountLockerStoreOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerStoreOutput, RuntimeError> {
         // If we should try to send first then attempt the deposit into the account
         let bucket = if try_direct_send {
             // Getting the node-id of the actor and constructing the non-fungible global id of the
@@ -325,17 +310,14 @@ impl AccountLockerBlueprint {
         Ok(())
     }
 
-    fn airdrop<Y>(
+    fn airdrop<Y: SystemApi<RuntimeError>>(
         AccountLockerAirdropInput {
             claimants,
             bucket,
             try_direct_send,
         }: AccountLockerAirdropInput,
         api: &mut Y,
-    ) -> Result<AccountLockerAirdropOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerAirdropOutput, RuntimeError> {
         // Distribute and call `store`
         let resource_address = bucket.resource_address(api)?;
         for (account_address, specifier) in claimants.iter() {
@@ -364,17 +346,14 @@ impl AccountLockerBlueprint {
         }
     }
 
-    fn recover<Y>(
+    fn recover<Y: SystemApi<RuntimeError>>(
         AccountLockerRecoverInput {
             claimant,
             resource_address,
             amount,
         }: AccountLockerRecoverInput,
         api: &mut Y,
-    ) -> Result<AccountLockerRecoverOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerRecoverOutput, RuntimeError> {
         // Recover the resources from the vault.
         let bucket = Self::with_vault_create_on_traversal(
             claimant.0,
@@ -398,17 +377,14 @@ impl AccountLockerBlueprint {
         Ok(bucket)
     }
 
-    fn recover_non_fungibles<Y>(
+    fn recover_non_fungibles<Y: SystemApi<RuntimeError>>(
         AccountLockerRecoverNonFungiblesInput {
             claimant,
             resource_address,
             ids,
         }: AccountLockerRecoverNonFungiblesInput,
         api: &mut Y,
-    ) -> Result<AccountLockerRecoverNonFungiblesOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerRecoverNonFungiblesOutput, RuntimeError> {
         // Recover the resources from the vault.
         let bucket = Self::with_vault_create_on_traversal(
             claimant.0,
@@ -432,17 +408,14 @@ impl AccountLockerBlueprint {
         Ok(bucket)
     }
 
-    fn claim<Y>(
+    fn claim<Y: SystemApi<RuntimeError>>(
         AccountLockerClaimInput {
             claimant,
             resource_address,
             amount,
         }: AccountLockerClaimInput,
         api: &mut Y,
-    ) -> Result<AccountLockerClaimOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerClaimOutput, RuntimeError> {
         // Read and assert against the owner role of the claimant.
         let claimant_owner_role = api
             .call_module_method(
@@ -477,17 +450,14 @@ impl AccountLockerBlueprint {
         Ok(bucket)
     }
 
-    fn claim_non_fungibles<Y>(
+    fn claim_non_fungibles<Y: SystemApi<RuntimeError>>(
         AccountLockerClaimNonFungiblesInput {
             claimant,
             resource_address,
             ids,
         }: AccountLockerClaimNonFungiblesInput,
         api: &mut Y,
-    ) -> Result<AccountLockerClaimNonFungiblesOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerClaimNonFungiblesOutput, RuntimeError> {
         // Read and assert against the owner role of the claimant.
         let claimant_owner_role = api
             .call_module_method(
@@ -522,16 +492,13 @@ impl AccountLockerBlueprint {
         Ok(bucket)
     }
 
-    fn get_amount<Y>(
+    fn get_amount<Y: SystemApi<RuntimeError>>(
         AccountLockerGetAmountInput {
             claimant,
             resource_address,
         }: AccountLockerGetAmountInput,
         api: &mut Y,
-    ) -> Result<AccountLockerGetAmountOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerGetAmountOutput, RuntimeError> {
         Self::with_vault(claimant.0, resource_address, api, |vault, api| {
             vault
                 .map(|vault| vault.amount(api))
@@ -539,17 +506,14 @@ impl AccountLockerBlueprint {
         })
     }
 
-    fn get_non_fungible_local_ids<Y>(
+    fn get_non_fungible_local_ids<Y: SystemApi<RuntimeError>>(
         AccountLockerGetNonFungibleLocalIdsInput {
             claimant,
             resource_address,
             limit,
         }: AccountLockerGetNonFungibleLocalIdsInput,
         api: &mut Y,
-    ) -> Result<AccountLockerGetNonFungibleLocalIdsOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<AccountLockerGetNonFungibleLocalIdsOutput, RuntimeError> {
         Self::with_vault(claimant.0, resource_address, api, |vault, api| {
             vault
                 .map(|vault| vault.non_fungible_local_ids(limit, api))
@@ -557,16 +521,12 @@ impl AccountLockerBlueprint {
         })
     }
 
-    fn with_vault_create_on_traversal<Y, F, O>(
+    fn with_vault_create_on_traversal<Y: SystemApi<RuntimeError>, O>(
         account_address: ComponentAddress,
         resource_address: ResourceAddress,
         api: &mut Y,
-        handler: F,
-    ) -> Result<O, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        F: FnOnce(Vault, &mut Y) -> Result<O, RuntimeError>,
-    {
+        handler: impl FnOnce(Vault, &mut Y) -> Result<O, RuntimeError>,
+    ) -> Result<O, RuntimeError> {
         // The collection on the blueprint maps an account address to a key value store. We read the
         // node id of that key value store.
         let account_claims_handle = api.actor_open_key_value_entry(
@@ -636,16 +596,12 @@ impl AccountLockerBlueprint {
         Ok(rtn)
     }
 
-    fn with_vault<Y, F, O>(
+    fn with_vault<Y: SystemApi<RuntimeError>, O>(
         account_address: ComponentAddress,
         resource_address: ResourceAddress,
         api: &mut Y,
-        handler: F,
-    ) -> Result<O, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        F: FnOnce(Option<Vault>, &mut Y) -> Result<O, RuntimeError>,
-    {
+        handler: impl FnOnce(Option<Vault>, &mut Y) -> Result<O, RuntimeError>,
+    ) -> Result<O, RuntimeError> {
         // The collection on the blueprint maps an account address to a key value store. We read the
         // node id of that key value store.
         let account_claims_handle = api.actor_open_key_value_entry(
@@ -696,13 +652,10 @@ impl AccountLockerBlueprint {
     }
 }
 
-fn bucket_to_resource_specifier<Y>(
+fn bucket_to_resource_specifier<Y: SystemApi<RuntimeError>>(
     bucket: &Bucket,
     api: &mut Y,
-) -> Result<(ResourceAddress, ResourceSpecifier), RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<(ResourceAddress, ResourceSpecifier), RuntimeError> {
     let resource_address = bucket.resource_address(api)?;
     if resource_address.is_fungible() {
         let amount = bucket.amount(api)?;

--- a/radix-engine/src/blueprints/locker/package.rs
+++ b/radix-engine/src/blueprints/locker/package.rs
@@ -15,14 +15,11 @@ impl LockerNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         // Delegated to the blueprint's dispatcher since it's the only blueprint in the package. If
         // we add more then we need to control the dispatch here.
         AccountLockerBlueprint::invoke_export(export_name, input, api)

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -374,10 +374,10 @@ fn validate_type_schemas<'a, I: Iterator<Item = &'a BlueprintDefinitionInit>>(
     Ok(())
 }
 
-fn validate_royalties<Y>(definition: &PackageDefinition, api: &mut Y) -> Result<(), RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+fn validate_royalties<Y: SystemApi<RuntimeError>>(
+    definition: &PackageDefinition,
+    api: &mut Y,
+) -> Result<(), RuntimeError> {
     for (blueprint, definition_init) in &definition.blueprints {
         match &definition_init.royalty_config {
             PackageRoyaltyConfig::Disabled => {}
@@ -790,16 +790,13 @@ pub fn create_package_partition_substates(
     node_substates
 }
 
-fn globalize_package<Y>(
+fn globalize_package<Y: SystemApi<RuntimeError>>(
     package_address_reservation: Option<GlobalAddressReservation>,
     package_structure: PackageStructure,
     metadata: Own,
     role_assignment: RoleAssignment,
     api: &mut Y,
-) -> Result<PackageAddress, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<PackageAddress, RuntimeError> {
     let vault = Vault(ResourceManager(XRD).new_empty_vault(api)?);
 
     let (fields, kv_entries) =
@@ -945,17 +942,13 @@ impl PackageNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y, V>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>, V: VmApi>(
         export_name: &str,
         input: &IndexedScryptoValue,
         version: PackageV1MinorVersion,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let restrict_reserved_key = match version {
             PackageV1MinorVersion::Zero => false,
             PackageV1MinorVersion::One => true,
@@ -1361,7 +1354,7 @@ impl PackageNativePackage {
         Ok(package_structure)
     }
 
-    pub(crate) fn publish_native<Y, V>(
+    pub(crate) fn publish_native<Y: SystemApi<RuntimeError>, V: VmApi>(
         package_address: Option<GlobalAddressReservation>,
         native_package_code_id: u64,
         definition: PackageDefinition,
@@ -1369,11 +1362,7 @@ impl PackageNativePackage {
         restrict_reserved_key: bool,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<PackageAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        V: VmApi,
-    {
+    ) -> Result<PackageAddress, RuntimeError> {
         validate_royalties(&definition, api)?;
         let package_structure = Self::validate_and_build_package_structure(
             definition,
@@ -1395,18 +1384,14 @@ impl PackageNativePackage {
         )
     }
 
-    pub(crate) fn publish_wasm<Y, V>(
+    pub(crate) fn publish_wasm<Y: SystemApi<RuntimeError>, V: VmApi>(
         code: Vec<u8>,
         definition: PackageDefinition,
         metadata_init: MetadataInit,
         restrict_reserved_key: bool,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<(PackageAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        V: VmApi,
-    {
+    ) -> Result<(PackageAddress, Bucket), RuntimeError> {
         validate_royalties(&definition, api)?;
 
         let package_structure = Self::validate_and_build_package_structure(
@@ -1444,7 +1429,7 @@ impl PackageNativePackage {
         Ok((address, bucket))
     }
 
-    pub(crate) fn publish_wasm_advanced<Y, V>(
+    pub(crate) fn publish_wasm_advanced<Y: SystemApi<RuntimeError>, V: VmApi>(
         package_address: Option<GlobalAddressReservation>,
         code: Vec<u8>,
         definition: PackageDefinition,
@@ -1453,11 +1438,7 @@ impl PackageNativePackage {
         restrict_reserved_key: bool,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<PackageAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        V: VmApi,
-    {
+    ) -> Result<PackageAddress, RuntimeError> {
         validate_royalties(&definition, api)?;
         let package_structure = Self::validate_and_build_package_structure(
             definition,
@@ -1483,16 +1464,12 @@ impl PackageNativePackage {
 pub struct PackageRoyaltyNativeBlueprint;
 
 impl PackageRoyaltyNativeBlueprint {
-    pub fn charge_package_royalty<Y, V>(
+    pub fn charge_package_royalty<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         ident: &str,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         {
             let mut service = SystemService::new(api);
             if !service.is_feature_enabled(
@@ -1567,10 +1544,9 @@ impl PackageRoyaltyNativeBlueprint {
         Ok(())
     }
 
-    pub(crate) fn claim_royalties<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn claim_royalties<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             PackageFeature::PackageRoyalty.feature_name(),
@@ -1599,16 +1575,15 @@ impl PackageRoyaltyNativeBlueprint {
 pub struct PackageAuthNativeBlueprint;
 
 impl PackageAuthNativeBlueprint {
-    pub fn resolve_function_permission<Y, V>(
+    pub fn resolve_function_permission<
+        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V>>,
+        V: SystemCallbackObject,
+    >(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         ident: &str,
         api: &mut Y,
-    ) -> Result<ResolvedPermission, RuntimeError>
-    where
-        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V>>,
-        V: SystemCallbackObject,
-    {
+    ) -> Result<ResolvedPermission, RuntimeError> {
         let auth_config = Self::get_bp_auth_template(receiver, bp_version_key, api)?;
         match auth_config.function_auth {
             FunctionAuth::AllowAll => Ok(ResolvedPermission::AllowAll),

--- a/radix-engine/src/blueprints/pool/v1/package.rs
+++ b/radix-engine/src/blueprints/pool/v1/package.rs
@@ -5,8 +5,6 @@ use super::substates::multi_resource_pool::*;
 use super::substates::one_resource_pool::*;
 use super::substates::two_resource_pool::*;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::*;
-use crate::system::system_callback::*;
 use crate::*;
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::blueprints::pool::*;
@@ -21,15 +19,12 @@ pub enum PoolV1MinorVersion {
 
 pub struct PoolNativePackage;
 impl PoolNativePackage {
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         minor_version: PoolV1MinorVersion,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             ONE_RESOURCE_POOL_INSTANTIATE_EXPORT_NAME => {
                 let OneResourcePoolInstantiateInput {

--- a/radix-engine/src/blueprints/pool/v1/v1_0/multi_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_0/multi_resource_pool_blueprint.rs
@@ -3,7 +3,6 @@ use crate::blueprints::pool::v1::errors::multi_resource_pool::*;
 use crate::blueprints::pool::v1::events::multi_resource_pool::*;
 use crate::blueprints::pool::v1::substates::multi_resource_pool::*;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::*;
 use radix_engine_interface::blueprints::component::*;
 use radix_engine_interface::blueprints::pool::*;
 use radix_engine_interface::prelude::*;
@@ -16,16 +15,13 @@ use radix_native_sdk::runtime::*;
 
 pub struct MultiResourcePoolBlueprint;
 impl MultiResourcePoolBlueprint {
-    pub fn instantiate<Y>(
+    pub fn instantiate<Y: SystemApi<RuntimeError>>(
         resource_addresses: IndexSet<ResourceAddress>,
         owner_role: OwnerRole,
         pool_manager_rule: AccessRule,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolInstantiateOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi,
-    {
+    ) -> Result<MultiResourcePoolInstantiateOutput, RuntimeError> {
         // A pool can't be created where one of the resources is non-fungible - error out if any of
         // them are
         for resource_address in resource_addresses.iter() {
@@ -199,13 +195,10 @@ impl MultiResourcePoolBlueprint {
     | k<sub>min</sub> |      |      | 1.33 |                                  |
     | ca              | 1333 | 2666 | 4000 | Amount of contribution to accept |
     */
-    pub fn contribute<Y>(
+    pub fn contribute<Y: SystemApi<RuntimeError>>(
         buckets: Vec<Bucket>,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolContributeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolContributeOutput, RuntimeError> {
         let (mut substate, lock_handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
         // Checks
@@ -415,13 +408,10 @@ impl MultiResourcePoolBlueprint {
         Ok((pool_units, change))
     }
 
-    pub fn redeem<Y>(
+    pub fn redeem<Y: SystemApi<RuntimeError>>(
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolRedeemOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolRedeemOutput, RuntimeError> {
         let (mut substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
         // Ensure that the passed pool resources are indeed pool resources
@@ -488,13 +478,10 @@ impl MultiResourcePoolBlueprint {
         Ok(buckets)
     }
 
-    pub fn protected_deposit<Y>(
+    pub fn protected_deposit<Y: SystemApi<RuntimeError>>(
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolProtectedDepositOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolProtectedDepositOutput, RuntimeError> {
         let (mut substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
         let resource_address = bucket.resource_address(api)?;
         let vault = substate.vaults.get_mut(&resource_address);
@@ -512,15 +499,12 @@ impl MultiResourcePoolBlueprint {
         }
     }
 
-    pub fn protected_withdraw<Y>(
+    pub fn protected_withdraw<Y: SystemApi<RuntimeError>>(
         resource_address: ResourceAddress,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolProtectedWithdrawOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolProtectedWithdrawOutput, RuntimeError> {
         let (mut substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
         let vault = substate.vaults.get_mut(&resource_address);
 
@@ -543,13 +527,10 @@ impl MultiResourcePoolBlueprint {
         }
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         amount_of_pool_units: Decimal,
         api: &mut Y,
-    ) -> Result<MultiResourcePoolGetRedemptionValueOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolGetRedemptionValueOutput, RuntimeError> {
         let (substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
         let pool_units_to_redeem = amount_of_pool_units;
@@ -594,12 +575,9 @@ impl MultiResourcePoolBlueprint {
         Ok(amounts_owed)
     }
 
-    pub fn get_vault_amounts<Y>(
+    pub fn get_vault_amounts<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
-    ) -> Result<MultiResourcePoolGetVaultAmountsOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<MultiResourcePoolGetVaultAmountsOutput, RuntimeError> {
         let (multi_resource_pool_substate, handle) =
             Self::lock_and_read(api, LockFlags::read_only())?;
         let amounts = multi_resource_pool_substate
@@ -618,13 +596,10 @@ impl MultiResourcePoolBlueprint {
     // Utility Functions
     //===================
 
-    fn lock_and_read<Y>(
+    fn lock_and_read<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
         lock_flags: LockFlags,
-    ) -> Result<(Substate, SubstateHandle), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(Substate, SubstateHandle), RuntimeError> {
         let substate_key = MultiResourcePoolField::State.into();
         let handle = api.actor_open_field(ACTOR_STATE_SELF, substate_key, lock_flags)?;
         let multi_resource_pool: VersionedMultiResourcePoolState = api.field_read_typed(handle)?;

--- a/radix-engine/src/blueprints/pool/v1/v1_0/one_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_0/one_resource_pool_blueprint.rs
@@ -3,7 +3,6 @@ use crate::blueprints::pool::v1::errors::one_resource_pool::*;
 use crate::blueprints::pool::v1::events::one_resource_pool::*;
 use crate::blueprints::pool::v1::substates::one_resource_pool::*;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::*;
 use radix_engine_interface::blueprints::component::*;
 use radix_engine_interface::blueprints::pool::*;
 use radix_engine_interface::prelude::*;
@@ -16,16 +15,13 @@ use radix_native_sdk::runtime::*;
 
 pub struct OneResourcePoolBlueprint;
 impl OneResourcePoolBlueprint {
-    pub fn instantiate<Y>(
+    pub fn instantiate<Y: SystemApi<RuntimeError>>(
         resource_address: ResourceAddress,
         owner_role: OwnerRole,
         pool_manager_rule: AccessRule,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<OneResourcePoolInstantiateOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi,
-    {
+    ) -> Result<OneResourcePoolInstantiateOutput, RuntimeError> {
         // Validate that the resource is a fungible resource - a pool can't be created with non
         // fungible resources.
         let resource_manager = ResourceManager(resource_address);
@@ -121,13 +117,10 @@ impl OneResourcePoolBlueprint {
         )))
     }
 
-    pub fn contribute<Y>(
+    pub fn contribute<Y: SystemApi<RuntimeError>>(
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<OneResourcePoolContributeOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolContributeOutput, RuntimeError> {
         // No check that the bucket is of the same resource as the vault. This check will be handled
         // by the vault itself on deposit.
 
@@ -197,13 +190,10 @@ impl OneResourcePoolBlueprint {
         Ok(pool_units)
     }
 
-    pub fn redeem<Y>(
+    pub fn redeem<Y: SystemApi<RuntimeError>>(
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<OneResourcePoolRedeemOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolRedeemOutput, RuntimeError> {
         let (pool_unit_resource_manager, mut vault, handle) = {
             let (substate, lock_handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
@@ -265,13 +255,10 @@ impl OneResourcePoolBlueprint {
         Ok(owed_resources)
     }
 
-    pub fn protected_deposit<Y>(
+    pub fn protected_deposit<Y: SystemApi<RuntimeError>>(
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<OneResourcePoolProtectedDepositOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolProtectedDepositOutput, RuntimeError> {
         let (mut substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
         let event = DepositEvent {
@@ -286,14 +273,11 @@ impl OneResourcePoolBlueprint {
         Ok(())
     }
 
-    pub fn protected_withdraw<Y>(
+    pub fn protected_withdraw<Y: SystemApi<RuntimeError>>(
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<OneResourcePoolProtectedWithdrawOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolProtectedWithdrawOutput, RuntimeError> {
         let (mut substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
         let bucket = substate
@@ -312,13 +296,10 @@ impl OneResourcePoolBlueprint {
         Ok(bucket)
     }
 
-    pub fn get_redemption_value<Y>(
+    pub fn get_redemption_value<Y: SystemApi<RuntimeError>>(
         amount_of_pool_units: Decimal,
         api: &mut Y,
-    ) -> Result<OneResourcePoolGetRedemptionValueOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolGetRedemptionValueOutput, RuntimeError> {
         let (pool_unit_resource_manager, vault, handle) = {
             let (substate, lock_handle) = Self::lock_and_read(api, LockFlags::read_only())?;
 
@@ -365,12 +346,9 @@ impl OneResourcePoolBlueprint {
         Ok(amount_owed)
     }
 
-    pub fn get_vault_amount<Y>(
+    pub fn get_vault_amount<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
-    ) -> Result<OneResourcePoolGetVaultAmountOutput, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<OneResourcePoolGetVaultAmountOutput, RuntimeError> {
         let (substate, handle) = Self::lock_and_read(api, LockFlags::read_only())?;
         let amount = substate.vault.amount(api)?;
         api.field_close(handle)?;
@@ -403,13 +381,10 @@ impl OneResourcePoolBlueprint {
         Ok(amount_owed)
     }
 
-    fn lock_and_read<Y>(
+    fn lock_and_read<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
         lock_flags: LockFlags,
-    ) -> Result<(Substate, SubstateHandle), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(Substate, SubstateHandle), RuntimeError> {
         let substate_key = OneResourcePoolField::State.into();
         let handle = api.actor_open_field(ACTOR_STATE_SELF, substate_key, lock_flags)?;
         let substate = api

--- a/radix-engine/src/blueprints/resource/auth_zone/blueprint.rs
+++ b/radix-engine/src/blueprints/resource/auth_zone/blueprint.rs
@@ -21,10 +21,7 @@ pub enum AuthZoneError {
 pub struct AuthZoneBlueprint;
 
 impl AuthZoneBlueprint {
-    pub fn pop<Y>(api: &mut Y) -> Result<Option<Proof>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn pop<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Option<Proof>, RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -38,10 +35,7 @@ impl AuthZoneBlueprint {
         Ok(maybe_proof)
     }
 
-    pub fn push<Y>(proof: Proof, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn push<Y: SystemApi<RuntimeError>>(proof: Proof, api: &mut Y) -> Result<(), RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -57,14 +51,13 @@ impl AuthZoneBlueprint {
         Ok(())
     }
 
-    pub fn create_proof_of_amount<Y>(
+    pub fn create_proof_of_amount<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+    >(
         resource_address: ResourceAddress,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Proof, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<Proof, RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -125,14 +118,13 @@ impl AuthZoneBlueprint {
         Ok(Proof(Own(node_id)))
     }
 
-    pub fn create_proof_of_non_fungibles<Y>(
+    pub fn create_proof_of_non_fungibles<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+    >(
         resource_address: ResourceAddress,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<Proof, RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -169,13 +161,12 @@ impl AuthZoneBlueprint {
         Ok(Proof(Own(node_id)))
     }
 
-    pub fn create_proof_of_all<Y>(
+    pub fn create_proof_of_all<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+    >(
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<Proof, RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -216,19 +207,15 @@ impl AuthZoneBlueprint {
         Ok(Proof(Own(node_id)))
     }
 
-    pub fn drop_proofs<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn drop_proofs<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         Self::drop_signature_proofs(api)?;
         Self::drop_regular_proofs(api)?;
         Ok(())
     }
 
-    pub fn drop_signature_proofs<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn drop_signature_proofs<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -242,10 +229,9 @@ impl AuthZoneBlueprint {
         Ok(())
     }
 
-    pub fn drop_regular_proofs<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn drop_regular_proofs<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -263,10 +249,7 @@ impl AuthZoneBlueprint {
         Ok(())
     }
 
-    pub fn drain<Y>(api: &mut Y) -> Result<Vec<Proof>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn drain<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Vec<Proof>, RuntimeError> {
         let auth_zone_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             AuthZoneField::AuthZone.into(),
@@ -280,13 +263,10 @@ impl AuthZoneBlueprint {
         Ok(proofs)
     }
 
-    pub fn assert_access_rule<Y, L: Default>(
+    pub fn assert_access_rule<Y: SystemApi<RuntimeError> + KernelSubstateApi<L>, L: Default>(
         access_rule: AccessRule,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelSubstateApi<L> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let node_id = api.actor_get_node_id(ACTOR_REF_SELF)?;
         let auth_result =
             Authorization::check_authorization_against_access_rule(api, &node_id, &access_rule)?;

--- a/radix-engine/src/blueprints/resource/bucket_common.rs
+++ b/radix-engine/src/blueprints/resource/bucket_common.rs
@@ -53,13 +53,10 @@ impl From<BucketError> for RuntimeError {
     }
 }
 
-pub fn drop_fungible_bucket<Y>(
+pub fn drop_fungible_bucket<Y: SystemApi<RuntimeError>>(
     bucket_node_id: &NodeId,
     api: &mut Y,
-) -> Result<DroppedFungibleBucket, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<DroppedFungibleBucket, RuntimeError> {
     let fields = api.drop_object(bucket_node_id)?;
     let bucket: DroppedFungibleBucket = fields.into();
     if bucket.locked.is_locked() {
@@ -71,13 +68,10 @@ where
     Ok(bucket)
 }
 
-pub fn drop_non_fungible_bucket<Y>(
+pub fn drop_non_fungible_bucket<Y: SystemApi<RuntimeError>>(
     bucket_node_id: &NodeId,
     api: &mut Y,
-) -> Result<DroppedNonFungibleBucket, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<DroppedNonFungibleBucket, RuntimeError> {
     let fields = api.drop_object(bucket_node_id)?;
     let bucket: DroppedNonFungibleBucket = fields.into();
     if bucket.locked.is_locked() {

--- a/radix-engine/src/blueprints/resource/fungible/fungible_bucket.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_bucket.rs
@@ -13,10 +13,7 @@ pub struct FungibleBucket;
 pub struct FungibleBucketBlueprint;
 
 impl FungibleBucketBlueprint {
-    fn get_divisibility<Y>(api: &mut Y) -> Result<u8, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn get_divisibility<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<u8, RuntimeError> {
         let divisibility_handle = api.actor_open_field(
             ACTOR_STATE_OUTER_OBJECT,
             FungibleResourceManagerField::Divisibility.into(),
@@ -31,21 +28,18 @@ impl FungibleBucketBlueprint {
         Ok(divisibility)
     }
 
-    pub fn take<Y>(amount: Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn take<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::take_advanced(amount, WithdrawStrategy::Exact, api)
     }
 
-    pub fn take_advanced<Y>(
+    pub fn take_advanced<Y: SystemApi<RuntimeError>>(
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         let taken = {
             let divisibility = Self::get_divisibility(api)?;
             // Apply withdraw strategy
@@ -69,10 +63,10 @@ impl FungibleBucketBlueprint {
         Ok(bucket)
     }
 
-    pub fn put<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn put<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         // This will fail if bucket is not an inner object of the current fungible resource
         let other_bucket = drop_fungible_bucket(bucket.0.as_node_id(), api)?;
         let resource = other_bucket.liquid;
@@ -91,10 +85,7 @@ impl FungibleBucketBlueprint {
         Ok(())
     }
 
-    pub fn get_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn get_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         Self::liquid_amount(api)?
             .checked_add(Self::locked_amount(api)?)
             .ok_or(RuntimeError::ApplicationError(
@@ -102,20 +93,19 @@ impl FungibleBucketBlueprint {
             ))
     }
 
-    pub fn get_resource_address<Y>(api: &mut Y) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn get_resource_address<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<ResourceAddress, RuntimeError> {
         let resource_address =
             ResourceAddress::new_or_panic(api.actor_get_node_id(ACTOR_REF_OUTER)?.into());
 
         Ok(resource_address)
     }
 
-    pub fn create_proof_of_amount<Y>(amount: Decimal, api: &mut Y) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn create_proof_of_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Proof, RuntimeError> {
         let divisibility = Self::get_divisibility(api)?;
         if !check_fungible_amount(&amount, divisibility) {
             return Err(RuntimeError::ApplicationError(
@@ -149,10 +139,9 @@ impl FungibleBucketBlueprint {
         Ok(Proof(Own(proof_id)))
     }
 
-    pub fn create_proof_of_all<Y>(api: &mut Y) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn create_proof_of_all<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Proof, RuntimeError> {
         Self::create_proof_of_amount(Self::get_amount(api)?, api)
     }
 
@@ -160,10 +149,10 @@ impl FungibleBucketBlueprint {
     // Protected method
     //===================
 
-    pub fn lock_amount<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn lock_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleBucketField::Locked.into(),
@@ -191,10 +180,10 @@ impl FungibleBucketBlueprint {
         Ok(())
     }
 
-    pub fn unlock_amount<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unlock_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleBucketField::Locked.into(),
@@ -226,10 +215,7 @@ impl FungibleBucketBlueprint {
     // Helper methods
     //===================
 
-    fn liquid_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn liquid_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleBucketField::Liquid.into(),
@@ -241,10 +227,7 @@ impl FungibleBucketBlueprint {
         Ok(amount)
     }
 
-    fn locked_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn locked_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleBucketField::Locked.into(),
@@ -256,13 +239,10 @@ impl FungibleBucketBlueprint {
         Ok(amount)
     }
 
-    fn internal_take<Y>(
+    fn internal_take<Y: SystemApi<RuntimeError>>(
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<LiquidFungibleResource, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<LiquidFungibleResource, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleBucketField::Liquid.into(),
@@ -279,10 +259,10 @@ impl FungibleBucketBlueprint {
         Ok(taken)
     }
 
-    fn internal_put<Y>(resource: LiquidFungibleResource, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn internal_put<Y: SystemApi<RuntimeError>>(
+        resource: LiquidFungibleResource,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         if resource.is_empty() {
             return Ok(());
         }

--- a/radix-engine/src/blueprints/resource/fungible/fungible_proof.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_proof.rs
@@ -69,10 +69,7 @@ impl FungibleProofSubstate {
 pub struct FungibleProofBlueprint;
 
 impl FungibleProofBlueprint {
-    pub(crate) fn clone<Y>(api: &mut Y) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn clone<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Proof, RuntimeError> {
         let moveable = {
             let handle = api.actor_open_field(
                 ACTOR_STATE_SELF,
@@ -108,10 +105,9 @@ impl FungibleProofBlueprint {
         Ok(Proof(Own(proof_id)))
     }
 
-    pub(crate) fn get_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_amount<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleProofField::ProofRefs.into(),
@@ -123,27 +119,23 @@ impl FungibleProofBlueprint {
         Ok(amount)
     }
 
-    pub(crate) fn get_resource_address<Y>(api: &mut Y) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_resource_address<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<ResourceAddress, RuntimeError> {
         let address = ResourceAddress::new_or_panic(api.actor_get_node_id(ACTOR_REF_OUTER)?.into());
         Ok(address)
     }
 
-    pub(crate) fn drop<Y>(proof: Proof, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn drop<Y: SystemApi<RuntimeError>>(
+        proof: Proof,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.drop_object(proof.0.as_node_id())?;
 
         Ok(())
     }
 
-    pub(crate) fn on_drop<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn on_drop<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleProofField::ProofRefs.into(),
@@ -156,15 +148,12 @@ impl FungibleProofBlueprint {
         Ok(())
     }
 
-    pub(crate) fn on_move<Y>(
+    pub(crate) fn on_move<Y: SystemApi<RuntimeError>>(
         is_moving_down: bool,
         is_to_barrier: bool,
         destination_blueprint_id: Option<BlueprintId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if is_moving_down {
             let is_to_self = destination_blueprint_id.eq(&Some(BlueprintId::new(
                 &RESOURCE_PACKAGE,

--- a/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -390,7 +390,7 @@ impl FungibleResourceManagerBlueprint {
         }
     }
 
-    pub(crate) fn create<Y>(
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         track_total_supply: bool,
         divisibility: u8,
@@ -398,10 +398,7 @@ impl FungibleResourceManagerBlueprint {
         metadata: ModuleConfig<MetadataInit>,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<ResourceAddress, RuntimeError> {
         let (object_id, roles) = Self::create_object(
             Decimal::ZERO,
             track_total_supply,
@@ -423,7 +420,7 @@ impl FungibleResourceManagerBlueprint {
         Ok(ResourceAddress::new_or_panic(address.into()))
     }
 
-    pub(crate) fn create_with_initial_supply<Y>(
+    pub(crate) fn create_with_initial_supply<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         track_total_supply: bool,
         divisibility: u8,
@@ -432,10 +429,7 @@ impl FungibleResourceManagerBlueprint {
         metadata: ModuleConfig<MetadataInit>,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<(ResourceAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(ResourceAddress, Bucket), RuntimeError> {
         let (object_id, roles) = Self::create_object(
             initial_supply,
             track_total_supply,
@@ -475,13 +469,10 @@ impl FungibleResourceManagerBlueprint {
         Ok((resource_address, bucket))
     }
 
-    fn create_address_reservation<Y>(
+    fn create_address_reservation<Y: SystemApi<RuntimeError>>(
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<GlobalAddressReservation, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<GlobalAddressReservation, RuntimeError> {
         let address_reservation = match address_reservation {
             Some(address_reservation) => address_reservation,
             None => {
@@ -496,16 +487,13 @@ impl FungibleResourceManagerBlueprint {
         Ok(address_reservation)
     }
 
-    fn create_object<Y>(
+    fn create_object<Y: SystemApi<RuntimeError>>(
         initial_supply: Decimal,
         track_total_supply: bool,
         divisibility: u8,
         resource_roles: FungibleResourceRoles,
         api: &mut Y,
-    ) -> Result<(NodeId, RoleAssignmentInit), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(NodeId, RoleAssignmentInit), RuntimeError> {
         verify_divisibility(divisibility)?;
 
         let mut fields = indexmap! {
@@ -550,10 +538,10 @@ impl FungibleResourceManagerBlueprint {
         Ok((object_id, roles))
     }
 
-    pub(crate) fn mint<Y>(amount: Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn mint<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_mintable(api)?;
 
         let divisibility = {
@@ -610,25 +598,25 @@ impl FungibleResourceManagerBlueprint {
         Ok(bucket)
     }
 
-    pub(crate) fn burn<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn burn<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::burn_internal(bucket, api)
     }
 
     /// Only callable within this package - this is to allow the burning of tokens from a vault.
-    pub(crate) fn package_burn<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn package_burn<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::burn_internal(bucket, api)
     }
 
-    fn burn_internal<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn burn_internal<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_burnable(api)?;
 
         // Drop other bucket
@@ -675,10 +663,10 @@ impl FungibleResourceManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn drop_empty_bucket<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn drop_empty_bucket<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let other_bucket = drop_fungible_bucket(bucket.0.as_node_id(), api)?;
 
         if other_bucket.liquid.amount().is_zero() {
@@ -692,17 +680,16 @@ impl FungibleResourceManagerBlueprint {
         }
     }
 
-    pub(crate) fn create_empty_bucket<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create_empty_bucket<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::create_bucket(0.into(), api)
     }
 
-    pub(crate) fn create_bucket<Y>(amount: Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create_bucket<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         let bucket_id = api.new_simple_object(
             FUNGIBLE_BUCKET_BLUEPRINT,
             indexmap! {
@@ -714,10 +701,9 @@ impl FungibleResourceManagerBlueprint {
         Ok(Bucket(Own(bucket_id)))
     }
 
-    pub(crate) fn create_empty_vault<Y>(api: &mut Y) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create_empty_vault<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Own, RuntimeError> {
         let mut fields: IndexMap<FieldIndex, FieldValue> = indexmap! {
             FungibleVaultField::Balance.into() => FieldValue::new(&FungibleVaultBalanceFieldPayload::from_content_source(
                     LiquidFungibleResource::default(),
@@ -744,10 +730,9 @@ impl FungibleResourceManagerBlueprint {
         Ok(Own(vault_id))
     }
 
-    pub(crate) fn get_resource_type<Y>(api: &mut Y) -> Result<ResourceType, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_resource_type<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<ResourceType, RuntimeError> {
         let divisibility_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleResourceManagerField::Divisibility.into(),
@@ -764,10 +749,9 @@ impl FungibleResourceManagerBlueprint {
         Ok(resource_type)
     }
 
-    pub(crate) fn get_total_supply<Y>(api: &mut Y) -> Result<Option<Decimal>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_total_supply<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Option<Decimal>, RuntimeError> {
         if api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             FungibleResourceManagerFeature::TrackTotalSupply.feature_name(),
@@ -788,14 +772,11 @@ impl FungibleResourceManagerBlueprint {
         }
     }
 
-    pub(crate) fn amount_for_withdrawal<Y>(
+    pub(crate) fn amount_for_withdrawal<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
-    ) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Decimal, RuntimeError> {
         let divisibility_handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleResourceManagerField::Divisibility.into(),
@@ -817,10 +798,7 @@ impl FungibleResourceManagerBlueprint {
             ))?)
     }
 
-    fn assert_mintable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_mintable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             FungibleResourceManagerFeature::Mint.feature_name(),
@@ -839,10 +817,7 @@ impl FungibleResourceManagerBlueprint {
         return Ok(());
     }
 
-    fn assert_burnable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_burnable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             FungibleResourceManagerFeature::Burn.feature_name(),

--- a/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
@@ -279,10 +279,7 @@ impl FungibleVaultBlueprint {
         }
     }
 
-    fn get_divisibility<Y>(api: &mut Y) -> Result<u8, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn get_divisibility<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<u8, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_OUTER_OBJECT,
             FungibleResourceManagerField::Divisibility.into(),
@@ -295,21 +292,18 @@ impl FungibleVaultBlueprint {
         Ok(divisibility)
     }
 
-    pub fn take<Y>(amount: &Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn take<Y: SystemApi<RuntimeError>>(
+        amount: &Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::take_advanced(amount, WithdrawStrategy::Exact, api)
     }
 
-    pub fn take_advanced<Y>(
+    pub fn take_advanced<Y: SystemApi<RuntimeError>>(
         amount: &Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::WITHDRAW, api)?;
 
         // Apply withdraw strategy
@@ -343,10 +337,10 @@ impl FungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn put<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn put<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::DEPOSIT, api)?;
 
         // This will fail if bucket is not an inner object of the current fungible resource
@@ -361,10 +355,7 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn get_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn get_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         Self::liquid_amount(api)?
             .checked_add(Self::locked_amount(api)?)
             .ok_or(RuntimeError::ApplicationError(
@@ -372,10 +363,11 @@ impl FungibleVaultBlueprint {
             ))
     }
 
-    pub fn lock_fee<Y>(amount: Decimal, contingent: bool, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn lock_fee<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        contingent: bool,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::WITHDRAW, api)?;
 
         // Check resource address and amount
@@ -439,10 +431,10 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn recall<Y>(amount: Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn recall<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_recallable(api)?;
 
         let divisibility = Self::get_divisibility(api)?;
@@ -461,10 +453,10 @@ impl FungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn freeze<Y>(to_freeze: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn freeze<Y: SystemApi<RuntimeError>>(
+        to_freeze: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_freezable(api)?;
 
         let frozen_flag_handle = api.actor_open_field(
@@ -485,10 +477,10 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn unfreeze<Y>(to_unfreeze: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unfreeze<Y: SystemApi<RuntimeError>>(
+        to_unfreeze: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_freezable(api)?;
 
         let frozen_flag_handle = api.actor_open_field(
@@ -508,10 +500,10 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn create_proof_of_amount<Y>(amount: Decimal, api: &mut Y) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn create_proof_of_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Proof, RuntimeError> {
         let divisibility = Self::get_divisibility(api)?;
         if !check_fungible_amount(&amount, divisibility) {
             return Err(RuntimeError::ApplicationError(
@@ -545,10 +537,10 @@ impl FungibleVaultBlueprint {
         Ok(Proof(Own(proof_id)))
     }
 
-    pub fn burn<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn burn<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::BURN, api)?;
 
         Self::take(&amount, api)?.package_burn(api)?;
@@ -559,10 +551,10 @@ impl FungibleVaultBlueprint {
     // Protected methods
     //===================
 
-    pub fn lock_amount<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn lock_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleVaultField::LockedBalance.into(),
@@ -594,10 +586,10 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn unlock_amount<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unlock_amount<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleVaultField::LockedBalance.into(),
@@ -634,10 +626,10 @@ impl FungibleVaultBlueprint {
     // Helper methods
     //===================
 
-    fn assert_not_frozen<Y>(flags: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_not_frozen<Y: SystemApi<RuntimeError>>(
+        flags: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             FungibleResourceManagerFeature::VaultFreeze.feature_name(),
@@ -664,10 +656,7 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    fn assert_freezable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_freezable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             FungibleResourceManagerFeature::VaultFreeze.feature_name(),
@@ -684,10 +673,7 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    fn assert_recallable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_recallable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             FungibleResourceManagerFeature::VaultRecall.feature_name(),
@@ -704,10 +690,7 @@ impl FungibleVaultBlueprint {
         Ok(())
     }
 
-    fn liquid_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn liquid_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleVaultField::Balance.into(),
@@ -721,10 +704,7 @@ impl FungibleVaultBlueprint {
         Ok(amount)
     }
 
-    fn locked_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn locked_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleVaultField::LockedBalance.into(),
@@ -738,13 +718,10 @@ impl FungibleVaultBlueprint {
         Ok(amount)
     }
 
-    fn internal_take<Y>(
+    fn internal_take<Y: SystemApi<RuntimeError>>(
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<LiquidFungibleResource, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<LiquidFungibleResource, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             FungibleVaultField::Balance.into(),
@@ -767,10 +744,10 @@ impl FungibleVaultBlueprint {
         Ok(taken)
     }
 
-    fn internal_put<Y>(resource: LiquidFungibleResource, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn internal_put<Y: SystemApi<RuntimeError>>(
+        resource: LiquidFungibleResource,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         if resource.is_empty() {
             return Ok(());
         }

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_proof.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_proof.rs
@@ -74,10 +74,7 @@ impl NonFungibleProofSubstate {
 pub struct NonFungibleProofBlueprint;
 
 impl NonFungibleProofBlueprint {
-    pub(crate) fn clone<Y>(api: &mut Y) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn clone<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Proof, RuntimeError> {
         let moveable = {
             let handle = api.actor_open_field(
                 ACTOR_STATE_SELF,
@@ -112,10 +109,9 @@ impl NonFungibleProofBlueprint {
         Ok(Proof(Own(proof_id)))
     }
 
-    pub(crate) fn get_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_amount<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleProofField::ProofRefs.into(),
@@ -127,12 +123,9 @@ impl NonFungibleProofBlueprint {
         Ok(amount)
     }
 
-    pub(crate) fn get_local_ids<Y>(
+    pub(crate) fn get_local_ids<Y: SystemApi<RuntimeError>>(
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleProofField::ProofRefs.into(),
@@ -144,27 +137,23 @@ impl NonFungibleProofBlueprint {
         Ok(ids)
     }
 
-    pub(crate) fn get_resource_address<Y>(api: &mut Y) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_resource_address<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<ResourceAddress, RuntimeError> {
         let address = ResourceAddress::new_or_panic(api.actor_get_node_id(ACTOR_REF_OUTER)?.into());
         Ok(address)
     }
 
-    pub(crate) fn drop<Y>(proof: Proof, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn drop<Y: SystemApi<RuntimeError>>(
+        proof: Proof,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.drop_object(proof.0.as_node_id())?;
 
         Ok(())
     }
 
-    pub(crate) fn on_drop<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn on_drop<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleProofField::ProofRefs.into(),
@@ -177,15 +166,12 @@ impl NonFungibleProofBlueprint {
         Ok(())
     }
 
-    pub(crate) fn on_move<Y>(
+    pub(crate) fn on_move<Y: SystemApi<RuntimeError>>(
         is_moving_down: bool,
         is_to_barrier: bool,
         destination_blueprint_id: Option<BlueprintId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if is_moving_down {
             let is_to_self = destination_blueprint_id.eq(&Some(BlueprintId::new(
                 &RESOURCE_PACKAGE,

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -115,16 +115,13 @@ pub enum InvalidNonFungibleSchema {
     MutableFieldDoesNotExist(String),
 }
 
-fn create_non_fungibles<Y>(
+fn create_non_fungibles<Y: SystemApi<RuntimeError>>(
     resource_address: ResourceAddress,
     id_type: NonFungibleIdType,
     entries: IndexMap<NonFungibleLocalId, ScryptoValue>,
     check_non_existence: bool,
     api: &mut Y,
-) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError>
-where
-    Y: SystemApi<RuntimeError>,
-{
+) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError> {
     let mut ids = index_set_new();
     for (non_fungible_local_id, value) in entries {
         if non_fungible_local_id.id_type() != id_type {
@@ -490,13 +487,10 @@ impl NonFungibleResourceManagerBlueprint {
         }
     }
 
-    fn resolve_and_validate_non_fungible_schema<Y>(
+    fn resolve_and_validate_non_fungible_schema<Y: SystemApi<RuntimeError>>(
         schema: &NonFungibleDataSchema,
         api: &mut Y,
-    ) -> Result<(GenericArgs, IndexMap<String, usize>), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(GenericArgs, IndexMap<String, usize>), RuntimeError> {
         match schema {
             NonFungibleDataSchema::Local {
                 schema,
@@ -628,7 +622,7 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(mutable_field_index)
     }
 
-    pub(crate) fn create<Y>(
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         id_type: NonFungibleIdType,
         track_total_supply: bool,
@@ -637,10 +631,7 @@ impl NonFungibleResourceManagerBlueprint {
         metadata: ModuleConfig<MetadataInit>,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<ResourceAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<ResourceAddress, RuntimeError> {
         let (object_id, roles) = Self::create_object(
             id_type,
             indexmap!(),
@@ -673,7 +664,7 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(ResourceAddress::new_or_panic(address.into()))
     }
 
-    pub(crate) fn create_with_initial_supply<Y>(
+    pub(crate) fn create_with_initial_supply<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         id_type: NonFungibleIdType,
         track_total_supply: bool,
@@ -683,10 +674,7 @@ impl NonFungibleResourceManagerBlueprint {
         metadata: ModuleConfig<MetadataInit>,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<(ResourceAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(ResourceAddress, Bucket), RuntimeError> {
         // TODO: Do this check in a better way (e.g. via type check)
         if id_type == NonFungibleIdType::RUID {
             return Err(RuntimeError::ApplicationError(
@@ -740,7 +728,7 @@ impl NonFungibleResourceManagerBlueprint {
         ))
     }
 
-    pub(crate) fn create_ruid_with_initial_supply<Y>(
+    pub(crate) fn create_ruid_with_initial_supply<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRole,
         track_total_supply: bool,
         non_fungible_schema: NonFungibleDataSchema,
@@ -749,10 +737,7 @@ impl NonFungibleResourceManagerBlueprint {
         metadata: ModuleConfig<MetadataInit>,
         address_reservation: Option<GlobalAddressReservation>,
         api: &mut Y,
-    ) -> Result<(ResourceAddress, Bucket), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(ResourceAddress, Bucket), RuntimeError> {
         let entries: Result<IndexMap<NonFungibleLocalId, (ScryptoValue,)>, RuntimeError> = entries
             .into_iter()
             .map(|e| {
@@ -807,13 +792,10 @@ impl NonFungibleResourceManagerBlueprint {
         ))
     }
 
-    pub(crate) fn mint_non_fungible<Y>(
+    pub(crate) fn mint_non_fungible<Y: SystemApi<RuntimeError>>(
         entries: IndexMap<NonFungibleLocalId, (ScryptoValue,)>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_mintable(api)?;
         let id_type = Self::assert_is_not_ruid(api)?;
         Self::update_total_supply(api, entries.len().into())?;
@@ -831,13 +813,10 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(bucket)
     }
 
-    pub(crate) fn mint_ruid_non_fungible<Y>(
+    pub(crate) fn mint_ruid_non_fungible<Y: SystemApi<RuntimeError>>(
         entries: Vec<(ScryptoValue,)>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_mintable(api)?;
         Self::assert_is_ruid(api)?;
         Self::update_total_supply(api, entries.len().into())?;
@@ -865,13 +844,10 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(bucket)
     }
 
-    pub(crate) fn mint_single_ruid_non_fungible<Y>(
+    pub(crate) fn mint_single_ruid_non_fungible<Y: SystemApi<RuntimeError>>(
         value: ScryptoValue,
         api: &mut Y,
-    ) -> Result<(Bucket, NonFungibleLocalId), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(Bucket, NonFungibleLocalId), RuntimeError> {
         Self::assert_mintable(api)?;
         Self::assert_is_ruid(api)?;
         Self::update_total_supply(api, Decimal::ONE)?;
@@ -899,15 +875,12 @@ impl NonFungibleResourceManagerBlueprint {
         Ok((bucket, id))
     }
 
-    pub(crate) fn update_non_fungible_data<Y>(
+    pub(crate) fn update_non_fungible_data<Y: SystemApi<RuntimeError>>(
         id: NonFungibleLocalId,
         field_name: String,
         data: ScryptoValue,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let field_index = {
             let data_schema_handle = api.actor_open_field(
                 ACTOR_STATE_SELF,
@@ -967,13 +940,10 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn non_fungible_exists<Y>(
+    pub(crate) fn non_fungible_exists<Y: SystemApi<RuntimeError>>(
         id: NonFungibleLocalId,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         let non_fungible_handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerCollection::DataKeyValue.collection_index(),
@@ -988,13 +958,10 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(non_fungible.is_some())
     }
 
-    pub(crate) fn get_non_fungible<Y>(
+    pub(crate) fn get_non_fungible<Y: SystemApi<RuntimeError>>(
         id: NonFungibleLocalId,
         api: &mut Y,
-    ) -> Result<ScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<ScryptoValue, RuntimeError> {
         let non_fungible_handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerCollection::DataKeyValue.collection_index(),
@@ -1020,20 +987,16 @@ impl NonFungibleResourceManagerBlueprint {
         }
     }
 
-    pub(crate) fn create_empty_bucket<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create_empty_bucket<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::create_bucket(index_set_new(), api)
     }
 
-    pub(crate) fn create_bucket<Y>(
+    pub(crate) fn create_bucket<Y: SystemApi<RuntimeError>>(
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         let bucket_id = api.new_simple_object(
             NON_FUNGIBLE_BUCKET_BLUEPRINT,
             indexmap! {
@@ -1045,25 +1008,25 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(Bucket(Own(bucket_id)))
     }
 
-    pub(crate) fn burn<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn burn<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::burn_internal(bucket, api)
     }
 
     /// Only callable within this package - this is to allow the burning of tokens from a vault.
-    pub(crate) fn package_burn<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn package_burn<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::burn_internal(bucket, api)
     }
 
-    fn burn_internal<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn burn_internal<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_burnable(api)?;
 
         // Drop the bucket
@@ -1099,10 +1062,10 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn drop_empty_bucket<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn drop_empty_bucket<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let other_bucket = drop_non_fungible_bucket(bucket.0.as_node_id(), api)?;
 
         if other_bucket.liquid.amount().is_zero() {
@@ -1116,10 +1079,9 @@ impl NonFungibleResourceManagerBlueprint {
         }
     }
 
-    pub(crate) fn create_empty_vault<Y>(api: &mut Y) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create_empty_vault<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Own, RuntimeError> {
         let balance = LiquidNonFungibleVault {
             amount: Decimal::zero(),
         };
@@ -1155,10 +1117,9 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(Own(vault_id))
     }
 
-    pub(crate) fn get_resource_type<Y>(api: &mut Y) -> Result<ResourceType, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_resource_type<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<ResourceType, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerField::IdType.into(),
@@ -1173,10 +1134,9 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(resource_type)
     }
 
-    pub(crate) fn get_total_supply<Y>(api: &mut Y) -> Result<Option<Decimal>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_total_supply<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Option<Decimal>, RuntimeError> {
         if api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerFeature::TrackTotalSupply.feature_name(),
@@ -1197,17 +1157,14 @@ impl NonFungibleResourceManagerBlueprint {
         }
     }
 
-    fn create_object<Y>(
+    fn create_object<Y: SystemApi<RuntimeError>>(
         id_type: NonFungibleIdType,
         entries: IndexMap<NonFungibleLocalId, (ScryptoValue,)>,
         track_total_supply: bool,
         non_fungible_schema: NonFungibleDataSchema,
         resource_roles: NonFungibleResourceRoles,
         api: &mut Y,
-    ) -> Result<(NodeId, RoleAssignmentInit), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(NodeId, RoleAssignmentInit), RuntimeError> {
         let (generic_args, mutable_field_index) =
             Self::resolve_and_validate_non_fungible_schema(&non_fungible_schema, api)?;
 
@@ -1280,10 +1237,9 @@ impl NonFungibleResourceManagerBlueprint {
         Ok((object_id, roles))
     }
 
-    fn assert_is_not_ruid<Y>(api: &mut Y) -> Result<NonFungibleIdType, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_is_not_ruid<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<NonFungibleIdType, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerField::IdType.into(),
@@ -1303,10 +1259,7 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(id_type)
     }
 
-    fn assert_is_ruid<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_is_ruid<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         // Check type
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -1329,10 +1282,7 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(())
     }
 
-    fn assert_mintable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_mintable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerFeature::Mint.feature_name(),
@@ -1351,10 +1301,7 @@ impl NonFungibleResourceManagerBlueprint {
         return Ok(());
     }
 
-    fn assert_burnable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_burnable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerFeature::Burn.feature_name(),
@@ -1373,10 +1320,10 @@ impl NonFungibleResourceManagerBlueprint {
         return Ok(());
     }
 
-    fn update_total_supply<Y>(api: &mut Y, amount: Decimal) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn update_total_supply<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+        amount: Decimal,
+    ) -> Result<(), RuntimeError> {
         if api.actor_is_feature_enabled(
             ACTOR_STATE_SELF,
             NonFungibleResourceManagerFeature::TrackTotalSupply.feature_name(),
@@ -1410,14 +1357,11 @@ impl NonFungibleResourceManagerBlueprint {
         Ok(())
     }
 
-    pub(crate) fn amount_for_withdrawal<Y>(
+    pub(crate) fn amount_for_withdrawal<Y: SystemApi<RuntimeError>>(
         _api: &mut Y,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
-    ) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Decimal, RuntimeError> {
         Ok(amount
             .for_withdrawal(0, withdraw_strategy)
             .ok_or(RuntimeError::ApplicationError(

--- a/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/non_fungible/non_fungible_vault.rs
@@ -361,21 +361,18 @@ impl NonFungibleVaultBlueprint {
         }
     }
 
-    pub fn take<Y>(amount: &Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn take<Y: SystemApi<RuntimeError>>(
+        amount: &Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::take_advanced(amount, WithdrawStrategy::Exact, api)
     }
 
-    pub fn take_advanced<Y>(
+    pub fn take_advanced<Y: SystemApi<RuntimeError>>(
         amount: &Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::WITHDRAW, api)?;
 
         let taken = {
@@ -403,13 +400,10 @@ impl NonFungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn take_non_fungibles<Y>(
+    pub fn take_non_fungibles<Y: SystemApi<RuntimeError>>(
         non_fungible_local_ids: &IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::WITHDRAW, api)?;
 
         // Take
@@ -424,10 +418,10 @@ impl NonFungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn put<Y>(bucket: Bucket, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn put<Y: SystemApi<RuntimeError>>(
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::DEPOSIT, api)?;
 
         // Drop other bucket
@@ -443,10 +437,7 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn get_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn get_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         Self::liquid_amount(api)?
             .checked_add(Self::locked_amount(api)?)
             .ok_or(RuntimeError::ApplicationError(
@@ -454,13 +445,10 @@ impl NonFungibleVaultBlueprint {
             ))
     }
 
-    pub fn contains_non_fungible<Y>(
+    pub fn contains_non_fungible<Y: SystemApi<RuntimeError>>(
         id: NonFungibleLocalId,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         let ids = Self::locked_non_fungible_local_ids(u32::MAX, api)?;
         if ids.contains(&id) {
             return Ok(true);
@@ -486,13 +474,10 @@ impl NonFungibleVaultBlueprint {
         Ok(exists)
     }
 
-    pub fn get_non_fungible_local_ids<Y>(
+    pub fn get_non_fungible_local_ids<Y: SystemApi<RuntimeError>>(
         limit: u32,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError> {
         let mut ids = Self::locked_non_fungible_local_ids(limit, api)?;
         let id_len: u32 = ids.len().try_into().unwrap();
 
@@ -504,10 +489,10 @@ impl NonFungibleVaultBlueprint {
         Ok(ids)
     }
 
-    pub fn recall<Y>(amount: Decimal, api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn recall<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_recallable(api)?;
 
         let n = check_non_fungible_amount(&amount).map_err(|_| {
@@ -526,10 +511,10 @@ impl NonFungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn freeze<Y>(to_freeze: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn freeze<Y: SystemApi<RuntimeError>>(
+        to_freeze: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_freezable(api)?;
 
         let frozen_flag_handle = api.actor_open_field(
@@ -550,10 +535,10 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn unfreeze<Y>(to_unfreeze: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn unfreeze<Y: SystemApi<RuntimeError>>(
+        to_unfreeze: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_freezable(api)?;
 
         let frozen_flag_handle = api.actor_open_field(
@@ -573,13 +558,10 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn recall_non_fungibles<Y>(
+    pub fn recall_non_fungibles<Y: SystemApi<RuntimeError>>(
         non_fungible_local_ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Bucket, RuntimeError> {
         Self::assert_recallable(api)?;
 
         let taken = Self::internal_take_non_fungibles(&non_fungible_local_ids, api)?;
@@ -592,13 +574,10 @@ impl NonFungibleVaultBlueprint {
         Ok(bucket)
     }
 
-    pub fn create_proof_of_non_fungibles<Y>(
+    pub fn create_proof_of_non_fungibles<Y: SystemApi<RuntimeError>>(
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Proof, RuntimeError> {
         Self::lock_non_fungibles(&ids, api)?;
 
         let proof_info = ProofMoveableSubstate { restricted: false };
@@ -622,23 +601,20 @@ impl NonFungibleVaultBlueprint {
         Ok(Proof(Own(proof_id)))
     }
 
-    pub fn burn<Y>(amount: Decimal, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn burn<Y: SystemApi<RuntimeError>>(
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::BURN, api)?;
 
         Self::take(&amount, api)?.package_burn(api)?;
         Ok(())
     }
 
-    pub fn burn_non_fungibles<Y>(
+    pub fn burn_non_fungibles<Y: SystemApi<RuntimeError>>(
         non_fungible_local_ids: &IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         Self::assert_not_frozen(VaultFreezeFlags::BURN, api)?;
 
         Self::take_non_fungibles(non_fungible_local_ids, api)?.package_burn(api)?;
@@ -649,13 +625,10 @@ impl NonFungibleVaultBlueprint {
     // Protected methods
     //===================
 
-    pub fn lock_non_fungibles<Y>(
+    pub fn lock_non_fungibles<Y: SystemApi<RuntimeError>>(
         ids: &IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::LockedResource.into(),
@@ -687,13 +660,10 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    pub fn unlock_non_fungibles<Y>(
+    pub fn unlock_non_fungibles<Y: SystemApi<RuntimeError>>(
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::LockedResource.into(),
@@ -728,10 +698,10 @@ impl NonFungibleVaultBlueprint {
     // Helper methods
     //===================
 
-    fn assert_not_frozen<Y>(flags: VaultFreezeFlags, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_not_frozen<Y: SystemApi<RuntimeError>>(
+        flags: VaultFreezeFlags,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             NonFungibleResourceManagerFeature::VaultFreeze.feature_name(),
@@ -758,10 +728,7 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    fn assert_freezable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_freezable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             NonFungibleResourceManagerFeature::VaultFreeze.feature_name(),
@@ -778,10 +745,7 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    fn assert_recallable<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn assert_recallable<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         if !api.actor_is_feature_enabled(
             ACTOR_STATE_OUTER_OBJECT,
             NonFungibleResourceManagerFeature::VaultRecall.feature_name(),
@@ -798,10 +762,7 @@ impl NonFungibleVaultBlueprint {
         Ok(())
     }
 
-    fn liquid_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn liquid_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::Balance.into(),
@@ -815,10 +776,7 @@ impl NonFungibleVaultBlueprint {
         Ok(amount)
     }
 
-    fn locked_amount<Y>(api: &mut Y) -> Result<Decimal, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn locked_amount<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Decimal, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::LockedResource.into(),
@@ -832,13 +790,10 @@ impl NonFungibleVaultBlueprint {
         Ok(amount)
     }
 
-    fn liquid_non_fungible_local_ids<Y>(
+    fn liquid_non_fungible_local_ids<Y: SystemApi<RuntimeError>>(
         limit: u32,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError> {
         let items: Vec<NonFungibleLocalId> = api.actor_index_scan_keys_typed(
             ACTOR_STATE_SELF,
             NonFungibleVaultCollection::NonFungibleIndex.collection_index(),
@@ -848,13 +803,10 @@ impl NonFungibleVaultBlueprint {
         Ok(ids)
     }
 
-    fn locked_non_fungible_local_ids<Y>(
+    fn locked_non_fungible_local_ids<Y: SystemApi<RuntimeError>>(
         limit: u32,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::LockedResource.into(),
@@ -869,13 +821,10 @@ impl NonFungibleVaultBlueprint {
         Ok(ids)
     }
 
-    fn internal_take_by_amount<Y>(
+    fn internal_take_by_amount<Y: SystemApi<RuntimeError>>(
         n: u32,
         api: &mut Y,
-    ) -> Result<LiquidNonFungibleResource, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<LiquidNonFungibleResource, RuntimeError> {
         // deduct from liquidity pool
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
@@ -919,13 +868,10 @@ impl NonFungibleVaultBlueprint {
         Ok(taken)
     }
 
-    pub fn internal_take_non_fungibles<Y>(
+    pub fn internal_take_non_fungibles<Y: SystemApi<RuntimeError>>(
         ids: &IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<LiquidNonFungibleResource, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<LiquidNonFungibleResource, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             NonFungibleVaultField::Balance.into(),
@@ -969,13 +915,10 @@ impl NonFungibleVaultBlueprint {
         Ok(LiquidNonFungibleResource::new(ids.clone()))
     }
 
-    pub fn internal_put<Y>(
+    pub fn internal_put<Y: SystemApi<RuntimeError>>(
         resource: LiquidNonFungibleResource,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if resource.is_empty() {
             return Ok(());
         }

--- a/radix-engine/src/blueprints/resource/package.rs
+++ b/radix-engine/src/blueprints/resource/package.rs
@@ -1143,14 +1143,13 @@ impl ResourceNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+    >(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             FUNGIBLE_RESOURCE_MANAGER_CREATE_EXPORT_NAME => {
                 let input: FungibleResourceManagerCreateInput = input.as_typed().map_err(|e| {

--- a/radix-engine/src/blueprints/resource/worktop.rs
+++ b/radix-engine/src/blueprints/resource/worktop.rs
@@ -1,7 +1,7 @@
 use crate::errors::ApplicationError;
 use crate::errors::RuntimeError;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
+use crate::kernel::kernel_api::KernelSubstateApi;
 use crate::system::system_callback::SystemLockData;
 use crate::system::system_substates::FieldSubstate;
 use radix_engine_interface::api::field_api::LockFlags;
@@ -35,13 +35,10 @@ pub struct WorktopBlueprint;
 //==============================================
 
 impl WorktopBlueprint {
-    pub(crate) fn drop<Y>(
+    pub(crate) fn drop<Y: SystemApi<RuntimeError> + KernelSubstateApi<SystemLockData>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         // TODO: add `drop` callback for drop atomicity, which will remove the necessity of kernel api.
 
         let input: WorktopDropInput = input
@@ -80,13 +77,10 @@ impl WorktopBlueprint {
         Ok(IndexedScryptoValue::from_typed(&()))
     }
 
-    pub(crate) fn put<Y>(
+    pub(crate) fn put<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopPutInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -115,13 +109,10 @@ impl WorktopBlueprint {
         }
     }
 
-    pub(crate) fn take<Y>(
+    pub(crate) fn take<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopTakeInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -164,13 +155,10 @@ impl WorktopBlueprint {
         }
     }
 
-    pub(crate) fn take_non_fungibles<Y>(
+    pub(crate) fn take_non_fungibles<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopTakeNonFungiblesInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -214,13 +202,10 @@ impl WorktopBlueprint {
         }
     }
 
-    pub(crate) fn take_all<Y>(
+    pub(crate) fn take_all<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopTakeAllInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -243,13 +228,10 @@ impl WorktopBlueprint {
         }
     }
 
-    pub(crate) fn assert_contains<Y>(
+    pub(crate) fn assert_contains<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopAssertContainsInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -274,13 +256,10 @@ impl WorktopBlueprint {
         Ok(IndexedScryptoValue::from_typed(&()))
     }
 
-    pub(crate) fn assert_contains_amount<Y>(
+    pub(crate) fn assert_contains_amount<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopAssertContainsAmountInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -305,13 +284,10 @@ impl WorktopBlueprint {
         Ok(IndexedScryptoValue::from_typed(&()))
     }
 
-    pub(crate) fn assert_contains_non_fungibles<Y>(
+    pub(crate) fn assert_contains_non_fungibles<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let input: WorktopAssertContainsNonFungiblesInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;
@@ -337,13 +313,10 @@ impl WorktopBlueprint {
         Ok(IndexedScryptoValue::from_typed(&()))
     }
 
-    pub(crate) fn drain<Y>(
+    pub(crate) fn drain<Y: SystemApi<RuntimeError>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let _input: WorktopDrainInput = input
             .as_typed()
             .map_err(|e| RuntimeError::ApplicationError(ApplicationError::InputDecodeError(e)))?;

--- a/radix-engine/src/blueprints/test_utils/blueprint.rs
+++ b/radix-engine/src/blueprints/test_utils/blueprint.rs
@@ -53,10 +53,10 @@ impl TestUtilsBlueprint {
         }
     }
 
-    pub fn panic<Y>(message: &str, _api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub fn panic<Y: SystemApi<RuntimeError>>(
+        message: &str,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         panic!("{}", message);
     }
 }

--- a/radix-engine/src/blueprints/test_utils/package.rs
+++ b/radix-engine/src/blueprints/test_utils/package.rs
@@ -18,14 +18,11 @@ impl TestUtilsNativePackage {
         }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             TEST_UTILS_PANIC_IDENT => {
                 let TestUtilsPanicInput(input) = input.as_typed().map_err(|e| {

--- a/radix-engine/src/blueprints/transaction_processor/package.rs
+++ b/radix-engine/src/blueprints/transaction_processor/package.rs
@@ -76,15 +76,14 @@ impl TransactionProcessorNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+    >(
         export_name: &str,
         input: &IndexedScryptoValue,
         version: TransactionProcessorV1MinorVersion,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<SystemLockData> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             TRANSACTION_PROCESSOR_RUN_IDENT => {
                 let input: TransactionProcessorRunInput = input.as_typed().map_err(|e| {

--- a/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
+++ b/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
@@ -73,19 +73,14 @@ impl From<TransactionProcessorError> for RuntimeError {
     }
 }
 
-fn handle_invocation<'a, 'p, 'w, F, Y, L>(
+fn handle_invocation<'a, 'p, 'w, Y: SystemApi<RuntimeError> + KernelSubstateApi<L>, L: Default>(
     api: &'a mut Y,
     processor: &'p mut TransactionProcessor,
     worktop: &'w mut Worktop,
     args: ManifestValue,
-    invocation_handler: F,
+    invocation_handler: impl FnOnce(&mut Y, ScryptoValue) -> Result<Vec<u8>, RuntimeError>,
     version: TransactionProcessorV1MinorVersion,
-) -> Result<InstructionOutput, RuntimeError>
-where
-    Y: SystemApi<RuntimeError> + KernelSubstateApi<L>,
-    F: FnOnce(&mut Y, ScryptoValue) -> Result<Vec<u8>, RuntimeError>,
-    L: Default,
-{
+) -> Result<InstructionOutput, RuntimeError> {
     let scrypto_value = {
         let mut processor_with_api = TransactionProcessorWithApi {
             worktop,
@@ -111,17 +106,17 @@ where
 pub struct TransactionProcessorBlueprint;
 
 impl TransactionProcessorBlueprint {
-    pub(crate) fn run<Y, L: Default>(
+    pub(crate) fn run<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<L>,
+        L: Default,
+    >(
         manifest_encoded_instructions: Vec<u8>,
         global_address_reservations: Vec<GlobalAddressReservation>,
         _references: Vec<Reference>, // Required so that the kernel passes the references to the processor frame
         blobs: IndexMap<Hash, Vec<u8>>,
         version: TransactionProcessorV1MinorVersion,
         api: &mut Y,
-    ) -> Result<Vec<InstructionOutput>, RuntimeError>
-    where
-        Y: KernelNodeApi + KernelSubstateApi<L> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<Vec<InstructionOutput>, RuntimeError> {
         // Create a worktop
         let worktop_node_id = api.kernel_allocate_node_id(EntityType::InternalGenericComponent)?;
         api.kernel_create_node(
@@ -656,15 +651,12 @@ impl TransactionProcessor {
         }
     }
 
-    fn handle_call_return_data<Y, L: Default>(
+    fn handle_call_return_data<Y: SystemApi<RuntimeError> + KernelSubstateApi<L>, L: Default>(
         &mut self,
         value: &IndexedScryptoValue,
         worktop: &Worktop,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelSubstateApi<L> + SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         // Auto move into worktop & auth_zone
         for node_id in value.owned_nodes() {
             let info = TypeInfoBlueprint::get_type(node_id, api)?;

--- a/radix-engine/src/blueprints/transaction_tracker/package.rs
+++ b/radix-engine/src/blueprints/transaction_tracker/package.rs
@@ -113,14 +113,11 @@ impl TransactionTrackerNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             TRANSACTION_TRACKER_CREATE_EXPORT_NAME => {
                 let input: TransactionTrackerCreateInput = input.as_typed().map_err(|e| {
@@ -240,13 +237,10 @@ impl TransactionTrackerSubstateV1 {
 pub struct TransactionTrackerBlueprint;
 
 impl TransactionTrackerBlueprint {
-    pub fn create<Y>(
+    pub fn create<Y: SystemApi<RuntimeError>>(
         address_reservation: GlobalAddressReservation,
         api: &mut Y,
-    ) -> Result<GlobalAddress, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<GlobalAddress, RuntimeError> {
         let current_epoch = Runtime::current_epoch(api)?;
         let intent_store = api.new_simple_object(
             TRANSACTION_TRACKER_BLUEPRINT,

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -114,6 +114,8 @@ pub enum RuntimeError {
     FinalizationCostingError(CostingError),
 }
 
+impl SystemApiError for RuntimeError {}
+
 impl From<KernelError> for RuntimeError {
     fn from(error: KernelError) -> Self {
         RuntimeError::KernelError(error.into())

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -171,15 +171,13 @@ pub trait KernelCallbackObject: Sized {
     ) -> Result<StableReferenceType, BootloadingError>;
 
     /// Start execution
-    fn start<Y>(
+    fn start<Y: KernelApi<Self>>(
         api: &mut Y,
         manifest_encoded_instructions: &[u8],
         pre_allocated_addresses: &Vec<PreAllocatedAddress>,
         references: &IndexSet<Reference>,
         blobs: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<Self::ExecutionOutput, RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    ) -> Result<Self::ExecutionOutput, RuntimeError>;
 
     /// Finish execution
     fn finish(&mut self, store_commit_info: StoreCommitInfo) -> Result<(), RuntimeError>;
@@ -196,39 +194,46 @@ pub trait KernelCallbackObject: Sized {
     fn on_pin_node(&mut self, node_id: &NodeId) -> Result<(), RuntimeError>;
 
     /// Callbacks before/on-io-access/after a new node is created
-    fn on_create_node<Y>(api: &mut Y, event: CreateNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_create_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CreateNodeEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callbacks before/on-io-access/after a node is dropped
-    fn on_drop_node<Y>(api: &mut Y, event: DropNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_drop_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: DropNodeEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback when a module is moved
-    fn on_move_module<Y>(api: &mut Y, event: MoveModuleEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_move_module<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: MoveModuleEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before/on-io-access/after a substate is opened
-    fn on_open_substate<Y>(api: &mut Y, event: OpenSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_open_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: OpenSubstateEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before a substate is closed
-    fn on_close_substate<Y>(api: &mut Y, event: CloseSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_close_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CloseSubstateEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before a substate is read
-    fn on_read_substate<Y>(api: &mut Y, event: ReadSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_read_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: ReadSubstateEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before a substate is written to
-    fn on_write_substate<Y>(api: &mut Y, event: WriteSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>;
+    fn on_write_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: WriteSubstateEvent,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before/on-io-access a substate is set
     fn on_set_substate(&mut self, event: SetSubstateEvent) -> Result<(), RuntimeError>;
@@ -249,46 +254,41 @@ pub trait KernelCallbackObject: Sized {
     ) -> Result<(), RuntimeError>;
 
     /// Callback before an invocation and a new call frame is created
-    fn before_invoke<Y>(
+    fn before_invoke<Y: KernelApi<Self>>(
         invocation: &KernelInvocation<Self::CallFrameData>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    ) -> Result<(), RuntimeError>;
 
     /// Callback after a new call frame is created for a new invocation
-    fn on_execution_start<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn on_execution_start<Y: KernelApi<Self>>(api: &mut Y) -> Result<(), RuntimeError>;
 
     /// Callback on invocation. This is where the callback object should execute application logic.
-    fn invoke_upstream<Y>(
+    fn invoke_upstream<Y: KernelApi<Self>>(
         args: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    ) -> Result<IndexedScryptoValue, RuntimeError>;
 
     /// Callback after invocation during call frame cleanup and nodes are still owned by the executed
     /// call frame
-    fn auto_drop<Y>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn auto_drop<Y: KernelApi<Self>>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError>;
 
     /// Callback right after execution of invocation and where call of execution still exists
-    fn on_execution_finish<Y>(message: &CallFrameMessage, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn on_execution_finish<Y: KernelApi<Self>>(
+        message: &CallFrameMessage,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback after an invocation and where invocation's call frame has already been destroyed
-    fn after_invoke<Y>(output: &IndexedScryptoValue, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn after_invoke<Y: KernelApi<Self>>(
+        output: &IndexedScryptoValue,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before node id allocation
-    fn on_allocate_node_id<Y>(entity_type: EntityType, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn on_allocate_node_id<Y: KernelApi<Self>>(
+        entity_type: EntityType,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>;
 
     /// Callback before a substate is marked as transient
     fn on_mark_substate_as_transient(
@@ -299,17 +299,16 @@ pub trait KernelCallbackObject: Sized {
     ) -> Result<(), RuntimeError>;
 
     /// Callback when a substate does not exist
-    fn on_substate_lock_fault<Y>(
+    fn on_substate_lock_fault<Y: KernelApi<Self>>(
         node_id: NodeId,
         partition_num: PartitionNumber,
         offset: &SubstateKey,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    ) -> Result<bool, RuntimeError>;
 
     /// Callback before a node is dropped
-    fn on_drop_node_mut<Y>(node_id: &NodeId, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>;
+    fn on_drop_node_mut<Y: KernelApi<Self>>(
+        node_id: &NodeId,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError>;
 }

--- a/radix-engine/src/object_modules/metadata/package.rs
+++ b/radix-engine/src/object_modules/metadata/package.rs
@@ -185,14 +185,11 @@ impl MetadataNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             METADATA_CREATE_IDENT => {
                 let _input: MetadataCreateInput = input.as_typed().map_err(|e| {
@@ -253,10 +250,7 @@ impl MetadataNativePackage {
         }
     }
 
-    pub(crate) fn create<Y>(api: &mut Y) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<Own, RuntimeError> {
         let node_id = api.new_object(
             METADATA_BLUEPRINT,
             vec![],
@@ -319,13 +313,10 @@ impl MetadataNativePackage {
         ))
     }
 
-    pub(crate) fn create_with_data<Y>(
+    pub(crate) fn create_with_data<Y: SystemApi<RuntimeError>>(
         metadata_init: MetadataInit,
         api: &mut Y,
-    ) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Own, RuntimeError> {
         for value in metadata_init.data.values() {
             if let Some(v) = &value.value {
                 validate_metadata_value(&v).map_err(|e| {
@@ -350,10 +341,11 @@ impl MetadataNativePackage {
         Ok(Own(node_id))
     }
 
-    pub(crate) fn set<Y>(key: String, value: MetadataValue, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn set<Y: SystemApi<RuntimeError>>(
+        key: String,
+        value: MetadataValue,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         validate_metadata_value(&value).map_err(|e| {
             RuntimeError::ApplicationError(ApplicationError::MetadataError(
                 MetadataError::MetadataValidationError(e),
@@ -396,10 +388,10 @@ impl MetadataNativePackage {
         Ok(())
     }
 
-    pub(crate) fn lock<Y>(key: String, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn lock<Y: SystemApi<RuntimeError>>(
+        key: String,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             MetadataCollection::EntryKeyValue.collection_index(),
@@ -412,10 +404,10 @@ impl MetadataNativePackage {
         Ok(())
     }
 
-    pub(crate) fn get<Y>(key: String, api: &mut Y) -> Result<Option<MetadataValue>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get<Y: SystemApi<RuntimeError>>(
+        key: String,
+        api: &mut Y,
+    ) -> Result<Option<MetadataValue>, RuntimeError> {
         let handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             MetadataCollection::EntryKeyValue.collection_index(),
@@ -429,10 +421,10 @@ impl MetadataNativePackage {
         Ok(substate.map(|v: MetadataEntryEntryPayload| v.fully_update_and_into_latest_version()))
     }
 
-    pub(crate) fn remove<Y>(key: String, api: &mut Y) -> Result<bool, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn remove<Y: SystemApi<RuntimeError>>(
+        key: String,
+        api: &mut Y,
+    ) -> Result<bool, RuntimeError> {
         let cur_value: Option<MetadataEntryEntryPayload> = api.actor_remove_key_value_entry_typed(
             ACTOR_STATE_SELF,
             0u8,

--- a/radix-engine/src/object_modules/role_assignment/package.rs
+++ b/radix-engine/src/object_modules/role_assignment/package.rs
@@ -203,14 +203,11 @@ impl RoleAssignmentNativePackage {
         Ok(permission)
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             ROLE_ASSIGNMENT_CREATE_IDENT => {
                 let input: RoleAssignmentCreateInput = input.as_typed().map_err(|e| {
@@ -448,14 +445,11 @@ impl RoleAssignmentNativePackage {
         ))
     }
 
-    pub(crate) fn create<Y>(
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(
         owner_role: OwnerRoleEntry,
         roles: IndexMap<ModuleId, RoleAssignmentInit>,
         api: &mut Y,
-    ) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Own, RuntimeError> {
         let (fields, kv_entries) = Self::init_system_struct(owner_role, roles).map_err(|e| {
             RuntimeError::ApplicationError(ApplicationError::RoleAssignmentError(e))
         })?;
@@ -471,10 +465,10 @@ impl RoleAssignmentNativePackage {
         Ok(Own(component_id))
     }
 
-    fn set_owner_role<Y>(rule: AccessRule, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn set_owner_role<Y: SystemApi<RuntimeError>>(
+        rule: AccessRule,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Self::verify_access_rule(&rule).map_err(|e| {
             RuntimeError::ApplicationError(ApplicationError::RoleAssignmentError(e))
         })?;
@@ -496,10 +490,7 @@ impl RoleAssignmentNativePackage {
         Ok(())
     }
 
-    fn lock_owner_role<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    fn lock_owner_role<Y: SystemApi<RuntimeError>>(api: &mut Y) -> Result<(), RuntimeError> {
         let handle = api.actor_open_field(ACTOR_STATE_SELF, 0u8, LockFlags::MUTABLE)?;
         let mut owner_role = api
             .field_read_typed::<RoleAssignmentOwnerFieldPayload>(handle)?
@@ -517,15 +508,12 @@ impl RoleAssignmentNativePackage {
         Ok(())
     }
 
-    fn set_role<Y>(
+    fn set_role<Y: SystemApi<RuntimeError>>(
         module: ModuleId,
         role_key: RoleKey,
         rule: AccessRule,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         if module.eq(&ModuleId::RoleAssignment) {
             return Err(RuntimeError::ApplicationError(
                 ApplicationError::RoleAssignmentError(RoleAssignmentError::UsedReservedSpace),
@@ -592,14 +580,11 @@ impl RoleAssignmentNativePackage {
         Ok(())
     }
 
-    pub(crate) fn get_role<Y>(
+    pub(crate) fn get_role<Y: SystemApi<RuntimeError>>(
         module: ModuleId,
         role_key: RoleKey,
         api: &mut Y,
-    ) -> Result<Option<AccessRule>, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Option<AccessRule>, RuntimeError> {
         let module_role_key = ModuleRoleKey::new(module, role_key);
 
         let handle = api.actor_open_key_value_entry(
@@ -643,14 +628,11 @@ impl RoleAssignmentBottlenoseExtension {
         (functions, schema)
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             ROLE_ASSIGNMENT_GET_OWNER_ROLE_IDENT => {
                 input
@@ -668,10 +650,9 @@ impl RoleAssignmentBottlenoseExtension {
         }
     }
 
-    pub(crate) fn get_owner_role<Y>(api: &mut Y) -> Result<OwnerRoleEntry, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn get_owner_role<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<OwnerRoleEntry, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             RoleAssignmentField::Owner.field_index(),

--- a/radix-engine/src/object_modules/royalty/package.rs
+++ b/radix-engine/src/object_modules/royalty/package.rs
@@ -164,14 +164,11 @@ impl RoyaltyNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn invoke_export<Y>(
+    pub fn invoke_export<Y: SystemApi<RuntimeError>>(
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         match export_name {
             COMPONENT_ROYALTY_CREATE_IDENT => {
                 let input: ComponentRoyaltyCreateInput = input.as_typed().map_err(|e| {
@@ -223,14 +220,11 @@ pub enum ComponentRoyaltyError {
 pub struct RoyaltyUtil;
 
 impl RoyaltyUtil {
-    pub fn verify_royalty_amounts<'a, I: Iterator<Item = &'a RoyaltyAmount>, Y>(
-        royalty_amounts: I,
+    pub fn verify_royalty_amounts<'a, Y: SystemApi<RuntimeError>>(
+        royalty_amounts: impl Iterator<Item = &'a RoyaltyAmount>,
         is_component: bool,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         let max_royalty_in_xrd = match api.max_per_function_royalty_in_xrd() {
             Ok(amount) => Ok(amount),
             Err(RuntimeError::SystemError(SystemError::CostingModuleNotEnabled)) => return Ok(()),
@@ -318,13 +312,10 @@ impl RoyaltyUtil {
 pub struct ComponentRoyaltyBlueprint;
 
 impl ComponentRoyaltyBlueprint {
-    pub(crate) fn create<Y>(
+    pub(crate) fn create<Y: SystemApi<RuntimeError>>(
         royalty_config: ComponentRoyaltyConfig,
         api: &mut Y,
-    ) -> Result<Own, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<Own, RuntimeError> {
         // Create a royalty vault
         let accumulator_substate = ComponentRoyaltySubstate {
             royalty_vault: Vault::create(XRD, api)?,
@@ -373,14 +364,11 @@ impl ComponentRoyaltyBlueprint {
         Ok(Own(component_id))
     }
 
-    pub(crate) fn set_royalty<Y>(
+    pub(crate) fn set_royalty<Y: SystemApi<RuntimeError>>(
         method: String,
         amount: RoyaltyAmount,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    ) -> Result<(), RuntimeError> {
         RoyaltyUtil::verify_royalty_amounts(vec![amount.clone()].iter(), true, api)?;
 
         let handle = api.actor_open_key_value_entry(
@@ -398,10 +386,10 @@ impl ComponentRoyaltyBlueprint {
         Ok(())
     }
 
-    pub(crate) fn lock_royalty<Y>(method: String, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn lock_royalty<Y: SystemApi<RuntimeError>>(
+        method: String,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let handle = api.actor_open_key_value_entry(
             ACTOR_STATE_SELF,
             ComponentRoyaltyCollection::MethodAmountKeyValue.collection_index(),
@@ -414,10 +402,9 @@ impl ComponentRoyaltyBlueprint {
         Ok(())
     }
 
-    pub(crate) fn claim_royalties<Y>(api: &mut Y) -> Result<Bucket, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-    {
+    pub(crate) fn claim_royalties<Y: SystemApi<RuntimeError>>(
+        api: &mut Y,
+    ) -> Result<Bucket, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             RoyaltyField::RoyaltyAccumulator.into(),

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -100,11 +100,7 @@ enum EmitterActor {
     AsObject(NodeId, Option<AttachedModuleId>),
 }
 
-impl<'a, Y, V> SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
-{
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
     pub fn new(api: &'a mut Y) -> Self {
         Self {
             api,
@@ -117,11 +113,7 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
-{
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
     fn validate_new_object(
         &mut self,
         blueprint_id: &BlueprintId,
@@ -1113,10 +1105,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemFieldApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemFieldApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1206,10 +1196,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemObjectApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemObjectApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1595,10 +1583,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueEntryApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1734,10 +1720,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemKeyValueStoreApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueStoreApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1888,10 +1872,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemActorIndexApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorIndexApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     fn actor_index_insert(
@@ -2022,10 +2004,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemActorSortedIndexApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorSortedIndexApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2142,10 +2122,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemBlueprintApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemBlueprintApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     fn call_function(
@@ -2190,10 +2168,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemCostingApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemCostingApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // No costing should be applied
     fn consume_cost_units(
@@ -2455,10 +2431,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemActorApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     #[trace_resources]
     fn actor_get_blueprint_id(&mut self) -> Result<BlueprintId, RuntimeError> {
@@ -2676,10 +2650,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemActorKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorKeyValueEntryApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2769,10 +2741,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemExecutionTraceApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemExecutionTraceApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     // No costing should be applied
     #[trace_resources]
@@ -2789,10 +2759,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemTransactionRuntimeApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemTransactionRuntimeApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
     #[trace_resources]
     fn get_transaction_hash(&mut self) -> Result<Hash, RuntimeError> {
@@ -2884,10 +2852,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> SystemApi<RuntimeError> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemApi<RuntimeError>
+    for SystemService<'a, Y, V>
 {
 }
 
@@ -2895,10 +2861,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> KernelNodeApi for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelNodeApi
+    for SystemService<'a, Y, V>
 {
     fn kernel_pin_node(&mut self, node_id: NodeId) -> Result<(), RuntimeError> {
         self.api.kernel_pin_node(node_id)
@@ -2933,10 +2897,8 @@ where
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y, V> KernelSubstateApi<SystemLockData> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelSubstateApi<SystemLockData>
+    for SystemService<'a, Y, V>
 {
     fn kernel_mark_substate_as_transient(
         &mut self,
@@ -3045,10 +3007,8 @@ where
     }
 }
 
-impl<'a, Y, V> KernelInternalApi<System<V>> for SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelInternalApi<System<V>>
+    for SystemService<'a, Y, V>
 {
     fn kernel_get_system_state(&mut self) -> SystemState<'_, System<V>> {
         self.api.kernel_get_system_state()

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -722,16 +722,13 @@ impl<C: SystemCallbackObject> System<C> {
         println!("{:-^120}", "Finish");
     }
 
-    fn on_move_node<Y>(
+    fn on_move_node<Y: KernelApi<Self>>(
         node_id: &NodeId,
         is_moving_down: bool,
         is_to_barrier: bool,
         destination_blueprint_id: Option<BlueprintId>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         let type_info = TypeInfoBlueprint::get_type(&node_id, api)?;
 
         match type_info {
@@ -980,16 +977,13 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         };
     }
 
-    fn start<Y>(
+    fn start<Y: KernelApi<Self>>(
         api: &mut Y,
         manifest_encoded_instructions: &[u8],
         pre_allocated_addresses: &Vec<PreAllocatedAddress>,
         references: &IndexSet<Reference>,
         blobs: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<Vec<InstructionOutput>, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<Vec<InstructionOutput>, RuntimeError> {
         let mut system = SystemService::new(api);
 
         // Allocate global addresses
@@ -1272,52 +1266,52 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         SystemModuleMixer::on_pin_node(self, node_id)
     }
 
-    fn on_create_node<Y>(api: &mut Y, event: CreateNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_create_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CreateNodeEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_create_node(api, &event)
     }
 
-    fn on_drop_node<Y>(api: &mut Y, event: DropNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_drop_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: DropNodeEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_drop_node(api, &event)
     }
 
-    fn on_move_module<Y>(api: &mut Y, event: MoveModuleEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_move_module<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: MoveModuleEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_move_module(api, &event)
     }
 
-    fn on_open_substate<Y>(api: &mut Y, event: OpenSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_open_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: OpenSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_open_substate(api, &event)
     }
 
-    fn on_close_substate<Y>(api: &mut Y, event: CloseSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_close_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CloseSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_close_substate(api, &event)
     }
 
-    fn on_read_substate<Y>(api: &mut Y, event: ReadSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_read_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: ReadSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_read_substate(api, &event)
     }
 
-    fn on_write_substate<Y>(api: &mut Y, event: WriteSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_write_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: WriteSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_write_substate(api, &event)
     }
 
@@ -1344,13 +1338,10 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         SystemModuleMixer::on_scan_sorted_substates(self, &event)
     }
 
-    fn before_invoke<Y>(
+    fn before_invoke<Y: KernelApi<Self>>(
         invocation: &KernelInvocation<Actor>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         let is_to_barrier = invocation.call_frame_data.is_barrier();
         let destination_blueprint_id = invocation.call_frame_data.blueprint_id();
 
@@ -1367,10 +1358,10 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         SystemModuleMixer::before_invoke(api, invocation)
     }
 
-    fn after_invoke<Y>(output: &IndexedScryptoValue, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn after_invoke<Y: KernelApi<Self>>(
+        output: &IndexedScryptoValue,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let current_actor = api.kernel_get_system_state().current_call_frame;
         let is_to_barrier = current_actor.is_barrier();
         let destination_blueprint_id = current_actor.blueprint_id();
@@ -1387,26 +1378,23 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         SystemModuleMixer::after_invoke(api, output)
     }
 
-    fn on_execution_start<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_start<Y: KernelApi<Self>>(api: &mut Y) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_execution_start(api)
     }
 
-    fn on_execution_finish<Y>(message: &CallFrameMessage, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_finish<Y: KernelApi<Self>>(
+        message: &CallFrameMessage,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_execution_finish(api, message)?;
 
         Ok(())
     }
 
-    fn on_allocate_node_id<Y>(entity_type: EntityType, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_allocate_node_id<Y: KernelApi<Self>>(
+        entity_type: EntityType,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_allocate_node_id(api, entity_type)
     }
 
@@ -1414,13 +1402,10 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
     // Note that the following logic doesn't go through mixer and is not costed
     //--------------------------------------------------------------------------
 
-    fn invoke_upstream<Y>(
+    fn invoke_upstream<Y: KernelApi<System<C>>>(
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelApi<System<C>>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let mut system = SystemService::new(api);
         let actor = system.current_actor();
         let node_id = actor.node_id();
@@ -1561,10 +1546,7 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
     }
 
     // Note: we check dangling nodes, in kernel, after auto-drop
-    fn auto_drop<Y>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn auto_drop<Y: KernelApi<Self>>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError> {
         // Round 1 - drop all proofs
         for node_id in nodes {
             let type_info = TypeInfoBlueprint::get_type(&node_id, api)?;
@@ -1628,15 +1610,12 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         )
     }
 
-    fn on_substate_lock_fault<Y>(
+    fn on_substate_lock_fault<Y: KernelApi<Self>>(
         node_id: NodeId,
         partition_num: PartitionNumber,
         offset: &SubstateKey,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<bool, RuntimeError> {
         // As currently implemented, this should always be called with partition_num=0 and offset=0
         // since all nodes are access by accessing their type info first
         // This check is simply a sanity check that this invariant remain true
@@ -1701,10 +1680,10 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
         }
     }
 
-    fn on_drop_node_mut<Y>(node_id: &NodeId, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_drop_node_mut<Y: KernelApi<Self>>(
+        node_id: &NodeId,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         let type_info = TypeInfoBlueprint::get_type(&node_id, api)?;
 
         match type_info {

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -15,15 +15,15 @@ pub trait SystemCallbackObject: Sized {
     fn init<S: BootStore>(store: &S, init_input: Self::Init) -> Result<Self, BootloadingError>;
 
     /// Invoke a function
-    fn invoke<Y>(
+    fn invoke<
+        Y: SystemApi<RuntimeError>
+            + KernelInternalApi<System<Self>>
+            + KernelNodeApi
+            + KernelSubstateApi<SystemLockData>,
+    >(
         package_address: &PackageAddress,
         package_export: PackageExport,
         input: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>
-            + KernelInternalApi<System<Self>>
-            + KernelNodeApi
-            + KernelSubstateApi<SystemLockData>;
+    ) -> Result<IndexedScryptoValue, RuntimeError>;
 }

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -74,15 +74,11 @@ impl AuthModule {
         Self { params }
     }
 
-    pub fn on_call_function<V, Y>(
+    pub fn on_call_function<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         blueprint_id: &BlueprintId,
         ident: &str,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         // Create AuthZone
         let auth_zone = {
             // TODO: Remove special casing use of transaction processor and just have virtual resources
@@ -129,29 +125,21 @@ impl AuthModule {
         Ok(auth_zone)
     }
 
-    pub fn on_call_function_finish<V, Y>(
+    pub fn on_call_function_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         auth_zone: NodeId,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         Self::teardown_auth_zone(api, auth_zone)
     }
 
-    pub fn on_call_method<V, Y>(
+    pub fn on_call_method<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         receiver: &NodeId,
         module_id: ModuleId,
         direct_access: bool,
         ident: &str,
         args: &IndexedScryptoValue,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         let auth_zone = AuthModule::create_auth_zone(
             api,
             Some((receiver, direct_access)),
@@ -184,39 +172,27 @@ impl AuthModule {
         Ok(auth_zone)
     }
 
-    pub fn on_call_method_finish<V, Y>(
+    pub fn on_call_method_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         auth_zone: NodeId,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         Self::teardown_auth_zone(api, auth_zone)
     }
 
     /// On CALL_FUNCTION or CALL_METHOD, when auth module is disabled.
-    pub fn on_call_fn_mock<V, Y>(
+    pub fn on_call_fn_mock<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         system: &mut SystemService<Y, V>,
         receiver: Option<(&NodeId, bool)>,
         virtual_resources: BTreeSet<ResourceAddress>,
         virtual_non_fungibles: BTreeSet<NonFungibleGlobalId>,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         Self::create_auth_zone(system, receiver, virtual_resources, virtual_non_fungibles)
     }
 
-    fn copy_global_caller<V, Y>(
+    fn copy_global_caller<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         system: &mut SystemService<Y, V>,
         node_id: &NodeId,
-    ) -> Result<(Option<(GlobalCaller, Reference)>, Option<SubstateHandle>), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(Option<(GlobalCaller, Reference)>, Option<SubstateHandle>), RuntimeError> {
         let handle = system.kernel_open_substate(
             node_id,
             MAIN_BASE_PARTITION,
@@ -232,16 +208,12 @@ impl AuthModule {
         Ok((auth_zone.into_payload().global_caller, Some(handle)))
     }
 
-    fn create_auth_zone<V, Y>(
+    fn create_auth_zone<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         system: &mut SystemService<Y, V>,
         receiver: Option<(&NodeId, bool)>,
         virtual_resources: BTreeSet<ResourceAddress>,
         virtual_non_fungibles: BTreeSet<NonFungibleGlobalId>,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         let (auth_zone, parent_lock_handle) = {
             let is_global_context_change = if let Some((receiver, direct_access)) = receiver {
                 let object_info = system.get_object_info(receiver)?;
@@ -359,14 +331,10 @@ impl AuthModule {
         Ok(new_auth_zone)
     }
 
-    pub fn teardown_auth_zone<V, Y>(
+    pub fn teardown_auth_zone<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         self_auth_zone: NodeId,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         // Detach proofs from the auth zone
         let handle = api.kernel_open_substate(
             &self_auth_zone,

--- a/radix-engine/src/system/system_modules/auth/authorization.rs
+++ b/radix-engine/src/system/system_modules/auth/authorization.rs
@@ -19,7 +19,7 @@ use sbor::rust::ops::Fn;
 pub struct Authorization;
 
 impl Authorization {
-    fn proof_matches<L: Default, Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>>(
+    fn proof_matches<Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>, L: Default>(
         resource_rule: &ResourceOrNonFungible,
         proof: &Proof,
         api: &mut Y,
@@ -41,20 +41,16 @@ impl Authorization {
         }
     }
 
-    fn global_auth_zone_matches<L: Default, Y, P>(
+    fn global_auth_zone_matches<Y: KernelSubstateApi<L>, L: Default>(
         api: &mut Y,
         auth_zone_id: &NodeId,
-        check: &P,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelSubstateApi<L>,
-        P: Fn(
+        check: &impl Fn(
             &[Proof],
             &BTreeSet<ResourceAddress>,
             BTreeSet<NonFungibleGlobalId>,
             &mut Y,
         ) -> Result<bool, RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         let mut pass = false;
         let mut current_auth_zone_id = *auth_zone_id;
         let mut handles = Vec::new();
@@ -108,21 +104,16 @@ impl Authorization {
         Ok(pass)
     }
 
-    fn auth_zone_stack_matches<P, L, Y>(
+    fn auth_zone_stack_matches<Y: KernelSubstateApi<L>, L: Default>(
         auth_zone: &NodeId,
         api: &mut Y,
-        check: P,
-    ) -> Result<bool, RuntimeError>
-    where
-        L: Default,
-        Y: KernelSubstateApi<L>,
-        P: Fn(
+        check: impl Fn(
             &[Proof],
             &BTreeSet<ResourceAddress>,
             BTreeSet<NonFungibleGlobalId>,
             &mut Y,
         ) -> Result<bool, RuntimeError>,
-    {
+    ) -> Result<bool, RuntimeError> {
         let handle = api.kernel_open_substate(
             &auth_zone,
             MAIN_BASE_PARTITION,
@@ -173,7 +164,7 @@ impl Authorization {
     }
 
     fn auth_zone_stack_has_amount<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         auth_zone: &NodeId,
@@ -196,7 +187,7 @@ impl Authorization {
     }
 
     fn auth_zone_stack_matches_rule<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         auth_zone: &NodeId,
@@ -229,7 +220,7 @@ impl Authorization {
     }
 
     pub fn verify_proof_rule<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         auth_zone: &NodeId,
@@ -288,7 +279,7 @@ impl Authorization {
         }
     }
 
-    pub fn verify_auth_rule<Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>, L: Default>(
+    pub fn verify_auth_rule<Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>, L: Default>(
         auth_zone: &NodeId,
         requirement_rule: &CompositeRequirement,
         api: &mut Y,
@@ -324,7 +315,7 @@ impl Authorization {
     }
 
     pub fn check_authorization_against_role_key_internal<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         auth_zone: &NodeId,
@@ -381,7 +372,7 @@ impl Authorization {
     }
 
     pub fn check_authorization_against_access_rule<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         api: &mut Y,
@@ -405,7 +396,7 @@ impl Authorization {
     }
 
     pub fn check_authorization_against_role_list<
-        Y: KernelSubstateApi<L> + SystemObjectApi<RuntimeError>,
+        Y: SystemObjectApi<RuntimeError> + KernelSubstateApi<L>,
         L: Default,
     >(
         auth_zone: &NodeId,

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -377,18 +377,14 @@ impl SystemModuleMixer {
     // - Kernel uses the `SystemModule<SystemConfig<V>>` trait above;
     // - System uses methods defined below (TODO: add a trait?)
 
-    pub fn on_call_method<Y, V>(
+    pub fn on_call_method<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         receiver: &NodeId,
         module_id: ModuleId,
         direct_access: bool,
         ident: &str,
         args: &IndexedScryptoValue,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         let auth_zone = if api
             .kernel_get_system_state()
             .system
@@ -409,26 +405,18 @@ impl SystemModuleMixer {
         Ok(auth_zone)
     }
 
-    pub fn on_call_method_finish<Y, V>(
+    pub fn on_call_method_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         auth_zone: NodeId,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         AuthModule::on_call_method_finish(api, auth_zone)
     }
 
-    pub fn on_call_function<V, Y>(
+    pub fn on_call_function<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         blueprint_id: &BlueprintId,
         ident: &str,
-    ) -> Result<NodeId, RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<NodeId, RuntimeError> {
         let auth_zone = if api
             .kernel_get_system_state()
             .system
@@ -444,14 +432,10 @@ impl SystemModuleMixer {
         Ok(auth_zone)
     }
 
-    pub fn on_call_function_finish<V, Y>(
+    pub fn on_call_function_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
         api: &mut SystemService<Y, V>,
         auth_zone: NodeId,
-    ) -> Result<(), RuntimeError>
-    where
-        V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
-    {
+    ) -> Result<(), RuntimeError> {
         AuthModule::on_call_function_finish(api, auth_zone)
     }
 

--- a/radix-engine/src/system/system_type_checker.rs
+++ b/radix-engine/src/system/system_type_checker.rs
@@ -55,11 +55,7 @@ pub enum TypeCheckError {
     MissingSchema,
 }
 
-impl<'a, Y, V> SystemService<'a, Y, V>
-where
-    Y: KernelApi<System<V>>,
-    V: SystemCallbackObject,
-{
+impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
     /// Validate that the type substitutions match the generic definition of a given blueprint
     pub fn validate_bp_generic_args(
         &mut self,

--- a/radix-engine/src/system/type_info.rs
+++ b/radix-engine/src/system/type_info.rs
@@ -32,13 +32,10 @@ impl TypeInfoSubstate {
 pub struct TypeInfoBlueprint;
 
 impl TypeInfoBlueprint {
-    pub(crate) fn get_type<Y, L: Default>(
+    pub(crate) fn get_type<Y: KernelSubstateApi<L>, L: Default>(
         receiver: &NodeId,
         api: &mut Y,
-    ) -> Result<TypeInfoSubstate, RuntimeError>
-    where
-        Y: KernelSubstateApi<L>,
-    {
+    ) -> Result<TypeInfoSubstate, RuntimeError> {
         let handle = api.kernel_open_substate(
             receiver,
             TYPE_INFO_FIELD_PARTITION,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -3,7 +3,6 @@ use crate::blueprints::consensus_manager::EpochChangeEvent;
 use crate::errors::*;
 use crate::internal_prelude::*;
 use crate::kernel::kernel_callback_api::ExecutionReceipt;
-use crate::system::actor::*;
 use crate::system::system_db_reader::SystemDatabaseReader;
 use crate::system::system_modules::costing::*;
 use crate::system::system_modules::execution_trace::*;
@@ -110,6 +109,9 @@ impl TransactionReceiptV1 {
         detailed_execution_cost_breakdown: &[DetailedExecutionCostBreakdownEntry],
         network_definition: &NetworkDefinition,
     ) -> String {
+        // Putting use in here so it doesn't cause unused import compile warning in no-std
+        use crate::system::actor::*;
+
         let address_bech32m_encoder = AddressBech32Encoder::new(&network_definition);
 
         let mut lines = Vec::<String>::new();

--- a/radix-engine/src/vm/native_vm.rs
+++ b/radix-engine/src/vm/native_vm.rs
@@ -93,17 +93,16 @@ impl<I: VmInvoke> NativeVmInstance<I> {
 
 impl<I: VmInvoke> VmInvoke for NativeVmInstance<I> {
     #[trace_resources(log=self.package_address().is_native_package(), log=self.package_address().to_hex(), log=export_name)]
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         #[allow(unused_mut)]
         let mut func = || match self {
             NativeVmInstance::Extension(e) => e.invoke(export_name, input, api, vm_api),
@@ -276,17 +275,16 @@ impl DefaultNativeVm {
 pub struct NullVmInvoke;
 
 impl VmInvoke for NullVmInvoke {
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         _export_name: &str,
         _input: &IndexedScryptoValue,
         _api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         panic!("Invocation was called on null VmInvoke");
     }
 }

--- a/radix-engine/src/vm/scrypto_vm.rs
+++ b/radix-engine/src/vm/scrypto_vm.rs
@@ -43,17 +43,13 @@ pub struct ScryptoVmInstance<I: WasmInstance> {
 
 impl<I: WasmInstance> VmInvoke for ScryptoVmInstance<I> {
     #[trace_resources(log=self.package_address.is_native_package(), log=self.package_address.to_hex(), log=export_name)]
-    fn invoke<Y, V>(
+    fn invoke<Y: SystemApi<RuntimeError>, V: VmApi>(
         &mut self,
         export_name: &str,
         args: &IndexedScryptoValue,
         api: &mut Y,
         _vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError>,
-        V: VmApi,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let rtn = {
             let mut runtime: Box<dyn WasmRuntime> = Box::new(ScryptoRuntime::new(
                 api,

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -98,19 +98,17 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
         })
     }
 
-    fn invoke<Y>(
-        address: &PackageAddress,
-        export: PackageExport,
-        input: &IndexedScryptoValue,
-        api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
+    fn invoke<
         Y: SystemApi<RuntimeError>
             + KernelInternalApi<System<Self>>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
-        W: WasmEngine,
-    {
+    >(
+        address: &PackageAddress,
+        export: PackageExport,
+        input: &IndexedScryptoValue,
+        api: &mut Y,
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         let vm_type = {
             let handle = api.kernel_open_substate_with_default(
                 address.as_node_id(),
@@ -225,16 +223,16 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
 
 pub trait VmInvoke {
     // TODO: Remove KernelNodeAPI + KernelSubstateAPI from api, unify with VmApi
-    fn invoke<Y, V>(
+    fn invoke<
+        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
+        V: VmApi,
+    >(
         &mut self,
         export_name: &str,
         input: &IndexedScryptoValue,
         api: &mut Y,
         vm_api: &V,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: SystemApi<RuntimeError> + KernelNodeApi + KernelSubstateApi<SystemLockData>,
-        V: VmApi;
+    ) -> Result<IndexedScryptoValue, RuntimeError>;
 }
 
 pub struct VmPackageValidation;

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -12,10 +12,7 @@ use radix_engine_profiling_derive::trace_resources;
 use sbor::rust::vec::Vec;
 
 /// A shim between SystemAPI and WASM, with buffer capability.
-pub struct ScryptoRuntime<'y, Y>
-where
-    Y: SystemApi<RuntimeError>,
-{
+pub struct ScryptoRuntime<'y, Y: SystemApi<RuntimeError>> {
     api: &'y mut Y,
     buffers: IndexMap<BufferId, Vec<u8>>,
     next_buffer_id: BufferId,
@@ -25,10 +22,7 @@ where
     max_number_of_buffers: usize,
 }
 
-impl<'y, Y> ScryptoRuntime<'y, Y>
-where
-    Y: SystemApi<RuntimeError>,
-{
+impl<'y, Y: SystemApi<RuntimeError>> ScryptoRuntime<'y, Y> {
     pub fn new(api: &'y mut Y, package_address: PackageAddress, export_name: String) -> Self {
         ScryptoRuntime {
             api,
@@ -53,10 +47,7 @@ where
     }
 }
 
-impl<'y, Y> WasmRuntime for ScryptoRuntime<'y, Y>
-where
-    Y: SystemApi<RuntimeError>,
-{
+impl<'y, Y: SystemApi<RuntimeError>> WasmRuntime for ScryptoRuntime<'y, Y> {
     fn allocate_buffer(
         &mut self,
         buffer: Vec<u8>,

--- a/radix-native-sdk/src/account/account.rs
+++ b/radix-native-sdk/src/account/account.rs
@@ -1,5 +1,5 @@
-use radix_common::data::scrypto::{scrypto_encode, ScryptoDecode};
-use radix_engine_interface::api::SystemObjectApi;
+use radix_common::data::scrypto::scrypto_encode;
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::account::{AccountDepositInput, ACCOUNT_DEPOSIT_IDENT};
 use radix_engine_interface::blueprints::resource::Bucket;
 use radix_engine_interface::types::ComponentAddress;
@@ -9,10 +9,11 @@ use sbor::rust::fmt::Debug;
 pub struct Account(pub ComponentAddress);
 
 impl Account {
-    pub fn deposit<Y, E: Debug + ScryptoDecode>(&self, bucket: Bucket, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    pub fn deposit<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), E> {
         api.call_method(
             self.0.as_node_id(),
             ACCOUNT_DEPOSIT_IDENT,

--- a/radix-native-sdk/src/consensus_manager/consensus_manager.rs
+++ b/radix-native-sdk/src/consensus_manager/consensus_manager.rs
@@ -1,7 +1,7 @@
 use radix_common::crypto::Secp256k1PublicKey;
-use radix_common::data::scrypto::{scrypto_decode, scrypto_encode, ScryptoDecode};
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::SystemObjectApi;
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::consensus_manager::{
     ConsensusManagerCreateValidatorInput, ConsensusManagerStartInput,
     CONSENSUS_MANAGER_CREATE_VALIDATOR_IDENT, CONSENSUS_MANAGER_START_IDENT,
@@ -14,16 +14,13 @@ use sbor::rust::fmt::Debug;
 pub struct ConsensusManager(pub ComponentAddress);
 
 impl ConsensusManager {
-    pub fn create_validator<Y, E: Debug + ScryptoDecode>(
+    pub fn create_validator<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         key: Secp256k1PublicKey,
         fee_factor: Decimal,
         xrd_payment: Bucket,
         api: &mut Y,
-    ) -> Result<(ComponentAddress, Bucket, Bucket), E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<(ComponentAddress, Bucket, Bucket), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             CONSENSUS_MANAGER_CREATE_VALIDATOR_IDENT,
@@ -38,10 +35,7 @@ impl ConsensusManager {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn start<Y, E: Debug + ScryptoDecode>(&self, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    pub fn start<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<(), E> {
         api.call_method(
             self.0.as_node_id(),
             CONSENSUS_MANAGER_START_IDENT,

--- a/radix-native-sdk/src/consensus_manager/validator.rs
+++ b/radix-native-sdk/src/consensus_manager/validator.rs
@@ -1,5 +1,5 @@
-use radix_common::data::scrypto::{scrypto_decode, scrypto_encode, ScryptoDecode};
-use radix_engine_interface::api::SystemObjectApi;
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::consensus_manager::{
     ValidatorAcceptsDelegatedStakeInput, ValidatorRegisterInput, ValidatorStakeInput,
     ValidatorUpdateAcceptDelegatedStakeInput, VALIDATOR_ACCEPTS_DELEGATED_STAKE_IDENT,
@@ -13,10 +13,7 @@ use sbor::rust::fmt::Debug;
 pub struct Validator(pub ComponentAddress);
 
 impl Validator {
-    pub fn register<Y, E: Debug + ScryptoDecode>(&self, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    pub fn register<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<(), E> {
         api.call_method(
             self.0.as_node_id(),
             VALIDATOR_REGISTER_IDENT,
@@ -26,14 +23,11 @@ impl Validator {
         Ok(())
     }
 
-    pub fn update_accept_delegated_stake<Y, E: Debug + ScryptoDecode>(
+    pub fn update_accept_delegated_stake<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         accept_delegated_stake: bool,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<(), E> {
         api.call_method(
             self.0.as_node_id(),
             VALIDATOR_UPDATE_ACCEPT_DELEGATED_STAKE_IDENT,
@@ -46,13 +40,10 @@ impl Validator {
         Ok(())
     }
 
-    pub fn accepts_delegated_stake<Y, E: Debug + ScryptoDecode>(
+    pub fn accepts_delegated_stake<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<bool, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<bool, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VALIDATOR_ACCEPTS_DELEGATED_STAKE_IDENT,
@@ -62,14 +53,11 @@ impl Validator {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn stake<Y, E: Debug + ScryptoDecode>(
+    pub fn stake<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         stake: Bucket,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VALIDATOR_STAKE_IDENT,

--- a/radix-native-sdk/src/modules/metadata/metadata.rs
+++ b/radix-native-sdk/src/modules/metadata/metadata.rs
@@ -1,7 +1,7 @@
 use radix_common::constants::METADATA_MODULE_PACKAGE;
 use radix_common::data::scrypto::model::Own;
 use radix_common::data::scrypto::*;
-use radix_engine_interface::api::SystemApi;
+use radix_engine_interface::api::*;
 use radix_engine_interface::object_modules::metadata::{
     MetadataCreateInput, MetadataCreateWithDataInput, MetadataInit, MetadataSetInput, MetadataVal,
     METADATA_BLUEPRINT, METADATA_CREATE_IDENT, METADATA_CREATE_WITH_DATA_IDENT, METADATA_SET_IDENT,
@@ -11,10 +11,7 @@ use sbor::rust::prelude::*;
 pub struct Metadata(pub Own);
 
 impl Metadata {
-    pub fn create<Y, E: Debug + ScryptoDecode>(api: &mut Y) -> Result<Own, E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn create<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<Own, E> {
         let rtn = api.call_function(
             METADATA_MODULE_PACKAGE,
             METADATA_BLUEPRINT,
@@ -26,13 +23,10 @@ impl Metadata {
         Ok(metadata)
     }
 
-    pub fn create_with_data<Y, E: Debug + ScryptoDecode>(
+    pub fn create_with_data<Y: SystemApi<E>, E: SystemApiError>(
         data: MetadataInit,
         api: &mut Y,
-    ) -> Result<Own, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Own, E> {
         let rtn = api.call_function(
             METADATA_MODULE_PACKAGE,
             METADATA_BLUEPRINT,
@@ -44,22 +38,16 @@ impl Metadata {
         Ok(metadata)
     }
 
-    pub fn new<Y, E: Debug + ScryptoDecode>(api: &mut Y) -> Result<Self, E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn new<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<Self, E> {
         Self::create(api).map(Self)
     }
 
-    pub fn set<Y, E: Debug + ScryptoDecode, S: AsRef<str>, V: MetadataVal>(
+    pub fn set<Y: SystemApi<E>, E: SystemApiError, S: AsRef<str>, V: MetadataVal>(
         &mut self,
         api: &mut Y,
         key: S,
         value: V,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         api.call_method(
             self.0.as_node_id(),
             METADATA_SET_IDENT,

--- a/radix-native-sdk/src/modules/role_assignment/role_assignment.rs
+++ b/radix-native-sdk/src/modules/role_assignment/role_assignment.rs
@@ -2,26 +2,22 @@ use radix_common::constants::ROLE_ASSIGNMENT_MODULE_PACKAGE;
 use radix_common::data::scrypto::model::Own;
 use radix_common::data::scrypto::*;
 use radix_engine_interface::api::object_api::ModuleId;
-use radix_engine_interface::api::{AttachedModuleId, SystemApi};
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::{
     AccessRule, OwnerRoleEntry, RoleAssignmentInit, RoleKey,
 };
 use radix_engine_interface::object_modules::role_assignment::*;
 use radix_engine_interface::types::NodeId;
-use sbor::rust::fmt::Debug;
 use sbor::rust::prelude::*;
 
 pub struct RoleAssignment(pub Own);
 
 impl RoleAssignment {
-    pub fn create<Y, R: Into<OwnerRoleEntry>, E: Debug + ScryptoDecode>(
+    pub fn create<Y: SystemApi<E>, E: SystemApiError, R: Into<OwnerRoleEntry>>(
         owner_role: R,
         roles: IndexMap<ModuleId, RoleAssignmentInit>,
         api: &mut Y,
-    ) -> Result<Self, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Self, E> {
         let rtn = api.call_function(
             ROLE_ASSIGNMENT_MODULE_PACKAGE,
             ROLE_ASSIGNMENT_BLUEPRINT,
@@ -56,7 +52,7 @@ impl RoleAssignmentObject for AttachedRoleAssignment {
 pub trait RoleAssignmentObject {
     fn self_id(&self) -> (&NodeId, Option<AttachedModuleId>);
 
-    fn set_owner_role<Y: SystemApi<E>, E: Debug + ScryptoDecode, A: Into<AccessRule>>(
+    fn set_owner_role<Y: SystemApi<E>, E: SystemApiError, A: Into<AccessRule>>(
         &self,
         rule: A,
         api: &mut Y,
@@ -83,10 +79,7 @@ pub trait RoleAssignmentObject {
         Ok(())
     }
 
-    fn lock_owner_role<Y: SystemApi<E>, E: Debug + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<(), E> {
+    fn lock_owner_role<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<(), E> {
         let (node_id, module_id) = self.self_id();
         match module_id {
             None => {
@@ -109,12 +102,7 @@ pub trait RoleAssignmentObject {
         Ok(())
     }
 
-    fn set_role<
-        Y: SystemApi<E>,
-        E: Debug + ScryptoDecode,
-        R: Into<RoleKey>,
-        A: Into<AccessRule>,
-    >(
+    fn set_role<Y: SystemApi<E>, E: SystemApiError, R: Into<RoleKey>, A: Into<AccessRule>>(
         &self,
         module: ModuleId,
         role_key: R,
@@ -153,7 +141,7 @@ pub trait RoleAssignmentObject {
         Ok(())
     }
 
-    fn get_role<Y: SystemApi<E>, E: Debug + ScryptoDecode, R: Into<RoleKey>>(
+    fn get_role<Y: SystemApi<E>, E: SystemApiError, R: Into<RoleKey>>(
         &self,
         module: ModuleId,
         role_key: R,
@@ -187,7 +175,7 @@ pub trait RoleAssignmentObject {
         }
     }
 
-    fn get_owner_role<Y: SystemApi<E>, E: Debug + ScryptoDecode, R: Into<RoleKey>>(
+    fn get_owner_role<Y: SystemApi<E>, E: SystemApiError, R: Into<RoleKey>>(
         &self,
         api: &mut Y,
     ) -> Result<RoleAssignmentGetOwnerRoleOutput, E> {

--- a/radix-native-sdk/src/modules/royalty/royalty.rs
+++ b/radix-native-sdk/src/modules/royalty/royalty.rs
@@ -10,13 +10,10 @@ use sbor::rust::prelude::*;
 pub struct ComponentRoyalty(pub Own);
 
 impl ComponentRoyalty {
-    pub fn create<Y, E: Debug + ScryptoDecode>(
+    pub fn create<Y: SystemApi<E>, E: SystemApiError>(
         royalty_config: ComponentRoyaltyConfig,
         api: &mut Y,
-    ) -> Result<Own, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Own, E> {
         let rtn = api.call_function(
             ROYALTY_MODULE_PACKAGE,
             COMPONENT_ROYALTY_BLUEPRINT,
@@ -28,15 +25,12 @@ impl ComponentRoyalty {
         Ok(component_royalty)
     }
 
-    pub fn set_royalty<Y, E: Debug + ScryptoDecode>(
+    pub fn set_royalty<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         method_name: &str,
         amount: RoyaltyAmount,
         api: &mut Y,
-    ) -> Result<ComponentRoyaltySetOutput, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<ComponentRoyaltySetOutput, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             COMPONENT_ROYALTY_SET_ROYALTY_IDENT,
@@ -50,14 +44,11 @@ impl ComponentRoyalty {
         Ok(rtn)
     }
 
-    pub fn lock_royalty<Y, E: Debug + ScryptoDecode>(
+    pub fn lock_royalty<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         method_name: &str,
         api: &mut Y,
-    ) -> Result<ComponentRoyaltyLockOutput, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<ComponentRoyaltyLockOutput, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             COMPONENT_ROYALTY_LOCK_ROYALTY_IDENT,
@@ -70,13 +61,10 @@ impl ComponentRoyalty {
         Ok(rtn)
     }
 
-    pub fn claim_royalty<Y, E: Debug + ScryptoDecode>(
+    pub fn claim_royalty<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         api: &mut Y,
-    ) -> Result<ComponentClaimRoyaltiesOutput, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<ComponentClaimRoyaltiesOutput, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             COMPONENT_ROYALTY_CLAIM_ROYALTIES_IDENT,

--- a/radix-native-sdk/src/resource/auth_zone.rs
+++ b/radix-native-sdk/src/resource/auth_zone.rs
@@ -1,94 +1,56 @@
 use radix_common::data::scrypto::model::*;
-use radix_common::data::scrypto::{
-    scrypto_decode, scrypto_encode, ScryptoCategorize, ScryptoDecode,
-};
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::SystemApi;
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
-use sbor::rust::fmt::Debug;
 use sbor::rust::vec::Vec;
 
 pub trait NativeAuthZone {
-    fn drain<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn drain<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Vec<Proof>, E>;
+
+    fn drop_proofs<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<(), E>;
+
+    fn drop_regular_proofs<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y)
+        -> Result<(), E>;
+
+    fn drop_signature_proofs<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<Vec<Proof>, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<(), E>;
 
-    fn drop_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    fn pop<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Option<Proof>, E>;
 
-    fn drop_regular_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
-
-    fn drop_signature_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
-
-    fn pop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Option<Proof>, E>
-    where
-        Y: SystemApi<E>;
-
-    fn create_proof_of_amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         amount: Decimal,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Proof, E>;
 
-    fn create_proof_of_non_fungibles<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         ids: &IndexSet<NonFungibleLocalId>,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Proof, E>;
 
-    fn create_proof_of_all<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_all<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Proof, E>;
 
-    fn push<P: Into<Proof>, Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn push<Y: SystemApi<E>, E: SystemApiError, P: Into<Proof>>(
         &self,
         proof: P,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<(), E>;
 }
 
 impl NativeAuthZone for AuthZoneRef {
-    fn drain<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Vec<Proof>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn drain<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Vec<Proof>, E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_DRAIN_IDENT,
@@ -97,13 +59,7 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn drop_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn drop_proofs<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<(), E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_DROP_PROOFS_IDENT,
@@ -112,13 +68,10 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn drop_regular_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn drop_regular_proofs<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_DROP_REGULAR_PROOFS_IDENT,
@@ -127,13 +80,10 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn drop_signature_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn drop_signature_proofs<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_DROP_SIGNATURE_PROOFS_IDENT,
@@ -142,13 +92,7 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn pop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Option<Proof>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn pop<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Option<Proof>, E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_POP_IDENT,
@@ -158,15 +102,12 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn create_proof_of_amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         amount: Decimal,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_CREATE_PROOF_OF_AMOUNT_IDENT,
@@ -180,15 +121,12 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn create_proof_of_non_fungibles<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         ids: &IndexSet<NonFungibleLocalId>,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_CREATE_PROOF_OF_NON_FUNGIBLES_IDENT,
@@ -202,14 +140,11 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn create_proof_of_all<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn create_proof_of_all<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let rtn = api.call_method(
             &self.0,
             AUTH_ZONE_CREATE_PROOF_OF_ALL_IDENT,
@@ -219,14 +154,11 @@ impl NativeAuthZone for AuthZoneRef {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn push<P: Into<Proof>, Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn push<Y: SystemApi<E>, E: SystemApiError, P: Into<Proof>>(
         &self,
         proof: P,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let proof: Proof = proof.into();
 
         let _rtn = api.call_method(

--- a/radix-native-sdk/src/resource/proof.rs
+++ b/radix-native-sdk/src/resource/proof.rs
@@ -1,61 +1,36 @@
 use radix_common::constants::RESOURCE_PACKAGE;
 use radix_common::data::scrypto::model::*;
-use radix_common::data::scrypto::{
-    scrypto_decode, scrypto_encode, ScryptoCategorize, ScryptoDecode,
-};
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::{SystemApi, SystemBlueprintApi, SystemObjectApi};
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
-use sbor::rust::fmt::Debug;
 
 pub trait NativeProof {
-    fn amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn amount<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E>;
+
+    fn resource_address<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<Decimal, E>
-    where
-        Y: SystemObjectApi<E>;
+    ) -> Result<ResourceAddress, E>;
 
-    fn resource_address<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<ResourceAddress, E>
-    where
-        Y: SystemObjectApi<E>;
+    fn clone<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Proof, E>;
 
-    fn clone<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemObjectApi<E>;
-
-    fn drop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(self, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    fn drop<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E>;
 }
 
 pub trait NativeFungibleProof {}
 
 pub trait NativeNonFungibleProof {
-    fn non_fungible_local_ids<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn non_fungible_local_ids<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, E>
-    where
-        Y: SystemObjectApi<E>;
+    ) -> Result<IndexSet<NonFungibleLocalId>, E>;
 }
 
 impl NativeProof for Proof {
-    fn amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Decimal, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    fn amount<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             PROOF_GET_AMOUNT_IDENT,
@@ -64,24 +39,15 @@ impl NativeProof for Proof {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn resource_address<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn resource_address<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<ResourceAddress, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<ResourceAddress, E> {
         let address = api.get_outer_object(self.0.as_node_id())?;
         Ok(ResourceAddress::try_from(address).unwrap())
     }
 
-    fn clone<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    fn clone<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Proof, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             PROOF_CLONE_IDENT,
@@ -90,10 +56,10 @@ impl NativeProof for Proof {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn drop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(self, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemObjectApi<E> + SystemBlueprintApi<E>,
-    {
+    fn drop<Y: SystemObjectApi<E> + SystemBlueprintApi<E>, E: SystemApiError>(
+        self,
+        api: &mut Y,
+    ) -> Result<(), E> {
         let blueprint_id = api.get_blueprint_id(self.0.as_node_id())?;
         api.call_function(
             RESOURCE_PACKAGE,
@@ -111,13 +77,10 @@ impl NativeProof for Proof {
 impl NativeFungibleProof for Proof {}
 
 impl NativeNonFungibleProof for Proof {
-    fn non_fungible_local_ids<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    fn non_fungible_local_ids<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, E>
-    where
-        Y: SystemObjectApi<E>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_PROOF_GET_LOCAL_IDS_IDENT,

--- a/radix-native-sdk/src/resource/vault.rs
+++ b/radix-native-sdk/src/resource/vault.rs
@@ -1,131 +1,105 @@
 use radix_common::data::scrypto::model::*;
-use radix_common::data::scrypto::{scrypto_decode, scrypto_encode, ScryptoDecode};
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::SystemApi;
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
-use sbor::rust::fmt::Debug;
 
 // TODO: split impl
 
 pub trait NativeVault {
-    fn create<Y, E: Debug + ScryptoDecode>(
+    fn create<Y: SystemApi<E>, E: SystemApiError>(
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Vault, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Vault, E>;
 
-    fn put<Y, E: Debug + ScryptoDecode>(&mut self, bucket: Bucket, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    fn put<Y: SystemApi<E>, E: SystemApiError>(
+        &mut self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), E>;
 
-    fn take<Y, E: Debug + ScryptoDecode>(
+    fn take<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Bucket, E>;
 
-    fn take_advanced<Y, E: Debug + ScryptoDecode>(
+    fn take_advanced<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Bucket, E>;
 
-    fn take_all<Y, E: Debug + ScryptoDecode>(&mut self, api: &mut Y) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>;
+    fn take_all<Y: SystemApi<E>, E: SystemApiError>(&mut self, api: &mut Y) -> Result<Bucket, E>;
 
-    fn amount<Y, E: Debug + ScryptoDecode>(&self, api: &mut Y) -> Result<Decimal, E>
-    where
-        Y: SystemApi<E>;
+    fn amount<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E>;
 
-    fn resource_address<Y, E: Debug + ScryptoDecode>(
+    fn resource_address<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<ResourceAddress, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<ResourceAddress, E>;
 
-    fn burn<Y, E: Debug + ScryptoDecode>(&mut self, amount: Decimal, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    fn burn<Y: SystemApi<E>, E: SystemApiError>(
+        &mut self,
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), E>;
 }
 
 pub trait NativeFungibleVault {
-    fn lock_fee<Y, E: Debug + ScryptoDecode>(
+    fn lock_fee<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         api: &mut Y,
         amount: Decimal,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<(), E>;
 
-    fn lock_contingent_fee<Y, E: Debug + ScryptoDecode>(
+    fn lock_contingent_fee<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         api: &mut Y,
         amount: Decimal,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<(), E>;
 
-    fn create_proof_of_amount<Y, E: Debug + ScryptoDecode>(
+    fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Proof, E>;
 }
 
 pub trait NativeNonFungibleVault {
-    fn non_fungible_local_ids<Y, E: Debug + ScryptoDecode>(
+    fn non_fungible_local_ids<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         limit: u32,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<IndexSet<NonFungibleLocalId>, E>;
 
-    fn take_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn take_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         non_fungible_local_ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Bucket, E>;
 
-    fn create_proof_of_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<Proof, E>;
 
-    fn burn_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn burn_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         non_fungible_local_ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>;
+    ) -> Result<(), E>;
 }
 
 impl NativeVault for Vault {
-    fn create<Y, E: Debug + ScryptoDecode>(
+    fn create<Y: SystemApi<E>, E: SystemApiError>(
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Vault, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Vault, E> {
         let rtn = api.call_method(
             resource_address.as_node_id(),
             RESOURCE_MANAGER_CREATE_EMPTY_VAULT_IDENT,
@@ -136,10 +110,11 @@ impl NativeVault for Vault {
         Ok(Self(own))
     }
 
-    fn put<Y, E: Debug + ScryptoDecode>(&mut self, bucket: Bucket, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn put<Y: SystemApi<E>, E: SystemApiError>(
+        &mut self,
+        bucket: Bucket,
+        api: &mut Y,
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VAULT_PUT_IDENT,
@@ -149,14 +124,11 @@ impl NativeVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn take<Y, E: Debug + ScryptoDecode>(
+    fn take<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VAULT_TAKE_IDENT,
@@ -166,15 +138,12 @@ impl NativeVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn take_advanced<Y, E: Debug + ScryptoDecode>(
+    fn take_advanced<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VAULT_TAKE_ADVANCED_IDENT,
@@ -188,10 +157,7 @@ impl NativeVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn take_all<Y, E: Debug + ScryptoDecode>(&mut self, api: &mut Y) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn take_all<Y: SystemApi<E>, E: SystemApiError>(&mut self, api: &mut Y) -> Result<Bucket, E> {
         // TODO: Replace with actual take all blueprint method
         let amount = self.amount(api)?;
         let rtn = api.call_method(
@@ -203,10 +169,7 @@ impl NativeVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn amount<Y, E: Debug + ScryptoDecode>(&self, api: &mut Y) -> Result<Decimal, E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn amount<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VAULT_GET_AMOUNT_IDENT,
@@ -216,21 +179,19 @@ impl NativeVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn resource_address<Y, E: Debug + ScryptoDecode>(
+    fn resource_address<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<ResourceAddress, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<ResourceAddress, E> {
         let address = api.get_outer_object(self.0.as_node_id())?;
         Ok(ResourceAddress::try_from(address.into_node_id().0).unwrap())
     }
 
-    fn burn<Y, E: Debug + ScryptoDecode>(&mut self, amount: Decimal, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    fn burn<Y: SystemApi<E>, E: SystemApiError>(
+        &mut self,
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             VAULT_BURN_IDENT,
@@ -242,14 +203,11 @@ impl NativeVault for Vault {
 }
 
 impl NativeFungibleVault for Vault {
-    fn lock_fee<Y, E: Debug + ScryptoDecode>(
+    fn lock_fee<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         api: &mut Y,
         amount: Decimal,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             FUNGIBLE_VAULT_LOCK_FEE_IDENT,
@@ -262,14 +220,11 @@ impl NativeFungibleVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn lock_contingent_fee<Y, E: Debug + ScryptoDecode>(
+    fn lock_contingent_fee<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         api: &mut Y,
         amount: Decimal,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             FUNGIBLE_VAULT_LOCK_FEE_IDENT,
@@ -282,14 +237,11 @@ impl NativeFungibleVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn create_proof_of_amount<Y, E: Debug + ScryptoDecode>(
+    fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             FUNGIBLE_VAULT_CREATE_PROOF_OF_AMOUNT_IDENT,
@@ -301,14 +253,11 @@ impl NativeFungibleVault for Vault {
 }
 
 impl NativeNonFungibleVault for Vault {
-    fn take_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn take_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         non_fungible_local_ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_VAULT_TAKE_NON_FUNGIBLES_IDENT,
@@ -321,14 +270,11 @@ impl NativeNonFungibleVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn create_proof_of_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_VAULT_CREATE_PROOF_OF_NON_FUNGIBLES_IDENT,
@@ -338,14 +284,11 @@ impl NativeNonFungibleVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn burn_non_fungibles<Y, E: Debug + ScryptoDecode>(
+    fn burn_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &mut self,
         non_fungible_local_ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_VAULT_BURN_NON_FUNGIBLES_IDENT,
@@ -358,14 +301,11 @@ impl NativeNonFungibleVault for Vault {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    fn non_fungible_local_ids<Y, E: Debug + ScryptoDecode>(
+    fn non_fungible_local_ids<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         limit: u32,
         api: &mut Y,
-    ) -> Result<IndexSet<NonFungibleLocalId>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<IndexSet<NonFungibleLocalId>, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_VAULT_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT,

--- a/radix-native-sdk/src/resource/worktop.rs
+++ b/radix-native-sdk/src/resource/worktop.rs
@@ -1,10 +1,8 @@
 use radix_common::constants::RESOURCE_PACKAGE;
 use radix_common::data::scrypto::model::*;
-use radix_common::data::scrypto::{
-    scrypto_decode, scrypto_encode, ScryptoCategorize, ScryptoDecode,
-};
+use radix_common::data::scrypto::{scrypto_decode, scrypto_encode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::SystemApi;
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
@@ -15,10 +13,7 @@ use sbor::rust::vec::Vec;
 pub struct Worktop(pub Own);
 
 impl Worktop {
-    pub fn drop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(self, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drop<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
         let _rtn = api.call_function(
             RESOURCE_PACKAGE,
             WORKTOP_BLUEPRINT,
@@ -32,14 +27,11 @@ impl Worktop {
         Ok(())
     }
 
-    pub fn put<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn put<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         bucket: Bucket,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let _rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_PUT_IDENT,
@@ -49,15 +41,12 @@ impl Worktop {
         Ok(())
     }
 
-    pub fn take<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn take<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_TAKE_IDENT,
@@ -71,15 +60,12 @@ impl Worktop {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn take_non_fungibles<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn take_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_TAKE_NON_FUNGIBLES_IDENT,
@@ -93,14 +79,11 @@ impl Worktop {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn take_all<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn take_all<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Bucket, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Bucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_TAKE_ALL_IDENT,
@@ -109,14 +92,11 @@ impl Worktop {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn assert_contains<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn assert_contains<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let _rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_ASSERT_CONTAINS_IDENT,
@@ -125,15 +105,12 @@ impl Worktop {
         Ok(())
     }
 
-    pub fn assert_contains_amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn assert_contains_amount<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let _rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_ASSERT_CONTAINS_AMOUNT_IDENT,
@@ -146,15 +123,12 @@ impl Worktop {
         Ok(())
     }
 
-    pub fn assert_contains_non_fungibles<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn assert_contains_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         resource_address: ResourceAddress,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let _rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_ASSERT_CONTAINS_NON_FUNGIBLES_IDENT,
@@ -167,13 +141,7 @@ impl Worktop {
         Ok(())
     }
 
-    pub fn drain<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        &self,
-        api: &mut Y,
-    ) -> Result<Vec<Bucket>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drain<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Vec<Bucket>, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             WORKTOP_DRAIN_IDENT,

--- a/radix-native-sdk/src/runtime/local_auth_zone.rs
+++ b/radix-native-sdk/src/runtime/local_auth_zone.rs
@@ -1,8 +1,7 @@
 use crate::resource::NativeAuthZone;
 use radix_common::data::scrypto::model::*;
-use radix_common::data::scrypto::{ScryptoCategorize, ScryptoDecode};
 use radix_common::math::Decimal;
-use radix_engine_interface::api::{SystemApi, ACTOR_REF_AUTH_ZONE};
+use radix_engine_interface::api::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::prelude::*;
@@ -10,98 +9,61 @@ use sbor::rust::prelude::*;
 pub struct LocalAuthZone {}
 
 impl LocalAuthZone {
-    pub fn drain<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        api: &mut Y,
-    ) -> Result<Vec<Proof>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drain<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<Vec<Proof>, E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).drain(api)
     }
 
-    pub fn drop_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drop_proofs<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<(), E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).drop_proofs(api)
     }
 
-    pub fn drop_regular_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drop_regular_proofs<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<(), E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).drop_regular_proofs(api)
     }
 
-    pub fn drop_signature_proofs<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn drop_signature_proofs<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<(), E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).drop_signature_proofs(api)
     }
 
-    pub fn pop<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
-        api: &mut Y,
-    ) -> Result<Option<Proof>, E>
-    where
-        Y: SystemApi<E>,
-    {
+    pub fn pop<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<Option<Proof>, E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).pop(api)
     }
 
-    pub fn create_proof_of_amount<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
         amount: Decimal,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).create_proof_of_amount(amount, resource_address, api)
     }
 
-    pub fn create_proof_of_non_fungibles<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         ids: &IndexSet<NonFungibleLocalId>,
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).create_proof_of_non_fungibles(ids, resource_address, api)
     }
 
-    pub fn create_proof_of_all<Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn create_proof_of_all<Y: SystemApi<E>, E: SystemApiError>(
         resource_address: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Proof, E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<Proof, E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         AuthZoneRef(auth_zone).create_proof_of_all(resource_address, api)
     }
 
-    pub fn push<P: Into<Proof>, Y, E: Debug + ScryptoCategorize + ScryptoDecode>(
+    pub fn push<Y: SystemApi<E>, E: SystemApiError, P: Into<Proof>>(
         proof: P,
         api: &mut Y,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-    {
+    ) -> Result<(), E> {
         let proof: Proof = proof.into();
 
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;

--- a/radix-native-sdk/src/runtime/runtime.rs
+++ b/radix-native-sdk/src/runtime/runtime.rs
@@ -16,14 +16,14 @@ use sbor::rust::prelude::*;
 pub struct Runtime {}
 
 impl Runtime {
-    pub fn emit_event<T: ScryptoEncode + ScryptoDescribe + ScryptoEvent, Y, E>(
+    pub fn emit_event<
+        Y: SystemApi<E>,
+        E: SystemApiError,
+        T: ScryptoEncode + ScryptoDescribe + ScryptoEvent,
+    >(
         api: &mut Y,
         event: T,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    ) -> Result<(), E> {
         api.actor_emit_event(
             T::EVENT_NAME.to_string(),
             scrypto_encode(&event).unwrap(),
@@ -31,14 +31,14 @@ impl Runtime {
         )
     }
 
-    pub fn emit_event_no_revert<T: ScryptoEncode + ScryptoDescribe + ScryptoEvent, Y, E>(
+    pub fn emit_event_no_revert<
+        Y: SystemApi<E>,
+        E: SystemApiError,
+        T: ScryptoEncode + ScryptoDescribe + ScryptoEvent,
+    >(
         api: &mut Y,
         event: T,
-    ) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    ) -> Result<(), E> {
         api.actor_emit_event(
             T::EVENT_NAME.to_string(),
             scrypto_encode(&event).unwrap(),
@@ -46,11 +46,9 @@ impl Runtime {
         )
     }
 
-    pub fn current_epoch<Y, E>(api: &mut Y) -> Result<Epoch, E>
-    where
-        Y: SystemObjectApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    pub fn current_epoch<Y: SystemObjectApi<E>, E: SystemApiError>(
+        api: &mut Y,
+    ) -> Result<Epoch, E> {
         let rtn = api.call_method(
             CONSENSUS_MANAGER.as_node_id(),
             CONSENSUS_MANAGER_GET_CURRENT_EPOCH_IDENT,
@@ -60,11 +58,10 @@ impl Runtime {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn current_time<Y, E>(api: &mut Y, precision: TimePrecision) -> Result<Instant, E>
-    where
-        Y: SystemObjectApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    pub fn current_time<Y: SystemObjectApi<E>, E: SystemApiError>(
+        precision: TimePrecision,
+        api: &mut Y,
+    ) -> Result<Instant, E> {
         let rtn = api.call_method(
             CONSENSUS_MANAGER.as_node_id(),
             CONSENSUS_MANAGER_GET_CURRENT_TIME_IDENT,
@@ -74,16 +71,12 @@ impl Runtime {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn compare_against_current_time<Y, E>(
-        api: &mut Y,
+    pub fn compare_against_current_time<Y: SystemObjectApi<E>, E: SystemApiError>(
         instant: Instant,
         precision: TimePrecision,
         operator: TimeComparisonOperator,
-    ) -> Result<bool, E>
-    where
-        Y: SystemObjectApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+        api: &mut Y,
+    ) -> Result<bool, E> {
         let rtn = api.call_method(
             CONSENSUS_MANAGER.as_node_id(),
             CONSENSUS_MANAGER_COMPARE_CURRENT_TIME_IDENT,
@@ -98,19 +91,14 @@ impl Runtime {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
-    pub fn generate_ruid<Y, E>(api: &mut Y) -> Result<[u8; 32], E>
-    where
-        Y: SystemApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    pub fn generate_ruid<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<[u8; 32], E> {
         api.generate_ruid()
     }
 
-    pub fn assert_access_rule<Y, E>(rule: AccessRule, api: &mut Y) -> Result<(), E>
-    where
-        Y: SystemApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    pub fn assert_access_rule<Y: SystemApi<E>, E: SystemApiError>(
+        rule: AccessRule,
+        api: &mut Y,
+    ) -> Result<(), E> {
         let auth_zone = api.actor_get_node_id(ACTOR_REF_AUTH_ZONE)?;
         let _rtn = api.call_method(
             &auth_zone,
@@ -121,19 +109,13 @@ impl Runtime {
         Ok(())
     }
 
-    pub fn get_node_id<Y, E>(api: &mut Y) -> Result<NodeId, E>
-    where
-        Y: SystemApi<E>,
-        E: Debug + ScryptoCategorize + ScryptoDecode,
-    {
+    pub fn get_node_id<Y: SystemApi<E>, E: SystemApiError>(api: &mut Y) -> Result<NodeId, E> {
         api.actor_get_node_id(ACTOR_REF_SELF)
     }
 
-    pub fn package_address<Y, E>(api: &mut Y) -> Result<PackageAddress, E>
-    where
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    pub fn package_address<Y: SystemApi<E>, E: SystemApiError>(
+        api: &mut Y,
+    ) -> Result<PackageAddress, E> {
         api.actor_get_blueprint_id().map(|x| x.package_address)
     }
 }

--- a/scrypto-derive/src/blueprint.rs
+++ b/scrypto-derive/src/blueprint.rs
@@ -1720,13 +1720,9 @@ fn generate_test_bindings_fns(bp_name: &str, items: &[ImplItem]) -> Result<Vec<T
             };
 
             let func = quote! {
-                pub fn #func_ident<Y, E> (
+                pub fn #func_ident<Y: SystemApi<E>, E: SystemApiError> (
                     #(#args),*
-                ) -> Result<#rtn_type, E>
-                where
-                    Y: ::scrypto::api::SystemApi<E>,
-                    E: Debug
-                {
+                ) -> Result<#rtn_type, E> {
                     let rtn = env. #invocation_type ( #invocation_args )?;
                     Ok(::scrypto::prelude::scrypto_decode(&rtn).unwrap())
                 }
@@ -2513,11 +2509,7 @@ mod tests {
                     }
 
                     impl Test {
-                        pub fn x<Y, E>(&self, i: u32, env: &mut Y) -> Result<u32, E>
-                        where
-                            Y: ::scrypto::api::SystemApi<E>,
-                            E: Debug
-                        {
+                        pub fn x<Y: SystemApi<E>, E: SystemApiError>(&self, i: u32, env: &mut Y) -> Result<u32, E> {
                             let rtn = env.call_method(
                                 &self.0,
                                 stringify!(x),
@@ -2526,15 +2518,11 @@ mod tests {
                             Ok(::scrypto::prelude::scrypto_decode(&rtn).unwrap())
                         }
 
-                        pub fn y<Y, E>(
+                        pub fn y<Y: SystemApi<E>, E: SystemApiError>(
                             i: u32,
                             blueprint_package_address: ::scrypto::prelude::PackageAddress,
                             env: &mut Y
-                        ) -> Result<u32, E>
-                        where
-                            Y: ::scrypto::api::SystemApi<E>,
-                            E: Debug
-                        {
+                        ) -> Result<u32, E> {
                             let rtn = env.call_function(
                                 blueprint_package_address,
                                 "Test",

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -750,7 +750,7 @@ where
 
     /// Gets the current time stamp from the Consensus Manager.
     pub fn get_current_time(&mut self) -> Instant {
-        Runtime::current_time(self, TimePrecision::Second).unwrap()
+        Runtime::current_time(TimePrecision::Second, self).unwrap()
     }
 
     pub fn set_current_time(&mut self, instant: Instant) {

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -115,16 +115,13 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
         self.system.verify_boot_ref_value(node_id, value)
     }
 
-    fn start<Y>(
+    fn start<Y: KernelApi<Self>>(
         api: &mut Y,
         manifest_encoded_instructions: &[u8],
         pre_allocated_addresses: &Vec<PreAllocatedAddress>,
         references: &IndexSet<Reference>,
         blobs: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<Vec<InstructionOutput>, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<Vec<InstructionOutput>, RuntimeError> {
         let mut api = wrapped_api!(api);
         System::start(
             &mut api,
@@ -154,64 +151,64 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
         self.system.on_pin_node(node_id)
     }
 
-    fn on_create_node<Y>(api: &mut Y, event: CreateNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_create_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CreateNodeEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_create_node(&mut api, event)
     }
 
-    fn on_drop_node<Y>(api: &mut Y, event: DropNodeEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_drop_node<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: DropNodeEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_drop_node(&mut api, event)
     }
 
-    fn on_move_module<Y>(api: &mut Y, event: MoveModuleEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_move_module<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: MoveModuleEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_move_module(&mut api, event)
     }
 
-    fn on_open_substate<Y>(api: &mut Y, event: OpenSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_open_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: OpenSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_open_substate(&mut api, event)
     }
 
-    fn on_close_substate<Y>(api: &mut Y, event: CloseSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_close_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: CloseSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_close_substate(&mut api, event)
     }
 
-    fn on_read_substate<Y>(api: &mut Y, event: ReadSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_read_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: ReadSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_read_substate(&mut api, event)
     }
 
-    fn on_write_substate<Y>(api: &mut Y, event: WriteSubstateEvent) -> Result<(), RuntimeError>
-    where
-        Y: KernelInternalApi<Self>,
-    {
+    fn on_write_substate<Y: KernelInternalApi<Self>>(
+        api: &mut Y,
+        event: WriteSubstateEvent,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
         System::on_write_substate(&mut api, event)
@@ -245,70 +242,58 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
         self.system.on_scan_sorted_substates(event)
     }
 
-    fn before_invoke<Y>(
+    fn before_invoke<Y: KernelApi<Self>>(
         invocation: &KernelInvocation<Self::CallFrameData>,
         api: &mut Y,
-    ) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::before_invoke(invocation, &mut api)
     }
 
-    fn on_execution_start<Y>(api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_start<Y: KernelApi<Self>>(api: &mut Y) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::on_execution_start(&mut api)
     }
 
-    fn invoke_upstream<Y>(
+    fn invoke_upstream<Y: KernelApi<Self>>(
         args: &IndexedScryptoValue,
         api: &mut Y,
-    ) -> Result<IndexedScryptoValue, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<IndexedScryptoValue, RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::invoke_upstream(args, &mut api)
     }
 
-    fn auto_drop<Y>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn auto_drop<Y: KernelApi<Self>>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::auto_drop(nodes, &mut api)
     }
 
-    fn on_execution_finish<Y>(message: &CallFrameMessage, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_execution_finish<Y: KernelApi<Self>>(
+        message: &CallFrameMessage,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::on_execution_finish(message, &mut api)
     }
 
-    fn after_invoke<Y>(output: &IndexedScryptoValue, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn after_invoke<Y: KernelApi<Self>>(
+        output: &IndexedScryptoValue,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::after_invoke(output, &mut api)
     }
 
-    fn on_allocate_node_id<Y>(entity_type: EntityType, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_allocate_node_id<Y: KernelApi<Self>>(
+        entity_type: EntityType,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::on_allocate_node_id(entity_type, &mut api)
@@ -325,24 +310,21 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
             .on_mark_substate_as_transient(node_id, partition_number, substate_key)
     }
 
-    fn on_substate_lock_fault<Y>(
+    fn on_substate_lock_fault<Y: KernelApi<Self>>(
         node_id: NodeId,
         partition_num: PartitionNumber,
         offset: &SubstateKey,
         api: &mut Y,
-    ) -> Result<bool, RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    ) -> Result<bool, RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::on_substate_lock_fault(node_id, partition_num, offset, &mut api)
     }
 
-    fn on_drop_node_mut<Y>(node_id: &NodeId, api: &mut Y) -> Result<(), RuntimeError>
-    where
-        Y: KernelApi<Self>,
-    {
+    fn on_drop_node_mut<Y: KernelApi<Self>>(
+        node_id: &NodeId,
+        api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
         System::on_drop_node_mut(node_id, &mut api)

--- a/scrypto-test/src/sdk/resource/resource_builder.rs
+++ b/scrypto-test/src/sdk/resource/resource_builder.rs
@@ -8,7 +8,6 @@ use radix_engine_interface::object_modules::role_assignment::RoleDefinition;
 use radix_engine_interface::object_modules::ModuleConfig;
 use radix_engine_interface::prelude::SystemApi;
 use sbor::rust::marker::PhantomData;
-use std::fmt::Debug;
 
 /// Not divisible.
 pub const DIVISIBILITY_NONE: u8 = 0;
@@ -466,11 +465,10 @@ pub trait CreateWithNoSupplyBuilder: private::CanCreateWithNoSupply {
     /// Creates the resource with no initial supply.
     ///
     /// The resource's address is returned.
-    fn create_with_no_initial_supply<Y, E>(self, env: &mut Y) -> Result<ResourceManager, E>
-    where
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    fn create_with_no_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
+        self,
+        env: &mut Y,
+    ) -> Result<ResourceManager, E> {
         match self.into_create_with_no_supply_invocation() {
             private::CreateWithNoSupply::Fungible {
                 owner_role,
@@ -566,16 +564,11 @@ impl InProgressResourceBuilder<FungibleResourceType> {
     /// let bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
     ///     .mint_initial_supply(5, &mut env);
     /// ```
-    pub fn mint_initial_supply<T, Y, E>(
+    pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
         mut self,
-        amount: T,
+        amount: impl Into<Decimal>,
         env: &mut Y,
-    ) -> Result<radix_engine_interface::blueprints::resource::Bucket, E>
-    where
-        T: Into<Decimal>,
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    ) -> Result<radix_engine_interface::blueprints::resource::Bucket, E> {
         let metadata = self
             .metadata_config
             .take()
@@ -630,12 +623,11 @@ impl<D: NonFungibleData>
     ///         &mut env
     ///     ]);
     /// ```
-    pub fn mint_initial_supply<T, Y, E>(mut self, entries: T, env: &mut Y) -> Result<Bucket, E>
-    where
-        T: IntoIterator<Item = (StringNonFungibleLocalId, D)>,
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
+        mut self,
+        entries: impl IntoIterator<Item = (StringNonFungibleLocalId, D)>,
+        env: &mut Y,
+    ) -> Result<Bucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -690,12 +682,11 @@ impl<D: NonFungibleData>
     ///         &mut env
     ///     ]);
     /// ```
-    pub fn mint_initial_supply<T, Y, E>(mut self, entries: T, env: &mut Y) -> Result<Bucket, E>
-    where
-        T: IntoIterator<Item = (IntegerNonFungibleLocalId, D)>,
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
+        mut self,
+        entries: impl IntoIterator<Item = (IntegerNonFungibleLocalId, D)>,
+        env: &mut Y,
+    ) -> Result<Bucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -750,12 +741,11 @@ impl<D: NonFungibleData>
     ///         &mut env
     ///     ]);
     /// ```
-    pub fn mint_initial_supply<T, Y, E>(mut self, entries: T, env: &mut Y) -> Result<Bucket, E>
-    where
-        T: IntoIterator<Item = (BytesNonFungibleLocalId, D)>,
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
+        mut self,
+        entries: impl IntoIterator<Item = (BytesNonFungibleLocalId, D)>,
+        env: &mut Y,
+    ) -> Result<Bucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -813,12 +803,11 @@ impl<D: NonFungibleData>
     ///         &mut env
     ///     ]);
     /// ```
-    pub fn mint_initial_supply<T, Y, E>(mut self, entries: T, env: &mut Y) -> Result<Bucket, E>
-    where
-        T: IntoIterator<Item = D>,
-        Y: SystemApi<E>,
-        E: Debug,
-    {
+    pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
+        mut self,
+        entries: impl IntoIterator<Item = D>,
+        env: &mut Y,
+    ) -> Result<Bucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 


### PR DESCRIPTION
## Summary
We previously had lots of inconsistent syntax for how we capture the API parameters.

As a move to tidy things up, and prepare the way for changes to Error tracking, I have:
* Introduced a `SystemApiError` trait.
  * This replaces various bounds like `Debug` and `ScryptoDecode + ScryptoCategorize` in various places. 
  * Only `RuntimeError` currently implements it. So it looks like maybe it's not even needed(?) but it will prove useful for future refactors I think, so I left it in for now.
* Moved type bounds which can be moved from a `where` expression to the generic parameters list. This has a few advantages in my eyes:
  * Where clauses are very noisy and bulky - this distracts from the intent of the code when reading a lot of code integrating with the system API. Putting the bounds by the generic parameter definitions gets them out of the way.
  * It moves the bound closer to the definition for clarity. You have fewer jumps to understand the generic parameters.
  * It makes the bounds more like parameter bounds
  * I prefer saving them for when bounds _have_ to go in a where clause - that way, it highlights that this bound is unusual, say, for example, the `AccessControllerV2Substate: Transition<I>` bound in `access_controller/v1/mod.rs`
* Re-ordered the type parameters in some places to start with `Y`
* Re-ordered the type bounds on `Y` to start with the `SystemApi` where possible.
* In some places where we expect generics to always be inferred, (typically `Fn` parameters and typed inputs), I used `impl X` to reduce the number of trait bounds.

I would actually also support inlining `api: &mut Y` to be `api: &mut impl SystemApi<...>`, to get rid of generic parameters completely (!), but didn't want to do this without approval, because that would be a lot of refactoring. 

## Testing
Just a syntax refactor, tests pass

## Update Recommendations
A few parameters re-orders, but I don't expect this to affect any users.