### PR TITLE
fix: Better align `NativeProof` / `NativeBucket` functionality with Scrypto

### DIFF
--- a/radix-engine-interface/src/blueprints/resource/bucket.rs
+++ b/radix-engine-interface/src/blueprints/resource/bucket.rs
@@ -77,9 +77,21 @@ pub struct FungibleBucket(pub Bucket);
 #[must_use]
 pub struct NonFungibleBucket(pub Bucket);
 
+impl AsRef<Bucket> for FungibleBucket {
+    fn as_ref(&self) -> &Bucket {
+        &self.0
+    }
+}
+
 impl From<FungibleBucket> for Bucket {
     fn from(value: FungibleBucket) -> Self {
         value.0
+    }
+}
+
+impl AsRef<Bucket> for NonFungibleBucket {
+    fn as_ref(&self) -> &Bucket {
+        &self.0
     }
 }
 

--- a/radix-engine-interface/src/blueprints/resource/proof.rs
+++ b/radix-engine-interface/src/blueprints/resource/proof.rs
@@ -51,14 +51,26 @@ pub struct Proof(pub Own);
 #[must_use]
 pub struct FungibleProof(pub Proof);
 
+impl AsRef<Proof> for FungibleProof {
+    fn as_ref(&self) -> &Proof {
+        &self.0
+    }
+}
+
+impl From<FungibleProof> for Proof {
+    fn from(value: FungibleProof) -> Self {
+        value.0
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash, ScryptoEncode, ScryptoDecode, ScryptoCategorize)]
 #[sbor(transparent)]
 #[must_use]
 pub struct NonFungibleProof(pub Proof);
 
-impl From<FungibleProof> for Proof {
-    fn from(value: FungibleProof) -> Self {
-        value.0
+impl AsRef<Proof> for NonFungibleProof {
+    fn as_ref(&self) -> &Proof {
+        &self.0
     }
 }
 

--- a/radix-engine-tests/tests/blueprints/pool_arithmetic.rs
+++ b/radix-engine-tests/tests/blueprints/pool_arithmetic.rs
@@ -471,7 +471,7 @@ fn two_resource_pool_initial_contribution_should_not_return_zero_pool_units(
 
     // Act
     let (pool_units, _) =
-        pool.contribute((bucket1, Bucket::create(resource_address2, env)?), env)?;
+        pool.contribute((bucket1, FungibleBucket(Bucket::create(resource_address2, env)?)), env)?;
 
     // Assert
     let pool_units_amount = pool_units.amount(env)?;

--- a/radix-engine/src/blueprints/account/blueprint.rs
+++ b/radix-engine/src/blueprints/account/blueprint.rs
@@ -641,12 +641,13 @@ impl AccountBlueprint {
             name: "Account Owner Badge".into(),
             account: ComponentAddress::new_or_panic(receiver.0),
         };
-        SecurifiedAccount::securify(
+        let bucket = SecurifiedAccount::securify(
             &receiver,
             owner_badge_data,
             Some(NonFungibleLocalId::bytes(receiver.0).unwrap()),
             api,
-        )
+        )?;
+        Ok(bucket.into())
     }
 
     pub fn create_advanced<Y: SystemApi<RuntimeError>>(

--- a/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
+++ b/radix-engine/src/blueprints/consensus_manager/consensus_manager.rs
@@ -1418,7 +1418,7 @@ impl ConsensusManagerBlueprint {
                 validator_info.address.as_node_id(),
                 VALIDATOR_APPLY_EMISSION_IDENT,
                 scrypto_encode(&ValidatorApplyEmissionInput {
-                    xrd_bucket: emission_xrd_bucket,
+                    xrd_bucket: emission_xrd_bucket.into(),
                     epoch,
                     proposals_made: validator_info.proposal_statistic.made,
                     proposals_missed: validator_info.proposal_statistic.missed,

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -558,21 +558,21 @@ impl ValidatorBlueprint {
         xrd_bucket: Bucket,
         api: &mut Y,
     ) -> Result<Bucket, RuntimeError> {
-        Self::stake_internal(xrd_bucket, true, api)
+        Ok(Self::stake_internal(xrd_bucket, true, api)?.into())
     }
 
     pub fn stake<Y: SystemApi<RuntimeError>>(
         xrd_bucket: Bucket,
         api: &mut Y,
     ) -> Result<Bucket, RuntimeError> {
-        Self::stake_internal(xrd_bucket, false, api)
+        Ok(Self::stake_internal(xrd_bucket, false, api)?.into())
     }
 
     fn stake_internal<Y: SystemApi<RuntimeError>>(
         xrd_bucket: Bucket,
         is_owner: bool,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError> {
+    ) -> Result<FungibleBucket, RuntimeError> {
         let handle = api.actor_open_field(
             ACTOR_STATE_SELF,
             ValidatorField::State.field_index(),
@@ -637,7 +637,7 @@ impl ValidatorBlueprint {
     pub fn unstake<Y: SystemApi<RuntimeError>>(
         stake_unit_bucket: Bucket,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError> {
+    ) -> Result<NonFungibleBucket, RuntimeError> {
         let stake_unit_bucket_amount = stake_unit_bucket.amount(api)?;
 
         let handle = api.actor_open_field(
@@ -1404,7 +1404,7 @@ impl ValidatorBlueprint {
         stake_xrd_vault.put(fee_xrd_bucket, api)?;
 
         // - immediately lock these new stake units in the internal owner's "public display" vault
-        Vault(substate.locked_owner_stake_unit_vault_id).put(fee_stake_unit_bucket, api)?;
+        Vault(substate.locked_owner_stake_unit_vault_id).put(fee_stake_unit_bucket.into(), api)?;
 
         // - update the index, since the stake increased (because of net emission + staking of the validator fee)
         let new_stake_xrd = starting_stake_pool_xrd
@@ -1471,7 +1471,7 @@ impl ValidatorBlueprint {
         stake_xrd_vault.put(xrd_bucket, api)?;
 
         // Lock these new stake units in the internal owner's "public display" vault
-        Vault(substate.locked_owner_stake_unit_vault_id).put(new_stake_unit_bucket, api)?;
+        Vault(substate.locked_owner_stake_unit_vault_id).put(new_stake_unit_bucket.into(), api)?;
 
         // Update the index, since the stake increased (because of staking of the reward)
         let new_stake_xrd = starting_stake_pool_xrd

--- a/radix-engine/src/blueprints/identity/package.rs
+++ b/radix-engine/src/blueprints/identity/package.rs
@@ -303,12 +303,13 @@ impl IdentityBlueprint {
             name: "Identity Owner Badge".into(),
             identity: ComponentAddress::new_or_panic(receiver.0),
         };
-        SecurifiedIdentity::securify(
+        let bucket = SecurifiedIdentity::securify(
             &receiver,
             owner_badge_data,
             Some(NonFungibleLocalId::bytes(receiver.0).unwrap()),
             api,
-        )
+        )?;
+        Ok(bucket.into())
     }
 
     fn create_object<Y: SystemApi<RuntimeError>>(

--- a/radix-engine/src/blueprints/locker/blueprint.rs
+++ b/radix-engine/src/blueprints/locker/blueprint.rs
@@ -324,7 +324,7 @@ impl AccountLockerBlueprint {
             let claim_bucket = match specifier {
                 ResourceSpecifier::Fungible(amount) => bucket.take(*amount, api)?,
                 ResourceSpecifier::NonFungible(ids) => {
-                    bucket.take_non_fungibles(ids.clone(), api)?
+                    bucket.take_non_fungibles(ids.clone(), api)?.into()
                 }
             };
 

--- a/radix-engine/src/blueprints/pool/v1/v1_0/multi_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_0/multi_resource_pool_blueprint.rs
@@ -405,7 +405,7 @@ impl MultiResourcePoolBlueprint {
         };
 
         api.field_close(lock_handle)?;
-        Ok((pool_units, change))
+        Ok((pool_units.into(), change))
     }
 
     pub fn redeem<Y: SystemApi<RuntimeError>>(

--- a/radix-engine/src/blueprints/pool/v1/v1_0/one_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_0/one_resource_pool_blueprint.rs
@@ -187,7 +187,7 @@ impl OneResourcePoolBlueprint {
             },
         )?;
 
-        Ok(pool_units)
+        Ok(pool_units.into())
     }
 
     pub fn redeem<Y: SystemApi<RuntimeError>>(

--- a/radix-engine/src/blueprints/pool/v1/v1_0/two_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_0/two_resource_pool_blueprint.rs
@@ -374,7 +374,7 @@ impl TwoResourcePoolBlueprint {
 
         Runtime::emit_event(api, event)?;
 
-        Ok((pool_units, change_bucket))
+        Ok((pool_units.into(), change_bucket))
     }
 
     pub fn redeem<Y: SystemApi<RuntimeError>>(

--- a/radix-engine/src/blueprints/pool/v1/v1_1/multi_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_1/multi_resource_pool_blueprint.rs
@@ -374,7 +374,7 @@ impl MultiResourcePoolBlueprint {
                 },
             )?;
 
-            Ok((pool_units, change_buckets))
+            Ok((pool_units.into(), change_buckets))
         })
     }
 

--- a/radix-engine/src/blueprints/pool/v1/v1_1/one_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_1/one_resource_pool_blueprint.rs
@@ -207,9 +207,11 @@ impl OneResourcePoolBlueprint {
             )?;
             substate.vault.put(bucket, api)?;
 
-            substate
+            let pool_units = substate
                 .pool_unit_resource_manager
-                .mint_fungible(pool_units_to_mint, api)
+                .mint_fungible(pool_units_to_mint, api)?;
+
+            Ok(pool_units.into())
         })
     }
 

--- a/radix-engine/src/blueprints/pool/v1/v1_1/two_resource_pool_blueprint.rs
+++ b/radix-engine/src/blueprints/pool/v1/v1_1/two_resource_pool_blueprint.rs
@@ -440,7 +440,7 @@ impl TwoResourcePoolBlueprint {
 
             Runtime::emit_event(api, event)?;
 
-            Ok((pool_units, change_bucket))
+            Ok((pool_units.into(), change_bucket))
         })
     }
 

--- a/radix-engine/src/blueprints/resource/fungible/fungible_bucket.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_bucket.rs
@@ -8,8 +8,6 @@ use radix_engine_interface::api::{
 use radix_engine_interface::blueprints::resource::*;
 use radix_native_sdk::runtime::Runtime;
 
-pub struct FungibleBucket;
-
 pub struct FungibleBucketBlueprint;
 
 impl FungibleBucketBlueprint {

--- a/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
+++ b/radix-engine/src/blueprints/transaction_processor/tx_processor.rs
@@ -250,14 +250,14 @@ impl TransactionProcessorBlueprint {
                 InstructionV1::CreateProofFromBucketOfAmount { bucket_id, amount } => {
                     let bucket = processor.get_bucket(&bucket_id)?;
                     let proof = bucket.create_proof_of_amount(amount, api)?;
-                    processor.create_manifest_proof(proof)?;
+                    processor.create_manifest_proof(proof.into())?;
                     InstructionOutput::None
                 }
                 InstructionV1::CreateProofFromBucketOfNonFungibles { bucket_id, ids } => {
                     let bucket = processor.get_bucket(&bucket_id)?;
                     let proof =
                         bucket.create_proof_of_non_fungibles(ids.into_iter().collect(), api)?;
-                    processor.create_manifest_proof(proof)?;
+                    processor.create_manifest_proof(proof.into())?;
                     InstructionOutput::None
                 }
                 InstructionV1::CreateProofFromBucketOfAll { bucket_id } => {

--- a/radix-engine/src/blueprints/util/securify.rs
+++ b/radix-engine/src/blueprints/util/securify.rs
@@ -38,14 +38,14 @@ pub trait SecurifiedRoleAssignment {
         }
         let roles = indexmap!(ModuleId::Main => roles);
         let role_assignment = RoleAssignment::create(OwnerRole::Fixed(owner_role), roles, api)?;
-        Ok((role_assignment, bucket))
+        Ok((role_assignment, bucket.into()))
     }
 
     fn mint_securified_badge<Y: SystemApi<RuntimeError>>(
         owner_badge_data: Self::OwnerBadgeNonFungibleData,
         non_fungible_local_id: Option<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<(Bucket, AccessRule), RuntimeError> {
+    ) -> Result<(NonFungibleBucket, AccessRule), RuntimeError> {
         let owner_token = ResourceManager(Self::OWNER_BADGE);
         let (bucket, owner_local_id) = if let Some(owner_local_id) = non_fungible_local_id {
             (
@@ -96,7 +96,7 @@ pub trait PresecurifiedRoleAssignment: SecurifiedRoleAssignment {
         owner_badge_data: Self::OwnerBadgeNonFungibleData,
         non_fungible_local_id: Option<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, RuntimeError> {
+    ) -> Result<NonFungibleBucket, RuntimeError> {
         let role_assignment = AttachedRoleAssignment(*receiver);
         if let Some(securify_role) = Self::SECURIFY_ROLE {
             role_assignment.set_role(

--- a/radix-native-sdk/src/resource/bucket.rs
+++ b/radix-native-sdk/src/resource/bucket.rs
@@ -219,13 +219,13 @@ impl NativeBucket for Bucket {
     }
 }
 
-pub trait SpecializedBucket: AsRef<Bucket> + Into<Bucket> {
+pub trait SpecificBucket: AsRef<Bucket> + Into<Bucket> {
     type ResourceManager: From<ResourceManager>;
     type Proof: SpecializedProof;
     fn from_bucket_of_correct_type(bucket: Bucket) -> Self;
 }
 
-impl SpecializedBucket for NonFungibleBucket {
+impl SpecificBucket for NonFungibleBucket {
     type ResourceManager = ResourceManager; // Change when we have a native NonFungibleResourceManager
     type Proof = NonFungibleProof;
 
@@ -234,7 +234,7 @@ impl SpecializedBucket for NonFungibleBucket {
     }
 }
 
-impl SpecializedBucket for FungibleBucket {
+impl SpecificBucket for FungibleBucket {
     type ResourceManager = ResourceManager; // Change when we have a native FungibleResourceManager
     type Proof = FungibleProof;
 
@@ -243,9 +243,9 @@ impl SpecializedBucket for FungibleBucket {
     }
 }
 
-impl<T: SpecializedBucket> NativeBucket for T {
-    type Proof = <Self as SpecializedBucket>::Proof;
-    type ResourceManager = <Self as SpecializedBucket>::ResourceManager;
+impl<T: SpecificBucket> NativeBucket for T {
+    type Proof = <Self as SpecificBucket>::Proof;
+    type ResourceManager = <Self as SpecificBucket>::ResourceManager;
 
     fn create<Y: SystemApi<E>, E: SystemApiError>(
         receiver: ResourceAddress,

--- a/radix-native-sdk/src/resource/bucket.rs
+++ b/radix-native-sdk/src/resource/bucket.rs
@@ -6,15 +6,22 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
 
-use super::ResourceManager;
+use super::{ResourceManager, SpecializedProof};
 
-// TODO: split impl
+// TODO: Move the fungible/non-fungible parts out of NativeBucket,
+//       and require the user opt in with `as_fungible` / `as_non_fungible` like in Scrypto.
+//       This will be a breaking change, so likely need some communication.
 
 pub trait NativeBucket {
+    type ResourceManager;
+    type Proof;
+
     fn create<Y: SystemApi<E>, E: SystemApiError>(
         receiver: ResourceAddress,
         api: &mut Y,
-    ) -> Result<Bucket, E>;
+    ) -> Result<Self, E>
+    where
+        Self: Sized;
 
     fn amount<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E>;
 
@@ -24,14 +31,18 @@ pub trait NativeBucket {
         &self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Bucket, E>;
+    ) -> Result<Self, E>
+    where
+        Self: Sized;
 
     fn take_advanced<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         amount: Decimal,
         withdraw_strategy: WithdrawStrategy,
         api: &mut Y,
-    ) -> Result<Bucket, E>;
+    ) -> Result<Self, E>
+    where
+        Self: Sized;
 
     fn burn<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E>;
 
@@ -42,10 +53,15 @@ pub trait NativeBucket {
         api: &mut Y,
     ) -> Result<ResourceAddress, E>;
 
+    fn resource_manager<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<Self::ResourceManager, E>;
+
     fn create_proof_of_all<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
-    ) -> Result<Proof, E>;
+    ) -> Result<Self::Proof, E>;
 
     fn is_empty<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<bool, E>;
 
@@ -57,7 +73,7 @@ pub trait NativeFungibleBucket {
         &self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Proof, E>;
+    ) -> Result<FungibleProof, E>;
 }
 
 pub trait NativeNonFungibleBucket {
@@ -70,25 +86,25 @@ pub trait NativeNonFungibleBucket {
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, E>;
+    ) -> Result<NonFungibleBucket, E>;
 
     fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, E>;
+    ) -> Result<NonFungibleProof, E>;
 }
 
 impl NativeBucket for Bucket {
+    type ResourceManager = ResourceManager;
+    type Proof = Proof;
+
     fn drop_empty<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
         let resource_address = self.resource_address(api)?;
         let rtn = api.call_method(
             resource_address.as_node_id(),
             RESOURCE_MANAGER_DROP_EMPTY_BUCKET_IDENT,
-            scrypto_encode(&ResourceManagerDropEmptyBucketInput {
-                bucket: Bucket(self.0),
-            })
-            .unwrap(),
+            scrypto_encode(&ResourceManagerDropEmptyBucketInput { bucket: self }).unwrap(),
         )?;
         Ok(scrypto_decode(&rtn).unwrap())
     }
@@ -191,8 +207,126 @@ impl NativeBucket for Bucket {
         Ok(scrypto_decode(&rtn).unwrap())
     }
 
+    fn resource_manager<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<ResourceManager, E> {
+        Ok(ResourceManager(self.resource_address(api)?))
+    }
+
     fn is_empty<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<bool, E> {
         Ok(self.amount(api)?.is_zero())
+    }
+}
+
+pub trait SpecializedBucket: AsRef<Bucket> + Into<Bucket> {
+    type ResourceManager: From<ResourceManager>;
+    type Proof: SpecializedProof;
+    fn from_bucket_of_correct_type(bucket: Bucket) -> Self;
+}
+
+impl SpecializedBucket for NonFungibleBucket {
+    type ResourceManager = ResourceManager; // Change when we have a native NonFungibleResourceManager
+    type Proof = NonFungibleProof;
+
+    fn from_bucket_of_correct_type(bucket: Bucket) -> Self {
+        Self(bucket)
+    }
+}
+
+impl SpecializedBucket for FungibleBucket {
+    type ResourceManager = ResourceManager; // Change when we have a native FungibleResourceManager
+    type Proof = FungibleProof;
+
+    fn from_bucket_of_correct_type(bucket: Bucket) -> Self {
+        Self(bucket)
+    }
+}
+
+impl<T: SpecializedBucket> NativeBucket for T {
+    type Proof = <Self as SpecializedBucket>::Proof;
+    type ResourceManager = <Self as SpecializedBucket>::ResourceManager;
+
+    fn create<Y: SystemApi<E>, E: SystemApiError>(
+        receiver: ResourceAddress,
+        api: &mut Y,
+    ) -> Result<Self, E> {
+        Ok(Self::from_bucket_of_correct_type(Bucket::create(
+            receiver, api,
+        )?))
+    }
+
+    fn amount<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E> {
+        self.as_ref().amount(api)
+    }
+
+    fn put<Y: SystemApi<E>, E: SystemApiError>(&self, other: Self, api: &mut Y) -> Result<(), E> {
+        self.as_ref().put(other.into(), api)
+    }
+
+    fn take<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<Self, E>
+    where
+        Self: Sized,
+    {
+        let bucket = self.as_ref().take(amount, api)?;
+        Ok(Self::from_bucket_of_correct_type(bucket))
+    }
+
+    fn take_advanced<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        amount: Decimal,
+        withdraw_strategy: WithdrawStrategy,
+        api: &mut Y,
+    ) -> Result<Self, E>
+    where
+        Self: Sized,
+    {
+        let bucket = self
+            .as_ref()
+            .take_advanced(amount, withdraw_strategy, api)?;
+        Ok(Self::from_bucket_of_correct_type(bucket))
+    }
+
+    fn burn<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
+        self.into().burn(api)
+    }
+
+    fn package_burn<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
+        self.into().package_burn(api)
+    }
+
+    fn resource_address<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<ResourceAddress, E> {
+        self.as_ref().resource_address(api)
+    }
+
+    fn resource_manager<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<Self::ResourceManager, E> {
+        Ok(self.as_ref().resource_manager(api)?.into())
+    }
+
+    fn create_proof_of_all<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<Self::Proof, E> {
+        let proof = self.as_ref().create_proof_of_all(api)?;
+        Ok(<Self::Proof as SpecializedProof>::from_proof_of_correct_type(proof))
+    }
+
+    fn is_empty<Y: SystemApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<bool, E> {
+        self.as_ref().is_empty(api)
+    }
+
+    fn drop_empty<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
+        self.into().drop_empty(api)
     }
 }
 
@@ -201,13 +335,23 @@ impl NativeFungibleBucket for Bucket {
         &self,
         amount: Decimal,
         api: &mut Y,
-    ) -> Result<Proof, E> {
+    ) -> Result<FungibleProof, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             FUNGIBLE_BUCKET_CREATE_PROOF_OF_AMOUNT_IDENT,
             scrypto_encode(&FungibleBucketCreateProofOfAmountInput { amount }).unwrap(),
         )?;
-        Ok(scrypto_decode(&rtn).unwrap())
+        Ok(FungibleProof(scrypto_decode(&rtn).unwrap()))
+    }
+}
+
+impl NativeFungibleBucket for FungibleBucket {
+    fn create_proof_of_amount<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        amount: Decimal,
+        api: &mut Y,
+    ) -> Result<FungibleProof, E> {
+        Ok(self.as_ref().create_proof_of_amount(amount, api)?.into())
     }
 }
 
@@ -229,7 +373,7 @@ impl NativeNonFungibleBucket for Bucket {
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Bucket, E> {
+    ) -> Result<NonFungibleBucket, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_BUCKET_TAKE_NON_FUNGIBLES_IDENT,
@@ -243,12 +387,37 @@ impl NativeNonFungibleBucket for Bucket {
         &self,
         ids: IndexSet<NonFungibleLocalId>,
         api: &mut Y,
-    ) -> Result<Proof, E> {
+    ) -> Result<NonFungibleProof, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
             NON_FUNGIBLE_BUCKET_CREATE_PROOF_OF_NON_FUNGIBLES_IDENT,
             scrypto_encode(&NonFungibleBucketCreateProofOfNonFungiblesInput { ids }).unwrap(),
         )?;
         Ok(scrypto_decode(&rtn).unwrap())
+    }
+}
+
+impl NativeNonFungibleBucket for NonFungibleBucket {
+    fn non_fungible_local_ids<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<IndexSet<NonFungibleLocalId>, E> {
+        self.as_ref().non_fungible_local_ids(api)
+    }
+
+    fn take_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        ids: IndexSet<NonFungibleLocalId>,
+        api: &mut Y,
+    ) -> Result<NonFungibleBucket, E> {
+        self.as_ref().take_non_fungibles(ids, api)
+    }
+
+    fn create_proof_of_non_fungibles<Y: SystemApi<E>, E: SystemApiError>(
+        &self,
+        ids: IndexSet<NonFungibleLocalId>,
+        api: &mut Y,
+    ) -> Result<NonFungibleProof, E> {
+        self.as_ref().create_proof_of_non_fungibles(ids, api)
     }
 }

--- a/radix-native-sdk/src/resource/proof.rs
+++ b/radix-native-sdk/src/resource/proof.rs
@@ -7,13 +7,26 @@ use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::types::*;
 use sbor::rust::collections::IndexSet;
 
+use super::ResourceManager;
+
+// TODO: Move the fungible/non-fungible parts out of NativeProof,
+//       and require the user opt in with `as_fungible` / `as_non_fungible` like in Scrypto.
+//       This will be a breaking change, so likely need some communication.
+
 pub trait NativeProof {
+    type ResourceManager;
+
     fn amount<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E>;
 
     fn resource_address<Y: SystemObjectApi<E>, E: SystemApiError>(
         &self,
         api: &mut Y,
     ) -> Result<ResourceAddress, E>;
+
+    fn resource_manager<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<Self::ResourceManager, E>;
 
     fn clone<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Proof, E>;
 
@@ -30,6 +43,8 @@ pub trait NativeNonFungibleProof {
 }
 
 impl NativeProof for Proof {
+    type ResourceManager = ResourceManager;
+
     fn amount<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E> {
         let rtn = api.call_method(
             self.0.as_node_id(),
@@ -45,6 +60,13 @@ impl NativeProof for Proof {
     ) -> Result<ResourceAddress, E> {
         let address = api.get_outer_object(self.0.as_node_id())?;
         Ok(ResourceAddress::try_from(address).unwrap())
+    }
+
+    fn resource_manager<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<ResourceManager, E> {
+        Ok(ResourceManager(self.resource_address(api)?))
     }
 
     fn clone<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Proof, E> {
@@ -74,7 +96,65 @@ impl NativeProof for Proof {
     }
 }
 
+pub trait SpecializedProof: AsRef<Proof> + Into<Proof> {
+    type ResourceManager: From<ResourceManager>;
+
+    /// Purposefully not From because we want to only use this when
+    /// we are confident it's the correct type
+    fn from_proof_of_correct_type(proof: Proof) -> Self;
+}
+
+impl SpecializedProof for FungibleProof {
+    // Change when we have a native FungibleResourceManager
+    type ResourceManager = ResourceManager;
+
+    fn from_proof_of_correct_type(proof: Proof) -> Self {
+        Self(proof)
+    }
+}
+
+impl SpecializedProof for NonFungibleProof {
+    // Change when we have a native NonFungibleResourceManager
+    type ResourceManager = ResourceManager;
+
+    fn from_proof_of_correct_type(proof: Proof) -> Self {
+        Self(proof)
+    }
+}
+
+impl<T: SpecializedProof> NativeProof for T {
+    type ResourceManager = <Self as SpecializedProof>::ResourceManager;
+
+    fn amount<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Decimal, E> {
+        self.as_ref().amount(api)
+    }
+
+    fn resource_address<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<ResourceAddress, E> {
+        self.as_ref().resource_address(api)
+    }
+
+    fn resource_manager<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<Self::ResourceManager, E> {
+        Ok(ResourceManager(self.resource_address(api)?).into())
+    }
+
+    fn clone<Y: SystemObjectApi<E>, E: SystemApiError>(&self, api: &mut Y) -> Result<Proof, E> {
+        self.as_ref().clone(api)
+    }
+
+    fn drop<Y: SystemApi<E>, E: SystemApiError>(self, api: &mut Y) -> Result<(), E> {
+        self.into().drop(api)
+    }
+}
+
 impl NativeFungibleProof for Proof {}
+
+impl NativeFungibleProof for FungibleProof {}
 
 impl NativeNonFungibleProof for Proof {
     fn non_fungible_local_ids<Y: SystemObjectApi<E>, E: SystemApiError>(
@@ -87,5 +167,14 @@ impl NativeNonFungibleProof for Proof {
             scrypto_encode(&NonFungibleProofGetLocalIdsInput {}).unwrap(),
         )?;
         Ok(scrypto_decode(&rtn).unwrap())
+    }
+}
+
+impl NativeNonFungibleProof for NonFungibleProof {
+    fn non_fungible_local_ids<Y: SystemObjectApi<E>, E: SystemApiError>(
+        &self,
+        api: &mut Y,
+    ) -> Result<IndexSet<NonFungibleLocalId>, E> {
+        self.as_ref().non_fungible_local_ids(api)
     }
 }

--- a/scrypto-test/src/sdk/resource/proof_factory.rs
+++ b/scrypto-test/src/sdk/resource/proof_factory.rs
@@ -9,7 +9,7 @@ impl ProofFactory {
         amount: Decimal,
         creation_strategy: CreationStrategy,
         env: &mut TestEnvironment<S>,
-    ) -> Result<Proof, RuntimeError>
+    ) -> Result<FungibleProof, RuntimeError>
     where
         S: SubstateDatabase + CommittableSubstateDatabase + 'static,
     {
@@ -22,7 +22,7 @@ impl ProofFactory {
         non_fungibles: I,
         creation_strategy: CreationStrategy,
         env: &mut TestEnvironment<S>,
-    ) -> Result<Proof, RuntimeError>
+    ) -> Result<NonFungibleProof, RuntimeError>
     where
         I: IntoIterator<Item = (NonFungibleLocalId, D)>,
         D: ScryptoEncode,

--- a/scrypto-test/src/sdk/resource/resource_builder.rs
+++ b/scrypto-test/src/sdk/resource/resource_builder.rs
@@ -561,14 +561,14 @@ impl InProgressResourceBuilder<FungibleResourceType> {
     /// ```no_run
     /// use scrypto_test::prelude::*;
     ///
-    /// let bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
+    /// let bucket: FungibleBucket = ResourceBuilder::new_fungible(OwnerRole::None)
     ///     .mint_initial_supply(5, &mut env);
     /// ```
     pub fn mint_initial_supply<Y: SystemApi<E>, E: SystemApiError>(
         mut self,
         amount: impl Into<Decimal>,
         env: &mut Y,
-    ) -> Result<radix_engine_interface::blueprints::resource::Bucket, E> {
+    ) -> Result<FungibleBucket, E> {
         let metadata = self
             .metadata_config
             .take()
@@ -590,12 +590,8 @@ impl InProgressResourceBuilder<FungibleResourceType> {
             .unwrap(),
         )?;
 
-        Ok(scrypto_decode::<(
-            ResourceAddress,
-            radix_engine_interface::blueprints::resource::Bucket,
-        )>(&bytes)
-        .unwrap()
-        .1)
+        let result: (ResourceAddress, FungibleBucket) = scrypto_decode(&bytes).unwrap();
+        Ok(result.1)
     }
 }
 
@@ -616,7 +612,7 @@ impl<D: NonFungibleData>
     ///     pub flag: bool,
     /// }
     ///
-    /// let bucket: Bucket = ResourceBuilder::new_string_non_fungible::<NFData>(OwnerRole::None)
+    /// let bucket: NonFungibleBucket = ResourceBuilder::new_string_non_fungible::<NFData>(OwnerRole::None)
     ///     .mint_initial_supply([
     ///         ("One".try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
     ///         ("Two".try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
@@ -627,7 +623,7 @@ impl<D: NonFungibleData>
         mut self,
         entries: impl IntoIterator<Item = (StringNonFungibleLocalId, D)>,
         env: &mut Y,
-    ) -> Result<Bucket, E> {
+    ) -> Result<NonFungibleBucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -652,9 +648,11 @@ impl<D: NonFungibleData>
             })
             .unwrap(),
         )?;
-        Ok(scrypto_decode::<(ResourceAddress, Bucket)>(&bytes)
-            .unwrap()
-            .1)
+        Ok(
+            scrypto_decode::<(ResourceAddress, NonFungibleBucket)>(&bytes)
+                .unwrap()
+                .1,
+        )
     }
 }
 
@@ -675,7 +673,7 @@ impl<D: NonFungibleData>
     ///     pub flag: bool,
     /// }
     ///
-    /// let bucket: Bucket = ResourceBuilder::new_integer_non_fungible(OwnerRole::None)
+    /// let bucket: NonFungibleBucket = ResourceBuilder::new_integer_non_fungible(OwnerRole::None)
     ///     .mint_initial_supply([
     ///         (1u64.into(), NFData { name: "NF One".to_owned(), flag: true }),
     ///         (2u64.into(), NFData { name: "NF Two".to_owned(), flag: true }),
@@ -686,7 +684,7 @@ impl<D: NonFungibleData>
         mut self,
         entries: impl IntoIterator<Item = (IntegerNonFungibleLocalId, D)>,
         env: &mut Y,
-    ) -> Result<Bucket, E> {
+    ) -> Result<NonFungibleBucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -711,9 +709,11 @@ impl<D: NonFungibleData>
             })
             .unwrap(),
         )?;
-        Ok(scrypto_decode::<(ResourceAddress, Bucket)>(&bytes)
-            .unwrap()
-            .1)
+        Ok(
+            scrypto_decode::<(ResourceAddress, NonFungibleBucket)>(&bytes)
+                .unwrap()
+                .1,
+        )
     }
 }
 
@@ -734,7 +734,7 @@ impl<D: NonFungibleData>
     ///     pub flag: bool,
     /// }
     ///
-    /// let bucket: Bucket = ResourceBuilder::new_bytes_non_fungible::<NFData>(OwnerRole::None)
+    /// let bucket: NonFungibleBucket = ResourceBuilder::new_bytes_non_fungible::<NFData>(OwnerRole::None)
     ///     .mint_initial_supply([
     ///         (vec![1u8].try_into().unwrap(), NFData { name: "NF One".to_owned(), flag: true }),
     ///         (vec![2u8].try_into().unwrap(), NFData { name: "NF Two".to_owned(), flag: true }),
@@ -745,7 +745,7 @@ impl<D: NonFungibleData>
         mut self,
         entries: impl IntoIterator<Item = (BytesNonFungibleLocalId, D)>,
         env: &mut Y,
-    ) -> Result<Bucket, E> {
+    ) -> Result<NonFungibleBucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -770,9 +770,11 @@ impl<D: NonFungibleData>
             })
             .unwrap(),
         )?;
-        Ok(scrypto_decode::<(ResourceAddress, Bucket)>(&bytes)
-            .unwrap()
-            .1)
+        Ok(
+            scrypto_decode::<(ResourceAddress, NonFungibleBucket)>(&bytes)
+                .unwrap()
+                .1,
+        )
     }
 }
 
@@ -796,7 +798,7 @@ impl<D: NonFungibleData>
     ///     pub flag: bool,
     /// }
     ///
-    /// let bucket: Bucket = ResourceBuilder::new_ruid_non_fungible::<NFData>(OwnerRole::None)
+    /// let bucket: NonFungibleBucket = ResourceBuilder::new_ruid_non_fungible::<NFData>(OwnerRole::None)
     ///     .mint_initial_supply([
     ///         (NFData { name: "NF One".to_owned(), flag: true }),
     ///         (NFData { name: "NF Two".to_owned(), flag: true }),
@@ -807,7 +809,7 @@ impl<D: NonFungibleData>
         mut self,
         entries: impl IntoIterator<Item = D>,
         env: &mut Y,
-    ) -> Result<Bucket, E> {
+    ) -> Result<NonFungibleBucket, E> {
         let non_fungible_schema =
             NonFungibleDataSchema::new_local_without_self_package_replacement::<D>();
 
@@ -840,9 +842,11 @@ impl<D: NonFungibleData>
             )
             .unwrap(),
         )?;
-        Ok(scrypto_decode::<(ResourceAddress, Bucket)>(&bytes)
-            .unwrap()
-            .1)
+        Ok(
+            scrypto_decode::<(ResourceAddress, NonFungibleBucket)>(&bytes)
+                .unwrap()
+                .1,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
After reports from a user on Telegram struggling with the `TestEnvironment`, and observing some issues using `FungibleBucket` / `NonFungibleBucket` in Radquest, this fixes:

* `FungibleBucket` and `NonFungibleBucket` to have features like `.resource_manager()` and not need manually converting into a `Bucket`. 
* `native-sdk`'s `ResourceManager` and `scrypto-test`'s `ResourceBuilder` to return `FungibleBucket` / `NonFungibleBucket` from relevant methods

Builds on top of `system-api-interface-refactor` #1857 (and actually motivated it).

Note this PR doesn't fully split fungible/non-fungible-specific functionality out of `NativeBucket` and `NativeProof` as those would be breaking changes - but maybe we should; as I have introduced breaking changes to `ResourceBuilder` and `ResourceManager` to make them easier to use.
