### PR TITLE
Abort early when deferred costs and loan are covered

### DIFF
--- a/radix-engine-interface/src/api/costing_api.rs
+++ b/radix-engine-interface/src/api/costing_api.rs
@@ -7,7 +7,7 @@ pub trait ClientCostingApi<E> {
     fn start_lock_fee(&mut self, amount: Decimal) -> Result<bool, E>;
 
     /// Add cost units to the reserve. This should never fail.
-    fn lock_fee(&mut self, locked_fee: LiquidFungibleResource, contingent: bool);
+    fn lock_fee(&mut self, locked_fee: LiquidFungibleResource, contingent: bool) -> Result<(), E>;
 
     fn consume_cost_units(&mut self, costing_entry: ClientCostingEntry) -> Result<(), E>;
 

--- a/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_vault.rs
@@ -434,7 +434,7 @@ impl FungibleVaultBlueprint {
         // At this point the vault fee take is guaranteed to be force-written
         // so we must take care not to error out before crediting the cost units
         // and emitting an event
-        api.lock_fee(fee, contingent);
+        api.lock_fee(fee, contingent)?;
 
         Ok(())
     }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2279,7 +2279,11 @@ where
 
     #[trace_resources]
     #[cfg_attr(feature = "std", catch_unwind_ignore)]
-    fn lock_fee(&mut self, locked_fee: LiquidFungibleResource, contingent: bool) {
+    fn lock_fee(
+        &mut self,
+        locked_fee: LiquidFungibleResource,
+        contingent: bool,
+    ) -> Result<(), RuntimeError> {
         // Credit cost units
         let vault_id = self
             .current_actor()
@@ -2288,7 +2292,8 @@ where
         self.api
             .kernel_get_system()
             .modules
-            .lock_fee(vault_id, locked_fee.clone(), contingent);
+            .lock_fee(vault_id, locked_fee.clone(), contingent)
+            .map_err(|e| RuntimeError::SystemModuleError(SystemModuleError::CostingError(e)))?;
 
         // Emit Locked Fee event
         {
@@ -2314,6 +2319,8 @@ where
                 .add_event_unchecked(event)
                 .expect("Event should never exceed size.");
         }
+
+        Ok(())
     }
 
     fn execution_cost_unit_limit(&mut self) -> Result<u32, RuntimeError> {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -257,8 +257,10 @@ impl CostingModule {
         vault_id: NodeId,
         locked_fee: LiquidFungibleResource,
         contingent: bool,
-    ) {
-        self.fee_reserve.lock_fee(vault_id, locked_fee, contingent);
+    ) -> Result<(), CostingError> {
+        self.fee_reserve
+            .lock_fee(vault_id, locked_fee, contingent)
+            .map_err(|e| CostingError::FeeReserveError(e))
     }
 }
 

--- a/radix-engine/src/system/system_modules/costing/fee_reserve.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_reserve.rs
@@ -572,9 +572,11 @@ impl ExecutionFeeReserve for SystemLoanFeeReserve {
         self.locked_fees
             .push((vault_id, fee.take_all(), contingent));
 
+        // Abort if deferred costs and loan are fully covered.
+        // We can further relax the rule to if deferred and accrued costs are covered.
         if self.abort_when_loan_repaid && self.is_deferred_costs_and_loan_covered()? {
             return Err(FeeReserveError::Abort(
-                AbortReason::ConfiguredAbortTriggeredOnFeeLoanRepayment,
+                AbortReason::ConfiguredAbortTriggeredOnLockFee,
             ));
         }
 
@@ -667,7 +669,7 @@ mod tests {
         assert_eq!(
             fee_reserve.lock_fee(TEST_VAULT_ID, LiquidFungibleResource::new(dec!(2)), false),
             Err(FeeReserveError::Abort(
-                AbortReason::ConfiguredAbortTriggeredOnFeeLoanRepayment
+                AbortReason::ConfiguredAbortTriggeredOnLockFee
             ))
         );
     }

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -669,9 +669,9 @@ impl SystemModuleMixer {
         vault_id: NodeId,
         locked_fee: LiquidFungibleResource,
         contingent: bool,
-    ) {
+    ) -> Result<(), CostingError> {
         if self.enabled_modules.contains(EnabledModules::COSTING) {
-            self.costing.lock_fee(vault_id, locked_fee, contingent);
+            self.costing.lock_fee(vault_id, locked_fee, contingent)
         } else {
             panic!("Fungible Vault Application layer should prevent call to credit if costing not enabled");
         }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -166,6 +166,7 @@ pub struct AbortResult {
 
 #[derive(Debug, Clone, Display, PartialEq, Eq, Sbor)]
 pub enum AbortReason {
+    ConfiguredAbortTriggeredOnLockFee,
     ConfiguredAbortTriggeredOnFeeLoanRepayment,
 }
 

--- a/scrypto-test/src/environment/client_api.rs
+++ b/scrypto-test/src/environment/client_api.rs
@@ -304,7 +304,7 @@ implement_client_api! {
             &mut self,
             locked_fee: LiquidFungibleResource,
             contingent: bool,
-        ) -> (),
+        ) -> Result<(), RuntimeError>,
         consume_cost_units: (&mut self, costing_entry: ClientCostingEntry) -> Result<(), RuntimeError>,
         execution_cost_unit_limit: (&mut self) -> Result<u32, RuntimeError>,
         execution_cost_unit_price: (&mut self) -> Result<Decimal, RuntimeError>,


### PR DESCRIPTION
## Summary

Aborts early when deferred costs and loan are covered, to help reduce overhead of pre-validating transactions.
