### PR TITLE
Architecture: Executable/Transaction Refactors

### DIFF
--- a/examples/everything/Cargo.lock
+++ b/examples/everything/Cargo.lock
@@ -1396,6 +1396,7 @@ name = "sbor-derive-common"
 version = "1.3.0-dev"
 dependencies = [
  "const-sha1",
+ "indexmap 2.2.6",
  "itertools",
  "proc-macro2",
  "quote",

--- a/examples/hello-world/Cargo.lock
+++ b/examples/hello-world/Cargo.lock
@@ -1396,6 +1396,7 @@ name = "sbor-derive-common"
 version = "1.3.0-dev"
 dependencies = [
  "const-sha1",
+ "indexmap 2.2.6",
  "itertools",
  "proc-macro2",
  "quote",

--- a/examples/no-std/Cargo.lock
+++ b/examples/no-std/Cargo.lock
@@ -580,6 +580,7 @@ name = "sbor-derive-common"
 version = "1.3.0-dev"
 dependencies = [
  "const-sha1",
+ "indexmap",
  "itertools",
  "proc-macro2",
  "quote",

--- a/radix-clis/src/replay/ledger_transaction.rs
+++ b/radix-clis/src/replay/ledger_transaction.rs
@@ -28,7 +28,8 @@ impl RoundUpdateTransactionV1 {
     }
 
     pub fn prepare(&self) -> Result<PreparedRoundUpdateTransactionV1, PrepareError> {
-        let prepared_instructions = InstructionsV1(self.create_instructions()).prepare_partial()?;
+        let prepared_instructions =
+            InstructionsV1(Rc::new(self.create_instructions())).prepare_partial()?;
         let encoded_source = manifest_encode(&self)?;
         // Minor TODO - for a slight performance improvement, change this to be read from the decoder
         // As per the other hashes, don't include the prefix byte
@@ -45,9 +46,9 @@ impl RoundUpdateTransactionV1 {
             .update(instructions_hash)
             .finalize();
         Ok(PreparedRoundUpdateTransactionV1 {
-            encoded_instructions: manifest_encode(&prepared_instructions.inner.0)?,
+            encoded_instructions: Rc::new(manifest_encode(&prepared_instructions.inner.0)?),
             references: prepared_instructions.references,
-            blobs: index_map_new(),
+            blobs: Rc::new(index_map_new()),
             summary: Summary {
                 effective_length: prepared_instructions.summary.effective_length,
                 total_bytes_hashed: prepared_instructions.summary.total_bytes_hashed,
@@ -98,9 +99,9 @@ impl SborEnumVariantFor<VersionedTransactionPayload, ManifestCustomValueKind>
 }
 
 pub struct PreparedRoundUpdateTransactionV1 {
-    pub encoded_instructions: Vec<u8>,
+    pub encoded_instructions: Rc<Vec<u8>>,
     pub references: IndexSet<Reference>,
-    pub blobs: IndexMap<Hash, Vec<u8>>,
+    pub blobs: Rc<IndexMap<Hash, Vec<u8>>>,
     pub summary: Summary,
 }
 
@@ -129,11 +130,11 @@ impl TransactionFullChildPreparable for PreparedRoundUpdateTransactionV1 {
 }
 
 impl PreparedRoundUpdateTransactionV1 {
-    pub fn get_executable(&self) -> Executable<'_> {
+    pub fn get_executable(&self) -> Executable {
         Executable::new(
-            &self.encoded_instructions,
-            &self.references,
-            &self.blobs,
+            self.encoded_instructions.clone(),
+            self.references.clone(),
+            self.blobs.clone(),
             ExecutionContext {
                 intent_hash: TransactionIntentHash::NotToCheck {
                     intent_hash: self.summary.hash,
@@ -494,7 +495,7 @@ impl ValidatedLedgerTransaction {
         }
     }
 
-    pub fn get_executable(&self) -> Executable<'_> {
+    pub fn get_executable(&self) -> Executable {
         match &self.inner {
             ValidatedLedgerTransactionInner::Genesis(genesis) => match genesis.as_ref() {
                 PreparedGenesisTransaction::Flash(_) => {

--- a/radix-clis/src/replay/ledger_transaction_execution.rs
+++ b/radix-clis/src/replay/ledger_transaction_execution.rs
@@ -82,7 +82,7 @@ pub fn execute_prepared_ledger_transaction<S: SubstateDatabase>(
                         &ExecutionConfig::for_genesis_transaction(network.clone())
                             .with_kernel_trace(trace)
                             .with_cost_breakdown(trace),
-                        &tx.get_executable(btreeset!(system_execution(SystemExecution::Protocol))),
+                        tx.get_executable(btreeset!(system_execution(SystemExecution::Protocol))),
                     );
                     LedgerTransactionReceipt::Standard(receipt)
                 }
@@ -98,7 +98,7 @@ pub fn execute_prepared_ledger_transaction<S: SubstateDatabase>(
                 &ExecutionConfig::for_notarized_transaction(network.clone())
                     .with_kernel_trace(trace)
                     .with_cost_breakdown(trace),
-                &NotarizedTransactionValidator::new(ValidationConfig::default(network.id))
+                NotarizedTransactionValidator::new(ValidationConfig::default(network.id))
                     .validate(tx.as_ref().clone())
                     .expect("Transaction validation failure")
                     .get_executable(),
@@ -115,7 +115,7 @@ pub fn execute_prepared_ledger_transaction<S: SubstateDatabase>(
                 &ExecutionConfig::for_system_transaction(network.clone())
                     .with_kernel_trace(trace)
                     .with_cost_breakdown(trace),
-                &tx.get_executable(),
+                tx.get_executable(),
             );
             LedgerTransactionReceipt::Standard(receipt)
         }

--- a/radix-clis/src/resim/mod.rs
+++ b/radix-clis/src/resim/mod.rs
@@ -173,7 +173,7 @@ pub fn handle_system_transaction<O: std::io::Write>(
 
     let nonce = get_nonce()?;
     let transaction = SystemTransactionV1 {
-        instructions: InstructionsV1(instructions),
+        instructions: InstructionsV1(Rc::new(instructions)),
         blobs: BlobsV1 {
             blobs: blobs.into_iter().map(|blob| BlobV1(blob)).collect(),
         },
@@ -186,7 +186,7 @@ pub fn handle_system_transaction<O: std::io::Write>(
         vm_init,
         &ExecutionConfig::for_system_transaction(NetworkDefinition::simulator())
             .with_kernel_trace(trace),
-        &transaction
+        transaction
             .prepare()
             .map_err(Error::TransactionPrepareError)?
             .get_executable(initial_proofs),
@@ -254,7 +254,7 @@ pub fn handle_manifest<O: std::io::Write>(
                 &mut db,
                 vm_init,
                 &ExecutionConfig::for_test_transaction().with_kernel_trace(trace),
-                &transaction
+                transaction
                     .prepare()
                     .map_err(Error::TransactionPrepareError)?
                     .get_executable(initial_proofs),

--- a/radix-clis/src/rtmd/mod.rs
+++ b/radix-clis/src/rtmd/mod.rs
@@ -7,6 +7,7 @@ use radix_transactions::manifest::{decompile, DecompileError};
 use radix_transactions::prelude::*;
 use std::fmt;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::str::FromStr;
 
 /// Radix transaction manifest decompiler
@@ -101,7 +102,7 @@ pub fn run() -> Result<(), String> {
                     };
 
                     let blobs: Vec<Vec<u8>> = blobs.into_iter().map(|item| item.0).collect();
-                    (manifest_instructions, blobs)
+                    (Rc::try_unwrap(manifest_instructions).unwrap(), blobs)
                 }
                 Err(_) => {
                     // return original error

--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -1,6 +1,6 @@
 use radix_common::prelude::*;
-use radix_engine::errors::{RejectionReason, RuntimeError, TransactionExecutionError};
-use radix_engine::kernel::call_frame::{CallFrameInit, CallFrameMessage};
+use radix_engine::errors::{RejectionReason, RuntimeError};
+use radix_engine::kernel::call_frame::CallFrameMessage;
 use radix_engine::kernel::id_allocator::IdAllocator;
 use radix_engine::kernel::kernel::Kernel;
 use radix_engine::kernel::kernel_api::{
@@ -14,14 +14,12 @@ use radix_engine::kernel::kernel_callback_api::{
     WriteSubstateEvent,
 };
 use radix_engine::system::checkers::KernelDatabaseChecker;
-use radix_engine::track::{
-    to_state_updates, BootStore, CommitableSubstateStore, StoreCommitInfo, Track,
-};
+use radix_engine::track::{to_state_updates, CommitableSubstateStore, Track};
 use radix_engine::transaction::ResourcesUsage;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
 use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
-use radix_substate_store_interface::interface::{CommittableSubstateDatabase, SubstateDatabase};
+use radix_substate_store_interface::interface::CommittableSubstateDatabase;
 use radix_transactions::model::Executable;
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
@@ -66,34 +64,6 @@ struct TestCallbackObject;
 impl KernelCallbackObject for TestCallbackObject {
     type LockData = ();
     type CallFrameData = TestCallFrameData;
-    type Init = ();
-    type Executable = Executable;
-    type ExecutionOutput = ();
-    type Receipt = TestReceipt;
-
-    fn init<S: BootStore + CommitableSubstateStore>(
-        _store: &mut S,
-        _executable: Executable,
-        _init_input: Self::Init,
-    ) -> Result<(Self, CallFrameInit<TestCallFrameData>), RejectionReason> {
-        Ok((Self, Default::default()))
-    }
-
-    fn start<Y: KernelApi<Self>>(_: &mut Y) -> Result<(), RuntimeError> {
-        unreachable!()
-    }
-
-    fn finish(&mut self, _info: StoreCommitInfo) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn create_receipt<S: SubstateDatabase>(
-        self,
-        _track: Track<S, SpreadPrefixKeyMapper>,
-        _result: Result<(), TransactionExecutionError>,
-    ) -> Self::Receipt {
-        TestReceipt
-    }
 
     fn on_pin_node(&mut self, _node_id: &NodeId) -> Result<(), RuntimeError> {
         Ok(())

--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -1,8 +1,6 @@
 use radix_common::prelude::*;
-use radix_engine::errors::{
-    BootloadingError, RejectionReason, RuntimeError, TransactionExecutionError,
-};
-use radix_engine::kernel::call_frame::{CallFrameMessage, StableReferenceType};
+use radix_engine::errors::{RejectionReason, RuntimeError, TransactionExecutionError};
+use radix_engine::kernel::call_frame::{CallFrameInit, CallFrameMessage};
 use radix_engine::kernel::id_allocator::IdAllocator;
 use radix_engine::kernel::kernel::Kernel;
 use radix_engine::kernel::kernel_api::{
@@ -31,13 +29,10 @@ use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 
+#[derive(Default)]
 struct TestCallFrameData;
 
 impl CallFrameReferences for TestCallFrameData {
-    fn root() -> Self {
-        TestCallFrameData
-    }
-
     fn global_references(&self) -> Vec<NodeId> {
         Default::default()
     }
@@ -77,8 +72,8 @@ impl KernelCallbackObject for TestCallbackObject {
         _store: &mut S,
         _executable: &Executable,
         _init_input: Self::Init,
-    ) -> Result<Self, RejectionReason> {
-        Ok(Self)
+    ) -> Result<(Self, CallFrameInit<TestCallFrameData>), RejectionReason> {
+        Ok((Self, Default::default()))
     }
 
     fn start<Y: KernelApi<Self>>(
@@ -102,14 +97,6 @@ impl KernelCallbackObject for TestCallbackObject {
         _result: Result<(), TransactionExecutionError>,
     ) -> Self::Receipt {
         TestReceipt
-    }
-
-    fn verify_boot_ref_value(
-        &mut self,
-        _node_id: &NodeId,
-        _value: &IndexedScryptoValue,
-    ) -> Result<StableReferenceType, BootloadingError> {
-        Ok(StableReferenceType::Global)
     }
 
     fn on_pin_node(&mut self, _node_id: &NodeId) -> Result<(), RuntimeError> {

--- a/radix-engine-tests/benches/transfer.rs
+++ b/radix-engine-tests/benches/transfer.rs
@@ -46,7 +46,7 @@ fn bench_transfer(c: &mut Criterion) {
                 &mut substate_db,
                 vm_init.clone(),
                 &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
-                &TestTransaction::new_from_nonce(manifest, 1)
+                TestTransaction::new_from_nonce(manifest, 1)
                     .prepare()
                     .unwrap()
                     .get_executable(btreeset![NonFungibleGlobalId::from_public_key(&public_key)]),
@@ -72,7 +72,7 @@ fn bench_transfer(c: &mut Criterion) {
             &mut substate_db,
             vm_init.clone(),
             &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
-            &TestTransaction::new_from_nonce(manifest.clone(), nonce)
+            TestTransaction::new_from_nonce(manifest.clone(), nonce)
                 .prepare()
                 .unwrap()
                 .get_executable(btreeset![NonFungibleGlobalId::from_public_key(&public_key)]),
@@ -95,7 +95,7 @@ fn bench_transfer(c: &mut Criterion) {
                 &mut substate_db,
                 vm_init.clone(),
                 &ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
-                &TestTransaction::new_from_nonce(manifest.clone(), nonce)
+                TestTransaction::new_from_nonce(manifest.clone(), nonce)
                     .prepare()
                     .unwrap()
                     .get_executable(btreeset![NonFungibleGlobalId::from_public_key(&public_key)]),

--- a/radix-engine-tests/tests/application/fuzz_transactions.rs
+++ b/radix-engine-tests/tests/application/fuzz_transactions.rs
@@ -61,7 +61,7 @@ impl TransactionFuzzer {
             &mut self.substate_db,
             vm_init,
             &execution_config,
-            &validated.get_executable(),
+            validated.get_executable(),
         );
     }
 

--- a/radix-engine-tests/tests/application/preview.rs
+++ b/radix-engine-tests/tests/application/preview.rs
@@ -252,11 +252,11 @@ fn notary_key_is_in_initial_proofs_when_notary_as_signatory_is_true() {
                     tip_percentage: 0,
                 },
                 instructions: InstructionsV1(
-                    ManifestBuilder::new()
+                    Rc::new(ManifestBuilder::new()
                         .lock_fee_and_withdraw(account, 10, XRD, 10)
                         .deposit_batch(account)
                         .build()
-                        .instructions,
+                        .instructions)
                 ),
                 blobs: Default::default(),
                 message: Default::default(),
@@ -297,11 +297,11 @@ fn notary_key_is_not_in_initial_proofs_when_notary_as_signatory_is_false() {
                     tip_percentage: 0,
                 },
                 instructions: InstructionsV1(
-                    ManifestBuilder::new()
+                    Rc::new(ManifestBuilder::new()
                         .lock_fee_and_withdraw(account, 10, XRD, 10)
                         .deposit_batch(account)
                         .build()
-                        .instructions,
+                        .instructions)
                 ),
                 blobs: Default::default(),
                 message: Default::default(),

--- a/radix-engine-tests/tests/application/transaction.rs
+++ b/radix-engine-tests/tests/application/transaction.rs
@@ -201,14 +201,14 @@ fn transaction_processor_produces_expected_error_for_undecodable_instructions() 
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
 
-    let invalid_encoded_instructions = [0xde, 0xad, 0xbe, 0xef];
+    let invalid_encoded_instructions = vec![0xde, 0xad, 0xbe, 0xef];
     let references = Default::default();
     let blobs = Default::default();
 
     let executable = Executable::new(
-        &invalid_encoded_instructions,
-        &references,
-        &blobs,
+        Rc::new(invalid_encoded_instructions),
+        references,
+        Rc::new(blobs),
         ExecutionContext {
             intent_hash: TransactionIntentHash::NotToCheck {
                 intent_hash: Hash([0; 32]),

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -1,6 +1,6 @@
 use radix_common::prelude::*;
-use radix_engine::errors::{BootloadingError, CallFrameError, KernelError, RejectionReason, RuntimeError, TransactionExecutionError};
-use radix_engine::kernel::call_frame::{CallFrameMessage, CloseSubstateError, CreateFrameError, CreateNodeError, MovePartitionError, PassMessageError, ProcessSubstateError, StableReferenceType, TakeNodeError, WriteSubstateError};
+use radix_engine::errors::{CallFrameError, KernelError, RejectionReason, RuntimeError, TransactionExecutionError};
+use radix_engine::kernel::call_frame::{CallFrameInit, CallFrameMessage, CloseSubstateError, CreateFrameError, CreateNodeError, MovePartitionError, PassMessageError, ProcessSubstateError, TakeNodeError, WriteSubstateError};
 use radix_engine::kernel::id_allocator::IdAllocator;
 use radix_engine::kernel::kernel::Kernel;
 use radix_engine::kernel::kernel_api::{
@@ -16,13 +16,10 @@ use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::SubstateDatabase;
 use radix_transactions::model::{Executable, PreAllocatedAddress};
 
+#[derive(Default)]
 struct TestCallFrameData;
 
 impl CallFrameReferences for TestCallFrameData {
-    fn root() -> Self {
-        TestCallFrameData
-    }
-
     fn global_references(&self) -> Vec<NodeId> {
         Default::default()
     }
@@ -63,12 +60,8 @@ impl KernelCallbackObject for TestCallbackObject {
         _store: &mut S,
         _executable: &Executable,
         _init_input: Self::Init,
-    ) -> Result<Self, RejectionReason> {
-        Ok(Self)
-    }
-
-    fn verify_boot_ref_value(&mut self, _node_id: &NodeId, _value: &IndexedScryptoValue) -> Result<StableReferenceType, BootloadingError> {
-        Ok(StableReferenceType::Global)
+    ) -> Result<(Self, CallFrameInit<TestCallFrameData>), RejectionReason> {
+        Ok((Self, Default::default()))
     }
 
     fn start<Y: KernelApi<Self>>(

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -1,6 +1,6 @@
 use radix_common::prelude::*;
-use radix_engine::errors::{CallFrameError, KernelError, RejectionReason, RuntimeError, TransactionExecutionError};
-use radix_engine::kernel::call_frame::{CallFrameInit, CallFrameMessage, CloseSubstateError, CreateFrameError, CreateNodeError, MovePartitionError, PassMessageError, ProcessSubstateError, TakeNodeError, WriteSubstateError};
+use radix_engine::errors::{CallFrameError, KernelError, RejectionReason, RuntimeError};
+use radix_engine::kernel::call_frame::{CallFrameMessage, CloseSubstateError, CreateFrameError, CreateNodeError, MovePartitionError, PassMessageError, ProcessSubstateError, TakeNodeError, WriteSubstateError};
 use radix_engine::kernel::id_allocator::IdAllocator;
 use radix_engine::kernel::kernel::Kernel;
 use radix_engine::kernel::kernel_api::{
@@ -8,12 +8,11 @@ use radix_engine::kernel::kernel_api::{
     KernelSubstateApi,
 };
 use radix_engine::kernel::kernel_callback_api::{CallFrameReferences, CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, ExecutionReceipt, KernelCallbackObject, MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent, ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent};
-use radix_engine::track::{BootStore, CommitableSubstateStore, StoreCommitInfo, Track};
+use radix_engine::track::{Track};
 use radix_engine::transaction::ResourcesUsage;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
 use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
-use radix_substate_store_interface::interface::SubstateDatabase;
 use radix_transactions::model::Executable;
 
 #[derive(Default)]
@@ -51,33 +50,10 @@ impl ExecutionReceipt for TestReceipt {
 }
 
 struct TestCallbackObject;
+
 impl KernelCallbackObject for TestCallbackObject {
     type LockData = ();
     type CallFrameData = TestCallFrameData;
-    type Init = ();
-    type Executable = Executable;
-    type ExecutionOutput = ();
-    type Receipt = TestReceipt;
-
-    fn init<S: BootStore + CommitableSubstateStore>(
-        _store: &mut S,
-        _executable: Executable,
-        _init_input: Self::Init,
-    ) -> Result<(Self, CallFrameInit<TestCallFrameData>), RejectionReason> {
-        Ok((Self, Default::default()))
-    }
-
-    fn start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
-        unreachable!()
-    }
-
-    fn finish(&mut self, _store_commit_info: StoreCommitInfo) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn create_receipt<S: SubstateDatabase>(self, _track: Track<S, SpreadPrefixKeyMapper>, _result: Result<(), TransactionExecutionError>) -> TestReceipt {
-        TestReceipt
-    }
 
     fn on_pin_node(&mut self, _node_id: &NodeId) -> Result<(), RuntimeError> {
         Ok(())
@@ -141,19 +117,7 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn after_invoke<Y: KernelApi<Self>>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
     fn on_execution_start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_execution_finish<Y: KernelApi<Self>>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_allocate_node_id<Y: KernelApi<Self>>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 
@@ -165,6 +129,18 @@ impl KernelCallbackObject for TestCallbackObject {
     }
 
     fn auto_drop<Y: KernelApi<Self>>(_nodes: Vec<NodeId>, _api: &mut Y) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_execution_finish<Y: KernelApi<Self>>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn after_invoke<Y: KernelApi<Self>>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_allocate_node_id<Y: KernelApi<Self>>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError> {
         Ok(())
     }
 

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -14,7 +14,7 @@ use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
 use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::SubstateDatabase;
-use radix_transactions::model::{Executable, PreAllocatedAddress};
+use radix_transactions::model::Executable;
 
 #[derive(Default)]
 struct TestCallFrameData;
@@ -40,6 +40,8 @@ impl CallFrameReferences for TestCallFrameData {
 struct TestReceipt;
 
 impl ExecutionReceipt for TestReceipt {
+    type Executed = Executable;
+
     fn from_rejection(_executable: Executable, _reason: RejectionReason) -> Self {
         Self
     }
@@ -53,24 +55,19 @@ impl KernelCallbackObject for TestCallbackObject {
     type LockData = ();
     type CallFrameData = TestCallFrameData;
     type Init = ();
+    type Executable = Executable;
     type ExecutionOutput = ();
     type Receipt = TestReceipt;
 
     fn init<S: BootStore + CommitableSubstateStore>(
         _store: &mut S,
-        _executable: &Executable,
+        _executable: Executable,
         _init_input: Self::Init,
     ) -> Result<(Self, CallFrameInit<TestCallFrameData>), RejectionReason> {
         Ok((Self, Default::default()))
     }
 
-    fn start<Y: KernelApi<Self>>(
-        _api: &mut Y,
-        _manifest_encoded_instructions: &[u8],
-        _pre_allocated_addresses: &Vec<PreAllocatedAddress>,
-        _references: &IndexSet<Reference>,
-        _blobs: &IndexMap<Hash, Vec<u8>>,
-    ) -> Result<(), RuntimeError> {
+    fn start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
         unreachable!()
     }
 
@@ -78,7 +75,7 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(())
     }
 
-    fn create_receipt<S: SubstateDatabase>(self, _track: Track<S, SpreadPrefixKeyMapper>, _executable: &Executable, _result: Result<(), TransactionExecutionError>) -> TestReceipt {
+    fn create_receipt<S: SubstateDatabase>(self, _track: Track<S, SpreadPrefixKeyMapper>, _result: Result<(), TransactionExecutionError>) -> TestReceipt {
         TestReceipt
     }
 

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -40,7 +40,7 @@ impl CallFrameReferences for TestCallFrameData {
 struct TestReceipt;
 
 impl ExecutionReceipt for TestReceipt {
-    fn from_rejection(_executable: &Executable, _reason: RejectionReason) -> Self {
+    fn from_rejection(_executable: Executable, _reason: RejectionReason) -> Self {
         Self
     }
 

--- a/radix-engine-tests/tests/kernel/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel/kernel_open_substate.rs
@@ -53,6 +53,7 @@ pub fn test_open_substate_of_invisible_package_address() {
 
     // Create kernel
     let mut system = System {
+        executable: Executable::mock(),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),

--- a/radix-engine-tests/tests/kernel/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel/kernel_open_substate.rs
@@ -53,7 +53,7 @@ pub fn test_open_substate_of_invisible_package_address() {
 
     // Create kernel
     let mut system = System {
-        executable: Executable::mock(),
+        executable: (),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),

--- a/radix-engine-tests/tests/kernel/panics.rs
+++ b/radix-engine-tests/tests/kernel/panics.rs
@@ -41,7 +41,7 @@ macro_rules! panic1 {
 
 pub struct MockKernel;
 
-impl<'g> KernelApi<System<Vm<'g, DefaultWasmEngine, NoExtension>>> for MockKernel {}
+impl<'g> KernelApi<System<Vm<'g, DefaultWasmEngine, NoExtension>, ()>> for MockKernel {}
 
 impl KernelNodeApi for MockKernel {
     fn kernel_pin_node(&mut self, _: NodeId) -> Result<(), RuntimeError> {
@@ -170,10 +170,10 @@ impl KernelInvokeApi<Actor> for MockKernel {
     }
 }
 
-impl<'g> KernelInternalApi<System<Vm<'g, DefaultWasmEngine, NoExtension>>> for MockKernel {
+impl<'g> KernelInternalApi<System<Vm<'g, DefaultWasmEngine, NoExtension>, ()>> for MockKernel {
     fn kernel_get_system_state(
         &mut self,
-    ) -> SystemState<'_, System<Vm<'g, DefaultWasmEngine, NoExtension>>> {
+    ) -> SystemState<'_, System<Vm<'g, DefaultWasmEngine, NoExtension>, ()>> {
         panic1!()
     }
 

--- a/radix-engine-tests/tests/kernel/transaction_executor.rs
+++ b/radix-engine-tests/tests/kernel/transaction_executor.rs
@@ -138,7 +138,7 @@ fn test_normal_transaction_flow() {
         &mut substate_db,
         vm_init,
         &execution_config,
-        &executable,
+        executable,
     );
 
     // Assert

--- a/radix-engine-tests/tests/kernel/transaction_multi_threaded.rs
+++ b/radix-engine-tests/tests/kernel/transaction_multi_threaded.rs
@@ -57,7 +57,7 @@ mod multi_threaded_test {
                     &mut substate_db,
                     vm_init.clone(),
                     &ExecutionConfig::for_test_transaction(),
-                    &TestTransaction::new(manifest, hash(format!("Account creation: {i}")))
+                    TestTransaction::new(manifest, hash(format!("Account creation: {i}")))
                         .prepare()
                         .unwrap()
                         .get_executable(btreeset![NonFungibleGlobalId::from_public_key(
@@ -84,7 +84,7 @@ mod multi_threaded_test {
                 &mut substate_db,
                 vm_init.clone(),
                 &ExecutionConfig::for_test_transaction(),
-                &TestTransaction::new(manifest.clone(), hash(format!("Fill account: {}", nonce)))
+                TestTransaction::new(manifest.clone(), hash(format!("Fill account: {}", nonce)))
                     .prepare()
                     .expect("Expected transaction to be preparable")
                     .get_executable(btreeset![NonFungibleGlobalId::from_public_key(&public_key)]),
@@ -109,7 +109,7 @@ mod multi_threaded_test {
                         &substate_db,
                         vm_init.clone(),
                         &ExecutionConfig::for_test_transaction(),
-                        &TestTransaction::new(manifest.clone(), hash(format!("Transfer")))
+                        TestTransaction::new(manifest.clone(), hash(format!("Transfer")))
                             .prepare()
                             .expect("Expected transaction to be preparable")
                             .get_executable(btreeset![NonFungibleGlobalId::from_public_key(

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -73,7 +73,7 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let intent_hash = Hash([0; 32]);
     let mut system = System {
-        executable: Executable::mock(),
+        executable: (),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),
@@ -155,7 +155,7 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let intent_hash = Hash([0; 32]);
     let mut system = System {
-        executable: Executable::mock(),
+        executable: (),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -73,6 +73,7 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let intent_hash = Hash([0; 32]);
     let mut system = System {
+        executable: Executable::mock(),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),
@@ -154,6 +155,7 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let intent_hash = Hash([0; 32]);
     let mut system = System {
+        executable: Executable::mock(),
         blueprint_cache: NonIterMap::new(),
         auth_cache: NonIterMap::new(),
         schema_cache: NonIterMap::new(),

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -1464,7 +1464,7 @@ impl PackageNativePackage {
 pub struct PackageRoyaltyNativeBlueprint;
 
 impl PackageRoyaltyNativeBlueprint {
-    pub fn charge_package_royalty<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
+    pub fn charge_package_royalty<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         ident: &str,
@@ -1576,8 +1576,9 @@ pub struct PackageAuthNativeBlueprint;
 
 impl PackageAuthNativeBlueprint {
     pub fn resolve_function_permission<
-        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V>>,
+        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V, E>>,
         V: SystemCallbackObject,
+        E,
     >(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
@@ -1613,13 +1614,13 @@ impl PackageAuthNativeBlueprint {
         }
     }
 
-    pub fn get_bp_auth_template<Y, V>(
+    pub fn get_bp_auth_template<Y, V, E>(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         api: &mut Y,
     ) -> Result<AuthConfig, RuntimeError>
     where
-        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V>>,
+        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V, E>>,
         V: SystemCallbackObject,
     {
         let package_bp_version_id = CanonicalBlueprintId {

--- a/radix-engine/src/kernel/call_frame.rs
+++ b/radix-engine/src/kernel/call_frame.rs
@@ -558,19 +558,17 @@ pub enum SubstateDiffError {
 }
 
 #[derive(Debug, Default)]
-pub struct CallFrameInit {
+pub struct CallFrameInit<C> {
+    pub data: C,
     pub global_addresses: IndexSet<GlobalAddress>,
     pub direct_accesses: IndexSet<InternalAddress>,
 }
 
 impl<C, L: Clone> CallFrame<C, L> {
-    pub fn new_root(
-        call_frame_data: C,
-        root_refs: CallFrameInit,
-    ) -> Self {
+    pub fn new_root(init: CallFrameInit<C>) -> Self {
         let mut call_frame = Self {
             depth: 0,
-            call_frame_data,
+            call_frame_data: init.data,
             stable_references: Default::default(),
             transient_references: NonIterMap::new(),
             owned_root_nodes: index_set_new(),
@@ -578,10 +576,10 @@ impl<C, L: Clone> CallFrame<C, L> {
             open_substates: index_map_new(),
         };
 
-        for global_ref in root_refs.global_addresses {
+        for global_ref in init.global_addresses {
             call_frame.add_global_reference(global_ref);
         }
-        for direct_access in root_refs.direct_accesses {
+        for direct_access in init.direct_accesses {
             call_frame.add_direct_access_reference(direct_access);
         }
 

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -10,12 +10,12 @@ use crate::kernel::call_frame::{
     TransientSubstates,
 };
 use crate::kernel::kernel_api::*;
-use crate::kernel::kernel_callback_api::ExecutionReceipt;
 use crate::kernel::kernel_callback_api::{
     CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, KernelCallbackObject,
     MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent,
     ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent,
 };
+use crate::kernel::kernel_callback_api::{ExecutionReceipt, KernelTransactionCallbackObject};
 use crate::kernel::substate_io::{SubstateDevice, SubstateIO};
 use crate::kernel::substate_locks::SubstateLocks;
 use crate::system::system_modules::execution_trace::{BucketSnapshot, ProofSnapshot};
@@ -47,14 +47,14 @@ impl KernelBoot {
 }
 
 /// Organizes the radix engine stack to make a function entrypoint available for execution
-pub struct BootLoader<'h, M: KernelCallbackObject, S: SubstateDatabase> {
+pub struct BootLoader<'h, M: KernelTransactionCallbackObject, S: SubstateDatabase> {
     pub id_allocator: IdAllocator,
     pub track: Track<'h, S, SpreadPrefixKeyMapper>,
     pub init: M::Init,
     pub phantom: PhantomData<M>,
 }
 
-impl<'h, M: KernelCallbackObject, S: SubstateDatabase> BootLoader<'h, M, S> {
+impl<'h, M: KernelTransactionCallbackObject, S: SubstateDatabase> BootLoader<'h, M, S> {
     /// Executes a transaction
     pub fn execute(self, executable: M::Executable) -> M::Receipt {
         // Start hardware resource usage tracker

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -57,7 +57,7 @@ pub struct BootLoader<'h, M: KernelCallbackObject, S: SubstateDatabase> {
 
 impl<'h, M: KernelCallbackObject, S: SubstateDatabase> BootLoader<'h, M, S> {
     /// Executes a transaction
-    pub fn execute<'a>(self, executable: &Executable) -> M::Receipt {
+    pub fn execute(self, executable: &Executable) -> M::Receipt {
         // Start hardware resource usage tracker
         #[cfg(all(target_os = "linux", feature = "std", feature = "cpu_ram_metrics"))]
         let mut resources_tracker =
@@ -82,10 +82,7 @@ impl<'h, M: KernelCallbackObject, S: SubstateDatabase> BootLoader<'h, M, S> {
         }
     }
 
-    fn execute_internal<'a>(
-        mut self,
-        executable: &Executable,
-    ) -> Result<M::Receipt, RejectionReason> {
+    fn execute_internal(mut self, executable: &Executable) -> Result<M::Receipt, RejectionReason> {
         #[cfg(feature = "resource_tracker")]
         radix_engine_profiling::QEMU_PLUGIN_CALIBRATOR.with(|v| {
             v.borrow_mut();

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -1,4 +1,4 @@
-use super::call_frame::{CallFrameMessage, CallFrameInit};
+use super::call_frame::{CallFrameInit, CallFrameMessage};
 use crate::errors::*;
 use crate::internal_prelude::*;
 use crate::kernel::kernel_api::KernelInvocation;
@@ -14,7 +14,6 @@ use radix_transactions::model::Executable;
 use radix_transactions::prelude::PreAllocatedAddress;
 
 pub trait CallFrameReferences {
-    fn root() -> Self;
     fn global_references(&self) -> Vec<NodeId>;
     fn direct_access_references(&self) -> Vec<NodeId>;
     fn stable_transient_references(&self) -> Vec<NodeId>;
@@ -161,7 +160,7 @@ pub trait KernelCallbackObject: Sized {
         store: &mut S,
         executable: &Executable,
         init: Self::Init,
-    ) -> Result<(Self, CallFrameInit), RejectionReason>;
+    ) -> Result<(Self, CallFrameInit<Self::CallFrameData>), RejectionReason>;
 
     /// Start execution
     fn start<Y: KernelApi<Self>>(

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -1,4 +1,4 @@
-use super::call_frame::{CallFrameMessage, StableReferenceType};
+use super::call_frame::{CallFrameMessage, CallFrameInit};
 use crate::errors::*;
 use crate::internal_prelude::*;
 use crate::kernel::kernel_api::KernelInvocation;
@@ -156,19 +156,12 @@ pub trait KernelCallbackObject: Sized {
     /// Final receipt to be created after transaction execution
     type Receipt: ExecutionReceipt;
 
-    /// Create the callback object (system layer) with data loaded from the substate store
+    /// Create the callback object (system layer) and the initial call frame configuration
     fn init<S: BootStore + CommitableSubstateStore>(
         store: &mut S,
         executable: &Executable,
         init: Self::Init,
-    ) -> Result<Self, RejectionReason>;
-
-    /// Verifies and returns the type of a given reference used during boot
-    fn verify_boot_ref_value(
-        &mut self,
-        node_id: &NodeId,
-        value: &IndexedScryptoValue,
-    ) -> Result<StableReferenceType, BootloadingError>;
+    ) -> Result<(Self, CallFrameInit), RejectionReason>;
 
     /// Start execution
     fn start<Y: KernelApi<Self>>(

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -142,12 +142,7 @@ pub trait ExecutionReceipt {
     fn set_resource_usage(&mut self, resources_usage: ResourcesUsage);
 }
 
-/// Upper layer callback object which a kernel interacts with during execution
-pub trait KernelCallbackObject: Sized {
-    /// Data to be stored with each substate lock
-    type LockData: Default + Clone;
-    /// Data to be stored with every call frame
-    type CallFrameData: CallFrameReferences;
+pub trait KernelTransactionCallbackObject: KernelCallbackObject {
     /// Initialization object
     type Init: Clone;
     /// Executable type
@@ -176,6 +171,14 @@ pub trait KernelCallbackObject: Sized {
         track: Track<S, SpreadPrefixKeyMapper>,
         result: Result<Self::ExecutionOutput, TransactionExecutionError>,
     ) -> Self::Receipt;
+}
+
+/// Upper layer callback object which a kernel interacts with during execution
+pub trait KernelCallbackObject: Sized {
+    /// Data to be stored with each substate lock
+    type LockData: Default + Clone;
+    /// Data to be stored with every call frame
+    type CallFrameData: CallFrameReferences;
 
     /// Callback before a node is pinned to it's device
     fn on_pin_node(&mut self, node_id: &NodeId) -> Result<(), RuntimeError>;

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -137,7 +137,7 @@ pub enum ScanSortedSubstatesEvent<'a> {
 
 /// A receipt created from executing a transaction
 pub trait ExecutionReceipt {
-    fn from_rejection(executable: &Executable, reason: RejectionReason) -> Self;
+    fn from_rejection(executable: Executable, reason: RejectionReason) -> Self;
 
     fn set_resource_usage(&mut self, resources_usage: ResourcesUsage);
 }

--- a/radix-engine/src/object_modules/role_assignment/package.rs
+++ b/radix-engine/src/object_modules/role_assignment/package.rs
@@ -155,11 +155,11 @@ impl RoleAssignmentNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn authorization<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
+    pub fn authorization<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
         global_address: &GlobalAddress,
         ident: &str,
         input: &IndexedScryptoValue,
-        api: &mut SystemService<Y, V>,
+        api: &mut SystemService<Y, V, E>,
     ) -> Result<ResolvedPermission, RuntimeError> {
         let permission = match ident {
             ROLE_ASSIGNMENT_SET_IDENT => {
@@ -298,11 +298,12 @@ impl RoleAssignmentNativePackage {
     }
 
     fn resolve_update_owner_role_method_permission<
-        Y: KernelApi<System<V>>,
+        Y: KernelApi<System<V, E>>,
         V: SystemCallbackObject,
+        E,
     >(
         receiver: &NodeId,
-        api: &mut SystemService<Y, V>,
+        api: &mut SystemService<Y, V, E>,
     ) -> Result<ResolvedPermission, RuntimeError> {
         let handle = api.kernel_open_substate(
             receiver,
@@ -333,11 +334,11 @@ impl RoleAssignmentNativePackage {
         Ok(ResolvedPermission::AccessRule(rule))
     }
 
-    fn resolve_update_role_method_permission<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
+    fn resolve_update_role_method_permission<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
         receiver: &NodeId,
         module: ModuleId,
         role_key: &RoleKey,
-        api: &mut SystemService<Y, V>,
+        api: &mut SystemService<Y, V, E>,
     ) -> Result<RoleList, RuntimeError> {
         if Self::is_role_key_reserved(&role_key) || module.eq(&ModuleId::RoleAssignment) {
             return Ok(RoleList::none());

--- a/radix-engine/src/object_modules/role_assignment/package.rs
+++ b/radix-engine/src/object_modules/role_assignment/package.rs
@@ -334,7 +334,11 @@ impl RoleAssignmentNativePackage {
         Ok(ResolvedPermission::AccessRule(rule))
     }
 
-    fn resolve_update_role_method_permission<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+    fn resolve_update_role_method_permission<
+        Y: KernelApi<System<V, E>>,
+        V: SystemCallbackObject,
+        E,
+    >(
         receiver: &NodeId,
         module: ModuleId,
         role_key: &RoleKey,

--- a/radix-engine/src/object_modules/royalty/package.rs
+++ b/radix-engine/src/object_modules/royalty/package.rs
@@ -421,14 +421,14 @@ impl ComponentRoyaltyBlueprint {
         Ok(bucket)
     }
 
-    pub fn charge_component_royalty<Y, V>(
+    pub fn charge_component_royalty<Y, V, E>(
         receiver: &NodeId,
         ident: &str,
         api: &mut Y,
     ) -> Result<(), RuntimeError>
     where
         V: SystemCallbackObject,
-        Y: KernelApi<System<V>>,
+        Y: KernelApi<System<V, E>>,
     {
         let accumulator_handle = api.kernel_open_substate(
             receiver,

--- a/radix-engine/src/system/actor.rs
+++ b/radix-engine/src/system/actor.rs
@@ -75,11 +75,13 @@ pub enum Actor {
     BlueprintHook(BlueprintHookActor),
 }
 
-impl CallFrameReferences for Actor {
-    fn root() -> Self {
-        Actor::Root
+impl Default for Actor {
+    fn default() -> Self {
+        Self::Root
     }
+}
 
+impl CallFrameReferences for Actor {
     fn global_references(&self) -> Vec<NodeId> {
         let mut global_refs = Vec::new();
 

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -412,7 +412,7 @@ where
             self.vm_init.clone(),
             &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
                 .with_kernel_trace(self.trace),
-            &transaction
+            transaction
                 .prepare()
                 .expect("Expected system bootstrap transaction to be preparable")
                 .get_executable(btreeset![system_execution(SystemExecution::Protocol)]),
@@ -441,7 +441,7 @@ where
             self.vm_init.clone(),
             &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
                 .with_kernel_trace(self.trace),
-            &transaction
+            transaction
                 .prepare()
                 .expect("Expected genesis data chunk transaction to be preparable")
                 .get_executable(btreeset![system_execution(SystemExecution::Protocol)]),
@@ -465,7 +465,7 @@ where
             self.vm_init.clone(),
             &ExecutionConfig::for_genesis_transaction(self.network_definition.clone())
                 .with_kernel_trace(self.trace),
-            &transaction
+            transaction
                 .prepare()
                 .expect("Expected genesis wrap up transaction to be preparable")
                 .get_executable(btreeset![system_execution(SystemExecution::Protocol)]),

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -1334,7 +1334,7 @@ pub fn create_system_bootstrap_transaction(
     }
 
     SystemTransactionV1 {
-        instructions: InstructionsV1(instructions),
+        instructions: InstructionsV1(Rc::new(instructions)),
         pre_allocated_addresses: pre_allocated_addresses
             .into_iter()
             .map(|allocation_pair| allocation_pair.into())
@@ -1360,7 +1360,7 @@ pub fn create_genesis_data_ingestion_transaction(
     });
 
     SystemTransactionV1 {
-        instructions: InstructionsV1(instructions),
+        instructions: InstructionsV1(Rc::new(instructions)),
         pre_allocated_addresses,
         blobs: BlobsV1 { blobs: vec![] },
         hash_for_execution: hash(format!("Genesis Data Chunk: {}", chunk_number)),
@@ -1432,7 +1432,7 @@ pub fn create_genesis_wrap_up_transaction() -> SystemTransactionV1 {
     });
 
     SystemTransactionV1 {
-        instructions: InstructionsV1(instructions),
+        instructions: InstructionsV1(Rc::new(instructions)),
         pre_allocated_addresses: vec![],
         blobs: BlobsV1 { blobs: vec![] },
         hash_for_execution: hash(format!("Genesis Wrap Up")),

--- a/radix-engine/src/system/payload_validation.rs
+++ b/radix-engine/src/system/payload_validation.rs
@@ -49,18 +49,18 @@ pub enum SchemaOrigin {
 // SYSTEM ADAPTERS
 //==================
 
-pub struct SystemServiceTypeInfoLookup<'s, 'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> {
-    system_service: RefCell<&'s mut SystemService<'a, Y, V>>,
+pub struct SystemServiceTypeInfoLookup<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> {
+    system_service: RefCell<&'s mut SystemService<'a, Y, V, E>>,
     schema_origin: SchemaOrigin,
     allow_ownership: bool,
     allow_non_global_ref: bool,
 }
 
-impl<'s, 'a, Y: KernelApi<System<V>>, V: SystemCallbackObject>
-    SystemServiceTypeInfoLookup<'s, 'a, Y, V>
+impl<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemServiceTypeInfoLookup<'s, 'a, Y, V, E>
 {
     pub fn new(
-        system_service: &'s mut SystemService<'a, Y, V>,
+        system_service: &'s mut SystemService<'a, Y, V, E>,
         schema_origin: SchemaOrigin,
         allow_ownership: bool,
         allow_non_global_ref: bool,
@@ -74,8 +74,8 @@ impl<'s, 'a, Y: KernelApi<System<V>>, V: SystemCallbackObject>
     }
 }
 
-impl<'s, 'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> ValidationContext
-    for SystemServiceTypeInfoLookup<'s, 'a, Y, V>
+impl<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> ValidationContext
+    for SystemServiceTypeInfoLookup<'s, 'a, Y, V, E>
 {
     type Error = RuntimeError;
 

--- a/radix-engine/src/system/payload_validation.rs
+++ b/radix-engine/src/system/payload_validation.rs
@@ -49,7 +49,13 @@ pub enum SchemaOrigin {
 // SYSTEM ADAPTERS
 //==================
 
-pub struct SystemServiceTypeInfoLookup<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> {
+pub struct SystemServiceTypeInfoLookup<
+    's,
+    'a,
+    Y: KernelApi<System<V, E>>,
+    V: SystemCallbackObject,
+    E,
+> {
     system_service: RefCell<&'s mut SystemService<'a, Y, V, E>>,
     schema_origin: SchemaOrigin,
     allow_ownership: bool,

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -52,7 +52,7 @@ pub const BOOT_LOADER_SYSTEM_VERSION_FIELD_KEY: FieldKey = 1u8;
 /// Provided to upper layer for invoking lower layer service
 pub struct SystemService<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> {
     pub api: &'a mut Y,
-    pub phantom: PhantomData<(V,E)>,
+    pub phantom: PhantomData<(V, E)>,
 }
 
 enum ActorStateRef {
@@ -1583,8 +1583,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemObjectApi
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemKeyValueEntryApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1720,8 +1720,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemKeyValueE
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemKeyValueStoreApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemKeyValueStoreApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2004,8 +2004,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorInde
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorSortedIndexApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemActorSortedIndexApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2650,8 +2650,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorApi<
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorKeyValueEntryApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemActorKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2741,8 +2741,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorKeyV
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemExecutionTraceApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemExecutionTraceApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     // No costing should be applied
     #[trace_resources]
@@ -2759,8 +2759,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemExecution
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemTransactionRuntimeApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
+    SystemTransactionRuntimeApi<RuntimeError> for SystemService<'a, Y, V, E>
 {
     #[trace_resources]
     fn get_transaction_hash(&mut self) -> Result<Hash, RuntimeError> {

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -50,9 +50,9 @@ use sbor::rust::vec::Vec;
 pub const BOOT_LOADER_SYSTEM_VERSION_FIELD_KEY: FieldKey = 1u8;
 
 /// Provided to upper layer for invoking lower layer service
-pub struct SystemService<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> {
+pub struct SystemService<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> {
     pub api: &'a mut Y,
-    pub phantom: PhantomData<V>,
+    pub phantom: PhantomData<(V,E)>,
 }
 
 enum ActorStateRef {
@@ -100,7 +100,7 @@ enum EmitterActor {
     AsObject(NodeId, Option<AttachedModuleId>),
 }
 
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
     pub fn new(api: &'a mut Y) -> Self {
         Self {
             api,
@@ -113,7 +113,7 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, 
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
     fn validate_new_object(
         &mut self,
         blueprint_id: &BlueprintId,
@@ -1105,8 +1105,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, 
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemFieldApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemFieldApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1196,8 +1196,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemFieldApi<Runtim
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemObjectApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemObjectApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1583,8 +1583,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemObjectApi<Runti
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueEntryApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemKeyValueEntryApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1720,8 +1720,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueEntryAp
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueStoreApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemKeyValueStoreApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -1872,8 +1872,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemKeyValueStoreAp
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorIndexApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorIndexApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     fn actor_index_insert(
@@ -2004,8 +2004,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorIndexApi<R
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorSortedIndexApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorSortedIndexApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2122,8 +2122,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorSortedInde
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemBlueprintApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemBlueprintApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     fn call_function(
@@ -2168,8 +2168,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemBlueprintApi<Ru
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemCostingApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemCostingApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // No costing should be applied
     fn consume_cost_units(
@@ -2431,8 +2431,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemCostingApi<Runt
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     #[trace_resources]
     fn actor_get_blueprint_id(&mut self) -> Result<BlueprintId, RuntimeError> {
@@ -2650,8 +2650,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorApi<Runtim
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorKeyValueEntryApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorKeyValueEntryApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2741,8 +2741,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemActorKeyValueEn
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemExecutionTraceApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemExecutionTraceApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     // No costing should be applied
     #[trace_resources]
@@ -2759,8 +2759,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemExecutionTraceA
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemTransactionRuntimeApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemTransactionRuntimeApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
     #[trace_resources]
     fn get_transaction_hash(&mut self) -> Result<Hash, RuntimeError> {
@@ -2852,8 +2852,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemTransactionRunt
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemApi<RuntimeError>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemApi<RuntimeError>
+    for SystemService<'a, Y, V, E>
 {
 }
 
@@ -2861,8 +2861,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemApi<RuntimeErro
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelNodeApi
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelNodeApi
+    for SystemService<'a, Y, V, E>
 {
     fn kernel_pin_node(&mut self, node_id: NodeId) -> Result<(), RuntimeError> {
         self.api.kernel_pin_node(node_id)
@@ -2897,8 +2897,8 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelNodeApi
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelSubstateApi<SystemLockData>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelSubstateApi<SystemLockData>
+    for SystemService<'a, Y, V, E>
 {
     fn kernel_mark_substate_as_transient(
         &mut self,
@@ -3007,10 +3007,10 @@ impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelSubstateApi<Sys
     }
 }
 
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> KernelInternalApi<System<V>>
-    for SystemService<'a, Y, V>
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelInternalApi<System<V, E>>
+    for SystemService<'a, Y, V, E>
 {
-    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<V>> {
+    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<V, E>> {
         self.api.kernel_get_system_state()
     }
 

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -198,7 +198,7 @@ impl<C: SystemCallbackObject, E> System<C, E> {
                             destination_blueprint_id,
                         }),
                     }))
-                        .map(|_| ())
+                    .map(|_| ())
                 } else {
                     Ok(())
                 }
@@ -771,7 +771,6 @@ impl<C: SystemCallbackObject> System<C, Executable> {
         }
         println!("{:-^120}", "Finish");
     }
-
 
     /// Checks that references exist in the store
     fn check_references<S: BootStore + CommitableSubstateStore>(

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -22,12 +22,12 @@ use crate::internal_prelude::*;
 use crate::kernel::call_frame::{CallFrameInit, CallFrameMessage, StableReferenceType};
 use crate::kernel::kernel_api::{KernelApi, KernelInvocation};
 use crate::kernel::kernel_api::{KernelInternalApi, KernelSubstateApi};
-use crate::kernel::kernel_callback_api::RefCheckEvent;
 use crate::kernel::kernel_callback_api::{
     CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, KernelCallbackObject,
     MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent,
     ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent,
 };
+use crate::kernel::kernel_callback_api::{KernelTransactionCallbackObject, RefCheckEvent};
 use crate::system::actor::Actor;
 use crate::system::actor::BlueprintHookActor;
 use crate::system::actor::FunctionActor;
@@ -866,9 +866,7 @@ impl<C: SystemCallbackObject> System<C> {
     }
 }
 
-impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
-    type LockData = SystemLockData;
-    type CallFrameData = Actor;
+impl<C: SystemCallbackObject> KernelTransactionCallbackObject for System<C> {
     type Init = SystemInit<C::Init>;
     type Executable = Executable;
     type ExecutionOutput = Vec<InstructionOutput>;
@@ -1319,6 +1317,11 @@ impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
 
         receipt
     }
+}
+
+impl<C: SystemCallbackObject> KernelCallbackObject for System<C> {
+    type LockData = SystemLockData;
+    type CallFrameData = Actor;
 
     fn on_pin_node(&mut self, node_id: &NodeId) -> Result<(), RuntimeError> {
         SystemModuleMixer::on_pin_node(self, node_id)

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -17,9 +17,10 @@ pub trait SystemCallbackObject: Sized {
     /// Invoke a function
     fn invoke<
         Y: SystemApi<RuntimeError>
-            + KernelInternalApi<System<Self>>
+            + KernelInternalApi<System<Self, E>>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
+        E
     >(
         package_address: &PackageAddress,
         package_export: PackageExport,

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -20,7 +20,7 @@ pub trait SystemCallbackObject: Sized {
             + KernelInternalApi<System<Self, E>>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
-        E
+        E,
     >(
         package_address: &PackageAddress,
         package_export: PackageExport,

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -74,8 +74,8 @@ impl AuthModule {
         Self { params }
     }
 
-    pub fn on_call_function<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_function<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         blueprint_id: &BlueprintId,
         ident: &str,
     ) -> Result<NodeId, RuntimeError> {
@@ -125,15 +125,15 @@ impl AuthModule {
         Ok(auth_zone)
     }
 
-    pub fn on_call_function_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_function_finish<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         auth_zone: NodeId,
     ) -> Result<(), RuntimeError> {
         Self::teardown_auth_zone(api, auth_zone)
     }
 
-    pub fn on_call_method<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_method<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         receiver: &NodeId,
         module_id: ModuleId,
         direct_access: bool,
@@ -172,16 +172,16 @@ impl AuthModule {
         Ok(auth_zone)
     }
 
-    pub fn on_call_method_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_method_finish<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         auth_zone: NodeId,
     ) -> Result<(), RuntimeError> {
         Self::teardown_auth_zone(api, auth_zone)
     }
 
     /// On CALL_FUNCTION or CALL_METHOD, when auth module is disabled.
-    pub fn on_call_fn_mock<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        system: &mut SystemService<Y, V>,
+    pub fn on_call_fn_mock<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        system: &mut SystemService<Y, V, E>,
         receiver: Option<(&NodeId, bool)>,
         virtual_resources: BTreeSet<ResourceAddress>,
         virtual_non_fungibles: BTreeSet<NonFungibleGlobalId>,
@@ -189,8 +189,8 @@ impl AuthModule {
         Self::create_auth_zone(system, receiver, virtual_resources, virtual_non_fungibles)
     }
 
-    fn copy_global_caller<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        system: &mut SystemService<Y, V>,
+    fn copy_global_caller<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        system: &mut SystemService<Y, V, E>,
         node_id: &NodeId,
     ) -> Result<(Option<(GlobalCaller, Reference)>, Option<SubstateHandle>), RuntimeError> {
         let handle = system.kernel_open_substate(
@@ -208,8 +208,8 @@ impl AuthModule {
         Ok((auth_zone.into_payload().global_caller, Some(handle)))
     }
 
-    fn create_auth_zone<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        system: &mut SystemService<Y, V>,
+    fn create_auth_zone<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        system: &mut SystemService<Y, V, E>,
         receiver: Option<(&NodeId, bool)>,
         virtual_resources: BTreeSet<ResourceAddress>,
         virtual_non_fungibles: BTreeSet<NonFungibleGlobalId>,
@@ -331,8 +331,8 @@ impl AuthModule {
         Ok(new_auth_zone)
     }
 
-    pub fn teardown_auth_zone<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn teardown_auth_zone<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         self_auth_zone: NodeId,
     ) -> Result<(), RuntimeError> {
         // Detach proofs from the auth zone
@@ -372,11 +372,11 @@ impl AuthModule {
         Ok(())
     }
 
-    fn check_permission<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
+    fn check_permission<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
         auth_zone: &NodeId,
         resolved_permission: ResolvedPermission,
         fn_identifier: FnIdentifier,
-        api: &mut SystemService<Y, V>,
+        api: &mut SystemService<Y, V, E>,
     ) -> Result<(), RuntimeError> {
         match resolved_permission {
             ResolvedPermission::AllowAll => return Ok(()),
@@ -426,8 +426,8 @@ impl AuthModule {
         }
     }
 
-    fn resolve_method_permission<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    fn resolve_method_permission<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         blueprint_id: &BlueprintId,
         receiver: &NodeId,
         module_id: &ModuleId,
@@ -517,4 +517,4 @@ impl AuthModule {
 }
 
 impl InitSystemModule for AuthModule {}
-impl<V: SystemCallbackObject> SystemModule<System<V>> for AuthModule {}
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for AuthModule {}

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -318,7 +318,7 @@ impl CostingModule {
     }
 }
 
-pub fn apply_royalty_cost<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
+pub fn apply_royalty_cost<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
     api: &mut Y,
     royalty_amount: RoyaltyAmount,
     recipient: RoyaltyRecipient,
@@ -361,8 +361,8 @@ impl InitSystemModule for CostingModule {
     }
 }
 
-impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
-    fn before_invoke<Y: KernelApi<System<V>>>(
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for CostingModule {
+    fn before_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
@@ -463,7 +463,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     #[inline(always)]
-    fn after_invoke<Y: KernelApi<System<V>>>(
+    fn after_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         output: &IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
@@ -500,7 +500,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_create_node<Y: KernelInternalApi<System<V>>>(
+    fn on_create_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -514,7 +514,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_pin_node(system: &mut System<V>, node_id: &NodeId) -> Result<(), RuntimeError> {
+    fn on_pin_node(system: &mut System<V, E>, node_id: &NodeId) -> Result<(), RuntimeError> {
         system
             .modules
             .costing
@@ -524,7 +524,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_drop_node<Y: KernelInternalApi<System<V>>>(
+    fn on_drop_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -538,7 +538,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_move_module<Y: KernelInternalApi<System<V>>>(
+    fn on_move_module<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &MoveModuleEvent,
     ) -> Result<(), RuntimeError> {
@@ -552,7 +552,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_open_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_open_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -567,7 +567,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     fn on_mark_substate_as_transient(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         node_id: &NodeId,
         partition_number: &PartitionNumber,
         substate_key: &SubstateKey,
@@ -585,7 +585,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_read_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_read_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -599,7 +599,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_write_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_write_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -613,7 +613,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_close_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_close_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CloseSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -628,7 +628,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     fn on_set_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &SetSubstateEvent,
     ) -> Result<(), RuntimeError> {
         system
@@ -641,7 +641,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     fn on_remove_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &RemoveSubstateEvent,
     ) -> Result<(), RuntimeError> {
         system
@@ -653,7 +653,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_scan_keys(system: &mut System<V>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
+    fn on_scan_keys(system: &mut System<V, E>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
         system
             .modules
             .costing
@@ -664,7 +664,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     fn on_drain_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &DrainSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         system
@@ -677,7 +677,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
     }
 
     fn on_scan_sorted_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &ScanSortedSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         system
@@ -689,7 +689,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for CostingModule {
         Ok(())
     }
 
-    fn on_allocate_node_id<Y: KernelApi<System<V>>>(
+    fn on_allocate_node_id<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         _entity_type: EntityType,
     ) -> Result<(), RuntimeError> {

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -291,8 +291,8 @@ impl ResourceSummary {
 
 impl InitSystemModule for ExecutionTraceModule {}
 
-impl<V: SystemCallbackObject> SystemModule<System<V>> for ExecutionTraceModule {
-    fn on_create_node<Y: KernelInternalApi<System<V>>>(
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for ExecutionTraceModule {
+    fn on_create_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -324,7 +324,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for ExecutionTraceModule {
         Ok(())
     }
 
-    fn on_drop_node<Y: KernelInternalApi<System<V>>>(
+    fn on_drop_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -352,7 +352,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for ExecutionTraceModule {
         Ok(())
     }
 
-    fn before_invoke<Y: KernelApi<System<V>>>(
+    fn before_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
@@ -374,7 +374,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for ExecutionTraceModule {
         Ok(())
     }
 
-    fn on_execution_finish<Y: KernelApi<System<V>>>(
+    fn on_execution_finish<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {

--- a/radix-engine/src/system/system_modules/kernel_trace/module.rs
+++ b/radix-engine/src/system/system_modules/kernel_trace/module.rs
@@ -33,8 +33,8 @@ impl InitSystemModule for KernelTraceModule {
 }
 
 #[allow(unused_variables)] // for no_std
-impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
-    fn before_invoke<Y: KernelApi<System<V>>>(
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for KernelTraceModule {
+    fn before_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
@@ -51,7 +51,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_execution_finish<Y: KernelApi<System<V>>>(
+    fn on_execution_finish<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {
@@ -60,7 +60,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn after_invoke<Y: KernelApi<System<V>>>(
+    fn after_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         output: &IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
@@ -68,7 +68,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_allocate_node_id<Y: KernelApi<System<V>>>(
+    fn on_allocate_node_id<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         entity_type: EntityType,
     ) -> Result<(), RuntimeError> {
@@ -76,7 +76,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_create_node<Y: KernelInternalApi<System<V>>>(
+    fn on_create_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -108,7 +108,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_drop_node<Y: KernelInternalApi<System<V>>>(
+    fn on_drop_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -121,7 +121,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_open_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_open_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -159,7 +159,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_read_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_read_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -183,7 +183,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_write_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_write_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -202,7 +202,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for KernelTraceModule {
         Ok(())
     }
 
-    fn on_close_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_close_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CloseSubstateEvent,
     ) -> Result<(), RuntimeError> {

--- a/radix-engine/src/system/system_modules/limits/module.rs
+++ b/radix-engine/src/system/system_modules/limits/module.rs
@@ -185,8 +185,8 @@ impl LimitsModule {
 
 impl InitSystemModule for LimitsModule {}
 
-impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
-    fn before_invoke<Y: KernelApi<System<V>>>(
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for LimitsModule {
+    fn before_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
@@ -215,7 +215,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_create_node<Y: KernelInternalApi<System<V>>>(
+    fn on_create_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -239,7 +239,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_drop_node<Y: KernelInternalApi<System<V>>>(
+    fn on_drop_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -255,7 +255,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_move_module<Y: KernelInternalApi<System<V>>>(
+    fn on_move_module<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &MoveModuleEvent,
     ) -> Result<(), RuntimeError> {
@@ -271,7 +271,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_open_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_open_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -294,7 +294,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_read_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_read_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -311,7 +311,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_write_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_write_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -333,7 +333,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
     }
 
     fn on_set_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &SetSubstateEvent,
     ) -> Result<(), RuntimeError> {
         match event {
@@ -353,7 +353,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
     }
 
     fn on_remove_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &RemoveSubstateEvent,
     ) -> Result<(), RuntimeError> {
         match event {
@@ -368,7 +368,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
         Ok(())
     }
 
-    fn on_scan_keys(system: &mut System<V>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
+    fn on_scan_keys(system: &mut System<V, E>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
         match event {
             ScanKeysEvent::IOAccess(io_access) => {
                 system.modules.limits.process_io_access(io_access)?;
@@ -380,7 +380,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
     }
 
     fn on_drain_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &DrainSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         match event {
@@ -394,7 +394,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for LimitsModule {
     }
 
     fn on_scan_sorted_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &ScanSortedSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         match event {

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -219,9 +219,9 @@ impl InitSystemModule for SystemModuleMixer {
     }
 }
 
-impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
+impl<V: SystemCallbackObject, E> SystemModule<System<V, E>> for SystemModuleMixer {
     #[trace_resources(log=invocation.len())]
-    fn before_invoke<Y: KernelApi<System<V>>>(
+    fn before_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
@@ -229,12 +229,12 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_execution_start<Y: KernelApi<System<V>>>(api: &mut Y) -> Result<(), RuntimeError> {
+    fn on_execution_start<Y: KernelApi<System<V, E>>>(api: &mut Y) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_execution_start(api))
     }
 
     #[trace_resources]
-    fn on_execution_finish<Y: KernelApi<System<V>>>(
+    fn on_execution_finish<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {
@@ -242,7 +242,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn after_invoke<Y: KernelApi<System<V>>>(
+    fn after_invoke<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         output: &IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
@@ -250,12 +250,12 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_pin_node(system: &mut System<V>, node_id: &NodeId) -> Result<(), RuntimeError> {
+    fn on_pin_node(system: &mut System<V, E>, node_id: &NodeId) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_pin_node(system, node_id))
     }
 
     #[trace_resources(log=entity_type)]
-    fn on_allocate_node_id<Y: KernelApi<System<V>>>(
+    fn on_allocate_node_id<Y: KernelApi<System<V, E>>>(
         api: &mut Y,
         entity_type: EntityType,
     ) -> Result<(), RuntimeError> {
@@ -266,7 +266,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_create_node<Y: KernelInternalApi<System<V>>>(
+    fn on_create_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -274,7 +274,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_move_module<Y: KernelInternalApi<System<V>>>(
+    fn on_move_module<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &MoveModuleEvent,
     ) -> Result<(), RuntimeError> {
@@ -282,7 +282,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_drop_node<Y: KernelInternalApi<System<V>>>(
+    fn on_drop_node<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
@@ -291,7 +291,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
 
     #[trace_resources]
     fn on_mark_substate_as_transient(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         node_id: &NodeId,
         partition_number: &PartitionNumber,
         substate_key: &SubstateKey,
@@ -303,7 +303,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_open_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_open_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -311,7 +311,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources(log=event.is_about_heap())]
-    fn on_read_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_read_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -319,7 +319,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_write_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_write_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -327,7 +327,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
     }
 
     #[trace_resources]
-    fn on_close_substate<Y: KernelInternalApi<System<V>>>(
+    fn on_close_substate<Y: KernelInternalApi<System<V, E>>>(
         api: &mut Y,
         event: &CloseSubstateEvent,
     ) -> Result<(), RuntimeError> {
@@ -336,7 +336,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
 
     #[trace_resources]
     fn on_set_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &SetSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_set_substate(system, event))
@@ -344,20 +344,20 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
 
     #[trace_resources]
     fn on_remove_substate(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &RemoveSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_remove_substate(system, event))
     }
 
     #[trace_resources]
-    fn on_scan_keys(system: &mut System<V>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
+    fn on_scan_keys(system: &mut System<V, E>, event: &ScanKeysEvent) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_scan_keys(system, event))
     }
 
     #[trace_resources]
     fn on_drain_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &DrainSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_drain_substates(system, event))
@@ -365,7 +365,7 @@ impl<V: SystemCallbackObject> SystemModule<System<V>> for SystemModuleMixer {
 
     #[trace_resources]
     fn on_scan_sorted_substates(
-        system: &mut System<V>,
+        system: &mut System<V, E>,
         event: &ScanSortedSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(system, on_scan_sorted_substates(system, event))
@@ -377,8 +377,8 @@ impl SystemModuleMixer {
     // - Kernel uses the `SystemModule<SystemConfig<V>>` trait above;
     // - System uses methods defined below (TODO: add a trait?)
 
-    pub fn on_call_method<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_method<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         receiver: &NodeId,
         module_id: ModuleId,
         direct_access: bool,
@@ -405,15 +405,15 @@ impl SystemModuleMixer {
         Ok(auth_zone)
     }
 
-    pub fn on_call_method_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_method_finish<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         auth_zone: NodeId,
     ) -> Result<(), RuntimeError> {
         AuthModule::on_call_method_finish(api, auth_zone)
     }
 
-    pub fn on_call_function<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_function<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         blueprint_id: &BlueprintId,
         ident: &str,
     ) -> Result<NodeId, RuntimeError> {
@@ -432,8 +432,8 @@ impl SystemModuleMixer {
         Ok(auth_zone)
     }
 
-    pub fn on_call_function_finish<Y: KernelApi<System<V>>, V: SystemCallbackObject>(
-        api: &mut SystemService<Y, V>,
+    pub fn on_call_function_finish<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+        api: &mut SystemService<Y, V, E>,
         auth_zone: NodeId,
     ) -> Result<(), RuntimeError> {
         AuthModule::on_call_function_finish(api, auth_zone)

--- a/radix-engine/src/system/system_type_checker.rs
+++ b/radix-engine/src/system/system_type_checker.rs
@@ -55,7 +55,7 @@ pub enum TypeCheckError {
     MissingSchema,
 }
 
-impl<'a, Y: KernelApi<System<V>>, V: SystemCallbackObject> SystemService<'a, Y, V> {
+impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
     /// Validate that the type substitutions match the generic definition of a given blueprint
     pub fn validate_bp_generic_args(
         &mut self,

--- a/radix-engine/src/transaction/preview_executor.rs
+++ b/radix-engine/src/transaction/preview_executor.rs
@@ -40,6 +40,6 @@ pub fn execute_preview<'s, S: SubstateDatabase, W: WasmEngine, E: NativeVmExtens
         substate_db,
         vm_init,
         &execution_config,
-        &validated.get_executable(),
+        validated.get_executable(),
     ))
 }

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -293,7 +293,7 @@ impl UniqueTransaction for Executable {
     }
 }
 
-pub struct TransactionExecutor<'s, S, V: KernelCallbackObject>
+pub struct TransactionExecutor<'s, S, V: KernelTransactionCallbackObject>
 where
     S: SubstateDatabase,
 {
@@ -305,7 +305,7 @@ where
 impl<'s, S, V> TransactionExecutor<'s, S, V>
 where
     S: SubstateDatabase,
-    V: KernelCallbackObject<Executable: UniqueTransaction>,
+    V: KernelTransactionCallbackObject<Executable: UniqueTransaction>,
 {
     pub fn new(substate_db: &'s S, system_init: V::Init) -> Self {
         Self {

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -283,12 +283,14 @@ impl<'a, S: SubstateDatabase> BootStore for SubstateBootStore<'a, S> {
     }
 }
 
+/// A transaction which has a unique id, useful for creating an IdAllocator which
+/// requires a unique input
 pub trait UniqueTransaction {
-    fn uniqe_id(&self) -> Hash;
+    fn unique_id(&self) -> Hash;
 }
 
 impl UniqueTransaction for Executable {
-    fn uniqe_id(&self) -> Hash {
+    fn unique_id(&self) -> Hash {
         self.intent_hash().to_hash()
     }
 }
@@ -317,7 +319,7 @@ where
 
     pub fn execute(&mut self, executable: V::Executable) -> V::Receipt {
         let kernel_boot = BootLoader {
-            id_allocator: IdAllocator::new(executable.uniqe_id()),
+            id_allocator: IdAllocator::new(executable.unique_id()),
             track: Track::<_, SpreadPrefixKeyMapper>::new(self.substate_db),
             init: self.system_init.clone(),
             phantom: PhantomData::<V>::default(),

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -305,7 +305,7 @@ where
         }
     }
 
-    pub fn execute(&mut self, executable: &Executable) -> V::Receipt {
+    pub fn execute(&mut self, executable: Executable) -> V::Receipt {
         let kernel_boot = BootLoader {
             id_allocator: IdAllocator::new(executable.intent_hash().to_hash()),
             track: Track::<_, SpreadPrefixKeyMapper>::new(self.substate_db),
@@ -321,7 +321,7 @@ pub fn execute_transaction_with_configuration<S: SubstateDatabase, V: SystemCall
     substate_db: &S,
     vms: V::Init,
     execution_config: &ExecutionConfig,
-    transaction: &Executable,
+    executable: Executable,
 ) -> TransactionReceipt {
     let mut executor = TransactionExecutor::<_, System<V>>::new(
         substate_db,
@@ -335,20 +335,20 @@ pub fn execute_transaction_with_configuration<S: SubstateDatabase, V: SystemCall
         },
     );
 
-    executor.execute(transaction)
+    executor.execute(executable)
 }
 
 pub fn execute_transaction<'s, S: SubstateDatabase, W: WasmEngine, E: NativeVmExtension>(
     substate_db: &S,
     vm_init: VmInit<'s, W, E>,
     execution_config: &ExecutionConfig,
-    transaction: &Executable,
+    executable: Executable,
 ) -> TransactionReceipt {
     execute_transaction_with_configuration::<S, Vm<'s, W, E>>(
         substate_db,
         vm_init,
         execution_config,
-        transaction,
+        executable,
     )
 }
 
@@ -361,7 +361,7 @@ pub fn execute_and_commit_transaction<
     substate_db: &mut S,
     vms: VmInit<'s, W, E>,
     execution_config: &ExecutionConfig,
-    transaction: &Executable,
+    transaction: Executable,
 ) -> TransactionReceipt {
     let receipt = execute_transaction_with_configuration::<S, Vm<'s, W, E>>(
         substate_db,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -333,7 +333,7 @@ pub fn execute_transaction_with_configuration<S: SubstateDatabase, V: SystemCall
     execution_config: &ExecutionConfig,
     executable: Executable,
 ) -> TransactionReceipt {
-    let mut executor = TransactionExecutor::<_, System<V>>::new(
+    let mut executor = TransactionExecutor::<_, System<V, Executable>>::new(
         substate_db,
         SystemInit {
             enable_kernel_trace: execution_config.enable_kernel_trace,

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -216,7 +216,7 @@ impl TransactionReceiptV1 {
 }
 
 impl ExecutionReceipt for TransactionReceipt {
-    fn from_rejection(executable: &Executable, reason: RejectionReason) -> Self {
+    fn from_rejection(executable: Executable, reason: RejectionReason) -> Self {
         TransactionReceipt {
             costing_parameters: CostingParameters::babylon_genesis(),
             transaction_costing_parameters: executable.costing_parameters().clone().into(),

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -216,6 +216,8 @@ impl TransactionReceiptV1 {
 }
 
 impl ExecutionReceipt for TransactionReceipt {
+    type Executed = Executable;
+
     fn from_rejection(executable: Executable, reason: RejectionReason) -> Self {
         TransactionReceipt {
             costing_parameters: CostingParameters::babylon_genesis(),

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -100,9 +100,10 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
 
     fn invoke<
         Y: SystemApi<RuntimeError>
-            + KernelInternalApi<System<Self>>
+            + KernelInternalApi<System<Self, T>>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
+        T,
     >(
         address: &PackageAddress,
         export: PackageExport,

--- a/radix-transaction-scenarios/src/executor.rs
+++ b/radix-transaction-scenarios/src/executor.rs
@@ -379,7 +379,7 @@ where
             &self.database,
             VmInit::new(&self.scrypto_vm, self.native_vm_extension.clone()),
             &self.scenario_execution_config,
-            &validated.get_executable(),
+            validated.get_executable(),
         );
 
         if let TransactionResult::Commit(commit) = &receipt.result {

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -112,24 +112,24 @@ impl From<TransactionCostingParameters> for TransactionCostingParametersReceipt 
 }
 
 /// Executable form of transaction, post stateless validation.
-#[derive(Debug, PartialEq, Eq)]
-pub struct Executable<'a> {
-    pub(crate) encoded_instructions: &'a [u8],
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Executable {
+    pub(crate) encoded_instructions: Rc<Vec<u8>>,
     pub(crate) references: IndexSet<Reference>,
-    pub(crate) blobs: &'a IndexMap<Hash, Vec<u8>>,
+    pub(crate) blobs: Rc<IndexMap<Hash, Vec<u8>>>,
     pub(crate) context: ExecutionContext,
     pub(crate) system: bool,
 }
 
-impl<'a> Executable<'a> {
+impl Executable {
     pub fn new(
-        encoded_instructions: &'a [u8],
-        references: &IndexSet<Reference>,
-        blobs: &'a IndexMap<Hash, Vec<u8>>,
+        encoded_instructions: Rc<Vec<u8>>,
+        references: IndexSet<Reference>,
+        blobs: Rc<IndexMap<Hash, Vec<u8>>>,
         context: ExecutionContext,
         system: bool,
     ) -> Self {
-        let mut references = references.clone();
+        let mut references = references;
 
         for proof in &context.auth_zone_params.initial_proofs {
             references.insert(proof.resource_address().clone().into());

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -23,22 +23,6 @@ pub struct ExecutionContext {
     pub costing_parameters: TransactionCostingParameters,
 }
 
-impl ExecutionContext {
-    pub fn mock() -> Self {
-        Self {
-            intent_hash: TransactionIntentHash::NotToCheck {
-                intent_hash: Hash([0u8; Hash::LENGTH]),
-            },
-            epoch_range: Default::default(),
-            pre_allocated_addresses: Default::default(),
-            payload_size: 0usize,
-            num_of_signature_validations: 0usize,
-            auth_zone_params: AuthZoneParams::default(),
-            costing_parameters: TransactionCostingParameters::default(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TransactionIntentHash {
     /// Should be checked with transaction tracker.

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -172,16 +172,6 @@ impl Executable {
         }
     }
 
-    pub fn mock() -> Self {
-        Self {
-            encoded_instructions: Default::default(),
-            references: Default::default(),
-            blobs: Default::default(),
-            context: ExecutionContext::mock(),
-            system: false,
-        }
-    }
-
     // Consuming builder-like customization methods:
 
     pub fn is_system(&self) -> bool {

--- a/radix-transactions/src/model/executable.rs
+++ b/radix-transactions/src/model/executable.rs
@@ -23,6 +23,22 @@ pub struct ExecutionContext {
     pub costing_parameters: TransactionCostingParameters,
 }
 
+impl ExecutionContext {
+    pub fn mock() -> Self {
+        Self {
+            intent_hash: TransactionIntentHash::NotToCheck {
+                intent_hash: Hash([0u8; Hash::LENGTH]),
+            },
+            epoch_range: Default::default(),
+            pre_allocated_addresses: Default::default(),
+            payload_size: 0usize,
+            num_of_signature_validations: 0usize,
+            auth_zone_params: AuthZoneParams::default(),
+            costing_parameters: TransactionCostingParameters::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum TransactionIntentHash {
     /// Should be checked with transaction tracker.
@@ -153,6 +169,16 @@ impl Executable {
             blobs,
             context,
             system,
+        }
+    }
+
+    pub fn mock() -> Self {
+        Self {
+            encoded_instructions: Default::default(),
+            references: Default::default(),
+            blobs: Default::default(),
+            context: ExecutionContext::mock(),
+            system: false,
         }
     }
 

--- a/radix-transactions/src/model/mod.rs
+++ b/radix-transactions/src/model/mod.rs
@@ -162,16 +162,16 @@ Enum<3u8>(
         assert_eq!(
             executable,
             Executable {
-                encoded_instructions: &manifest_encode(&manifest.instructions).unwrap(),
+                encoded_instructions: Rc::new(manifest_encode(&manifest.instructions).unwrap()),
                 references: indexset!(
                     Reference(FAUCET.into_node_id()),
                     // NOTE: not needed
                     Reference(SECP256K1_SIGNATURE_RESOURCE.into_node_id()),
                     Reference(ED25519_SIGNATURE_RESOURCE.into_node_id())
                 ),
-                blobs: &indexmap!(
+                blobs: Rc::new(indexmap!(
                     hash(&[1, 2]) => vec![1, 2]
-                ),
+                )),
                 context: ExecutionContext {
                     intent_hash: TransactionIntentHash::ToCheck {
                         intent_hash: hash(

--- a/radix-transactions/src/model/v1/blobs.rs
+++ b/radix-transactions/src/model/v1/blobs.rs
@@ -19,7 +19,7 @@ impl TransactionPartialEncode for BlobsV1 {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreparedBlobsV1 {
-    pub blobs_by_hash: IndexMap<Hash, Vec<u8>>,
+    pub blobs_by_hash: Rc<IndexMap<Hash, Vec<u8>>>,
     pub summary: Summary,
 }
 
@@ -42,7 +42,7 @@ impl TransactionFullChildPreparable for PreparedBlobsV1 {
         }
 
         Ok(PreparedBlobsV1 {
-            blobs_by_hash,
+            blobs_by_hash: Rc::new(blobs_by_hash),
             summary,
         })
     }

--- a/radix-transactions/src/model/v1/instructions.rs
+++ b/radix-transactions/src/model/v1/instructions.rs
@@ -3,7 +3,7 @@ use crate::internal_prelude::*;
 
 #[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
 #[sbor(transparent)]
-pub struct InstructionsV1(pub Vec<InstructionV1>);
+pub struct InstructionsV1(pub Rc<Vec<InstructionV1>>);
 
 impl TransactionPartialEncode for InstructionsV1 {
     type Prepared = PreparedInstructionsV1;

--- a/radix-transactions/src/model/v1/manifest.rs
+++ b/radix-transactions/src/model/v1/manifest.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::internal_prelude::*;
+use std::ops::Deref;
 
 //=================================================================================
 // NOTE:
@@ -16,7 +17,7 @@ pub struct TransactionManifestV1 {
 impl TransactionManifestV1 {
     pub fn from_intent(intent: &IntentV1) -> Self {
         Self {
-            instructions: intent.instructions.0.clone(),
+            instructions: intent.instructions.0.deref().clone(),
             blobs: intent
                 .blobs
                 .blobs
@@ -28,7 +29,7 @@ impl TransactionManifestV1 {
 
     pub fn for_intent(self) -> (InstructionsV1, BlobsV1) {
         (
-            InstructionsV1(self.instructions),
+            InstructionsV1(Rc::new(self.instructions)),
             BlobsV1 {
                 blobs: self
                     .blobs

--- a/radix-transactions/src/model/v1/preview_transaction.rs
+++ b/radix-transactions/src/model/v1/preview_transaction.rs
@@ -18,13 +18,13 @@ pub struct PreviewIntentV1 {
 
 pub struct ValidatedPreviewIntent {
     pub intent: PreparedIntentV1,
-    pub encoded_instructions: Vec<u8>,
+    pub encoded_instructions: Rc<Vec<u8>>,
     pub signer_public_keys: Vec<PublicKey>,
     pub flags: PreviewFlags,
 }
 
 impl ValidatedPreviewIntent {
-    pub fn get_executable<'a>(&'a self) -> Executable<'a> {
+    pub fn get_executable(&self) -> Executable {
         let intent = &self.intent;
         let flags = &self.flags;
 
@@ -55,9 +55,9 @@ impl ValidatedPreviewIntent {
         let intent_hash = intent.intent_hash();
 
         Executable::new(
-            &self.encoded_instructions,
-            &intent.instructions.references,
-            &intent.blobs.blobs_by_hash,
+            self.encoded_instructions.clone(),
+            intent.instructions.references.clone(),
+            intent.blobs.blobs_by_hash.clone(),
             ExecutionContext {
                 intent_hash: if flags.skip_epoch_check {
                     TransactionIntentHash::NotToCheck {

--- a/radix-transactions/src/model/v1/validated_notarized_transaction.rs
+++ b/radix-transactions/src/model/v1/validated_notarized_transaction.rs
@@ -4,7 +4,7 @@ use radix_common::constants::AuthAddresses;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ValidatedNotarizedTransactionV1 {
     pub prepared: PreparedNotarizedTransactionV1,
-    pub encoded_instructions: Vec<u8>,
+    pub encoded_instructions: Rc<Vec<u8>>,
     pub signer_keys: Vec<PublicKey>,
     pub num_of_signature_validations: usize,
 }
@@ -28,16 +28,16 @@ impl HasNotarizedTransactionHash for ValidatedNotarizedTransactionV1 {
 }
 
 impl ValidatedNotarizedTransactionV1 {
-    pub fn get_executable<'a>(&'a self) -> Executable<'a> {
+    pub fn get_executable(&self) -> Executable {
         let intent = &self.prepared.signed_intent.intent;
         let header = &intent.header.inner;
         let intent_hash = intent.intent_hash();
         let summary = &self.prepared.summary;
 
         Executable::new(
-            &self.encoded_instructions,
-            &intent.instructions.references,
-            &intent.blobs.blobs_by_hash,
+            self.encoded_instructions.clone(),
+            intent.instructions.references.clone(),
+            intent.blobs.blobs_by_hash.clone(),
             ExecutionContext {
                 intent_hash: TransactionIntentHash::ToCheck {
                     intent_hash: intent_hash.into_hash(),

--- a/radix-transactions/src/model/versioned.rs
+++ b/radix-transactions/src/model/versioned.rs
@@ -85,7 +85,7 @@ mod tests {
 
         let instructions = vec![InstructionV1::DropAuthZoneProofs];
         let expected_instructions_hash = hash_manifest_encoded_without_prefix_byte(&instructions);
-        let instructions_v1 = InstructionsV1(instructions);
+        let instructions_v1 = InstructionsV1(Rc::new(instructions));
 
         let blob1: Vec<u8> = vec![0, 1, 2, 3];
         let blob2: Vec<u8> = vec![5, 6];
@@ -282,7 +282,7 @@ mod tests {
     pub fn v1_system_transaction_structure() {
         let instructions = vec![InstructionV1::DropAuthZoneProofs];
         let expected_instructions_hash = hash_manifest_encoded_without_prefix_byte(&instructions);
-        let instructions_v1 = InstructionsV1(instructions);
+        let instructions_v1 = InstructionsV1(Rc::new(instructions));
 
         let blob1: Vec<u8> = vec![0, 1, 2, 3];
         let blob2: Vec<u8> = vec![5, 6];

--- a/radix-transactions/src/validation/transaction_validator.rs
+++ b/radix-transactions/src/validation/transaction_validator.rs
@@ -108,8 +108,9 @@ impl TransactionValidator<PreparedNotarizedTransactionV1> for NotarizedTransacti
     ) -> Result<Self::Validated, TransactionValidationError> {
         self.validate_intent_v1(&transaction.signed_intent.intent)?;
 
-        let encoded_instructions =
-            manifest_encode(&transaction.signed_intent.intent.instructions.inner.0)?;
+        let encoded_instructions = Rc::new(manifest_encode(
+            &transaction.signed_intent.intent.instructions.inner.0,
+        )?);
 
         let signer_keys = self
             .validate_signatures_v1(&transaction)
@@ -145,7 +146,7 @@ impl NotarizedTransactionValidator {
 
         self.validate_intent_v1(&intent)?;
 
-        let encoded_instructions = manifest_encode(&intent.instructions.inner.0)?;
+        let encoded_instructions = Rc::new(manifest_encode(&intent.instructions.inner.0)?);
 
         Ok(ValidatedPreviewIntent {
             intent,

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -289,7 +289,7 @@ where
                         costing_module,
                         ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
                     ),
-                    executable: Executable::mock(),
+                    executable: (),
                 }
             },
             |system_config, track, id_allocator| {

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -304,7 +304,7 @@ where
                         pinned_to_heap: Default::default(),
                     },
                     id_allocator,
-                    CallFrame::new_root(Actor::Root),
+                    CallFrame::new_root(Actor::Root, Default::default()),
                     vec![],
                     system_config,
                 )

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -289,6 +289,7 @@ where
                         costing_module,
                         ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
                     ),
+                    executable: Executable::mock(),
                 }
             },
             |system_config, track, id_allocator| {

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -304,7 +304,7 @@ where
                         pinned_to_heap: Default::default(),
                     },
                     id_allocator,
-                    CallFrame::new_root(Actor::Root, Default::default()),
+                    CallFrame::new_root(Default::default()),
                     vec![],
                     system_config,
                 )

--- a/scrypto-test/src/environment/types.rs
+++ b/scrypto-test/src/environment/types.rs
@@ -5,6 +5,6 @@ use crate::prelude::*;
 
 pub type TestVm<'g> = Vm<'g, DefaultWasmEngine, NoExtension>;
 pub type TestTrack<'g, D> = Track<'g, D, SpreadPrefixKeyMapper>;
-pub type TestSystemConfig<'g> = System<TestVm<'g>>;
+pub type TestSystemConfig<'g> = System<TestVm<'g>, ()>;
 pub type TestKernel<'g, D> = Kernel<'g, TestSystemConfig<'g>, TestTrack<'g, D>>;
-pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>, TestVm<'g>>;
+pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>, TestVm<'g>, ()>;

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -39,7 +39,7 @@ pub struct InjectCostingErrorInput<I> {
 
 pub struct InjectCostingError<K: SystemCallbackObject> {
     fail_after: Rc<RefCell<u64>>,
-    system: System<K>,
+    system: System<K, Executable>,
 }
 
 impl<K: SystemCallbackObject> InjectCostingError<K> {
@@ -95,7 +95,7 @@ impl<K: SystemCallbackObject> KernelTransactionCallbackObject for InjectCostingE
         init_input: Self::Init,
     ) -> Result<(Self, CallFrameInit<Actor>), RejectionReason> {
         let (mut system, call_frame_init) =
-            System::<K>::init(store, executable, init_input.system_input)?;
+            System::<K, _>::init(store, executable, init_input.system_input)?;
 
         let fail_after = Rc::new(RefCell::new(init_input.error_after_count));
         system.modules.costing_mut().unwrap().on_apply_cost = OnApplyCost::ForceFailOnCount {
@@ -139,7 +139,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_create_node(&mut api, event)
+        System::<_, Executable>::on_create_node(&mut api, event)
     }
 
     fn on_drop_node<Y: KernelInternalApi<Self>>(
@@ -148,7 +148,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_drop_node(&mut api, event)
+        System::<_, Executable>::on_drop_node(&mut api, event)
     }
 
     fn on_move_module<Y: KernelInternalApi<Self>>(
@@ -157,7 +157,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_move_module(&mut api, event)
+        System::<_, Executable>::on_move_module(&mut api, event)
     }
 
     fn on_open_substate<Y: KernelInternalApi<Self>>(
@@ -166,7 +166,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_open_substate(&mut api, event)
+        System::<_, Executable>::on_open_substate(&mut api, event)
     }
 
     fn on_close_substate<Y: KernelInternalApi<Self>>(
@@ -175,7 +175,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_close_substate(&mut api, event)
+        System::<_, Executable>::on_close_substate(&mut api, event)
     }
 
     fn on_read_substate<Y: KernelInternalApi<Self>>(
@@ -184,7 +184,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_read_substate(&mut api, event)
+        System::<_, Executable>::on_read_substate(&mut api, event)
     }
 
     fn on_write_substate<Y: KernelInternalApi<Self>>(
@@ -193,7 +193,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_internal_api!(api);
-        System::on_write_substate(&mut api, event)
+        System::<_, Executable>::on_write_substate(&mut api, event)
     }
 
     fn on_set_substate(&mut self, event: SetSubstateEvent) -> Result<(), RuntimeError> {
@@ -230,13 +230,13 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::before_invoke(invocation, &mut api)
+        System::<_, Executable>::before_invoke(invocation, &mut api)
     }
 
     fn on_execution_start<Y: KernelApi<Self>>(api: &mut Y) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::on_execution_start(&mut api)
+        System::<_, Executable>::on_execution_start(&mut api)
     }
 
     fn invoke_upstream<Y: KernelApi<Self>>(
@@ -245,13 +245,13 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<IndexedScryptoValue, RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::invoke_upstream(args, &mut api)
+        System::<_, Executable>::invoke_upstream(args, &mut api)
     }
 
     fn auto_drop<Y: KernelApi<Self>>(nodes: Vec<NodeId>, api: &mut Y) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::auto_drop(nodes, &mut api)
+        System::<_, Executable>::auto_drop(nodes, &mut api)
     }
 
     fn on_execution_finish<Y: KernelApi<Self>>(
@@ -260,7 +260,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::on_execution_finish(message, &mut api)
+        System::<_, Executable>::on_execution_finish(message, &mut api)
     }
 
     fn after_invoke<Y: KernelApi<Self>>(
@@ -269,7 +269,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::after_invoke(output, &mut api)
+        System::<_, Executable>::after_invoke(output, &mut api)
     }
 
     fn on_allocate_node_id<Y: KernelApi<Self>>(
@@ -278,7 +278,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::on_allocate_node_id(entity_type, &mut api)
+        System::<_, Executable>::on_allocate_node_id(entity_type, &mut api)
     }
 
     fn on_mark_substate_as_transient(
@@ -300,7 +300,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<bool, RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::on_substate_lock_fault(node_id, partition_num, offset, &mut api)
+        System::<_, Executable>::on_substate_lock_fault(node_id, partition_num, offset, &mut api)
     }
 
     fn on_drop_node_mut<Y: KernelApi<Self>>(
@@ -309,7 +309,7 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> Result<(), RuntimeError> {
         api.kernel_get_system_state().system.maybe_err()?;
         let mut api = wrapped_api!(api);
-        System::on_drop_node_mut(node_id, &mut api)
+        System::<_, Executable>::on_drop_node_mut(node_id, &mut api)
     }
 }
 
@@ -471,10 +471,10 @@ impl<'a, M: SystemCallbackObject + 'a, K: KernelApi<InjectCostingError<M>>> Kern
     }
 }
 
-impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelInternalApi<System<M>>
+impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelInternalApi<System<M, Executable>>
     for WrappedKernelApi<'a, M, K>
 {
-    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<M>> {
+    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<M, Executable>> {
         let state = self.api.kernel_get_system_state();
         SystemState {
             system: &mut state.system.system,
@@ -500,7 +500,7 @@ impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelInt
     }
 }
 
-impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelApi<System<M>>
+impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelApi<System<M, Executable>>
     for WrappedKernelApi<'a, M, K>
 {
 }
@@ -515,9 +515,9 @@ pub struct WrappedKernelInternalApi<
 }
 
 impl<'a, M: SystemCallbackObject, K: KernelInternalApi<InjectCostingError<M>>>
-    KernelInternalApi<System<M>> for WrappedKernelInternalApi<'a, M, K>
+    KernelInternalApi<System<M, Executable>> for WrappedKernelInternalApi<'a, M, K>
 {
-    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<M>> {
+    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<M, Executable>> {
         let state = self.api.kernel_get_system_state();
         SystemState {
             system: &mut state.system.system,

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -8,8 +8,9 @@ use radix_engine::kernel::kernel_api::{
 };
 use radix_engine::kernel::kernel_callback_api::{
     CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, KernelCallbackObject,
-    MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent,
-    ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent,
+    KernelTransactionCallbackObject, MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent,
+    RemoveSubstateEvent, ScanKeysEvent, ScanSortedSubstatesEvent, SetSubstateEvent,
+    WriteSubstateEvent,
 };
 use radix_engine::system::actor::Actor;
 use radix_engine::system::system_callback::{System, SystemInit, SystemLockData};
@@ -82,10 +83,7 @@ macro_rules! wrapped_internal_api {
     };
 }
 
-impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
-    type LockData = SystemLockData;
-    type CallFrameData = Actor;
-
+impl<K: SystemCallbackObject> KernelTransactionCallbackObject for InjectCostingError<K> {
     type Init = InjectCostingErrorInput<SystemInit<K::Init>>;
     type Executable = Executable;
     type ExecutionOutput = Vec<InstructionOutput>;
@@ -124,6 +122,11 @@ impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
     ) -> TransactionReceipt {
         self.system.create_receipt(track, result)
     }
+}
+
+impl<K: SystemCallbackObject> KernelCallbackObject for InjectCostingError<K> {
+    type LockData = SystemLockData;
+    type CallFrameData = Actor;
 
     fn on_pin_node(&mut self, node_id: &NodeId) -> Result<(), RuntimeError> {
         self.maybe_err()?;

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -471,8 +471,8 @@ impl<'a, M: SystemCallbackObject + 'a, K: KernelApi<InjectCostingError<M>>> Kern
     }
 }
 
-impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelInternalApi<System<M, Executable>>
-    for WrappedKernelApi<'a, M, K>
+impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>>
+    KernelInternalApi<System<M, Executable>> for WrappedKernelApi<'a, M, K>
 {
     fn kernel_get_system_state(&mut self) -> SystemState<'_, System<M, Executable>> {
         let state = self.api.kernel_get_system_state();
@@ -500,8 +500,8 @@ impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelInt
     }
 }
 
-impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>> KernelApi<System<M, Executable>>
-    for WrappedKernelApi<'a, M, K>
+impl<'a, M: SystemCallbackObject, K: KernelApi<InjectCostingError<M>>>
+    KernelApi<System<M, Executable>> for WrappedKernelApi<'a, M, K>
 {
 }
 

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -1387,7 +1387,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
             },
         );
 
-        let transaction_receipt = executor.execute(&executable);
+        let transaction_receipt = executor.execute(executable);
 
         if let TransactionResult::Commit(commit) = &transaction_receipt.result {
             let database_updates = commit
@@ -1466,7 +1466,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
             _,
             Vm<'_, DefaultWasmEngine, E>,
         >(
-            &mut self.database, vm_init, &execution_config, &executable
+            &mut self.database, vm_init, &execution_config, executable
         );
         if let TransactionResult::Commit(commit) = &transaction_receipt.result {
             let database_updates = commit

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -1158,7 +1158,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
 
         let receipt = self.execute_transaction(
             SystemTransactionV1 {
-                instructions: InstructionsV1(vec![InstructionV1::CallFunction {
+                instructions: InstructionsV1(Rc::new(vec![InstructionV1::CallFunction {
                     package_address: PACKAGE_PACKAGE.into(),
                     blueprint_name: PACKAGE_BLUEPRINT.to_string(),
                     function_name: PACKAGE_PUBLISH_WASM_ADVANCED_IDENT.to_string(),
@@ -1169,7 +1169,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
                         package_address: Some(ManifestAddressReservation(0)),
                         owner_role: OwnerRole::Fixed(AccessRule::AllowAll),
                     }),
-                }]),
+                }])),
                 blobs: BlobsV1 {
                     blobs: vec![BlobV1(code)],
                 },
@@ -1429,7 +1429,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
 
         self.execute_transaction(
             SystemTransactionV1 {
-                instructions: InstructionsV1(instructions),
+                instructions: InstructionsV1(Rc::new(instructions)),
                 blobs: BlobsV1 { blobs: vec![] },
                 hash_for_execution: hash(format!("Test runner txn: {}", nonce)),
                 pre_allocated_addresses,
@@ -1529,7 +1529,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
                         notary_is_signatory: false,
                         tip_percentage,
                     },
-                    instructions: InstructionsV1(manifest.instructions),
+                    instructions: InstructionsV1(Rc::new(manifest.instructions)),
                     blobs: BlobsV1 {
                         blobs: manifest.blobs.values().map(|x| BlobV1(x.clone())).collect(),
                     },


### PR DESCRIPTION
## Summary
Various refactors to clean up transaction handling. No protocol changes.
* Use `Rc` instead of borrows with `Executable` so that we don't need to worry about generic lifetimes
* Separate System traits for transaction-specific APIs and runtime-specific APIs in order to decouple what's actually needed if a simple test environment without transaction support is needed
* Refactored CallFrame initialization api between Kernel and System to be simpler
* Decoupled kernel from `Executable` object (It is a system layer object now)
