### PR TITLE
Refactor engine internal traits for better encapsulation

### DIFF
--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -65,138 +65,155 @@ impl KernelCallbackObject for TestCallbackObject {
     type LockData = ();
     type CallFrameData = TestCallFrameData;
 
-    fn on_pin_node(&mut self, _node_id: &NodeId) -> Result<(), RuntimeError> {
+    fn on_pin_node<Y: KernelInternalApi<System = Self>>(
+        _node_id: &NodeId,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_create_node<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_create_node<Y: KernelInternalApi<System = Self>>(
         _event: CreateNodeEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_drop_node<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_drop_node<Y: KernelInternalApi<System = Self>>(
         _event: DropNodeEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_move_module<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_move_module<Y: KernelInternalApi<System = Self>>(
         _event: MoveModuleEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_open_substate<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_open_substate<Y: KernelInternalApi<System = Self>>(
         _event: OpenSubstateEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_close_substate<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_close_substate<Y: KernelInternalApi<System = Self>>(
         _event: CloseSubstateEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_read_substate<Y: KernelInternalApi<Self>>(
-        _api: &mut Y,
+    fn on_read_substate<Y: KernelInternalApi<System = Self>>(
         _event: ReadSubstateEvent,
-    ) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_write_substate<Y: KernelInternalApi<Self>>(
         _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_write_substate<Y: KernelInternalApi<System = Self>>(
         _event: WriteSubstateEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_set_substate(&mut self, _event: SetSubstateEvent) -> Result<(), RuntimeError> {
+    fn on_set_substate<Y: KernelInternalApi<System = Self>>(
+        _event: SetSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_remove_substate(&mut self, _event: RemoveSubstateEvent) -> Result<(), RuntimeError> {
+    fn on_remove_substate<Y: KernelInternalApi<System = Self>>(
+        _event: RemoveSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_scan_keys(&mut self, _event: ScanKeysEvent) -> Result<(), RuntimeError> {
+    fn on_scan_keys<Y: KernelInternalApi<System = Self>>(
+        _event: ScanKeysEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_drain_substates(&mut self, _event: DrainSubstatesEvent) -> Result<(), RuntimeError> {
+    fn on_drain_substates<Y: KernelInternalApi<System = Self>>(
+        _event: DrainSubstatesEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_scan_sorted_substates(
-        &mut self,
+    fn on_scan_sorted_substates<Y: KernelInternalApi<System = Self>>(
         _event: ScanSortedSubstatesEvent,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn before_invoke<Y: KernelApi<Self>>(
+    fn before_invoke<Y: KernelApi<CallbackObject = Self>>(
         _invocation: &KernelInvocation<Self::CallFrameData>,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn after_invoke<Y: KernelApi<Self>>(
+    fn after_invoke<Y: KernelApi<CallbackObject = Self>>(
         _output: &IndexedScryptoValue,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
+    fn on_execution_start<Y: KernelInternalApi<System = Self>>(
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_finish<Y: KernelApi<Self>>(
+    fn on_execution_finish<Y: KernelInternalApi<System = Self>>(
         _message: &CallFrameMessage,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_allocate_node_id<Y: KernelApi<Self>>(
+    fn on_allocate_node_id<Y: KernelInternalApi<System = Self>>(
         _entity_type: EntityType,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn invoke_upstream<Y: KernelApi<Self>>(
+    fn invoke_upstream<Y: KernelApi<CallbackObject = Self>>(
         args: &IndexedScryptoValue,
         _api: &mut Y,
     ) -> Result<IndexedScryptoValue, RuntimeError> {
         Ok(args.clone())
     }
 
-    fn auto_drop<Y: KernelApi<Self>>(
+    fn auto_drop<Y: KernelApi<CallbackObject = Self>>(
         _nodes: Vec<NodeId>,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_mark_substate_as_transient(
-        &mut self,
+    fn on_mark_substate_as_transient<Y: KernelInternalApi<System = Self>>(
         _node_id: &NodeId,
         _partition_number: &PartitionNumber,
         _substate_key: &SubstateKey,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_substate_lock_fault<Y: KernelApi<Self>>(
+    fn on_substate_lock_fault<Y: KernelApi<CallbackObject = Self>>(
         _node_id: NodeId,
         _partition_num: PartitionNumber,
         _offset: &SubstateKey,
@@ -205,7 +222,7 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(false)
     }
 
-    fn on_drop_node_mut<Y: KernelApi<Self>>(
+    fn on_drop_node_mut<Y: KernelApi<CallbackObject = Self>>(
         _node_id: &NodeId,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -8,7 +8,7 @@ use radix_engine::kernel::kernel_api::{
     KernelSubstateApi,
 };
 use radix_engine::kernel::kernel_callback_api::{CallFrameReferences, CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, ExecutionReceipt, KernelCallbackObject, MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent, ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent};
-use radix_engine::track::{Track};
+use radix_engine::track::Track;
 use radix_engine::transaction::ResourcesUsage;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
@@ -50,110 +50,156 @@ impl ExecutionReceipt for TestReceipt {
 }
 
 struct TestCallbackObject;
-
 impl KernelCallbackObject for TestCallbackObject {
     type LockData = ();
     type CallFrameData = TestCallFrameData;
 
-    fn on_pin_node(&mut self, _node_id: &NodeId) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_create_node<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: CreateNodeEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_drop_node<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: DropNodeEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_move_module<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: MoveModuleEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_open_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: OpenSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_close_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: CloseSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_read_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: ReadSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_write_substate<Y: KernelInternalApi<Self>>(_api: &mut Y, _event: WriteSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_set_substate(&mut self, _event: SetSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_remove_substate(&mut self, _event: RemoveSubstateEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_scan_keys(&mut self, _event: ScanKeysEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_drain_substates(&mut self, _event: DrainSubstatesEvent) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_scan_sorted_substates(
-        &mut self,
-        _event: ScanSortedSubstatesEvent,
+    fn on_pin_node<Y: KernelInternalApi<System = Self>>(
+        _node_id: &NodeId,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn before_invoke<Y: KernelApi<Self>>(
+    fn on_create_node<Y: KernelInternalApi<System = Self>>(
+        _event: CreateNodeEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_drop_node<Y: KernelInternalApi<System = Self>>(
+        _event: DropNodeEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_move_module<Y: KernelInternalApi<System = Self>>(
+        _event: MoveModuleEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_open_substate<Y: KernelInternalApi<System = Self>>(
+        _event: OpenSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_close_substate<Y: KernelInternalApi<System = Self>>(
+        _event: CloseSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_read_substate<Y: KernelInternalApi<System = Self>>(
+        _event: ReadSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_write_substate<Y: KernelInternalApi<System = Self>>(
+        _event: WriteSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_set_substate<Y: KernelInternalApi<System = Self>>(
+        _event: SetSubstateEvent,
+        _api: &mut Y,) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_remove_substate<Y: KernelInternalApi<System = Self>>(
+        _event: RemoveSubstateEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_scan_keys<Y: KernelInternalApi<System = Self>>(
+        _event: ScanKeysEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_drain_substates<Y: KernelInternalApi<System = Self>>(
+        _event: DrainSubstatesEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_scan_sorted_substates<Y: KernelInternalApi<System = Self>>(
+        _event: ScanSortedSubstatesEvent,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn before_invoke<Y: KernelApi<CallbackObject = Self>>(
         _invocation: &KernelInvocation<Self::CallFrameData>,
         _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_execution_start<Y: KernelApi<Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
+    fn after_invoke<Y: KernelApi<CallbackObject = Self>>(
+        _output: &IndexedScryptoValue,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn invoke_upstream<Y: KernelApi<Self>>(
+    fn on_execution_start<Y: KernelInternalApi<System = Self>>(_api: &mut Y) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_execution_finish<Y: KernelInternalApi<System = Self>>(
+        _message: &CallFrameMessage,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_allocate_node_id<Y: KernelInternalApi<System = Self>>(
+        _entity_type: EntityType,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn invoke_upstream<Y: KernelApi<CallbackObject = Self>>(
         args: &IndexedScryptoValue,
         _api: &mut Y,
     ) -> Result<IndexedScryptoValue, RuntimeError> {
         Ok(args.clone())
     }
 
-    fn auto_drop<Y: KernelApi<Self>>(_nodes: Vec<NodeId>, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_execution_finish<Y: KernelApi<Self>>(_message: &CallFrameMessage, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn after_invoke<Y: KernelApi<Self>>(_output: &IndexedScryptoValue, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_allocate_node_id<Y: KernelApi<Self>>(_entity_type: EntityType, _api: &mut Y) -> Result<(), RuntimeError> {
-        Ok(())
-    }
-
-    fn on_mark_substate_as_transient(
-        &mut self,
-        _node_id: &NodeId,
-        _partition_number: &PartitionNumber,
-        _substate_key: &SubstateKey,
+    fn auto_drop<Y: KernelApi<CallbackObject = Self>>(
+        _nodes: Vec<NodeId>,
+        _api: &mut Y,
     ) -> Result<(), RuntimeError> {
         Ok(())
     }
 
-    fn on_substate_lock_fault<Y: KernelApi<Self>>(
+    fn on_mark_substate_as_transient<Y: KernelInternalApi<System = Self>>(
+        _node_id: &NodeId,
+        _partition_number: &PartitionNumber,
+        _substate_key: &SubstateKey,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    fn on_substate_lock_fault<Y: KernelApi<CallbackObject = Self>>(
         _node_id: NodeId,
         _partition_num: PartitionNumber,
         _offset: &SubstateKey,
@@ -162,7 +208,10 @@ impl KernelCallbackObject for TestCallbackObject {
         Ok(false)
     }
 
-    fn on_drop_node_mut<Y: KernelApi<Self>>(_node_id: &NodeId, _api: &mut Y) -> Result<(), RuntimeError> {
+    fn on_drop_node_mut<Y: KernelApi<CallbackObject = Self>>(
+        _node_id: &NodeId,
+        _api: &mut Y,
+    ) -> Result<(), RuntimeError> {
         Ok(())
     }
 }

--- a/radix-engine-tests/tests/kernel/panics.rs
+++ b/radix-engine-tests/tests/kernel/panics.rs
@@ -18,9 +18,7 @@ use scrypto_test::prelude::SystemCallbackObject;
 fn panics_at_the_system_layer_or_below_can_be_caught() {
     // Arrange
     let mut kernel = MockKernel(PhantomData::<Vm<DefaultWasmEngine, NoExtension>>);
-    let mut system_service = SystemService {
-        api: &mut kernel,
-    };
+    let mut system_service = SystemService::new(&mut kernel);
 
     // Act
     let actor = system_service.actor_get_blueprint_id();

--- a/radix-engine-tests/tests/kernel/panics.rs
+++ b/radix-engine-tests/tests/kernel/panics.rs
@@ -6,7 +6,6 @@ use radix_engine::system::actor::*;
 #[cfg(not(feature = "alloc"))]
 use radix_engine::system::system::SystemService;
 use radix_engine::system::system_callback::*;
-use radix_engine::system::system_modules::execution_trace::*;
 use radix_engine::track::*;
 use radix_engine::vm::wasm::*;
 use radix_engine::vm::*;
@@ -188,12 +187,8 @@ impl<M: SystemCallbackObject> KernelInternalApi for MockKernel<M> {
     fn kernel_get_node_visibility(&self, _: &NodeId) -> NodeVisibility {
         panic1!()
     }
-
-    fn kernel_read_bucket(&self, _: &NodeId) -> Option<BucketSnapshot> {
-        panic1!()
-    }
-
-    fn kernel_read_proof(&self, _: &NodeId) -> Option<ProofSnapshot> {
+    
+    fn kernel_read_substate_uncosted(&self, _node_id: &NodeId, _partition_num: PartitionNumber, _substate_key: &SubstateKey) -> Option<&IndexedScryptoValue> {
         panic1!()
     }
 }

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -109,9 +109,7 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
     let mut id_allocator = IdAllocator::new(intent_hash);
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
 
-    let mut api = SystemService {
-        api: &mut kernel,
-    };
+    let mut api = SystemService::new(&mut kernel);
 
     // Act
     let rtn = api.call_function(
@@ -189,9 +187,7 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let mut id_allocator = IdAllocator::new(intent_hash);
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
-    let mut api = SystemService {
-        api: &mut kernel,
-    };
+    let mut api = SystemService::new(&mut kernel);
 
     // Act
     let rtn = api.call_function(

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -111,7 +111,6 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
 
     let mut api = SystemService {
         api: &mut kernel,
-        phantom: Default::default(),
     };
 
     // Act
@@ -192,7 +191,6 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
     let mut api = SystemService {
         api: &mut kernel,
-        phantom: Default::default(),
     };
 
     // Act

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -1531,7 +1531,7 @@ impl PackageRoyaltyNativeBlueprint {
                 .0;
             let package_address = PackageAddress::new_or_panic(receiver.0);
             apply_royalty_cost(
-                api,
+                &mut api.system_module_api(),
                 royalty_charge,
                 RoyaltyRecipient::Package(package_address, vault_id.0),
             )?;

--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -1,7 +1,6 @@
 use super::substates::*;
 use crate::blueprints::util::{check_name, InvalidNameError, SecurifiedRoleAssignment};
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::{KernelApi, KernelSubstateApi};
 use crate::object_modules::metadata::MetadataNativePackage;
 use crate::system::node_init::type_info_partition;
 use crate::system::system_modules::costing::{apply_royalty_cost, RoyaltyRecipient};
@@ -25,8 +24,7 @@ use crate::object_modules::role_assignment::*;
 use crate::object_modules::royalty::RoyaltyUtil;
 use crate::roles_template;
 use crate::system::system::*;
-use crate::system::system_callback::{System, SystemLockData};
-use crate::system::system_callback_api::SystemCallbackObject;
+use crate::system::system_callback::*;
 use crate::system::system_modules::auth::{AuthError, ResolvedPermission};
 use crate::system::system_type_checker::SystemMapper;
 use crate::vm::{VmApi, VmPackageValidation};
@@ -1464,7 +1462,7 @@ impl PackageNativePackage {
 pub struct PackageRoyaltyNativeBlueprint;
 
 impl PackageRoyaltyNativeBlueprint {
-    pub fn charge_package_royalty<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+    pub fn charge_package_royalty<Y: SystemBasedKernelApi>(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         ident: &str,
@@ -1575,15 +1573,11 @@ impl PackageRoyaltyNativeBlueprint {
 pub struct PackageAuthNativeBlueprint;
 
 impl PackageAuthNativeBlueprint {
-    pub fn resolve_function_permission<
-        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V, E>>,
-        V: SystemCallbackObject,
-        E,
-    >(
+    pub fn resolve_function_permission(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
         ident: &str,
-        api: &mut Y,
+        api: &mut impl SystemBasedKernelApi,
     ) -> Result<ResolvedPermission, RuntimeError> {
         let auth_config = Self::get_bp_auth_template(receiver, bp_version_key, api)?;
         match auth_config.function_auth {
@@ -1614,15 +1608,11 @@ impl PackageAuthNativeBlueprint {
         }
     }
 
-    pub fn get_bp_auth_template<Y, V, E>(
+    pub fn get_bp_auth_template(
         receiver: &NodeId,
         bp_version_key: &BlueprintVersionKey,
-        api: &mut Y,
-    ) -> Result<AuthConfig, RuntimeError>
-    where
-        Y: KernelSubstateApi<SystemLockData> + KernelApi<System<V, E>>,
-        V: SystemCallbackObject,
-    {
+        api: &mut impl SystemBasedKernelApi,
+    ) -> Result<AuthConfig, RuntimeError> {
         let package_bp_version_id = CanonicalBlueprintId {
             address: PackageAddress::new_or_panic(receiver.0.clone()),
             blueprint: bp_version_key.blueprint.to_string(),

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -1,28 +1,17 @@
-use super::call_frame::{CallFrame, CallFrameInit, NodeVisibility, OpenSubstateError};
 use super::heap::Heap;
 use super::id_allocator::IdAllocator;
 use crate::blueprints::resource::*;
-use crate::errors::RuntimeError;
 use crate::errors::*;
 use crate::internal_prelude::*;
-use crate::kernel::call_frame::{
-    CallFrameIOAccessHandler, CallFrameMessage, CallFrameSubstateReadHandler, NonGlobalNodeRefs,
-    TransientSubstates,
-};
+use crate::kernel::call_frame::*;
 use crate::kernel::kernel_api::*;
-use crate::kernel::kernel_callback_api::{
-    CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, KernelCallbackObject,
-    MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent, RemoveSubstateEvent, ScanKeysEvent,
-    ScanSortedSubstatesEvent, SetSubstateEvent, WriteSubstateEvent,
-};
+use crate::kernel::kernel_callback_api::*;
 use crate::kernel::kernel_callback_api::{ExecutionReceipt, KernelTransactionCallbackObject};
 use crate::kernel::substate_io::{SubstateDevice, SubstateIO};
 use crate::kernel::substate_locks::SubstateLocks;
 use crate::system::system_modules::execution_trace::{BucketSnapshot, ProofSnapshot};
 use crate::system::type_info::TypeInfoSubstate;
-use crate::track::interface::{
-    BootStore, CallbackError, CommitableSubstateStore, IOAccess, NodeSubstates,
-};
+use crate::track::interface::*;
 use crate::track::Track;
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_interface::blueprints::resource::*;
@@ -30,6 +19,17 @@ use radix_engine_profiling_derive::trace_resources;
 use radix_substate_store_interface::db_key_mapper::{SpreadPrefixKeyMapper, SubstateKeyContent};
 use radix_substate_store_interface::interface::SubstateDatabase;
 use sbor::rust::mem;
+
+macro_rules! as_read_only {
+    ($kernel:expr) => {{
+        KernelReadOnly {
+            current_frame: &$kernel.current_frame,
+            prev_frame: $kernel.prev_frame_stack.last(),
+            heap: &$kernel.substate_io.heap,
+            callback: $kernel.callback,
+        }
+    }};
+}
 
 pub const BOOT_LOADER_KERNEL_BOOT_FIELD_KEY: FieldKey = 0u8;
 
@@ -258,25 +258,14 @@ impl<
         };
 
         M::on_read_substate(
-            &mut read_only,
             ReadSubstateEvent::OnRead {
                 handle,
                 value,
                 device,
             },
+            &mut read_only,
         )
     }
-}
-
-macro_rules! as_read_only {
-    ($kernel:expr) => {{
-        KernelReadOnly {
-            current_frame: &$kernel.current_frame,
-            prev_frame: $kernel.prev_frame_stack.last(),
-            heap: &$kernel.substate_io.heap,
-            callback: $kernel.callback,
-        }
-    }};
 }
 
 impl<'g, M, S> KernelNodeApi for Kernel<'g, M, S>
@@ -286,7 +275,7 @@ where
 {
     #[trace_resources]
     fn kernel_pin_node(&mut self, node_id: NodeId) -> Result<(), RuntimeError> {
-        self.callback.on_pin_node(&node_id)?;
+        M::on_pin_node(&node_id, &mut as_read_only!(self))?;
 
         self.current_frame
             .pin_node(&mut self.substate_io, node_id)
@@ -312,15 +301,15 @@ where
     ) -> Result<(), RuntimeError> {
         let mut read_only = as_read_only!(self);
         M::on_create_node(
-            &mut read_only,
             CreateNodeEvent::Start(&node_id, &node_substates),
+            &mut read_only,
         )?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                M::on_create_node(api, CreateNodeEvent::IOAccess(&io_access))
+                M::on_create_node(CreateNodeEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -334,7 +323,7 @@ where
             })?;
 
         let mut read_only = as_read_only!(self);
-        M::on_create_node(&mut read_only, CreateNodeEvent::End(&node_id))?;
+        M::on_create_node(CreateNodeEvent::End(&node_id), &mut read_only)?;
 
         Ok(())
     }
@@ -349,15 +338,15 @@ where
             let node_substates = NodeSubstates::new();
             let mut read_only = as_read_only!(self);
             M::on_create_node(
-                &mut read_only,
                 CreateNodeEvent::Start(&node_id, &node_substates),
+                &mut read_only,
             )?;
 
             let mut handler = KernelHandler {
                 callback: self.callback,
                 prev_frame: self.prev_frame_stack.last(),
                 on_io_access: |api, io_access| {
-                    M::on_create_node(api, CreateNodeEvent::IOAccess(&io_access))
+                    M::on_create_node(CreateNodeEvent::IOAccess(&io_access), api)
                 },
             };
 
@@ -376,7 +365,7 @@ where
                 })?;
 
             let mut read_only = as_read_only!(self);
-            M::on_create_node(&mut read_only, CreateNodeEvent::End(&node_id))?;
+            M::on_create_node(CreateNodeEvent::End(&node_id), &mut read_only)?;
         }
 
         {
@@ -384,7 +373,7 @@ where
                 callback: self.callback,
                 prev_frame: self.prev_frame_stack.last(),
                 on_io_access: |api, io_access| {
-                    M::on_move_module(api, MoveModuleEvent::IOAccess(&io_access))
+                    M::on_move_module(MoveModuleEvent::IOAccess(&io_access), api)
                 },
             };
 
@@ -413,7 +402,7 @@ where
     #[trace_resources]
     fn kernel_drop_node(&mut self, node_id: &NodeId) -> Result<DroppedNode, RuntimeError> {
         let mut read_only = as_read_only!(self);
-        M::on_drop_node(&mut read_only, DropNodeEvent::Start(node_id))?;
+        M::on_drop_node(DropNodeEvent::Start(node_id), &mut read_only)?;
 
         M::on_drop_node_mut(node_id, self)?;
 
@@ -421,7 +410,7 @@ where
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                M::on_drop_node(api, DropNodeEvent::IOAccess(&io_access))
+                M::on_drop_node(DropNodeEvent::IOAccess(&io_access), api)
             },
         };
         let dropped_node = self
@@ -436,8 +425,8 @@ where
 
         let mut read_only = as_read_only!(self);
         M::on_drop_node(
-            &mut read_only,
             DropNodeEvent::End(node_id, &dropped_node.substates),
+            &mut read_only,
         )?;
 
         Ok(dropped_node)
@@ -445,11 +434,11 @@ where
 }
 
 // TODO: Remove
-impl<'g, M, S> KernelInternalApi<M> for Kernel<'g, M, S>
-where
-    M: KernelCallbackObject,
-    S: CommitableSubstateStore,
+impl<'g, M: KernelCallbackObject, S: CommitableSubstateStore> KernelInternalApi
+    for Kernel<'g, M, S>
 {
+    type System = M;
+
     fn kernel_get_node_visibility(&self, node_id: &NodeId) -> NodeVisibility {
         self.current_frame.get_node_visibility(node_id)
     }
@@ -473,14 +462,12 @@ where
         }
     }
 
-    fn kernel_read_bucket(&mut self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        let mut read_only = as_read_only!(self);
-        read_only.kernel_read_bucket(bucket_id)
+    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
+        read_bucket_uncosted(&self.substate_io.heap, bucket_id)
     }
 
-    fn kernel_read_proof(&mut self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        let mut read_only = as_read_only!(self);
-        read_only.kernel_read_proof(proof_id)
+    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
+        read_proof_uncosted(&self.substate_io.heap, proof_id)
     }
 }
 
@@ -494,10 +481,9 @@ where
     callback: &'g mut M,
 }
 
-impl<'g, M> KernelInternalApi<M> for KernelReadOnly<'g, M>
-where
-    M: KernelCallbackObject,
-{
+impl<'g, M: KernelCallbackObject> KernelInternalApi for KernelReadOnly<'g, M> {
+    type System = M;
+
     fn kernel_get_node_visibility(&self, node_id: &NodeId) -> NodeVisibility {
         self.current_frame.get_node_visibility(node_id)
     }
@@ -521,152 +507,152 @@ where
         }
     }
 
-    fn kernel_read_bucket(&mut self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        let (is_fungible_bucket, resource_address) = if let Some(substate) = self.heap.get_substate(
-            &bucket_id,
-            TYPE_INFO_FIELD_PARTITION,
-            &TypeInfoField::TypeInfo.into(),
-        ) {
-            let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
-            match type_info {
-                TypeInfoSubstate::Object(info)
-                    if info.blueprint_info.blueprint_id.package_address == RESOURCE_PACKAGE
-                        && (info.blueprint_info.blueprint_id.blueprint_name
-                            == FUNGIBLE_BUCKET_BLUEPRINT
-                            || info.blueprint_info.blueprint_id.blueprint_name
-                                == NON_FUNGIBLE_BUCKET_BLUEPRINT) =>
-                {
-                    let is_fungible = info
-                        .blueprint_info
-                        .blueprint_id
-                        .blueprint_name
-                        .eq(FUNGIBLE_BUCKET_BLUEPRINT);
-                    let parent = info.get_outer_object();
-                    let resource_address: ResourceAddress =
-                        ResourceAddress::new_or_panic(parent.as_bytes().try_into().unwrap());
-                    (is_fungible, resource_address)
-                }
-                _ => {
-                    return None;
-                }
-            }
-        } else {
-            return None;
-        };
-
-        if is_fungible_bucket {
-            let substate = self
-                .heap
-                .get_substate(
-                    bucket_id,
-                    MAIN_BASE_PARTITION,
-                    &FungibleBucketField::Liquid.into(),
-                )
-                .unwrap();
-            let liquid: FieldSubstate<LiquidFungibleResource> = substate.as_typed().unwrap();
-
-            Some(BucketSnapshot::Fungible {
-                resource_address,
-                liquid: liquid.into_payload().amount(),
-            })
-        } else {
-            let substate = self
-                .heap
-                .get_substate(
-                    bucket_id,
-                    MAIN_BASE_PARTITION,
-                    &NonFungibleBucketField::Liquid.into(),
-                )
-                .unwrap();
-            let liquid: FieldSubstate<LiquidNonFungibleResource> = substate.as_typed().unwrap();
-
-            Some(BucketSnapshot::NonFungible {
-                resource_address,
-                liquid: liquid.into_payload().ids().clone(),
-            })
-        }
+    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
+        read_bucket_uncosted(&self.heap, bucket_id)
     }
 
-    fn kernel_read_proof(&mut self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        let is_fungible = if let Some(substate) = self.heap.get_substate(
-            &proof_id,
-            TYPE_INFO_FIELD_PARTITION,
-            &TypeInfoField::TypeInfo.into(),
-        ) {
-            let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
-            match type_info {
-                TypeInfoSubstate::Object(ObjectInfo {
-                    blueprint_info: BlueprintInfo { blueprint_id, .. },
-                    ..
-                }) if blueprint_id.package_address == RESOURCE_PACKAGE
-                    && (blueprint_id.blueprint_name == NON_FUNGIBLE_PROOF_BLUEPRINT
-                        || blueprint_id.blueprint_name == FUNGIBLE_PROOF_BLUEPRINT) =>
-                {
-                    blueprint_id.blueprint_name.eq(FUNGIBLE_PROOF_BLUEPRINT)
-                }
-                _ => {
-                    return None;
-                }
+    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
+        read_proof_uncosted(&self.heap, proof_id)
+    }
+}
+
+fn read_bucket_uncosted(heap: &Heap, bucket_id: &NodeId) -> Option<BucketSnapshot> {
+    let (is_fungible_bucket, resource_address) = if let Some(substate) = heap.get_substate(
+        &bucket_id,
+        TYPE_INFO_FIELD_PARTITION,
+        &TypeInfoField::TypeInfo.into(),
+    ) {
+        let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
+        match type_info {
+            TypeInfoSubstate::Object(info)
+                if info.blueprint_info.blueprint_id.package_address == RESOURCE_PACKAGE
+                    && (info.blueprint_info.blueprint_id.blueprint_name
+                        == FUNGIBLE_BUCKET_BLUEPRINT
+                        || info.blueprint_info.blueprint_id.blueprint_name
+                            == NON_FUNGIBLE_BUCKET_BLUEPRINT) =>
+            {
+                let is_fungible = info
+                    .blueprint_info
+                    .blueprint_id
+                    .blueprint_name
+                    .eq(FUNGIBLE_BUCKET_BLUEPRINT);
+                let parent = info.get_outer_object();
+                let resource_address: ResourceAddress =
+                    ResourceAddress::new_or_panic(parent.as_bytes().try_into().unwrap());
+                (is_fungible, resource_address)
             }
-        } else {
-            return None;
-        };
-
-        if is_fungible {
-            let substate = self
-                .heap
-                .get_substate(
-                    proof_id,
-                    TYPE_INFO_FIELD_PARTITION,
-                    &TypeInfoField::TypeInfo.into(),
-                )
-                .unwrap();
-            let info: TypeInfoSubstate = substate.as_typed().unwrap();
-            let resource_address =
-                ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
-
-            let substate = self
-                .heap
-                .get_substate(
-                    proof_id,
-                    MAIN_BASE_PARTITION,
-                    &FungibleProofField::ProofRefs.into(),
-                )
-                .unwrap();
-            let proof: FieldSubstate<FungibleProofSubstate> = substate.as_typed().unwrap();
-
-            Some(ProofSnapshot::Fungible {
-                resource_address,
-                total_locked: proof.into_payload().amount(),
-            })
-        } else {
-            let substate = self
-                .heap
-                .get_substate(
-                    proof_id,
-                    TYPE_INFO_FIELD_PARTITION,
-                    &TypeInfoField::TypeInfo.into(),
-                )
-                .unwrap();
-            let info: TypeInfoSubstate = substate.as_typed().unwrap();
-            let resource_address =
-                ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
-
-            let substate = self
-                .heap
-                .get_substate(
-                    proof_id,
-                    MAIN_BASE_PARTITION,
-                    &NonFungibleProofField::ProofRefs.into(),
-                )
-                .unwrap();
-            let proof: FieldSubstate<NonFungibleProofSubstate> = substate.as_typed().unwrap();
-
-            Some(ProofSnapshot::NonFungible {
-                resource_address,
-                total_locked: proof.into_payload().non_fungible_local_ids().clone(),
-            })
+            _ => {
+                return None;
+            }
         }
+    } else {
+        return None;
+    };
+
+    if is_fungible_bucket {
+        let substate = heap
+            .get_substate(
+                bucket_id,
+                MAIN_BASE_PARTITION,
+                &FungibleBucketField::Liquid.into(),
+            )
+            .unwrap();
+        let liquid: FieldSubstate<LiquidFungibleResource> = substate.as_typed().unwrap();
+
+        Some(BucketSnapshot::Fungible {
+            resource_address,
+            liquid: liquid.into_payload().amount(),
+        })
+    } else {
+        let substate = heap
+            .get_substate(
+                bucket_id,
+                MAIN_BASE_PARTITION,
+                &NonFungibleBucketField::Liquid.into(),
+            )
+            .unwrap();
+        let liquid: FieldSubstate<LiquidNonFungibleResource> = substate.as_typed().unwrap();
+
+        Some(BucketSnapshot::NonFungible {
+            resource_address,
+            liquid: liquid.into_payload().ids().clone(),
+        })
+    }
+}
+
+fn read_proof_uncosted(heap: &Heap, proof_id: &NodeId) -> Option<ProofSnapshot> {
+    let is_fungible = if let Some(substate) = heap.get_substate(
+        &proof_id,
+        TYPE_INFO_FIELD_PARTITION,
+        &TypeInfoField::TypeInfo.into(),
+    ) {
+        let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
+        match type_info {
+            TypeInfoSubstate::Object(ObjectInfo {
+                blueprint_info: BlueprintInfo { blueprint_id, .. },
+                ..
+            }) if blueprint_id.package_address == RESOURCE_PACKAGE
+                && (blueprint_id.blueprint_name == NON_FUNGIBLE_PROOF_BLUEPRINT
+                    || blueprint_id.blueprint_name == FUNGIBLE_PROOF_BLUEPRINT) =>
+            {
+                blueprint_id.blueprint_name.eq(FUNGIBLE_PROOF_BLUEPRINT)
+            }
+            _ => {
+                return None;
+            }
+        }
+    } else {
+        return None;
+    };
+
+    if is_fungible {
+        let substate = heap
+            .get_substate(
+                proof_id,
+                TYPE_INFO_FIELD_PARTITION,
+                &TypeInfoField::TypeInfo.into(),
+            )
+            .unwrap();
+        let info: TypeInfoSubstate = substate.as_typed().unwrap();
+        let resource_address = ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
+
+        let substate = heap
+            .get_substate(
+                proof_id,
+                MAIN_BASE_PARTITION,
+                &FungibleProofField::ProofRefs.into(),
+            )
+            .unwrap();
+        let proof: FieldSubstate<FungibleProofSubstate> = substate.as_typed().unwrap();
+
+        Some(ProofSnapshot::Fungible {
+            resource_address,
+            total_locked: proof.into_payload().amount(),
+        })
+    } else {
+        let substate = heap
+            .get_substate(
+                proof_id,
+                TYPE_INFO_FIELD_PARTITION,
+                &TypeInfoField::TypeInfo.into(),
+            )
+            .unwrap();
+        let info: TypeInfoSubstate = substate.as_typed().unwrap();
+        let resource_address = ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
+
+        let substate = heap
+            .get_substate(
+                proof_id,
+                MAIN_BASE_PARTITION,
+                &NonFungibleProofField::ProofRefs.into(),
+            )
+            .unwrap();
+        let proof: FieldSubstate<NonFungibleProofSubstate> = substate.as_typed().unwrap();
+
+        Some(ProofSnapshot::NonFungible {
+            resource_address,
+            total_locked: proof.into_payload().non_fungible_local_ids().clone(),
+        })
     }
 }
 
@@ -682,8 +668,7 @@ where
         partition_num: PartitionNumber,
         key: SubstateKey,
     ) -> Result<(), RuntimeError> {
-        self.callback
-            .on_mark_substate_as_transient(&node_id, &partition_num, &key)?;
+        M::on_mark_substate_as_transient(&node_id, &partition_num, &key, &mut as_read_only!(self))?;
 
         self.current_frame
             .mark_substate_as_transient(&mut self.substate_io, node_id, partition_num, key)
@@ -704,22 +689,21 @@ where
         default: Option<F>,
         data: M::LockData,
     ) -> Result<SubstateHandle, RuntimeError> {
-        let mut read_only = as_read_only!(self);
         M::on_open_substate(
-            &mut read_only,
             OpenSubstateEvent::Start {
                 node_id: &node_id,
                 partition_num: &partition_num,
                 substate_key,
                 flags: &flags,
             },
+            &mut as_read_only!(self),
         )?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                M::on_open_substate(api, OpenSubstateEvent::IOAccess(&io_access))
+                M::on_open_substate(OpenSubstateEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -746,7 +730,7 @@ where
                         callback: self.callback,
                         prev_frame: self.prev_frame_stack.last(),
                         on_io_access: |api, io_access| {
-                            M::on_open_substate(api, OpenSubstateEvent::IOAccess(&io_access))
+                            M::on_open_substate(OpenSubstateEvent::IOAccess(&io_access), api)
                         },
                     };
 
@@ -791,12 +775,12 @@ where
 
         let mut read_only = as_read_only!(self);
         M::on_open_substate(
-            &mut read_only,
             OpenSubstateEvent::End {
                 handle: lock_handle,
                 node_id: &node_id,
                 size: value_size,
             },
+            &mut read_only,
         )?;
 
         Ok(lock_handle)
@@ -823,7 +807,7 @@ where
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                M::on_read_substate(api, ReadSubstateEvent::IOAccess(&io_access))
+                M::on_read_substate(ReadSubstateEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -848,18 +832,18 @@ where
     ) -> Result<(), RuntimeError> {
         let mut read_only = as_read_only!(self);
         M::on_write_substate(
-            &mut read_only,
             WriteSubstateEvent::Start {
                 handle: lock_handle,
                 value: &value,
             },
+            &mut read_only,
         )?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                M::on_write_substate(api, WriteSubstateEvent::IOAccess(&io_access))
+                M::on_write_substate(WriteSubstateEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -882,7 +866,7 @@ where
         // certain invariants might break such as a costing error occurring after a vault
         // lock_fee has been force committed.
         let mut read_only = as_read_only!(self);
-        M::on_close_substate(&mut read_only, CloseSubstateEvent::Start(lock_handle))?;
+        M::on_close_substate(CloseSubstateEvent::Start(lock_handle), &mut read_only)?;
 
         self.current_frame
             .close_substate(&mut self.substate_io, lock_handle)
@@ -903,19 +887,16 @@ where
         substate_key: SubstateKey,
         value: IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
-        self.callback.on_set_substate(SetSubstateEvent::Start(
-            node_id,
-            &partition_num,
-            &substate_key,
-            &value,
-        ))?;
+        M::on_set_substate(
+            SetSubstateEvent::Start(node_id, &partition_num, &substate_key, &value),
+            &mut as_read_only!(self),
+        )?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                api.callback
-                    .on_set_substate(SetSubstateEvent::IOAccess(&io_access))
+                M::on_set_substate(SetSubstateEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -945,19 +926,16 @@ where
         partition_num: PartitionNumber,
         substate_key: &SubstateKey,
     ) -> Result<Option<IndexedScryptoValue>, RuntimeError> {
-        self.callback
-            .on_remove_substate(RemoveSubstateEvent::Start(
-                node_id,
-                &partition_num,
-                substate_key,
-            ))?;
+        M::on_remove_substate(
+            RemoveSubstateEvent::Start(node_id, &partition_num, substate_key),
+            &mut as_read_only!(self),
+        )?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                api.callback
-                    .on_remove_substate(RemoveSubstateEvent::IOAccess(&io_access))
+                M::on_remove_substate(RemoveSubstateEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -987,14 +965,13 @@ where
         partition_num: PartitionNumber,
         limit: u32,
     ) -> Result<Vec<SubstateKey>, RuntimeError> {
-        self.callback.on_scan_keys(ScanKeysEvent::Start)?;
+        M::on_scan_keys(ScanKeysEvent::Start, &mut as_read_only!(self))?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                api.callback
-                    .on_scan_keys(ScanKeysEvent::IOAccess(&io_access))
+                M::on_scan_keys(ScanKeysEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -1024,15 +1001,13 @@ where
         partition_num: PartitionNumber,
         limit: u32,
     ) -> Result<Vec<(SubstateKey, IndexedScryptoValue)>, RuntimeError> {
-        self.callback
-            .on_drain_substates(DrainSubstatesEvent::Start(limit))?;
+        M::on_drain_substates(DrainSubstatesEvent::Start(limit), &mut as_read_only!(self))?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                api.callback
-                    .on_drain_substates(DrainSubstatesEvent::IOAccess(&io_access))
+                M::on_drain_substates(DrainSubstatesEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -1062,15 +1037,13 @@ where
         partition_num: PartitionNumber,
         limit: u32,
     ) -> Result<Vec<(SortedKey, IndexedScryptoValue)>, RuntimeError> {
-        self.callback
-            .on_scan_sorted_substates(ScanSortedSubstatesEvent::Start)?;
+        M::on_scan_sorted_substates(ScanSortedSubstatesEvent::Start, &mut as_read_only!(self))?;
 
         let mut handler = KernelHandler {
             callback: self.callback,
             prev_frame: self.prev_frame_stack.last(),
             on_io_access: |api, io_access| {
-                api.callback
-                    .on_scan_sorted_substates(ScanSortedSubstatesEvent::IOAccess(&io_access))
+                M::on_scan_sorted_substates(ScanSortedSubstatesEvent::IOAccess(&io_access), api)
             },
         };
 
@@ -1132,7 +1105,7 @@ where
 
             // Auto drop locks
             for handle in self.current_frame.open_substates() {
-                M::on_close_substate(self, CloseSubstateEvent::Start(handle))?;
+                M::on_close_substate(CloseSubstateEvent::Start(handle), self)?;
             }
             self.current_frame
                 .close_all_substates(&mut self.substate_io);
@@ -1143,7 +1116,7 @@ where
 
             // Auto-drop locks again in case module forgot to drop
             for handle in self.current_frame.open_substates() {
-                M::on_close_substate(self, CloseSubstateEvent::Start(handle))?;
+                M::on_close_substate(CloseSubstateEvent::Start(handle), self)?;
             }
             self.current_frame
                 .close_all_substates(&mut self.substate_io);
@@ -1193,19 +1166,12 @@ where
     }
 }
 
-impl<'g, M, S> KernelApi<M> for Kernel<'g, M, S>
-where
-    M: KernelCallbackObject,
-    S: CommitableSubstateStore,
-{
+impl<'g, M: KernelCallbackObject, S: CommitableSubstateStore> KernelApi for Kernel<'g, M, S> {
+    type CallbackObject = M;
 }
 
 #[cfg(feature = "radix_engine_tests")]
-impl<'g, M, S> Kernel<'g, M, S>
-where
-    M: KernelCallbackObject,
-    S: CommitableSubstateStore,
-{
+impl<'g, M: KernelCallbackObject, S: CommitableSubstateStore> Kernel<'g, M, S> {
     pub fn kernel_create_kernel_for_testing(
         substate_io: SubstateIO<'g, S>,
         id_allocator: &'g mut IdAllocator,

--- a/radix-engine/src/kernel/kernel_api.rs
+++ b/radix-engine/src/kernel/kernel_api.rs
@@ -2,7 +2,6 @@ use super::call_frame::*;
 use crate::errors::*;
 use crate::internal_prelude::*;
 use crate::kernel::kernel_callback_api::*;
-use crate::system::system_modules::execution_trace::*;
 use crate::track::interface::*;
 use radix_engine_interface::api::field_api::*;
 use radix_substate_store_interface::db_key_mapper::*;
@@ -197,9 +196,13 @@ pub trait KernelInternalApi {
     /// Returns the visibility of a node
     fn kernel_get_node_visibility(&self, node_id: &NodeId) -> NodeVisibility;
 
-    /* Super unstable interface, specifically for `ExecutionTrace` kernel module */
-    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot>;
-    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot>;
+    /// Only intended for use in debug modules
+    fn kernel_read_substate_uncosted(
+        &self,
+        node_id: &NodeId,
+        partition_num: PartitionNumber,
+        substate_key: &SubstateKey,
+    ) -> Option<&IndexedScryptoValue>;
 }
 
 pub trait KernelApi:

--- a/radix-engine/src/object_modules/role_assignment/package.rs
+++ b/radix-engine/src/object_modules/role_assignment/package.rs
@@ -326,20 +326,20 @@ impl RoleAssignmentNativePackage {
         receiver: &NodeId,
         module: ModuleId,
         role_key: &RoleKey,
-        api: &mut SystemService<Y>,
+        service: &mut SystemService<Y>,
     ) -> Result<RoleList, RuntimeError> {
         if Self::is_role_key_reserved(&role_key) || module.eq(&ModuleId::RoleAssignment) {
             return Ok(RoleList::none());
         }
 
-        let blueprint_id = api
+        let blueprint_id = service
             .get_blueprint_info(receiver, module.into())?
             .blueprint_id;
 
         let auth_template = PackageAuthNativeBlueprint::get_bp_auth_template(
             blueprint_id.package_address.as_node_id(),
             &BlueprintVersionKey::new_default(blueprint_id.blueprint_name.as_str()),
-            api.api,
+            service.api(),
         )?
         .method_auth;
 

--- a/radix-engine/src/object_modules/role_assignment/package.rs
+++ b/radix-engine/src/object_modules/role_assignment/package.rs
@@ -2,25 +2,17 @@ use crate::blueprints::models::*;
 use crate::blueprints::package::PackageAuthNativeBlueprint;
 use crate::blueprints::util::*;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::{KernelApi, KernelSubstateApi};
+use crate::kernel::kernel_api::KernelSubstateApi;
 use crate::object_modules::role_assignment::{LockOwnerRoleEvent, SetOwnerRoleEvent};
 use crate::system::system::SystemService;
-use crate::system::system_callback::{System, SystemLockData};
-use crate::system::system_callback_api::SystemCallbackObject;
+use crate::system::system_callback::*;
 use crate::system::system_modules::auth::{AuthError, ResolvedPermission};
 use crate::system::system_substates::FieldSubstate;
 use crate::{errors::*, event_schema};
-use radix_blueprint_schema_init::{
-    BlueprintFunctionsSchemaInit, BlueprintSchemaInit, FunctionSchemaInit, TypeRef,
-};
+use radix_blueprint_schema_init::*;
 use radix_engine_interface::api::field_api::LockFlags;
-use radix_engine_interface::api::{
-    FieldValue, GenericArgs, KVEntry, ModuleId, SystemApi, ACTOR_STATE_SELF,
-};
-use radix_engine_interface::blueprints::package::{
-    AuthConfig, BlueprintDefinitionInit, BlueprintType, BlueprintVersionKey, FunctionAuth,
-    MethodAuthTemplate, PackageDefinition, RoleSpecification,
-};
+use radix_engine_interface::api::*;
+use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_interface::object_modules::role_assignment::*;
 use radix_engine_interface::types::*;
@@ -155,11 +147,11 @@ impl RoleAssignmentNativePackage {
         PackageDefinition { blueprints }
     }
 
-    pub fn authorization<Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>(
+    pub fn authorization<Y: SystemBasedKernelApi>(
         global_address: &GlobalAddress,
         ident: &str,
         input: &IndexedScryptoValue,
-        api: &mut SystemService<Y, V, E>,
+        api: &mut SystemService<Y>,
     ) -> Result<ResolvedPermission, RuntimeError> {
         let permission = match ident {
             ROLE_ASSIGNMENT_SET_IDENT => {
@@ -297,13 +289,9 @@ impl RoleAssignmentNativePackage {
         access_rule.dfs_traverse_nodes(&mut AccessRuleVerifier(0))
     }
 
-    fn resolve_update_owner_role_method_permission<
-        Y: KernelApi<System<V, E>>,
-        V: SystemCallbackObject,
-        E,
-    >(
+    fn resolve_update_owner_role_method_permission<Y: SystemBasedKernelApi>(
         receiver: &NodeId,
-        api: &mut SystemService<Y, V, E>,
+        api: &mut SystemService<Y>,
     ) -> Result<ResolvedPermission, RuntimeError> {
         let handle = api.kernel_open_substate(
             receiver,
@@ -334,15 +322,11 @@ impl RoleAssignmentNativePackage {
         Ok(ResolvedPermission::AccessRule(rule))
     }
 
-    fn resolve_update_role_method_permission<
-        Y: KernelApi<System<V, E>>,
-        V: SystemCallbackObject,
-        E,
-    >(
+    fn resolve_update_role_method_permission<Y: SystemBasedKernelApi>(
         receiver: &NodeId,
         module: ModuleId,
         role_key: &RoleKey,
-        api: &mut SystemService<Y, V, E>,
+        api: &mut SystemService<Y>,
     ) -> Result<RoleList, RuntimeError> {
         if Self::is_role_key_reserved(&role_key) || module.eq(&ModuleId::RoleAssignment) {
             return Ok(RoleList::none());

--- a/radix-engine/src/object_modules/royalty/package.rs
+++ b/radix-engine/src/object_modules/royalty/package.rs
@@ -472,7 +472,7 @@ impl ComponentRoyaltyBlueprint {
             let component_address = ComponentAddress::new_or_panic(receiver.0);
 
             apply_royalty_cost(
-                api,
+                &mut api.system_module_api(),
                 royalty_charge,
                 RoyaltyRecipient::Component(component_address, vault_id.into()),
             )?;

--- a/radix-engine/src/system/module.rs
+++ b/radix-engine/src/system/module.rs
@@ -101,8 +101,18 @@ pub trait InitSystemModule {
     }
 }
 
+pub trait PrivilegedSystemModule {
+    #[inline(always)]
+    fn privileged_before_invoke(
+        _api: &mut impl SystemBasedKernelApi,
+        _invocation: &KernelInvocation<Actor>,
+    ) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}
+
 pub trait SystemModule<ModuleApi: SystemModuleApiFor<Self>>:
-    InitSystemModule + ResolvableSystemModule
+    InitSystemModule + ResolvableSystemModule + PrivilegedSystemModule
 {
     //======================
     // Invocation events

--- a/radix-engine/src/system/module.rs
+++ b/radix-engine/src/system/module.rs
@@ -22,7 +22,9 @@ pub trait InitSystemModule {
     }
 }
 
-pub trait SystemModule<ModuleApi: SystemModuleApi>: InitSystemModule {
+pub trait SystemModule<ModuleApi: SystemModuleApiFor<Self>>:
+    InitSystemModule + ResolvableSystemModule
+{
     //======================
     // Invocation events
     //

--- a/radix-engine/src/system/module.rs
+++ b/radix-engine/src/system/module.rs
@@ -115,7 +115,7 @@ pub trait SystemModule<ModuleApi: SystemModuleApiFor<Self>>:
 
     #[inline(always)]
     fn before_invoke(
-        _api: &mut ModuleApi, // For charge_package_royalty in the Costing Module
+        _api: &mut ModuleApi,
         _invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
         Ok(())

--- a/radix-engine/src/system/payload_validation.rs
+++ b/radix-engine/src/system/payload_validation.rs
@@ -1,6 +1,5 @@
 use crate::errors::RuntimeError;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::KernelApi;
 use radix_common::constants::*;
 use radix_engine_interface::blueprints::resource::{
     FUNGIBLE_BUCKET_BLUEPRINT, FUNGIBLE_PROOF_BLUEPRINT, NON_FUNGIBLE_BUCKET_BLUEPRINT,
@@ -10,8 +9,7 @@ use sbor::rust::prelude::*;
 use sbor::traversal::TerminalValueRef;
 
 use super::system::SystemService;
-use super::system_callback::System;
-use super::system_callback_api::SystemCallbackObject;
+use super::system_callback::*;
 use super::type_info::TypeInfoSubstate;
 
 //=======================================================================================================
@@ -49,24 +47,16 @@ pub enum SchemaOrigin {
 // SYSTEM ADAPTERS
 //==================
 
-pub struct SystemServiceTypeInfoLookup<
-    's,
-    'a,
-    Y: KernelApi<System<V, E>>,
-    V: SystemCallbackObject,
-    E,
-> {
-    system_service: RefCell<&'s mut SystemService<'a, Y, V, E>>,
+pub struct SystemServiceTypeInfoLookup<'s, 'a, Y: SystemBasedKernelApi> {
+    system_service: RefCell<&'s mut SystemService<'a, Y>>,
     schema_origin: SchemaOrigin,
     allow_ownership: bool,
     allow_non_global_ref: bool,
 }
 
-impl<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemServiceTypeInfoLookup<'s, 'a, Y, V, E>
-{
+impl<'s, 'a, Y: SystemBasedKernelApi> SystemServiceTypeInfoLookup<'s, 'a, Y> {
     pub fn new(
-        system_service: &'s mut SystemService<'a, Y, V, E>,
+        system_service: &'s mut SystemService<'a, Y>,
         schema_origin: SchemaOrigin,
         allow_ownership: bool,
         allow_non_global_ref: bool,
@@ -80,9 +70,7 @@ impl<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     }
 }
 
-impl<'s, 'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> ValidationContext
-    for SystemServiceTypeInfoLookup<'s, 'a, Y, V, E>
-{
+impl<'s, 'a, Y: SystemBasedKernelApi> ValidationContext for SystemServiceTypeInfoLookup<'s, 'a, Y> {
     type Error = RuntimeError;
 
     fn get_node_type_info(&self, node_id: &NodeId) -> Result<TypeInfoForValidation, RuntimeError> {

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2,21 +2,14 @@ use super::id_allocation::IDAllocation;
 use super::system_modules::costing::ExecutionCostingEntry;
 use crate::blueprints::package::PackageBlueprintVersionDefinitionEntrySubstate;
 use crate::blueprints::resource::fungible_vault::LockFeeEvent;
-use crate::errors::{
-    ApplicationError, CannotGlobalizeError, CreateObjectError, InvalidDropAccess,
-    InvalidGlobalizeAccess, InvalidModuleType, RuntimeError, SystemError, SystemModuleError,
-};
+use crate::errors::*;
 use crate::errors::{EventError, SystemUpstreamError};
 use crate::internal_prelude::*;
-use crate::internal_prelude::{IndexEntrySubstate, SortedIndexEntrySubstate};
 use crate::kernel::call_frame::{NodeVisibility, ReferenceOrigin};
 use crate::kernel::kernel_api::*;
 use crate::system::actor::{Actor, FunctionActor, InstanceContext, MethodActor, MethodType};
 use crate::system::node_init::type_info_partition;
-use crate::system::system_callback::{
-    FieldLockData, KeyValueEntryLockData, System, SystemLockData,
-};
-use crate::system::system_callback_api::SystemCallbackObject;
+use crate::system::system_callback::*;
 use crate::system::system_modules::execution_trace::{BucketSnapshot, ProofSnapshot};
 use crate::system::system_modules::transaction_runtime::Event;
 use crate::system::system_modules::{EnabledModules, SystemModuleMixer};
@@ -44,15 +37,12 @@ use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::blueprints::resource::*;
 use radix_engine_profiling_derive::trace_resources;
 use radix_substate_store_interface::db_key_mapper::SubstateKeyContent;
-use sbor::rust::string::ToString;
-use sbor::rust::vec::Vec;
 
 pub const BOOT_LOADER_SYSTEM_VERSION_FIELD_KEY: FieldKey = 1u8;
 
-/// Provided to upper layer for invoking lower layer service
-pub struct SystemService<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> {
+/// Provided to upper layers (VM and System) for invoking lower layer service
+pub struct SystemService<'a, Y: SystemBasedKernelApi> {
     pub api: &'a mut Y,
-    pub phantom: PhantomData<(V, E)>,
 }
 
 enum ActorStateRef {
@@ -100,12 +90,9 @@ enum EmitterActor {
     AsObject(NodeId, Option<AttachedModuleId>),
 }
 
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
+impl<'a, Y: SystemBasedKernelApi> SystemService<'a, Y> {
     pub fn new(api: &'a mut Y) -> Self {
-        Self {
-            api,
-            phantom: PhantomData::default(),
-        }
+        Self { api }
     }
 }
 
@@ -113,7 +100,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
+impl<'a, Y: SystemBasedKernelApi> SystemService<'a, Y> {
     fn validate_new_object(
         &mut self,
         blueprint_id: &BlueprintId,
@@ -1105,9 +1092,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemFieldApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemFieldApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     #[trace_resources]
     fn field_read(&mut self, handle: FieldHandle) -> Result<Vec<u8>, RuntimeError> {
@@ -1196,9 +1181,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemFieldApi<
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemObjectApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemObjectApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     #[trace_resources]
     fn new_object(
@@ -1583,9 +1566,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemObjectApi
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemKeyValueEntryApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     #[trace_resources]
     fn key_value_entry_get(
@@ -1720,9 +1701,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemKeyValueStoreApi<RuntimeError> for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemKeyValueStoreApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     #[trace_resources]
     fn key_value_store_new(
@@ -1872,9 +1851,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorIndexApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemActorIndexApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     fn actor_index_insert(
         &mut self,
@@ -2004,9 +1981,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorInde
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemActorSortedIndexApi<RuntimeError> for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemActorSortedIndexApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     #[trace_resources]
     fn actor_sorted_index_insert(
@@ -2122,9 +2097,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemBlueprintApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemBlueprintApi<RuntimeError> for SystemService<'a, Y> {
     // Costing through kernel
     fn call_function(
         &mut self,
@@ -2168,9 +2141,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemBlueprint
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemCostingApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemCostingApi<RuntimeError> for SystemService<'a, Y> {
     // No costing should be applied
     fn consume_cost_units(
         &mut self,
@@ -2431,9 +2402,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemCostingAp
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemActorApi<RuntimeError> for SystemService<'a, Y> {
     #[trace_resources]
     fn actor_get_blueprint_id(&mut self) -> Result<BlueprintId, RuntimeError> {
         self.api
@@ -2650,8 +2619,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemActorApi<
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemActorKeyValueEntryApi<RuntimeError> for SystemService<'a, Y, V, E>
+impl<'a, Y: SystemBasedKernelApi> SystemActorKeyValueEntryApi<RuntimeError>
+    for SystemService<'a, Y>
 {
     // Costing through kernel
     #[trace_resources]
@@ -2741,9 +2710,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemExecutionTraceApi<RuntimeError> for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> SystemExecutionTraceApi<RuntimeError> for SystemService<'a, Y> {
     // No costing should be applied
     #[trace_resources]
     fn update_instruction_index(&mut self, new_index: usize) -> Result<(), RuntimeError> {
@@ -2759,8 +2726,8 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
-    SystemTransactionRuntimeApi<RuntimeError> for SystemService<'a, Y, V, E>
+impl<'a, Y: SystemBasedKernelApi> SystemTransactionRuntimeApi<RuntimeError>
+    for SystemService<'a, Y>
 {
     #[trace_resources]
     fn get_transaction_hash(&mut self) -> Result<Hash, RuntimeError> {
@@ -2852,18 +2819,13 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E>
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemApi<RuntimeError>
-    for SystemService<'a, Y, V, E>
-{
-}
+impl<'a, Y: SystemBasedKernelApi> SystemApi<RuntimeError> for SystemService<'a, Y> {}
 
 #[cfg_attr(
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelNodeApi
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> KernelNodeApi for SystemService<'a, Y> {
     fn kernel_pin_node(&mut self, node_id: NodeId) -> Result<(), RuntimeError> {
         self.api.kernel_pin_node(node_id)
     }
@@ -2897,9 +2859,7 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelNodeApi
     feature = "std",
     catch_unwind(crate::utils::catch_unwind_system_panic_transformer)
 )]
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelSubstateApi<SystemLockData>
-    for SystemService<'a, Y, V, E>
-{
+impl<'a, Y: SystemBasedKernelApi> KernelSubstateApi<SystemLockData> for SystemService<'a, Y> {
     fn kernel_mark_substate_as_transient(
         &mut self,
         node_id: NodeId,
@@ -3007,10 +2967,10 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelSubstateA
     }
 }
 
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelInternalApi<System<V, E>>
-    for SystemService<'a, Y, V, E>
-{
-    fn kernel_get_system_state(&mut self) -> SystemState<'_, System<V, E>> {
+impl<'a, Y: SystemBasedKernelApi> KernelInternalApi for SystemService<'a, Y> {
+    type System = Y::CallbackObject;
+
+    fn kernel_get_system_state(&mut self) -> SystemState<'_, Y::CallbackObject> {
         self.api.kernel_get_system_state()
     }
 
@@ -3022,11 +2982,11 @@ impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> KernelInternalA
         self.api.kernel_get_node_visibility(node_id)
     }
 
-    fn kernel_read_bucket(&mut self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
+    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
         self.api.kernel_read_bucket(bucket_id)
     }
 
-    fn kernel_read_proof(&mut self, proof_id: &NodeId) -> Option<ProofSnapshot> {
+    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
         self.api.kernel_read_proof(proof_id)
     }
 }

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -10,7 +10,6 @@ use crate::kernel::kernel_api::*;
 use crate::system::actor::{Actor, FunctionActor, InstanceContext, MethodActor, MethodType};
 use crate::system::node_init::type_info_partition;
 use crate::system::system_callback::*;
-use crate::system::system_modules::execution_trace::{BucketSnapshot, ProofSnapshot};
 use crate::system::system_modules::transaction_runtime::Event;
 use crate::system::system_modules::{EnabledModules, SystemModuleMixer};
 use crate::system::system_substates::{KeyValueEntrySubstate, LockStatus};
@@ -2982,11 +2981,13 @@ impl<'a, Y: SystemBasedKernelApi> KernelInternalApi for SystemService<'a, Y> {
         self.api.kernel_get_node_visibility(node_id)
     }
 
-    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        self.api.kernel_read_bucket(bucket_id)
-    }
-
-    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        self.api.kernel_read_proof(proof_id)
+    fn kernel_read_substate_uncosted(
+        &self,
+        node_id: &NodeId,
+        partition_num: PartitionNumber,
+        substate_key: &SubstateKey,
+    ) -> Option<&IndexedScryptoValue> {
+        self.api
+            .kernel_read_substate_uncosted(node_id, partition_num, substate_key)
     }
 }

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -1,7 +1,7 @@
 use crate::errors::RuntimeError;
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::{KernelInternalApi, KernelNodeApi, KernelSubstateApi};
-use crate::system::system_callback::{System, SystemLockData};
+use crate::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
+use crate::system::system_callback::*;
 use crate::track::BootStore;
 use radix_engine_interface::api::SystemApi;
 use radix_engine_interface::blueprints::package::PackageExport;
@@ -17,10 +17,9 @@ pub trait SystemCallbackObject: Sized {
     /// Invoke a function
     fn invoke<
         Y: SystemApi<RuntimeError>
-            + KernelInternalApi<System<Self, E>>
+            + SystemModuleApi<SystemCallback = Self>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
-        E,
     >(
         package_address: &PackageAddress,
         package_export: PackageExport,

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -17,7 +17,7 @@ pub trait SystemCallbackObject: Sized {
     /// Invoke a function
     fn invoke<
         Y: SystemApi<RuntimeError>
-            + SystemModuleApi<SystemCallback = Self>
+            + SystemBasedKernelInternalApi<SystemCallback = Self>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
     >(

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -11,6 +11,7 @@ use crate::system::module::{InitSystemModule, SystemModule};
 use crate::system::node_init::type_info_partition;
 use crate::system::system::SystemService;
 use crate::system::system_callback::*;
+use crate::system::system_callback_api::SystemCallbackObject;
 use crate::system::type_info::TypeInfoSubstate;
 use radix_engine_interface::api::{AttachedModuleId, LockFlags, ModuleId, SystemBlueprintApi};
 use radix_engine_interface::blueprints::package::{
@@ -516,4 +517,9 @@ impl AuthModule {
 }
 
 impl InitSystemModule for AuthModule {}
-impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for AuthModule {}
+impl ResolvableSystemModule for AuthModule {
+    fn resolve_from_system<V: SystemCallbackObject, E>(system: &mut System<V, E>) -> &mut Self {
+        &mut system.modules.auth
+    }
+}
+impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for AuthModule {}

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -527,4 +527,5 @@ impl ResolvableSystemModule for AuthModule {
         &mut system.modules.auth
     }
 }
+impl PrivilegedSystemModule for AuthModule {}
 impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for AuthModule {}

--- a/radix-engine/src/system/system_modules/auth/auth_module.rs
+++ b/radix-engine/src/system/system_modules/auth/auth_module.rs
@@ -7,7 +7,7 @@ use crate::kernel::call_frame::ReferenceOrigin;
 use crate::kernel::kernel_api::{KernelInternalApi, KernelNodeApi, KernelSubstateApi};
 use crate::object_modules::role_assignment::RoleAssignmentNativePackage;
 use crate::system::actor::Actor;
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::node_init::type_info_partition;
 use crate::system::system::SystemService;
 use crate::system::system_callback::*;
@@ -75,7 +75,7 @@ impl AuthModule {
     }
 
     pub fn on_call_function<Y: SystemBasedKernelApi>(
-        api: &mut SystemService<Y>,
+        system: &mut SystemService<Y>,
         blueprint_id: &BlueprintId,
         ident: &str,
     ) -> Result<NodeId, RuntimeError> {
@@ -89,10 +89,10 @@ impl AuthModule {
                 && blueprint_id
                     .blueprint_name
                     .eq(TRANSACTION_PROCESSOR_BLUEPRINT);
-            let is_at_root = api.kernel_get_current_depth() == 0;
+            let is_at_root = system.kernel_get_current_depth() == 0;
             let (virtual_resources, virtual_non_fungibles) =
                 if is_transaction_processor_blueprint && is_at_root {
-                    let auth_module = &api.kernel_get_system().modules.auth;
+                    let auth_module = &system.kernel_get_system().modules.auth;
                     (
                         auth_module.params.virtual_resources.clone(),
                         auth_module.params.initial_proofs.clone(),
@@ -101,7 +101,7 @@ impl AuthModule {
                     (BTreeSet::new(), BTreeSet::new())
                 };
 
-            Self::create_auth_zone(api, None, virtual_resources, virtual_non_fungibles)?
+            Self::create_auth_zone(system, None, virtual_resources, virtual_non_fungibles)?
         };
 
         // Check authorization
@@ -111,7 +111,7 @@ impl AuthModule {
                 blueprint_id.package_address.as_node_id(),
                 &BlueprintVersionKey::new_default(blueprint_id.blueprint_name.as_str()),
                 ident,
-                api.api,
+                system.api(),
             )?;
 
             // Step 2: Check permission
@@ -119,7 +119,7 @@ impl AuthModule {
                 blueprint_id: blueprint_id.clone(),
                 ident: ident.to_string(),
             };
-            Self::check_permission(&auth_zone, permission, fn_identifier, api)?;
+            Self::check_permission(&auth_zone, permission, fn_identifier, system)?;
         }
 
         Ok(auth_zone)
@@ -301,10 +301,10 @@ impl AuthModule {
 
         // Create node
         let new_auth_zone = system
-            .api
+            .api()
             .kernel_allocate_node_id(EntityType::InternalGenericComponent)?;
 
-        system.api.kernel_create_node(
+        system.api().kernel_create_node(
             new_auth_zone,
             btreemap!(
                 MAIN_BASE_PARTITION => btreemap!(
@@ -322,7 +322,7 @@ impl AuthModule {
                 }))
             ),
         )?;
-        system.api.kernel_pin_node(new_auth_zone)?;
+        system.api().kernel_pin_node(new_auth_zone)?;
 
         if let Some(parent_lock_handle) = parent_lock_handle {
             system.kernel_close_substate(parent_lock_handle)?;
@@ -427,7 +427,7 @@ impl AuthModule {
     }
 
     fn resolve_method_permission<Y: SystemBasedKernelApi>(
-        api: &mut SystemService<Y>,
+        system: &mut SystemService<Y>,
         blueprint_id: &BlueprintId,
         receiver: &NodeId,
         module_id: &ModuleId,
@@ -439,17 +439,22 @@ impl AuthModule {
         if let ModuleId::RoleAssignment = module_id {
             // Only global objects have role assignment modules
             let global_address = GlobalAddress::new_or_panic(receiver.0);
-            return RoleAssignmentNativePackage::authorization(&global_address, ident, args, api);
+            return RoleAssignmentNativePackage::authorization(
+                &global_address,
+                ident,
+                args,
+                system,
+            );
         }
 
         let auth_template = PackageAuthNativeBlueprint::get_bp_auth_template(
             blueprint_id.package_address.as_node_id(),
             &BlueprintVersionKey::new_default(blueprint_id.blueprint_name.as_str()),
-            api.api,
+            system.api(),
         )?
         .method_auth;
 
-        let receiver_object_info = api.get_object_info(&receiver)?;
+        let receiver_object_info = system.get_object_info(&receiver)?;
 
         let (role_assignment_of, method_permissions) = match auth_template {
             MethodAuthTemplate::StaticRoleDefinition(static_roles) => {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -359,10 +359,10 @@ impl ResolvableSystemModule for CostingModule {
     }
 }
 
-impl CostingModule {
+impl PrivilegedSystemModule for CostingModule {
     /// Runs after SystemModule::before_invoke
     /// Called from the Module Mixer
-    pub fn privileged_before_invoke(
+    fn privileged_before_invoke(
         api: &mut impl SystemBasedKernelApi,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -366,6 +366,13 @@ impl CostingModule {
         api: &mut impl SystemBasedKernelApi,
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
+        let depth = api.kernel_get_current_depth();
+
+        // Skip invocation costing for transaction processor
+        if depth == 0 {
+            return Ok(());
+        }
+
         // Identify the function, and optional component address
         let (optional_blueprint_id, ident, maybe_object_royalties) = {
             let (maybe_component, ident) = match &invocation.call_frame_data {
@@ -435,7 +442,7 @@ impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for CostingMod
         invocation: &KernelInvocation<Actor>,
     ) -> Result<(), RuntimeError> {
         let depth = api.current_stack_depth();
-        let costing_module = &mut api.module();
+        let costing_module = api.module();
 
         // Add invocation information to the execution cost breakdown.
         if let Some(ref mut detailed_cost_breakdown) = costing_module.detailed_cost_breakdown {

--- a/radix-engine/src/system/system_modules/costing/costing_module.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_module.rs
@@ -6,7 +6,7 @@ use crate::kernel::kernel_api::*;
 use crate::kernel::kernel_callback_api::*;
 use crate::object_modules::royalty::ComponentRoyaltyBlueprint;
 use crate::system::actor::{Actor, FunctionActor, MethodActor, MethodType};
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::{

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -5,7 +5,7 @@ use crate::kernel::call_frame::CallFrameMessage;
 use crate::kernel::kernel_api::*;
 use crate::kernel::kernel_callback_api::*;
 use crate::system::actor::{Actor, FunctionActor, MethodActor};
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::system::type_info::TypeInfoSubstate;
@@ -103,12 +103,12 @@ trait SystemModuleApiResourceSnapshotExtension {
     fn read_proof_uncosted(&self, proof_id: &NodeId) -> Option<ProofSnapshot>;
 }
 
-impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
-    SystemModuleApiResourceSnapshotExtension for K
+impl<'a, V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
+    SystemModuleApiResourceSnapshotExtension for SystemModuleApiImpl<'a, K>
 {
     fn read_bucket_uncosted(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        let (is_fungible_bucket, resource_address) = if let Some(substate) = self
-            .kernel_read_substate_uncosted(
+        let (is_fungible_bucket, resource_address) = if let Some(substate) =
+            self.api_ref().kernel_read_substate_uncosted(
                 &bucket_id,
                 TYPE_INFO_FIELD_PARTITION,
                 &TypeInfoField::TypeInfo.into(),
@@ -142,6 +142,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
 
         if is_fungible_bucket {
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     bucket_id,
                     MAIN_BASE_PARTITION,
@@ -156,6 +157,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
             })
         } else {
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     bucket_id,
                     MAIN_BASE_PARTITION,
@@ -172,7 +174,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
     }
 
     fn read_proof_uncosted(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        let is_fungible = if let Some(substate) = self.kernel_read_substate_uncosted(
+        let is_fungible = if let Some(substate) = self.api_ref().kernel_read_substate_uncosted(
             &proof_id,
             TYPE_INFO_FIELD_PARTITION,
             &TypeInfoField::TypeInfo.into(),
@@ -198,6 +200,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
 
         if is_fungible {
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     proof_id,
                     TYPE_INFO_FIELD_PARTITION,
@@ -209,6 +212,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
                 ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
 
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     proof_id,
                     MAIN_BASE_PARTITION,
@@ -223,6 +227,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
             })
         } else {
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     proof_id,
                     TYPE_INFO_FIELD_PARTITION,
@@ -234,6 +239,7 @@ impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
                 ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
 
             let substate = self
+                .api_ref()
                 .kernel_read_substate_uncosted(
                     proof_id,
                     MAIN_BASE_PARTITION,

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -1,12 +1,14 @@
-use crate::blueprints::resource::VaultUtil;
+use crate::blueprints::resource::*;
 use crate::errors::*;
 use crate::internal_prelude::*;
 use crate::kernel::call_frame::CallFrameMessage;
-use crate::kernel::kernel_api::KernelInvocation;
-use crate::kernel::kernel_callback_api::{CreateNodeEvent, DropNodeEvent};
+use crate::kernel::kernel_api::*;
+use crate::kernel::kernel_callback_api::*;
 use crate::system::actor::{Actor, FunctionActor, MethodActor};
 use crate::system::module::{InitSystemModule, SystemModule};
 use crate::system::system_callback::*;
+use crate::system::system_callback_api::SystemCallbackObject;
+use crate::system::type_info::TypeInfoSubstate;
 use crate::transaction::{FeeLocks, TransactionExecutionTrace};
 use radix_common::math::Decimal;
 use radix_engine_interface::blueprints::resource::*;
@@ -94,6 +96,158 @@ pub enum VaultOp {
     TakeAdvanced(ResourceAddress, Decimal),
     Recall(ResourceAddress, Decimal),
     LockFee(Decimal, bool),
+}
+
+trait SystemModuleApiResourceSnapshotExtension {
+    fn read_bucket_uncosted(&self, bucket_id: &NodeId) -> Option<BucketSnapshot>;
+    fn read_proof_uncosted(&self, proof_id: &NodeId) -> Option<ProofSnapshot>;
+}
+
+impl<V: SystemCallbackObject, E, K: KernelInternalApi<System = System<V, E>>>
+    SystemModuleApiResourceSnapshotExtension for K
+{
+    fn read_bucket_uncosted(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
+        let (is_fungible_bucket, resource_address) = if let Some(substate) = self
+            .kernel_read_substate_uncosted(
+                &bucket_id,
+                TYPE_INFO_FIELD_PARTITION,
+                &TypeInfoField::TypeInfo.into(),
+            ) {
+            let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
+            match type_info {
+                TypeInfoSubstate::Object(info)
+                    if info.blueprint_info.blueprint_id.package_address == RESOURCE_PACKAGE
+                        && (info.blueprint_info.blueprint_id.blueprint_name
+                            == FUNGIBLE_BUCKET_BLUEPRINT
+                            || info.blueprint_info.blueprint_id.blueprint_name
+                                == NON_FUNGIBLE_BUCKET_BLUEPRINT) =>
+                {
+                    let is_fungible = info
+                        .blueprint_info
+                        .blueprint_id
+                        .blueprint_name
+                        .eq(FUNGIBLE_BUCKET_BLUEPRINT);
+                    let parent = info.get_outer_object();
+                    let resource_address: ResourceAddress =
+                        ResourceAddress::new_or_panic(parent.as_bytes().try_into().unwrap());
+                    (is_fungible, resource_address)
+                }
+                _ => {
+                    return None;
+                }
+            }
+        } else {
+            return None;
+        };
+
+        if is_fungible_bucket {
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    bucket_id,
+                    MAIN_BASE_PARTITION,
+                    &FungibleBucketField::Liquid.into(),
+                )
+                .unwrap();
+            let liquid: FieldSubstate<LiquidFungibleResource> = substate.as_typed().unwrap();
+
+            Some(BucketSnapshot::Fungible {
+                resource_address,
+                liquid: liquid.into_payload().amount(),
+            })
+        } else {
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    bucket_id,
+                    MAIN_BASE_PARTITION,
+                    &NonFungibleBucketField::Liquid.into(),
+                )
+                .unwrap();
+            let liquid: FieldSubstate<LiquidNonFungibleResource> = substate.as_typed().unwrap();
+
+            Some(BucketSnapshot::NonFungible {
+                resource_address,
+                liquid: liquid.into_payload().ids().clone(),
+            })
+        }
+    }
+
+    fn read_proof_uncosted(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
+        let is_fungible = if let Some(substate) = self.kernel_read_substate_uncosted(
+            &proof_id,
+            TYPE_INFO_FIELD_PARTITION,
+            &TypeInfoField::TypeInfo.into(),
+        ) {
+            let type_info: TypeInfoSubstate = substate.as_typed().unwrap();
+            match type_info {
+                TypeInfoSubstate::Object(ObjectInfo {
+                    blueprint_info: BlueprintInfo { blueprint_id, .. },
+                    ..
+                }) if blueprint_id.package_address == RESOURCE_PACKAGE
+                    && (blueprint_id.blueprint_name == NON_FUNGIBLE_PROOF_BLUEPRINT
+                        || blueprint_id.blueprint_name == FUNGIBLE_PROOF_BLUEPRINT) =>
+                {
+                    blueprint_id.blueprint_name.eq(FUNGIBLE_PROOF_BLUEPRINT)
+                }
+                _ => {
+                    return None;
+                }
+            }
+        } else {
+            return None;
+        };
+
+        if is_fungible {
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    proof_id,
+                    TYPE_INFO_FIELD_PARTITION,
+                    &TypeInfoField::TypeInfo.into(),
+                )
+                .unwrap();
+            let info: TypeInfoSubstate = substate.as_typed().unwrap();
+            let resource_address =
+                ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
+
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    proof_id,
+                    MAIN_BASE_PARTITION,
+                    &FungibleProofField::ProofRefs.into(),
+                )
+                .unwrap();
+            let proof: FieldSubstate<FungibleProofSubstate> = substate.as_typed().unwrap();
+
+            Some(ProofSnapshot::Fungible {
+                resource_address,
+                total_locked: proof.into_payload().amount(),
+            })
+        } else {
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    proof_id,
+                    TYPE_INFO_FIELD_PARTITION,
+                    &TypeInfoField::TypeInfo.into(),
+                )
+                .unwrap();
+            let info: TypeInfoSubstate = substate.as_typed().unwrap();
+            let resource_address =
+                ResourceAddress::new_or_panic(info.outer_object().unwrap().into());
+
+            let substate = self
+                .kernel_read_substate_uncosted(
+                    proof_id,
+                    MAIN_BASE_PARTITION,
+                    &NonFungibleProofField::ProofRefs.into(),
+                )
+                .unwrap();
+            let proof: FieldSubstate<NonFungibleProofSubstate> = substate.as_typed().unwrap();
+
+            Some(ProofSnapshot::NonFungible {
+                resource_address,
+                total_locked: proof.into_payload().non_fungible_local_ids().clone(),
+            })
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, ScryptoSbor)]
@@ -255,27 +409,33 @@ impl ResourceSummary {
         self.buckets.is_empty() && self.proofs.is_empty()
     }
 
-    pub fn from_message(api: &mut impl SystemModuleApi, message: &CallFrameMessage) -> Self {
+    fn from_message(
+        api: &mut impl SystemModuleApiResourceSnapshotExtension,
+        message: &CallFrameMessage,
+    ) -> Self {
         let mut buckets = index_map_new();
         let mut proofs = index_map_new();
         for node_id in &message.move_nodes {
-            if let Some(x) = api.kernel_read_bucket(node_id) {
+            if let Some(x) = api.read_bucket_uncosted(node_id) {
                 buckets.insert(*node_id, x);
             }
-            if let Some(x) = api.kernel_read_proof(node_id) {
+            if let Some(x) = api.read_proof_uncosted(node_id) {
                 proofs.insert(*node_id, x);
             }
         }
         Self { buckets, proofs }
     }
 
-    pub fn from_node_id(api: &mut impl SystemModuleApi, node_id: &NodeId) -> Self {
+    fn from_node_id(
+        api: &mut impl SystemModuleApiResourceSnapshotExtension,
+        node_id: &NodeId,
+    ) -> Self {
         let mut buckets = index_map_new();
         let mut proofs = index_map_new();
-        if let Some(x) = api.kernel_read_bucket(node_id) {
+        if let Some(x) = api.read_bucket_uncosted(node_id) {
             buckets.insert(*node_id, x);
         }
-        if let Some(x) = api.kernel_read_proof(node_id) {
+        if let Some(x) = api.read_proof_uncosted(node_id) {
             proofs.insert(*node_id, x);
         }
         Self { buckets, proofs }
@@ -283,31 +443,30 @@ impl ResourceSummary {
 }
 
 impl InitSystemModule for ExecutionTraceModule {}
+impl ResolvableSystemModule for ExecutionTraceModule {
+    fn resolve_from_system<V: SystemCallbackObject, E>(system: &mut System<V, E>) -> &mut Self {
+        &mut system.modules.execution_trace
+    }
+}
 
-impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for ExecutionTraceModule {
+impl<ModuleApi: SystemModuleApiFor<Self> + SystemModuleApiResourceSnapshotExtension>
+    SystemModule<ModuleApi> for ExecutionTraceModule
+{
     fn on_create_node(api: &mut ModuleApi, event: &CreateNodeEvent) -> Result<(), RuntimeError> {
         match event {
             CreateNodeEvent::Start(..) => {
-                api.kernel_get_system_state()
-                    .system
-                    .modules
-                    .execution_trace
-                    .handle_before_create_node();
+                api.module().handle_before_create_node();
             }
             CreateNodeEvent::IOAccess(..) => {}
             CreateNodeEvent::End(node_id) => {
-                let current_depth = api.kernel_get_current_depth();
+                let current_depth = api.current_stack_depth();
                 let resource_summary = ResourceSummary::from_node_id(api, node_id);
-                let system_state = api.kernel_get_system_state();
-                system_state
-                    .system
-                    .modules
-                    .execution_trace
-                    .handle_after_create_node(
-                        system_state.current_call_frame,
-                        current_depth,
-                        resource_summary,
-                    );
+                let system_state = api.system_state();
+                Self::resolve_from_system(system_state.system).handle_after_create_node(
+                    system_state.current_call_frame,
+                    current_depth,
+                    resource_summary,
+                );
             }
         }
 
@@ -318,15 +477,11 @@ impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for ExecutionTraceModul
         match event {
             DropNodeEvent::Start(node_id) => {
                 let resource_summary = ResourceSummary::from_node_id(api, node_id);
-                api.kernel_get_system_state()
-                    .system
-                    .modules
-                    .execution_trace
-                    .handle_before_drop_node(resource_summary);
+                api.module().handle_before_drop_node(resource_summary);
             }
             DropNodeEvent::End(..) => {
-                let current_depth = api.kernel_get_current_depth();
-                let system_state = api.kernel_get_system_state();
+                let current_depth = api.current_stack_depth();
+                let system_state = api.system_state();
                 system_state
                     .system
                     .modules
@@ -347,7 +502,7 @@ impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for ExecutionTraceModul
         let resource_summary = ResourceSummary::from_message(api, &message);
         let callee = &invocation.call_frame_data;
         let args = &invocation.args;
-        let system_state = api.kernel_get_system_state();
+        let system_state = api.system_state();
         system_state
             .system
             .modules
@@ -365,10 +520,10 @@ impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for ExecutionTraceModul
         api: &mut ModuleApi,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {
-        let current_depth = api.kernel_get_current_depth();
+        let current_depth = api.current_stack_depth();
         let resource_summary = ResourceSummary::from_message(api, message);
 
-        let system_state = api.kernel_get_system_state();
+        let system_state = api.system_state();
 
         let caller = TraceActor::from_actor(system_state.caller_call_frame);
 

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -454,6 +454,7 @@ impl ResolvableSystemModule for ExecutionTraceModule {
         &mut system.modules.execution_trace
     }
 }
+impl PrivilegedSystemModule for ExecutionTraceModule {}
 
 impl<ModuleApi: SystemModuleApiFor<Self> + SystemModuleApiResourceSnapshotExtension>
     SystemModule<ModuleApi> for ExecutionTraceModule

--- a/radix-engine/src/system/system_modules/kernel_trace/module.rs
+++ b/radix-engine/src/system/system_modules/kernel_trace/module.rs
@@ -207,3 +207,5 @@ impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for KernelTrac
         Ok(())
     }
 }
+
+impl PrivilegedSystemModule for KernelTraceModule {}

--- a/radix-engine/src/system/system_modules/kernel_trace/module.rs
+++ b/radix-engine/src/system/system_modules/kernel_trace/module.rs
@@ -4,7 +4,7 @@ use crate::kernel::call_frame::CallFrameMessage;
 use crate::kernel::kernel_api::KernelInvocation;
 use crate::kernel::kernel_callback_api::*;
 use crate::system::actor::Actor;
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use colored::Colorize;

--- a/radix-engine/src/system/system_modules/limits/module.rs
+++ b/radix-engine/src/system/system_modules/limits/module.rs
@@ -185,6 +185,8 @@ impl ResolvableSystemModule for LimitsModule {
         &mut system.modules.limits
     }
 }
+impl PrivilegedSystemModule for LimitsModule {}
+
 impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for LimitsModule {
     fn before_invoke(
         api: &mut ModuleApi,

--- a/radix-engine/src/system/system_modules/limits/module.rs
+++ b/radix-engine/src/system/system_modules/limits/module.rs
@@ -2,7 +2,7 @@ use crate::internal_prelude::*;
 use crate::kernel::kernel_api::KernelInvocation;
 use crate::kernel::kernel_callback_api::*;
 use crate::system::actor::Actor;
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::*;
 use crate::track::interface::IOAccess;

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -246,13 +246,15 @@ impl SystemModuleMixer {
     }
 
     #[trace_resources]
-    pub fn on_execution_start(api: &mut impl SystemModuleApi) -> Result<(), RuntimeError> {
+    pub fn on_execution_start(
+        api: &mut impl SystemBasedKernelInternalApi,
+    ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_execution_start(api))
     }
 
     #[trace_resources]
     pub fn on_execution_finish(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_execution_finish(api, message))
@@ -260,7 +262,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn after_invoke(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         output: &IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), after_invoke(api, output))
@@ -268,7 +270,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_pin_node(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         node_id: &NodeId,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_pin_node(api, node_id))
@@ -276,7 +278,7 @@ impl SystemModuleMixer {
 
     #[trace_resources(log=entity_type)]
     pub fn on_allocate_node_id(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         entity_type: EntityType,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(
@@ -287,7 +289,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_create_node(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_create_node(api, event))
@@ -295,7 +297,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_move_module(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &MoveModuleEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_move_module(api, event))
@@ -303,7 +305,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_drop_node(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_drop_node(api, event))
@@ -311,7 +313,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_mark_substate_as_transient(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         node_id: &NodeId,
         partition_number: &PartitionNumber,
         substate_key: &SubstateKey,
@@ -324,7 +326,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_open_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_open_substate(api, event))
@@ -332,7 +334,7 @@ impl SystemModuleMixer {
 
     #[trace_resources(log=event.is_about_heap())]
     pub fn on_read_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_read_substate(api, event))
@@ -340,7 +342,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_write_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_write_substate(api, event))
@@ -348,7 +350,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_close_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &CloseSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_close_substate(api, event))
@@ -356,7 +358,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_set_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &SetSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_set_substate(api, event))
@@ -364,7 +366,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_remove_substate(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &RemoveSubstateEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_remove_substate(api, event))
@@ -372,7 +374,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_scan_keys(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &ScanKeysEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_scan_keys(api, event))
@@ -380,7 +382,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_drain_substates(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &DrainSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(api.kernel_get_system(), on_drain_substates(api, event))
@@ -388,7 +390,7 @@ impl SystemModuleMixer {
 
     #[trace_resources]
     pub fn on_scan_sorted_substates(
-        api: &mut impl SystemModuleApi,
+        api: &mut impl SystemBasedKernelInternalApi,
         event: &ScanSortedSubstatesEvent,
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(

--- a/radix-engine/src/system/system_modules/module_mixer.rs
+++ b/radix-engine/src/system/system_modules/module_mixer.rs
@@ -87,14 +87,14 @@ pub struct SystemModuleMixer {
 macro_rules! internal_call_dispatch {
     (
         $system:expr,
-        $fn:ident ( $($param:ident),* )
+        $fn:ident ( $($param:expr),* )
         $(, PRIVILEGED: {
-            $(kernel_trace: $privileged_kernel_trace_fn:ident ( $($privileged_kernel_trace_fn_param:ident),* ),)?
-            $(limits: $privileged_limits_fn:ident ( $($privileged_limits_fn_param:ident),* ),)?
-            $(costing: $privileged_costing_fn:ident ( $($privileged_costing_fn_param:ident),* ),)?
-            $(auth: $privileged_auth_fn:ident ( $($privileged_auth_fn_param:ident),* ),)?
-            $(runtime: $privileged_runtime_fn:ident ( $($privileged_runtime_fn_param:ident),* ),)?
-            $(execution_trace: $privileged_execution_trace_fn:ident ( $($privileged_execution_trace_fn_param:ident),* ),)?
+            $(kernel_trace: $privileged_kernel_trace_fn:ident ( $($privileged_kernel_trace_fn_param:expr),* ),)?
+            $(limits: $privileged_limits_fn:ident ( $($privileged_limits_fn_param:expr),* ),)?
+            $(costing: $privileged_costing_fn:ident ( $($privileged_costing_fn_param:expr),* ),)?
+            $(auth: $privileged_auth_fn:ident ( $($privileged_auth_fn_param:expr),* ),)?
+            $(runtime: $privileged_runtime_fn:ident ( $($privileged_runtime_fn_param:expr),* ),)?
+            $(execution_trace: $privileged_execution_trace_fn:ident ( $($privileged_execution_trace_fn_param:expr),* ),)?
         })?
     ) => {
         paste! {
@@ -238,7 +238,7 @@ impl SystemModuleMixer {
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(
             api.kernel_get_system(),
-            before_invoke(api, invocation),
+            before_invoke(&mut api.system_module_api(), invocation),
             PRIVILEGED: {
                 costing: privileged_before_invoke(api, invocation),
             }
@@ -249,7 +249,10 @@ impl SystemModuleMixer {
     pub fn on_execution_start(
         api: &mut impl SystemBasedKernelInternalApi,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_execution_start(api))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_execution_start(&mut api.system_module_api())
+        )
     }
 
     #[trace_resources]
@@ -257,7 +260,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         message: &CallFrameMessage,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_execution_finish(api, message))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_execution_finish(&mut api.system_module_api(), message)
+        )
     }
 
     #[trace_resources]
@@ -265,7 +271,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         output: &IndexedScryptoValue,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), after_invoke(api, output))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            after_invoke(&mut api.system_module_api(), output)
+        )
     }
 
     #[trace_resources]
@@ -273,7 +282,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         node_id: &NodeId,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_pin_node(api, node_id))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_pin_node(&mut api.system_module_api(), node_id)
+        )
     }
 
     #[trace_resources(log=entity_type)]
@@ -283,7 +295,7 @@ impl SystemModuleMixer {
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(
             api.kernel_get_system(),
-            on_allocate_node_id(api, entity_type)
+            on_allocate_node_id(&mut api.system_module_api(), entity_type)
         )
     }
 
@@ -292,7 +304,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &CreateNodeEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_create_node(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_create_node(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -300,7 +315,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &MoveModuleEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_move_module(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_move_module(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -308,7 +326,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &DropNodeEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_drop_node(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_drop_node(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -320,7 +341,12 @@ impl SystemModuleMixer {
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(
             api.kernel_get_system(),
-            on_mark_substate_as_transient(api, node_id, partition_number, substate_key)
+            on_mark_substate_as_transient(
+                &mut api.system_module_api(),
+                node_id,
+                partition_number,
+                substate_key
+            )
         )
     }
 
@@ -329,7 +355,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &OpenSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_open_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_open_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources(log=event.is_about_heap())]
@@ -337,7 +366,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &ReadSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_read_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_read_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -345,7 +377,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &WriteSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_write_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_write_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -353,7 +388,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &CloseSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_close_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_close_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -361,7 +399,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &SetSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_set_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_set_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -369,7 +410,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &RemoveSubstateEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_remove_substate(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_remove_substate(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -377,7 +421,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &ScanKeysEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_scan_keys(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_scan_keys(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -385,7 +432,10 @@ impl SystemModuleMixer {
         api: &mut impl SystemBasedKernelInternalApi,
         event: &DrainSubstatesEvent,
     ) -> Result<(), RuntimeError> {
-        internal_call_dispatch!(api.kernel_get_system(), on_drain_substates(api, event))
+        internal_call_dispatch!(
+            api.kernel_get_system(),
+            on_drain_substates(&mut api.system_module_api(), event)
+        )
     }
 
     #[trace_resources]
@@ -395,7 +445,7 @@ impl SystemModuleMixer {
     ) -> Result<(), RuntimeError> {
         internal_call_dispatch!(
             api.kernel_get_system(),
-            on_scan_sorted_substates(api, event)
+            on_scan_sorted_substates(&mut api.system_module_api(), event)
         )
     }
 }

--- a/radix-engine/src/system/system_modules/transaction_runtime/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_runtime/module.rs
@@ -1,5 +1,5 @@
 use crate::internal_prelude::*;
-use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::module::*;
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use radix_common::crypto::Hash;

--- a/radix-engine/src/system/system_modules/transaction_runtime/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_runtime/module.rs
@@ -110,6 +110,7 @@ impl ResolvableSystemModule for TransactionRuntimeModule {
         &mut system.modules.transaction_runtime
     }
 }
+impl PrivilegedSystemModule for TransactionRuntimeModule {}
 impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for TransactionRuntimeModule {}
 
 #[cfg(test)]

--- a/radix-engine/src/system/system_modules/transaction_runtime/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_runtime/module.rs
@@ -1,6 +1,6 @@
 use crate::internal_prelude::*;
-use crate::kernel::kernel_callback_api::KernelCallbackObject;
 use crate::system::module::{InitSystemModule, SystemModule};
+use crate::system::system_callback::*;
 use radix_common::crypto::Hash;
 use radix_engine_interface::api::actor_api::EventFlags;
 use radix_engine_interface::api::ModuleId;
@@ -104,7 +104,7 @@ impl TransactionRuntimeModule {
 }
 
 impl InitSystemModule for TransactionRuntimeModule {}
-impl<K: KernelCallbackObject> SystemModule<K> for TransactionRuntimeModule {}
+impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for TransactionRuntimeModule {}
 
 #[cfg(test)]
 mod tests {

--- a/radix-engine/src/system/system_modules/transaction_runtime/module.rs
+++ b/radix-engine/src/system/system_modules/transaction_runtime/module.rs
@@ -1,6 +1,7 @@
 use crate::internal_prelude::*;
 use crate::system::module::{InitSystemModule, SystemModule};
 use crate::system::system_callback::*;
+use crate::system::system_callback_api::SystemCallbackObject;
 use radix_common::crypto::Hash;
 use radix_engine_interface::api::actor_api::EventFlags;
 use radix_engine_interface::api::ModuleId;
@@ -104,7 +105,12 @@ impl TransactionRuntimeModule {
 }
 
 impl InitSystemModule for TransactionRuntimeModule {}
-impl<ModuleApi: SystemModuleApi> SystemModule<ModuleApi> for TransactionRuntimeModule {}
+impl ResolvableSystemModule for TransactionRuntimeModule {
+    fn resolve_from_system<V: SystemCallbackObject, E>(system: &mut System<V, E>) -> &mut Self {
+        &mut system.modules.transaction_runtime
+    }
+}
+impl<ModuleApi: SystemModuleApiFor<Self>> SystemModule<ModuleApi> for TransactionRuntimeModule {}
 
 #[cfg(test)]
 mod tests {

--- a/radix-engine/src/system/system_type_checker.rs
+++ b/radix-engine/src/system/system_type_checker.rs
@@ -1,10 +1,8 @@
 use super::payload_validation::*;
 use crate::errors::{RuntimeError, SystemError};
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::KernelApi;
 use crate::system::system::SystemService;
-use crate::system::system_callback::{System, SystemLockData};
-use crate::system::system_callback_api::SystemCallbackObject;
+use crate::system::system_callback::*;
 use crate::system::system_substates::{FieldSubstate, KeyValueEntrySubstate, LockStatus};
 use crate::track::interface::NodeSubstates;
 use radix_blueprint_schema_init::KeyValueStoreGenericSubstitutions;
@@ -55,7 +53,7 @@ pub enum TypeCheckError {
     MissingSchema,
 }
 
-impl<'a, Y: KernelApi<System<V, E>>, V: SystemCallbackObject, E> SystemService<'a, Y, V, E> {
+impl<'a, Y: SystemBasedKernelApi> SystemService<'a, Y> {
     /// Validate that the type substitutions match the generic definition of a given blueprint
     pub fn validate_bp_generic_args(
         &mut self,

--- a/radix-engine/src/system/system_type_checker.rs
+++ b/radix-engine/src/system/system_type_checker.rs
@@ -375,17 +375,12 @@ impl<'a, Y: SystemBasedKernelApi> SystemService<'a, Y> {
         node_id: &NodeId,
         schema_hash: &SchemaHash,
     ) -> Result<Rc<VersionedScryptoSchema>, RuntimeError> {
-        let def = self
-            .api
-            .kernel_get_system_state()
-            .system
-            .schema_cache
-            .get(schema_hash);
+        let def = self.system().schema_cache.get(schema_hash);
         if let Some(schema) = def {
             return Ok(schema.clone());
         }
 
-        let handle = self.api.kernel_open_substate_with_default(
+        let handle = self.api().kernel_open_substate_with_default(
             node_id,
             SCHEMAS_PARTITION,
             &SubstateKey::Map(scrypto_encode(schema_hash).unwrap()),
@@ -398,14 +393,12 @@ impl<'a, Y: SystemBasedKernelApi> SystemService<'a, Y> {
         )?;
 
         let substate: KeyValueEntrySubstate<VersionedScryptoSchema> =
-            self.api.kernel_read_substate(handle)?.as_typed().unwrap();
-        self.api.kernel_close_substate(handle)?;
+            self.api().kernel_read_substate(handle)?.as_typed().unwrap();
+        self.api().kernel_close_substate(handle)?;
 
         let schema = Rc::new(substate.into_value().unwrap());
 
-        self.api
-            .kernel_get_system_state()
-            .system
+        self.system()
             .schema_cache
             .insert(schema_hash.clone(), schema.clone());
 

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -131,12 +131,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
                 .unwrap_or_else(|| panic!("Vm type not found: {:?}", export))
         };
 
-        let vm_api = api
-            .kernel_get_system_state()
-            .system
-            .callback
-            .vm_boot
-            .clone();
+        let vm_api = api.system().callback.vm_boot.clone();
 
         let output = match vm_type.fully_update_and_into_latest_version().vm_type {
             VmType::Native => {
@@ -163,7 +158,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
                         .unwrap_or_else(|| panic!("Original code not found: {:?}", export))
                 };
 
-                let mut vm_instance = api.kernel_get_system().callback.native_vm.create_instance(
+                let mut vm_instance = api.system().callback.native_vm.create_instance(
                     address,
                     &original_code.fully_update_and_into_latest_version().code,
                 )?;
@@ -198,7 +193,7 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
                 };
 
                 let mut scrypto_vm_instance = {
-                    api.kernel_get_system().callback.scrypto_vm.create_instance(
+                    api.system().callback.scrypto_vm.create_instance(
                         address,
                         export.code_hash,
                         &instrumented_code.instrumented_code,

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -1,8 +1,8 @@
 use crate::blueprints::package::*;
 use crate::errors::{ApplicationError, RuntimeError};
 use crate::internal_prelude::*;
-use crate::kernel::kernel_api::{KernelInternalApi, KernelNodeApi, KernelSubstateApi};
-use crate::system::system_callback::{System, SystemLockData};
+use crate::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
+use crate::system::system_callback::{SystemLockData, SystemModuleApi};
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::system::system_substates::KeyValueEntrySubstate;
 use crate::track::BootStore;
@@ -100,10 +100,9 @@ impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'
 
     fn invoke<
         Y: SystemApi<RuntimeError>
-            + KernelInternalApi<System<Self, T>>
+            + SystemModuleApi<SystemCallback = Self>
             + KernelNodeApi
             + KernelSubstateApi<SystemLockData>,
-        T,
     >(
         address: &PackageAddress,
         export: PackageExport,

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -351,7 +351,7 @@ where
         {
             // Creating the auth zone of the next call-frame
             let auth_zone = env.0.with_kernel_mut(|kernel| {
-                let mut system_service = SystemService { api: kernel };
+                let mut system_service = SystemService::new(kernel);
                 AuthModule::on_call_fn_mock(
                     &mut system_service,
                     Some((TRANSACTION_PROCESSOR_PACKAGE.as_node_id(), false)),

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -351,10 +351,7 @@ where
         {
             // Creating the auth zone of the next call-frame
             let auth_zone = env.0.with_kernel_mut(|kernel| {
-                let mut system_service = SystemService {
-                    api: kernel,
-                    phantom: PhantomData,
-                };
+                let mut system_service = SystemService { api: kernel };
                 AuthModule::on_call_fn_mock(
                     &mut system_service,
                     Some((TRANSACTION_PROCESSOR_PACKAGE.as_node_id(), false)),

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -825,10 +825,10 @@ where
         O: ScryptoEncode,
     {
         let object_info = self.0.with_kernel_mut(|kernel| {
-            SystemService { api: kernel }.get_object_info(&node_id.into())
+            SystemService::new(kernel).get_object_info(&node_id.into())
         })?;
         let auth_zone = self.0.with_kernel_mut(|kernel| {
-            let mut system_service = SystemService { api: kernel };
+            let mut system_service = SystemService::new(kernel);
             AuthModule::on_call_fn_mock(
                 &mut system_service,
                 Some((&node_id.into(), false)),

--- a/scrypto-test/src/environment/env.rs
+++ b/scrypto-test/src/environment/env.rs
@@ -825,17 +825,10 @@ where
         O: ScryptoEncode,
     {
         let object_info = self.0.with_kernel_mut(|kernel| {
-            SystemService {
-                api: kernel,
-                phantom: PhantomData,
-            }
-            .get_object_info(&node_id.into())
+            SystemService { api: kernel }.get_object_info(&node_id.into())
         })?;
         let auth_zone = self.0.with_kernel_mut(|kernel| {
-            let mut system_service = SystemService {
-                api: kernel,
-                phantom: PhantomData,
-            };
+            let mut system_service = SystemService { api: kernel };
             AuthModule::on_call_fn_mock(
                 &mut system_service,
                 Some((&node_id.into(), false)),

--- a/scrypto-test/src/environment/system_api.rs
+++ b/scrypto-test/src/environment/system_api.rs
@@ -64,7 +64,6 @@ macro_rules! implement_system_api {
                         let rtn = self.0.with_kernel_mut(|kernel| {
                             SystemService {
                                 api: kernel,
-                                phantom: PhantomData,
                             }.$func_ident( $($input_ident),* )
                         });
 

--- a/scrypto-test/src/environment/system_api.rs
+++ b/scrypto-test/src/environment/system_api.rs
@@ -62,9 +62,7 @@ macro_rules! implement_system_api {
                         });
 
                         let rtn = self.0.with_kernel_mut(|kernel| {
-                            SystemService {
-                                api: kernel,
-                            }.$func_ident( $($input_ident),* )
+                            SystemService::new(kernel).$func_ident( $($input_ident),* )
                         });
 
                         self.0.with_kernel_mut(|kernel| {

--- a/scrypto-test/src/environment/types.rs
+++ b/scrypto-test/src/environment/types.rs
@@ -7,4 +7,4 @@ pub type TestVm<'g> = Vm<'g, DefaultWasmEngine, NoExtension>;
 pub type TestTrack<'g, D> = Track<'g, D, SpreadPrefixKeyMapper>;
 pub type TestSystemConfig<'g> = System<TestVm<'g>, ()>;
 pub type TestKernel<'g, D> = Kernel<'g, TestSystemConfig<'g>, TestTrack<'g, D>>;
-pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>, TestVm<'g>, ()>;
+pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>>;

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -2,24 +2,13 @@ use radix_common::prelude::*;
 use radix_engine::errors::{RejectionReason, TransactionExecutionError};
 use radix_engine::errors::{RuntimeError, SystemModuleError};
 use radix_engine::kernel::call_frame::{CallFrameInit, CallFrameMessage, NodeVisibility};
-use radix_engine::kernel::kernel_api::{
-    DroppedNode, KernelApi, KernelInternalApi, KernelInvocation, KernelInvokeApi, KernelNodeApi,
-    KernelSubstateApi, SystemState,
-};
-use radix_engine::kernel::kernel_callback_api::{
-    CloseSubstateEvent, CreateNodeEvent, DrainSubstatesEvent, DropNodeEvent, KernelCallbackObject,
-    KernelTransactionCallbackObject, MoveModuleEvent, OpenSubstateEvent, ReadSubstateEvent,
-    RemoveSubstateEvent, ScanKeysEvent, ScanSortedSubstatesEvent, SetSubstateEvent,
-    WriteSubstateEvent,
-};
+use radix_engine::kernel::kernel_api::*;
+use radix_engine::kernel::kernel_callback_api::*;
 use radix_engine::system::actor::Actor;
 use radix_engine::system::system_callback::{System, SystemInit, SystemLockData};
 use radix_engine::system::system_callback_api::SystemCallbackObject;
 use radix_engine::system::system_modules::costing::{CostingError, FeeReserveError, OnApplyCost};
-use radix_engine::system::system_modules::execution_trace::{BucketSnapshot, ProofSnapshot};
-use radix_engine::track::{
-    BootStore, CommitableSubstateStore, NodeSubstates, StoreCommitInfo, Track,
-};
+use radix_engine::track::*;
 use radix_engine::transaction::TransactionReceipt;
 use radix_engine::vm::wasm::DefaultWasmEngine;
 use radix_engine::vm::Vm;
@@ -525,12 +514,14 @@ impl<'a, M: SystemCallbackObject, K: KernelApi<CallbackObject = InjectCostingErr
         self.api.kernel_get_node_visibility(node_id)
     }
 
-    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        self.api.kernel_read_bucket(bucket_id)
-    }
-
-    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        self.api.kernel_read_proof(proof_id)
+    fn kernel_read_substate_uncosted(
+        &self,
+        node_id: &NodeId,
+        partition_num: PartitionNumber,
+        substate_key: &SubstateKey,
+    ) -> Option<&IndexedScryptoValue> {
+        self.api
+            .kernel_read_substate_uncosted(node_id, partition_num, substate_key)
     }
 }
 
@@ -570,11 +561,13 @@ impl<'a, M: SystemCallbackObject, K: KernelInternalApi<System = InjectCostingErr
         self.api.kernel_get_node_visibility(node_id)
     }
 
-    fn kernel_read_bucket(&self, bucket_id: &NodeId) -> Option<BucketSnapshot> {
-        self.api.kernel_read_bucket(bucket_id)
-    }
-
-    fn kernel_read_proof(&self, proof_id: &NodeId) -> Option<ProofSnapshot> {
-        self.api.kernel_read_proof(proof_id)
+    fn kernel_read_substate_uncosted(
+        &self,
+        node_id: &NodeId,
+        partition_num: PartitionNumber,
+        substate_key: &SubstateKey,
+    ) -> Option<&IndexedScryptoValue> {
+        self.api
+            .kernel_read_substate_uncosted(node_id, partition_num, substate_key)
     }
 }


### PR DESCRIPTION
## Summary

Refactors the Engine traits for much better encapsulation, notably:

* Using associated types to capture things like the callbacks and the errors
* Introduced `SystemBasedKernelApi` trait to capture "a Kernel API which knows its callback is System", and can therefore access both Kernel API and System APIs.
* Creating a new `SystemModuleApi` trait, to abstract away the kernel from system modules
* Made the `KernelCallbackObject` trait more consistent:
  * By having each property take an API (either a KernelInternalApi, or in some cases, a KernelApi).
  * By moving all the api parameters to the end

I toyed with getting rid of a `SystemService` struct, and replacing it with a `SystemServiceApi` trait... but when you try to do `impl<Y: SystemBasedKernelApi> SystemFieldApi<RuntimeError> for Y` you get this painful trait coherency error: https://stackoverflow.com/a/63131661 - so I aborted that attempt, and added comments to prevent anyone trying again in such a foolhardy manner!

## In the future

* I would like to do some renames:
  * `KernelCallbackObject` => `S: SystemKernelHooks` (which I think is a better name, as [they're not callbacks](https://stackoverflow.com/questions/467557/what-is-meant-by-the-term-hook-in-programming))
  * `KernelInternalApi` => `KernelModuleApi`
  * `SystemCallbackObject` => `V: VmSystemHooks`
* And some file renames:
  * `system.rs` => `system_service.rs`
  * `system_callback.rs` => `system.rs`
  * `kernel_callback_api.rs` => `system_kernel_hooks_api.rs`
  * `system_callback_api.rs` => `vm_system_hooks_api.rs`

## Testing
N/A - just a refactor - current tests should hold.

