### PR TITLE
fix: LedgerSimulator disables kernel trace by default

### DIFF
--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -282,7 +282,7 @@ fn bench_deserialize_wasm(c: &mut Criterion) {
 }
 
 fn bench_prepare_wasm(c: &mut Criterion) {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let code =
         include_workspace_asset_bytes!("radix-transaction-scenarios", "radiswap.wasm").to_vec();
     let package_definition: PackageDefinition = manifest_decode(include_workspace_asset_bytes!(
@@ -304,7 +304,7 @@ fn bench_prepare_wasm(c: &mut Criterion) {
 }
 
 fn bench_execute_transaction_creating_big_vec_substates(c: &mut Criterion) {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let (code, definition) = PackageLoader::get("transaction_limits");
     let package_address =
@@ -337,7 +337,7 @@ fn bench_execute_transaction_creating_big_vec_substates(c: &mut Criterion) {
 }
 
 fn bench_execute_transaction_reading_big_vec_substates(c: &mut Criterion) {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let (code, definition) = PackageLoader::get("transaction_limits");
     let package_address =

--- a/radix-engine-tests/benches/radiswap.rs
+++ b/radix-engine-tests/benches/radiswap.rs
@@ -38,10 +38,9 @@ fn bench_radiswap(c: &mut Criterion) {
         .with_custom_database(RocksDBWithMerkleTreeSubstateStore::clear(PathBuf::from(
             "/tmp/radiswap",
         )))
-        .without_kernel_trace()
         .build();
     #[cfg(not(feature = "rocksdb"))]
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     // Create account and publish package
     let (pk, _, account) = ledger.new_allocated_account();

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -363,7 +363,7 @@ fn test_manifest_with_restricted_minting_resource<F>(
     ) -> (String, Vec<Vec<u8>>),
 {
     // Creating a new test runner
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     // Creating the account component required for this test
     let (public_key, _, component_address) = ledger.new_account(false);
@@ -441,7 +441,7 @@ where
     F: Fn(&ComponentAddress, &[ComponentAddress], &AddressBech32Encoder) -> (String, Vec<Vec<u8>>),
 {
     // Creating a new test runner
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     // Creating the account component required for this test
     let (public_key, _, component_address) = ledger.new_account(false);

--- a/radix-engine-tests/tests/application/metering.rs
+++ b/radix-engine-tests/tests/application/metering.rs
@@ -39,7 +39,7 @@ fn run_all(mode: CostingTaskMode) {
                             file: &'static str| {
             let ledger = LedgerSimulatorBuilder::new()
                 .with_custom_protocol(|builder| builder.from_bootstrap_to(protocol_version))
-                .without_kernel_trace()
+                
                 .build();
             let receipt = run(ledger);
             let relative_file_path = format!("{}/{}", protocol_version.logical_name(), file);

--- a/radix-engine-tests/tests/application/preview.rs
+++ b/radix-engine-tests/tests/application/preview.rs
@@ -9,7 +9,7 @@ use radix_transactions::validation::{TransactionValidator, ValidationConfig};
 
 #[test]
 fn test_preview_invalid_direct_access() {
-    let mut sim = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut sim = LedgerSimulatorBuilder::new().build();
     let (public_key, _, _) = sim.new_allocated_account();
 
     let manifest = ManifestBuilder::new()
@@ -229,7 +229,7 @@ fn test_preview_no_auth() {
 #[test]
 fn notary_key_is_in_initial_proofs_when_notary_as_signatory_is_true() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(true);
     let current_epoch = ledger.get_current_epoch();
 
@@ -274,7 +274,7 @@ fn notary_key_is_in_initial_proofs_when_notary_as_signatory_is_true() {
 #[test]
 fn notary_key_is_not_in_initial_proofs_when_notary_as_signatory_is_false() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(true);
     let current_epoch = ledger.get_current_epoch();
 

--- a/radix-engine-tests/tests/application/stake_reconciliation.rs
+++ b/radix-engine-tests/tests/application/stake_reconciliation.rs
@@ -19,6 +19,7 @@ fn test_stake_reconciliation() {
     // Arrange
     let pub_key = Secp256k1PrivateKey::from_u64(1u64).unwrap().public_key();
     let mut ledger = LedgerSimulatorBuilder::new()
+        .with_kernel_trace()
         .with_custom_protocol(|builder| builder
             .configure_babylon(|_| BabylonSettings::test_minimal())
             .only_babylon()

--- a/radix-engine-tests/tests/application/storage.rs
+++ b/radix-engine-tests/tests/application/storage.rs
@@ -5,7 +5,7 @@ use scrypto_test::prelude::*;
 #[test]
 fn test_kv_store_with_many_large_keys() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(PackageLoader::get("storage"));
 
     // Act

--- a/radix-engine-tests/tests/blueprints/access_controller.rs
+++ b/radix-engine-tests/tests/blueprints/access_controller.rs
@@ -1651,7 +1651,7 @@ struct AccessControllerLedgerSimulator {
 impl AccessControllerLedgerSimulator {
     pub fn new(timed_recovery_delay_in_minutes: Option<u32>) -> Self {
         let mut ledger = LedgerSimulatorBuilder::new()
-            .without_kernel_trace()
+            
             .build();
 
         // Creating a new account - this is where the badges will be held

--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -463,7 +463,7 @@ struct AccountDepositModesLedgerSimulator {
 
 impl AccountDepositModesLedgerSimulator {
     pub fn new(preallocated_account: bool) -> Self {
-        let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+        let mut ledger = LedgerSimulatorBuilder::new().build();
         let (public_key, _, component_address) = ledger.new_account(preallocated_account);
 
         Self {

--- a/radix-engine-tests/tests/blueprints/account_locker.rs
+++ b/radix-engine-tests/tests/blueprints/account_locker.rs
@@ -15,7 +15,7 @@ use scrypto_test::ledger_simulator::*;
 fn account_locker_cant_be_instantiated_before_protocol_update() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
-        .without_kernel_trace()
+        
         .with_custom_protocol(|builder| builder.from_bootstrap_to(ProtocolVersion::Anemone))
         .build();
     let (_, _, account) = ledger.new_account(false);
@@ -49,7 +49,7 @@ fn account_locker_cant_be_instantiated_before_protocol_update() {
 #[test]
 fn account_locker_can_be_instantiated_after_protocol_update() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     // Act
@@ -76,7 +76,7 @@ fn account_locker_can_be_instantiated_after_protocol_update() {
 #[test]
 fn account_locker_has_an_account_locker_entity_type() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     // Act
@@ -112,7 +112,7 @@ fn account_locker_has_an_account_locker_entity_type() {
 #[test]
 fn account_locker_component_address_have_the_expected_bech32m_encoding() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     // Act
@@ -148,7 +148,7 @@ fn account_locker_component_address_have_the_expected_bech32m_encoding() {
 #[test]
 fn store_can_only_be_called_by_storer_role() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -226,7 +226,7 @@ fn store_can_only_be_called_by_storer_role() {
 #[test]
 fn airdrop_can_only_be_called_by_storer_role() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -304,7 +304,7 @@ fn airdrop_can_only_be_called_by_storer_role() {
 #[test]
 fn recover_can_only_be_called_by_recoverer_role() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -379,7 +379,7 @@ fn recover_can_only_be_called_by_recoverer_role() {
 #[test]
 fn recover_non_fungibles_can_only_be_called_by_recoverer_role() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -455,7 +455,7 @@ fn recover_non_fungibles_can_only_be_called_by_recoverer_role() {
 fn send_or_store_stores_the_resources_if_the_account_rejects_the_deposit_and_the_locker_is_not_and_authorized_depositor(
 ) {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (user_account_public_key, _, user_account) = ledger.new_account(false);
 
@@ -551,7 +551,7 @@ fn send_or_store_stores_the_resources_if_the_account_rejects_the_deposit_and_the
 #[test]
 fn send_or_store_sends_the_resources_if_the_locker_is_an_authorized_depositor() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (user_account_public_key, _, user_account) = ledger.new_account(false);
 
@@ -654,7 +654,7 @@ fn send_or_store_sends_the_resources_if_the_locker_is_an_authorized_depositor() 
 #[test]
 fn claim_is_public_and_callable_by_all() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -729,7 +729,7 @@ fn claim_is_public_and_callable_by_all() {
 #[test]
 fn claim_non_fungibles_is_public_and_callable_by_all() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
 
     let [owner_badge, storer_badge, recoverer_badge] =
@@ -804,7 +804,7 @@ fn claim_non_fungibles_is_public_and_callable_by_all() {
 #[test]
 fn an_account_can_claim_its_resources_from_the_account_locker() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (user_account1_public_key, _, user_account1) = ledger.new_account(false);
 
@@ -902,7 +902,7 @@ fn an_account_can_claim_its_resources_from_the_account_locker() {
 #[test]
 fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (_, _, user_account1) = ledger.new_account(false);
     let (user_account2_public_key, _, _) = ledger.new_account(false);
@@ -1002,7 +1002,7 @@ fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
 #[test]
 fn account_locker_admin_can_recover_resources_from_an_account_locker() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (_, _, user_account1) = ledger.new_account(false);
 
@@ -1101,7 +1101,7 @@ fn account_locker_admin_can_recover_resources_from_an_account_locker() {
 #[test]
 fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disabled() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (_, _, user_account1) = ledger.new_account(false);
 
@@ -1203,7 +1203,7 @@ fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disab
 #[test]
 fn get_amount_method_reports_the_correct_amount_in_the_vault() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (_, _, user_account1) = ledger.new_account(false);
 
@@ -1294,7 +1294,7 @@ fn get_amount_method_reports_the_correct_amount_in_the_vault() {
 #[test]
 fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
     let (_, _, user_account1) = ledger.new_account(false);
 
@@ -1395,7 +1395,7 @@ fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
 
 #[test]
 fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
 
     let [(user_account1_public_key, _, user_account1), (user_account2_public_key, _, user_account2), (user_account3_public_key, _, user_account3)] =
@@ -3062,7 +3062,7 @@ pub impl DefaultLedgerSimulator {
 #[test]
 fn send_does_not_accept_an_address_that_is_not_an_account() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
 
     let (account_locker, account_locker_badge) = {
@@ -3145,7 +3145,7 @@ fn send_does_not_accept_an_address_that_is_not_an_account() {
 #[test]
 fn airdrop_does_not_accept_an_address_that_is_not_an_account() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
 
     let (account_locker, account_locker_badge) = {
@@ -3230,7 +3230,7 @@ fn airdrop_does_not_accept_an_address_that_is_not_an_account() {
 #[test]
 fn claim_does_not_accept_an_address_that_is_not_an_account() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
 
     let (account_locker, account_locker_badge) = {
@@ -3309,7 +3309,7 @@ fn claim_does_not_accept_an_address_that_is_not_an_account() {
 #[test]
 fn recover_does_not_accept_an_address_that_is_not_an_account() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (badge_holder_account_public_key, _, badge_holder_account) = ledger.new_account(false);
 
     let (account_locker, account_locker_badge) = {
@@ -3388,7 +3388,7 @@ fn recover_does_not_accept_an_address_that_is_not_an_account() {
 #[test]
 fn exceeding_one_of_the_limits_when_airdropping_returns_the_expected_error() {
     for airdrops in 1u64.. {
-        let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+        let mut ledger = LedgerSimulatorBuilder::new().build();
         let (pk, _, account) = ledger.new_account(false);
 
         let keys_and_accounts = (1..=airdrops)

--- a/radix-engine-tests/tests/blueprints/non_fungible.rs
+++ b/radix-engine-tests/tests/blueprints/non_fungible.rs
@@ -1399,7 +1399,7 @@ fn cant_create_non_fungible_with_id_type_does_not_match() {
 #[test]
 fn test_non_fungible_global_id() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(PackageLoader::get("resource"));
 
     // Act

--- a/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
@@ -406,7 +406,7 @@ fn contributing_tokens_that_do_not_belong_to_pool_fails() {
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     let non_fungible_resource = ledger.create_non_fungible_resource(account);
@@ -822,7 +822,7 @@ impl<const N: usize> TestEnvironment<N> {
     }
 
     pub fn new_with_owner(divisibility: [u8; N], owner_role: OwnerRole) -> Self {
-        let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+        let mut ledger = LedgerSimulatorBuilder::new().build();
         let (public_key, _, account) = ledger.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/blueprints/pool_one_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_one_resource.rs
@@ -437,7 +437,7 @@ fn protected_deposit_into_the_pool_increases_how_much_resources_the_pool_units_a
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     let non_fungible_resource = ledger.create_non_fungible_resource(account);
@@ -712,7 +712,7 @@ impl TestEnvironment {
     }
 
     fn new_with_owner(divisibility: u8, owner_role: OwnerRole) -> Self {
-        let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+        let mut ledger = LedgerSimulatorBuilder::new().build();
         let (public_key, _, account) = ledger.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/blueprints/pool_two_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_two_resource.rs
@@ -426,7 +426,7 @@ fn contributing_tokens_that_do_not_belong_to_the_pool_fails() {
 #[test]
 fn creating_a_pool_with_non_fungible_resources_fails() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     let non_fungible_resource = ledger.create_non_fungible_resource(account);
@@ -994,7 +994,7 @@ impl TestEnvironment {
     }
 
     pub fn new_with_owner((divisibility1, divisibility2): (u8, u8), owner_role: OwnerRole) -> Self {
-        let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+        let mut ledger = LedgerSimulatorBuilder::new().build();
         let (public_key, _, account) = ledger.new_account(false);
         let virtual_signature_badge = NonFungibleGlobalId::from_public_key(&public_key);
 

--- a/radix-engine-tests/tests/db/substate_database_overlay.rs
+++ b/radix-engine-tests/tests/db/substate_database_overlay.rs
@@ -378,7 +378,7 @@ fn substates_written_on_a_staging_database_from_transactions_can_be_read_later()
     let database = SubstateDatabaseOverlay::new_unmergeable(&root_database);
     let mut ledger = LedgerSimulatorBuilder::new()
         .with_custom_database(database)
-        .without_kernel_trace()
+        
         .build();
 
     let (public_key1, _, account1) = ledger.new_account(false);
@@ -486,7 +486,7 @@ fn run_scenarios_in_memory_and_on_overlay(
         LedgerSimulatorBuilder::new()
             .with_custom_database(overlay)
             .with_custom_protocol(|builder| builder.unbootstrapped())
-            .without_kernel_trace()
+            
             .build(),
     ));
     let network_definition = NetworkDefinition::simulator();

--- a/radix-engine-tests/tests/flash/access_controller.rs
+++ b/radix-engine-tests/tests/flash/access_controller.rs
@@ -30,7 +30,7 @@ fn access_controller_package_definition_v1_0_matches_expected() {
 fn access_controller_instantiated_before_protocol_update_has_v1_state() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
-        .without_kernel_trace()
+        
         .with_custom_protocol(|builder| builder.only_babylon())
         .build();
 
@@ -68,7 +68,7 @@ fn access_controller_instantiated_before_protocol_update_has_v1_state() {
 #[test]
 fn access_controller_instantiated_after_protocol_update_has_v2_state() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let access_controller = ledger
         .execute_manifest(
@@ -227,7 +227,7 @@ fn before_protocol_update_calling_any_method_on_an_access_controller_with_v1_sta
 
     for (method_name, args) in invocations {
         let mut ledger = LedgerSimulatorBuilder::new()
-            .without_kernel_trace()
+            
             .with_custom_protocol(|builder| builder.only_babylon())
             .build();
         let (_, _, account) = ledger.new_account(false);
@@ -497,7 +497,7 @@ fn after_protocol_update_calling_any_method_on_an_access_controller_with_v1_stat
 
     for (method_name, args) in invocations {
         let mut ledger = LedgerSimulatorBuilder::new()
-            .without_kernel_trace()
+            
             .with_custom_protocol(|builder| builder.only_babylon())
             .build();
         let (_, _, account) = ledger.new_account(false);
@@ -630,7 +630,7 @@ fn lock_recovery_fee_is_only_callable_by_primary_recovery_or_confirmation() {
         (Role::Recovery, true),
         (Role::Confirmation, true),
     ];
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_account(false);
 
     let primary_badge_resource = ledger.create_fungible_resource(dec!(1), 0, account);
@@ -735,7 +735,7 @@ fn withdraw_recovery_fee_is_only_callable_by_primary() {
         (Role::Recovery, false),
         (Role::Confirmation, false),
     ];
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_account(false);
 
     let primary_badge_resource = ledger.create_fungible_resource(dec!(1), 0, account);
@@ -835,7 +835,7 @@ fn withdraw_recovery_fee_is_only_callable_by_primary() {
 #[test]
 fn contribute_recovery_fee_is_callable_without_auth() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let access_controller = ledger
         .execute_manifest(
@@ -883,7 +883,7 @@ fn contribute_recovery_fee_is_callable_without_auth() {
 #[test]
 fn deposit_event_is_emitted_when_recovery_xrd_is_contributed() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let access_controller = ledger
         .execute_manifest(
@@ -959,7 +959,7 @@ fn deposit_event_is_emitted_when_recovery_xrd_is_contributed() {
 #[test]
 fn withdraw_event_is_emitted_when_recovery_xrd_is_withdrawn() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     let access_controller = ledger
@@ -1046,7 +1046,7 @@ fn withdraw_event_is_emitted_when_recovery_xrd_is_withdrawn() {
 #[test]
 fn fees_can_be_locked_from_an_access_controller_with_a_badge_primary_role() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_account(false);
 
     let primary_badge_resource = ledger.create_fungible_resource(dec!(1), 0, account);

--- a/radix-engine-tests/tests/flash/account.rs
+++ b/radix-engine-tests/tests/flash/account.rs
@@ -5,7 +5,7 @@ use scrypto_test::prelude::*;
 fn before_protocol_update_try_deposit_or_refund_fails_if_claimed_authorized_depositor_is_not_one() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
-        .without_kernel_trace()
+        
         .with_custom_protocol(|builder| builder.only_babylon())
         .build();
     let (user_public_key, _, user_account) = ledger.new_account(false);
@@ -52,7 +52,7 @@ fn after_protocol_update_try_deposit_or_refund_refunds_resources_if_claimed_auth
 ) {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
-        .without_kernel_trace()
+        
         .build();
     let (user_public_key, _, user_account) = ledger.new_account(false);
 

--- a/radix-engine-tests/tests/flash/pools.rs
+++ b/radix-engine-tests/tests/flash/pools.rs
@@ -11,7 +11,7 @@ fn database_is_consistent_before_and_after_protocol_update() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
         .with_custom_protocol(|builder| builder.only_babylon())
-        .without_kernel_trace()
+        
         .build();
 
     let (pk, _, account) = ledger.new_account(false);
@@ -82,7 +82,7 @@ fn single_sided_contributions_to_two_resource_pool_are_only_allowed_after_protoc
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
         .with_custom_protocol(|builder| builder.only_babylon())
-        .without_kernel_trace()
+        
         .build();
 
     let (pk, _, account) = ledger.new_account(false);
@@ -237,7 +237,7 @@ fn single_sided_contributions_to_multi_resource_pool_are_only_allowed_after_prot
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
         .with_custom_protocol(|builder| builder.only_babylon())
-        .without_kernel_trace()
+        
         .build();
 
     let (pk, _, account) = ledger.new_account(false);

--- a/radix-engine-tests/tests/flash/role_assignment.rs
+++ b/radix-engine-tests/tests/flash/role_assignment.rs
@@ -5,7 +5,7 @@ use scrypto_test::prelude::*;
 fn get_owner_role_method_call_fails_without_the_protocol_update() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new()
-        .without_kernel_trace()
+        
         .with_custom_protocol(|builder| builder.only_babylon())
         .build();
 
@@ -49,7 +49,7 @@ fn get_owner_role_method_call_fails_without_the_protocol_update() {
 #[test]
 fn get_owner_role_method_call_succeeds_with_the_protocol_update1() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     // Act
     let receipt = ledger.execute_manifest(
@@ -78,7 +78,7 @@ fn get_owner_role_method_call_succeeds_with_the_protocol_update1() {
 #[test]
 fn get_owner_role_method_call_succeeds_with_the_protocol_update2() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let account =
         ledger.new_account_advanced(OwnerRole::Fixed(rule!(require_amount(dec!(100), XRD))));
 

--- a/radix-engine-tests/tests/system/auth_account.rs
+++ b/radix-engine-tests/tests/system/auth_account.rs
@@ -338,7 +338,7 @@ fn cannot_set_royalty_on_accounts() {
 #[test]
 fn can_call_function_requiring_count_of_zero() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_account(false);
     let package_address = ledger.publish_package_simple(PackageLoader::get("auth_scenarios"));
 

--- a/radix-engine-tests/tests/system/consensus_manager.rs
+++ b/radix-engine-tests/tests/system/consensus_manager.rs
@@ -392,7 +392,7 @@ fn next_round_after_target_duration_does_not_cause_epoch_change_without_min_roun
 #[test]
 fn create_validator_twice() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_allocated_account();
 
     // Act
@@ -3137,7 +3137,7 @@ fn significant_protocol_updates_are_emitted_in_epoch_change_event() {
     );
     let mut ledger = LedgerSimulatorBuilder::new()
         .with_custom_protocol(|builder| builder.configure_babylon(|_| genesis).from_bootstrap_to_latest())
-        .without_kernel_trace()
+        
         .build();
 
     let validators_addresses: Vec<ComponentAddress> = validators_keys

--- a/radix-engine-tests/tests/system/core.rs
+++ b/radix-engine-tests/tests/system/core.rs
@@ -324,7 +324,7 @@ fn cant_store_role_assignment() {
 
 #[test]
 fn test_globalize_with_very_deep_own() {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(PackageLoader::get("core"));
 
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/system/events.rs
+++ b/radix-engine-tests/tests/system/events.rs
@@ -205,7 +205,7 @@ fn create_proof_emits_correct_events() {
 #[test]
 fn scrypto_cant_emit_unregistered_event() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(PackageLoader::get("events"));
 
     let manifest = ManifestBuilder::new()
@@ -286,7 +286,7 @@ fn scrypto_can_emit_registered_events() {
 #[test]
 fn cant_publish_a_package_with_non_struct_or_enum_event() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let (code, definition) = PackageLoader::get("events_invalid");
     let manifest = ManifestBuilder::new()
@@ -311,7 +311,7 @@ fn cant_publish_a_package_with_non_struct_or_enum_event() {
 #[test]
 fn local_type_id_with_misleading_name_fails() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let (code, mut definition) = PackageLoader::get("events");
     let blueprint_setup = definition.blueprints.get_mut("ScryptoEvents").unwrap();
@@ -352,7 +352,7 @@ fn local_type_id_with_misleading_name_fails() {
 #[test]
 fn locking_fee_against_a_vault_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     let manifest = ManifestBuilder::new().lock_fee(FAUCET, 500).build();
 
@@ -384,7 +384,7 @@ fn locking_fee_against_a_vault_emits_correct_events() {
 #[test]
 fn vault_fungible_recall_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let recallable_resource_address = ledger.create_recallable_token(account);
     let vault_id = ledger.get_component_vaults(account, recallable_resource_address)[0];
@@ -441,7 +441,7 @@ fn vault_fungible_recall_emits_correct_events() {
 #[test]
 fn vault_non_fungible_recall_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let (recallable_resource_address, non_fungible_local_id) = {
         let id = NonFungibleLocalId::Integer(IntegerNonFungibleLocalId::new(1));
@@ -535,7 +535,7 @@ fn vault_non_fungible_recall_emits_correct_events() {
 #[test]
 fn resource_manager_new_vault_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     let manifest = ManifestBuilder::new()
@@ -608,7 +608,7 @@ fn resource_manager_new_vault_emits_correct_events() {
 #[test]
 fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -695,7 +695,7 @@ fn resource_manager_mint_and_burn_fungible_resource_emits_correct_events() {
 #[test]
 fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -785,7 +785,7 @@ fn resource_manager_mint_and_burn_non_fungible_resource_emits_correct_events() {
 #[test]
 fn vault_take_non_fungibles_by_amount_emits_correct_event() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
     let resource_address = {
         let manifest = ManifestBuilder::new()
@@ -1725,7 +1725,7 @@ fn validator_update_stake_delegation_status_emits_correct_event() {
 #[test]
 fn setting_metadata_emits_correct_events() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let resource_address = create_all_allowed_resource(&mut ledger);
 
     let manifest = ManifestBuilder::new()
@@ -1772,7 +1772,7 @@ fn setting_metadata_emits_correct_events() {
 #[test]
 fn create_account_events_can_be_looked_up() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
 
     // Act
     let manifest = ManifestBuilder::new()
@@ -1838,7 +1838,7 @@ fn create_all_allowed_resource(ledger: &mut DefaultLedgerSimulator) -> ResourceA
 
 #[test]
 fn mint_burn_events_should_match_total_supply_for_fungible_resource() {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_allocated_account();
 
     // Create
@@ -1934,7 +1934,7 @@ fn mint_burn_events_should_match_total_supply_for_fungible_resource() {
 
 #[test]
 fn mint_burn_events_should_match_total_supply_for_non_fungible_resource() {
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (pk, _, account) = ledger.new_allocated_account();
 
     // Create

--- a/radix-engine-tests/tests/system/role_assignment.rs
+++ b/radix-engine-tests/tests/system/role_assignment.rs
@@ -189,7 +189,7 @@ fn component_role_assignment_can_be_mutated_to_non_fungible_resource_through_man
 #[test]
 fn assert_access_rule_through_component_when_not_fulfilled_fails() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(PackageLoader::get("role_assignment"));
     let component_address = {
         let manifest = ManifestBuilder::new()
@@ -227,7 +227,7 @@ fn assert_access_rule_through_component_when_not_fulfilled_fails() {
 #[test]
 fn assert_access_rule_through_component_when_fulfilled_succeeds() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
     let package_address = ledger.publish_package_simple(PackageLoader::get("role_assignment"));
 

--- a/radix-engine-tests/tests/system/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/system/royalty_edge_cases.rs
@@ -447,7 +447,7 @@ package_interactions_tests! {
 #[test]
 fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (code, mut definition) = CODE_AND_DEF.clone();
 
     for blueprint_definition in definition.blueprints.values_mut() {
@@ -481,7 +481,7 @@ fn test_package_with_non_exhaustive_package_royalties_fails_instantiation() {
 #[test]
 fn component_and_package_royalties_are_both_applied() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (code, mut definition) = CODE_AND_DEF.clone();
     let royalty_amount = RoyaltyAmount::Xrd(10.into());
     update_package_royalties(&mut definition, royalty_amount);
@@ -526,7 +526,7 @@ fn component_and_package_royalties_are_both_applied() {
 #[test]
 fn test_component_with_missing_method_royalty() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package_simple(CODE_AND_DEF.clone());
 
     let manifest = ManifestBuilder::new()
@@ -643,7 +643,7 @@ macro_rules! component_instantiation_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+                let mut ledger = LedgerSimulatorBuilder::new().build();
                 let package_address =
                     ledger.publish_package_simple(CODE_AND_DEF.clone());
 
@@ -689,7 +689,7 @@ macro_rules! component_interaction_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+                let mut ledger = LedgerSimulatorBuilder::new().build();
                 let package_address =
                     ledger.publish_package_simple(CODE_AND_DEF.clone());
 
@@ -749,7 +749,7 @@ macro_rules! package_publishing_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+                let mut ledger = LedgerSimulatorBuilder::new().build();
                 let (code, mut definition) = CODE_AND_DEF.clone();
 
                 update_package_royalties(&mut definition, royalty_amount);
@@ -797,7 +797,7 @@ macro_rules! package_interactions_tests {
                 let royalty_amount: RoyaltyAmount = $royalty_amount;
                 let error_checking_fn: Option<fn(&RuntimeError) -> bool> = $error_checking_fn;
 
-                let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+                let mut ledger = LedgerSimulatorBuilder::new().build();
                 let (code, mut definition) = CODE_AND_DEF.clone();
 
                 update_package_royalties(&mut definition, royalty_amount);

--- a/radix-engine-tests/tests/system/toolkit_receipt.rs
+++ b/radix-engine-tests/tests/system/toolkit_receipt.rs
@@ -13,7 +13,7 @@ use scrypto_test::prelude::*;
 #[test]
 fn test_toolkit_receipt_roundtrip_property() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
 
     // Act
@@ -147,7 +147,7 @@ fn test_serialized_scenario_transaction_receipts_can_be_deserialized_and_convert
 #[test]
 fn commit_success_receipt_is_mapped_correctly() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -174,7 +174,7 @@ fn commit_success_receipt_is_mapped_correctly() {
 #[test]
 fn commit_failure_receipt_is_mapped_correctly() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -204,7 +204,7 @@ fn commit_failure_receipt_is_mapped_correctly() {
 #[test]
 fn rejection_receipt_is_mapped_correctly() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -230,7 +230,7 @@ fn rejection_receipt_is_mapped_correctly() {
 #[test]
 fn newly_created_entities_are_mapped_correctly_in_receipt() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (wasm, definition) = (
         include_workspace_asset_bytes!("radix-transaction-scenarios", "radiswap.wasm").to_vec(),
         manifest_decode(include_workspace_asset_bytes!(
@@ -302,7 +302,7 @@ fn newly_created_entities_are_mapped_correctly_in_receipt() {
 #[test]
 fn metadata_updates_show_in_receipt() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (public_key, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -378,7 +378,7 @@ fn non_fungible_data_updates_are_mapped_correctly_in_receipt() {
         pub field: u32,
     }
 
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let execution_config = ExecutionConfig::for_preview_no_auth(NetworkDefinition::simulator());
 
@@ -488,7 +488,7 @@ fn newly_minted_non_fungibles_are_mapped_correctly_in_receipt() {
         pub field: u32,
     }
 
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account1) = ledger.new_account(false);
     let (_, _, account2) = ledger.new_account(false);
     let execution_config = ExecutionConfig::for_preview_no_auth(NetworkDefinition::simulator());
@@ -596,7 +596,7 @@ fn newly_minted_non_fungibles_are_mapped_correctly_in_receipt() {
 #[test]
 fn worktop_changes_are_mapped_correctly_in_receipt() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -640,7 +640,7 @@ fn worktop_changes_are_mapped_correctly_in_receipt() {
 #[test]
 fn fee_summary_are_mapped_correctly_in_receipt() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()
@@ -687,7 +687,7 @@ fn fee_summary_are_mapped_correctly_in_receipt() {
 #[test]
 fn locked_fees_are_mapped_correctly_in_receipt() {
     // Arrange
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let (_, _, account) = ledger.new_account(false);
     let receipt = ledger.preview_manifest(
         ManifestBuilder::new()

--- a/radix-engine-tests/tests/vm/logging_limits.rs
+++ b/radix-engine-tests/tests/vm/logging_limits.rs
@@ -67,7 +67,7 @@ fn prepare_code(message_size: usize, iterations: usize) -> Vec<u8> {
 fn test_emit_log(message_size: usize, iterations: usize, expected_err: Option<RuntimeError>) {
     // Arrange
     let code = prepare_code(message_size, iterations);
-    let mut ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let mut ledger = LedgerSimulatorBuilder::new().build();
     let package_address = ledger.publish_package(
         (code, single_function_package_definition("Test", "f")),
         BTreeMap::new(),

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -64,7 +64,7 @@ impl LedgerSimulatorBuilder<NoExtension, InMemorySubstateDatabase> {
             custom_database: InMemorySubstateDatabase::standard(),
             protocol_executor: ProtocolBuilder::for_network(&NetworkDefinition::simulator())
                 .from_bootstrap_to_latest(),
-            with_kernel_trace: true,
+            with_kernel_trace: false,
             with_receipt_substate_check: true,
         }
     }


### PR DESCRIPTION
## Summary
After discussions with Yulong, this PR disables kernel trace by default in the `LedgerSimulator`.

Kernel trace causes tests to run a little slower, and causes lots of pretty indecipherable logs to appear in test output.

It can be re-enabled when needed using `.with_kernel_trace()` (basically by us for engine determinism debugging).

NOTE: Ensure this PR's base is updated to `develop` before merging.

## Update Recommendations
### For dApp Developers
You may wish to add `.with_kernel_trace()` to your LedgerSimulator if debugging a gnarly test execution.
