### PR TITLE
Fixed `scrypt-test` `set_current_time()` function

### DIFF
--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -912,4 +912,21 @@ mod tests {
     pub fn test_env_can_be_created() {
         let _ = TestEnvironment::new();
     }
+
+    #[test]
+    pub fn timec_set() {
+        // Arrange
+        let mut env = TestEnvironment::new();
+        let mut current_time = env.get_current_time();
+        current_time.seconds_since_unix_epoch += 60; // add 1 minute
+
+        // Act
+        env.set_current_time(current_time);
+
+        // Assert
+        let t1 = Runtime::current_time(&mut env, TimePrecision::Second).unwrap();
+        let t2 = Runtime::current_time(&mut env, TimePrecision::Minute).unwrap();
+
+        assert_eq!(t1, t2)
+    }
 }

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -938,7 +938,7 @@ mod tests {
     }
 
     #[test]
-    pub fn timec_set() {
+    pub fn test_time_set() {
         // Arrange
         let mut env = TestEnvironment::new();
         let mut current_time = env.get_current_time();


### PR DESCRIPTION
## Summary
`TestEnvironment` from `scrypto-test` module have incomplete implementation of `set_current_time()` function which lacks setting of Minute timestamp field.

## Details
Implemented fix adds writing Minutes filed in `set_current_time()` function.
There is an example code provided by Community member which reproduces the issue: https://github.com/yr12345678/bored_clock_club/

## Testing
Added new unit test `test_time_set()` which sets current time and verifies if values returned for both precisions: Seconds and Minutes are equals. On current develop branch time returned for Minute precision is 0 instead of 60.
