### PR TITLE
tweak: Added more comprehensive mapped helper extensions to `SubstateDatabase` and its relatives

### DIFF
--- a/radix-clis/src/replay/cmd_alloc_dump.rs
+++ b/radix-clis/src/replay/cmd_alloc_dump.rs
@@ -8,7 +8,6 @@ use radix_common::prelude::*;
 use radix_engine::vm::VmModules;
 use radix_engine_profiling::info_alloc::*;
 use radix_substate_store_impls::rocks_db_with_merkle_tree::RocksDBWithMerkleTreeSubstateStore;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::*;
 use radix_transactions::prelude::*;
 use std::fs::File;
@@ -139,9 +138,7 @@ impl TxnAllocDump {
                 let execution_cost_units = receipt
                     .fee_summary()
                     .map(|x| x.total_execution_cost_units_consumed.clone());
-                let database_updates = receipt
-                    .into_state_updates()
-                    .create_database_updates::<SpreadPrefixKeyMapper>();
+                let database_updates = receipt.into_state_updates().create_database_updates();
                 database.commit(&database_updates);
                 match validated.inner {
                     ValidatedLedgerTransactionInner::User(tx) => {

--- a/radix-clis/src/replay/cmd_execute.rs
+++ b/radix-clis/src/replay/cmd_execute.rs
@@ -7,7 +7,6 @@ use flume;
 use radix_common::prelude::*;
 use radix_engine::vm::VmModules;
 use radix_substate_store_impls::rocks_db_with_merkle_tree::RocksDBWithMerkleTreeSubstateStore;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::*;
 use std::fs::File;
 use std::path::PathBuf;
@@ -84,8 +83,7 @@ impl TxnExecute {
                     trace,
                 );
                 let state_updates = receipt.into_state_updates();
-                let database_updates =
-                    state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+                let database_updates = state_updates.create_database_updates();
                 database.commit(&database_updates);
 
                 let new_state_root_hash = database.get_current_root_hash();

--- a/radix-clis/src/replay/cmd_execute_in_memory.rs
+++ b/radix-clis/src/replay/cmd_execute_in_memory.rs
@@ -8,7 +8,6 @@ use radix_common::prelude::*;
 use radix_engine::vm::VmModules;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
 use radix_substate_store_impls::state_tree_support::StateTreeUpdatingDatabase;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::*;
 use std::fs::File;
 use std::path::PathBuf;
@@ -96,8 +95,7 @@ impl TxnExecuteInMemory {
                     trace,
                 );
                 let state_updates = receipt.into_state_updates();
-                let database_updates =
-                    state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+                let database_updates = state_updates.create_database_updates();
                 database.commit(&database_updates);
 
                 let new_state_root_hash = database.get_current_root_hash();

--- a/radix-clis/src/replay/cmd_measure.rs
+++ b/radix-clis/src/replay/cmd_measure.rs
@@ -7,7 +7,6 @@ use flume;
 use radix_common::prelude::*;
 use radix_engine::vm::*;
 use radix_substate_store_impls::rocks_db_with_merkle_tree::RocksDBWithMerkleTreeSubstateStore;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::*;
 use radix_transactions::prelude::*;
 use std::fs::File;
@@ -110,9 +109,7 @@ impl TxnMeasure {
                 let finalization_cost_units = receipt
                     .fee_summary()
                     .map(|x| x.total_finalization_cost_units_consumed.clone());
-                let database_updates = receipt
-                    .into_state_updates()
-                    .create_database_updates::<SpreadPrefixKeyMapper>();
+                let database_updates = receipt.into_state_updates().create_database_updates();
                 database.commit(&database_updates);
                 let tx_processing_time = tx_start_time.elapsed();
                 if let ValidatedLedgerTransactionInner::User(tx) = validated.inner {

--- a/radix-clis/src/replay/cmd_sync.rs
+++ b/radix-clis/src/replay/cmd_sync.rs
@@ -6,7 +6,6 @@ use flume::Sender;
 use radix_common::prelude::*;
 use radix_engine::vm::VmModules;
 use radix_substate_store_impls::rocks_db_with_merkle_tree::RocksDBWithMerkleTreeSubstateStore;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::*;
 use radix_transactions::prelude::*;
 use rocksdb::{Direction, IteratorMode, Options, DB};
@@ -74,8 +73,7 @@ impl TxnSync {
                     trace,
                 );
                 let state_updates = receipt.into_state_updates();
-                let database_updates =
-                    state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+                let database_updates = state_updates.create_database_updates();
 
                 let current_version = database.get_current_version();
                 let new_version = current_version + 1;

--- a/radix-clis/src/resim/cmd_publish.rs
+++ b/radix-clis/src/resim/cmd_publish.rs
@@ -10,11 +10,8 @@ use radix_engine_interface::blueprints::package::{
 };
 use radix_engine_interface::prelude::*;
 use radix_rust::ContextualDisplay;
-use radix_substate_store_interface::interface::DatabaseUpdates;
-use radix_substate_store_interface::{
-    db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper},
-    interface::*,
-};
+use radix_substate_store_interface::db_key_mapper::*;
+use radix_substate_store_interface::interface::*;
 use radix_substate_store_queries::typed_substate_layout::*;
 use std::ffi::OsStr;
 use std::fs;

--- a/radix-clis/src/resim/cmd_show_ledger.rs
+++ b/radix-clis/src/resim/cmd_show_ledger.rs
@@ -5,10 +5,7 @@ use radix_common::time::Instant;
 use radix_common::time::UtcDateTime;
 use radix_engine_interface::blueprints::consensus_manager::*;
 use radix_substate_store_impls::rocks_db::RocksdbSubstateStore;
-use radix_substate_store_interface::{
-    db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper},
-    interface::ListableSubstateDatabase,
-};
+use radix_substate_store_interface::interface::*;
 
 use crate::resim::*;
 
@@ -54,8 +51,7 @@ impl ShowLedger {
         let mut components: Vec<ComponentAddress> = vec![];
         let mut resources: Vec<ResourceAddress> = vec![];
 
-        for key in substate_db.list_partition_keys() {
-            let (node_id, _) = SpreadPrefixKeyMapper::from_db_partition_key(&key);
+        for (node_id, _) in substate_db.read_partition_keys() {
             if let Ok(address) = PackageAddress::try_from(node_id.as_ref()) {
                 if !packages.contains(&address) {
                     packages.push(address);

--- a/radix-clis/src/resim/dumper.rs
+++ b/radix-clis/src/resim/dumper.rs
@@ -35,7 +35,7 @@ pub fn dump_package<T: SubstateDatabase, O: std::io::Write>(
 ) -> Result<(), EntityDumpError> {
     let address_bech32_encoder = AddressBech32Encoder::new(&NetworkDefinition::simulator());
     let (_, substate) = substate_db
-        .read_map_entries_values_typed::<PackageCodeOriginalCodeEntrySubstate>(
+        .list_map_values::<PackageCodeOriginalCodeEntrySubstate>(
             package_address,
             PackagePartitionOffset::CodeOriginalCodeKeyValue.as_main_partition(),
             None::<SubstateKey>,

--- a/radix-clis/src/resim/dumper.rs
+++ b/radix-clis/src/resim/dumper.rs
@@ -12,10 +12,7 @@ use radix_engine_interface::blueprints::resource::NON_FUNGIBLE_RESOURCE_MANAGER_
 use radix_engine_interface::types::{BlueprintPartitionOffset, CollectionDescriptor};
 use radix_engine_interface::{prelude::MetadataValue, types::PackagePartitionOffset};
 use radix_rust::ContextualDisplay;
-use radix_substate_store_interface::{
-    db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper},
-    interface::SubstateDatabase,
-};
+use radix_substate_store_interface::interface::*;
 use radix_substate_store_queries::query::ResourceAccounter;
 use radix_substate_store_queries::typed_substate_layout::*;
 
@@ -38,9 +35,10 @@ pub fn dump_package<T: SubstateDatabase, O: std::io::Write>(
 ) -> Result<(), EntityDumpError> {
     let address_bech32_encoder = AddressBech32Encoder::new(&NetworkDefinition::simulator());
     let (_, substate) = substate_db
-        .list_mapped::<SpreadPrefixKeyMapper, PackageCodeOriginalCodeEntrySubstate, MapKey>(
-            package_address.as_node_id(),
+        .read_map_entries_values_typed::<PackageCodeOriginalCodeEntrySubstate>(
+            package_address,
             PackagePartitionOffset::CodeOriginalCodeKeyValue.as_main_partition(),
+            None::<SubstateKey>,
         )
         .next()
         .ok_or(EntityDumpError::PackageNotFound)?;

--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -9,7 +9,7 @@ use radix_engine::kernel::kernel_api::{
 };
 use radix_engine::kernel::kernel_callback_api::*;
 use radix_engine::system::checkers::KernelDatabaseChecker;
-use radix_engine::track::{to_state_updates, CommitableSubstateStore, Track};
+use radix_engine::track::{CommitableSubstateStore, Track};
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
 use radix_substate_store_interface::interface::CommittableSubstateDatabase;
@@ -469,7 +469,7 @@ fn kernel_fuzz<F: FnMut(&mut KernelFuzzer) -> Vec<KernelFuzzAction>>(
     let txn_hash = &seed.to_be_bytes().repeat(4)[..];
     let mut id_allocator = IdAllocator::new(Hash(txn_hash.try_into().unwrap()));
     let mut substate_db = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
+    let mut track = Track::new(&substate_db);
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);
 
@@ -488,7 +488,7 @@ fn kernel_fuzz<F: FnMut(&mut KernelFuzzer) -> Vec<KernelFuzzAction>>(
 
     let result = track.finalize();
     if let Ok((tracked_substates, _)) = result {
-        let (_, state_updates) = to_state_updates(tracked_substates);
+        let (_, state_updates) = tracked_substates.to_state_updates();
 
         let database_updates = state_updates.create_database_updates();
         substate_db.commit(&database_updates);

--- a/radix-engine-monkey-tests/tests/fuzz_kernel.rs
+++ b/radix-engine-monkey-tests/tests/fuzz_kernel.rs
@@ -12,14 +12,13 @@ use radix_engine::system::checkers::KernelDatabaseChecker;
 use radix_engine::track::{to_state_updates, CommitableSubstateStore, Track};
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::CommittableSubstateDatabase;
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
-use scrypto_test::prelude::CreateDatabaseUpdates;
+use scrypto_test::prelude::*;
 
 #[derive(Default)]
 struct TestCallFrameData;
@@ -470,7 +469,7 @@ fn kernel_fuzz<F: FnMut(&mut KernelFuzzer) -> Vec<KernelFuzzAction>>(
     let txn_hash = &seed.to_be_bytes().repeat(4)[..];
     let mut id_allocator = IdAllocator::new(Hash(txn_hash.try_into().unwrap()));
     let mut substate_db = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&substate_db);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);
 
@@ -489,9 +488,9 @@ fn kernel_fuzz<F: FnMut(&mut KernelFuzzer) -> Vec<KernelFuzzAction>>(
 
     let result = track.finalize();
     if let Ok((tracked_substates, _)) = result {
-        let (_, state_updates) = to_state_updates::<SpreadPrefixKeyMapper>(tracked_substates);
+        let (_, state_updates) = to_state_updates(tracked_substates);
 
-        let database_updates = state_updates.create_database_updates::<SpreadPrefixKeyMapper>();
+        let database_updates = state_updates.create_database_updates();
         substate_db.commit(&database_updates);
         let mut checker = KernelDatabaseChecker::new();
         checker.check_db(&substate_db).unwrap_or_else(|_| {

--- a/radix-engine-profiling/src/rocks_db_metrics/mod.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/mod.rs
@@ -73,13 +73,13 @@ impl SubstateStoreWithMetrics<InMemorySubstateDatabase> {
 impl<S: SubstateDatabase + CommittableSubstateDatabase> SubstateDatabase
     for SubstateStoreWithMetrics<S>
 {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
     ) -> Option<DbSubstateValue> {
         let start = std::time::Instant::now();
-        let ret = self.db.get_substate(partition_key, sort_key);
+        let ret = self.db.get_raw_substate_by_db_key(partition_key, sort_key);
         let duration = start.elapsed();
 
         if let Some(value) = ret {
@@ -95,12 +95,13 @@ impl<S: SubstateDatabase + CommittableSubstateDatabase> SubstateDatabase
         }
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
-        self.db.list_entries_from(partition_key, from_sort_key)
+        self.db
+            .list_raw_values_from_db_key(partition_key, from_sort_key)
     }
 }
 
@@ -152,7 +153,7 @@ impl<S: SubstateDatabase + CommittableSubstateDatabase> CommittableSubstateDatab
                                 )
                             } else {
                                 delete_found = true;
-                                if let Some(value) = self.get_substate(
+                                if let Some(value) = self.get_raw_substate_by_db_key(
                                     &DbPartitionKey {
                                         node_key: node_key.clone(),
                                         partition_num: *partition_num,

--- a/radix-engine-profiling/src/rocks_db_metrics/tests/read.rs
+++ b/radix-engine-profiling/src/rocks_db_metrics/tests/read.rs
@@ -219,7 +219,7 @@ fn run_read_test<S: SubstateDatabase + CommittableSubstateDatabase>(
             print!("\rRead {}/{}  ", j + 1, data_index_vector.len());
             std::io::stdout().flush().ok();
 
-            let read_value = substate_db.get_substate(&p, &s);
+            let read_value = substate_db.get_raw_substate_by_db_key(&p, &s);
 
             assert!(read_value.is_some());
             assert_eq!(read_value.unwrap().len(), *v);
@@ -275,7 +275,7 @@ fn run_read_not_found_test<S: SubstateDatabase + CommittableSubstateDatabase>(
         data_index_vector.shuffle(&mut rng);
 
         for (p, s) in data_index_vector.iter() {
-            let read_value = substate_db.get_substate(&p, &s);
+            let read_value = substate_db.get_raw_substate_by_db_key(&p, &s);
             assert!(read_value.is_none());
         }
     }

--- a/radix-engine-tests/tests/application/stake_reconciliation.rs
+++ b/radix-engine-tests/tests/application/stake_reconciliation.rs
@@ -49,7 +49,7 @@ fn test_stake_reconciliation() {
     let db = ledger.substate_db();
     let old_keys: Vec<DbPartitionKey> = db.list_partition_keys().collect();
     for key in old_keys {
-        let entries = db.list_entries(&key);
+        let entries = db.list_raw_values_from_db_key(&key, None);
         for (sort_key, value) in entries {
             pre_transaction_substates.insert((key.clone(), sort_key), value);
         }
@@ -327,7 +327,7 @@ fn test_stake_reconciliation() {
     }
 
     for key in post_transaction_partitions {
-        let partition_entries = ledger.substate_db().list_entries(&key);
+        let partition_entries = ledger.substate_db().list_raw_values_from_db_key(&key, None);
         for (sort_key, current_value) in partition_entries {
             let full_key = (key.clone(), sort_key.clone());
             let address = AddressBech32Encoder::for_simulator()

--- a/radix-engine-tests/tests/application/stake_reconciliation.rs
+++ b/radix-engine-tests/tests/application/stake_reconciliation.rs
@@ -89,7 +89,7 @@ fn test_stake_reconciliation() {
     //     let partition_num = PartitionNumber(1);
     //     let substate_key = SubstateKey::Map(ScryptoRawPayload::from_valid_payload(vec![92, 32, 7, 32, 220, 0, 156, 5, 6, 83, 96, 189, 222, 100, 29, 145, 160, 147, 193, 127, 71, 54, 135, 62, 103, 35, 126, 168, 230, 117, 203, 71, 36, 132, 155, 157]));
     //     let value_from_database: ScryptoRawValue = ledger.substate_db()
-    //         .get_mapped::<SpreadPrefixKeyMapper, _>(&node_id, partition_num, &substate_key)
+    //         .read_substate_typed(&node_id, partition_num, substate_key)
     //         .unwrap();
     //     let substate_value = value_from_database.into_payload_bytes();
     //     let state_updates = StateUpdates {

--- a/radix-engine-tests/tests/blueprints/account_locker.rs
+++ b/radix-engine-tests/tests/blueprints/account_locker.rs
@@ -3055,7 +3055,7 @@ pub impl DefaultLedgerSimulator {
         execution_config.system_overrides = Some(SystemOverrides {
             disable_auth,
             disable_costing,
-            ..Default::default()
+            ..SystemOverrides::default_for_network(&NetworkDefinition::mainnet())
         });
 
         let nonce = self.next_transaction_nonce();

--- a/radix-engine-tests/tests/db/substate_database_overlay.rs
+++ b/radix-engine-tests/tests/db/substate_database_overlay.rs
@@ -33,7 +33,7 @@ fn substates_written_to_root_database_can_be_read() {
     let db = SubstateDatabaseOverlay::new_unmergeable(&root);
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -68,7 +68,7 @@ fn substates_written_to_overlay_can_be_read_later() {
     });
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -116,7 +116,7 @@ fn substate_deletes_to_overlay_prevent_substate_from_being_read() {
     });
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -162,7 +162,7 @@ fn partition_deletes_to_overlay_prevent_substate_from_being_read() {
     });
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -210,7 +210,7 @@ fn partition_resets_to_overlay_return_new_substate_data() {
     });
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -269,7 +269,7 @@ fn partition_resets_are_not_combined() {
     });
 
     // Act
-    let substate = db.get_substate(
+    let substate = db.get_raw_substate_by_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -304,7 +304,7 @@ fn from_sort_key_in_list_entries_from_works_when_the_overlay_is_in_reset_mode() 
     });
 
     // Act
-    let mut substates = db.list_entries_from(
+    let mut substates = db.list_raw_values_from_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -348,7 +348,7 @@ fn from_sort_key_in_list_entries_from_works_when_the_overlay_is_in_delta_mode() 
     });
 
     // Act
-    let mut substates = db.list_entries_from(
+    let mut substates = db.list_raw_values_from_db_key(
         &DbPartitionKey {
             node_key: b"some-node".to_vec(),
             partition_num: 0,
@@ -441,7 +441,7 @@ fn create_database_contents_hash<D: SubstateDatabase + ListableSubstateDatabase>
     let mut accumulator_hash = Hash([0; 32]);
     for (node_id, partition_number) in database.read_partition_keys() {
         for (substate_key, substate_value) in
-            database.read_entries_unknown_key(node_id, partition_number, None::<SubstateKey>)
+            database.list_raw_values(node_id, partition_number, None::<SubstateKey>)
         {
             let entry_hash = hash(
                 scrypto_encode(&(node_id, partition_number, substate_key, substate_value)).unwrap(),

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -211,7 +211,7 @@ fn kernel_move_node_via_create_with_opened_substate(
     variation: MoveVariation,
 ) -> Result<(), RuntimeError> {
     let database = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
+    let mut track = Track::new(&database);
     let mut id_allocator = IdAllocator::new(Hash([0u8; Hash::LENGTH]));
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);
@@ -348,7 +348,7 @@ fn test_kernel_move_node_via_invoke_with_opened_substate() {
 fn kernel_close_substate_should_fail_if_opened_child_exists() {
     // Arrange
     let database = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
+    let mut track = Track::new(&database);
     let mut id_allocator = IdAllocator::new(Hash([0u8; Hash::LENGTH]));
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);

--- a/radix-engine-tests/tests/kernel/kernel.rs
+++ b/radix-engine-tests/tests/kernel/kernel.rs
@@ -5,10 +5,9 @@ use radix_engine::kernel::id_allocator::IdAllocator;
 use radix_engine::kernel::kernel::Kernel;
 use radix_engine::kernel::kernel_api::*;
 use radix_engine::kernel::kernel_callback_api::*;
-use radix_engine::track::Track;
+use radix_engine::track::*;
 use radix_engine_interface::prelude::*;
-use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
+use scrypto_test::prelude::*;
 
 #[derive(Default)]
 struct TestCallFrameData;
@@ -212,7 +211,7 @@ fn kernel_move_node_via_create_with_opened_substate(
     variation: MoveVariation,
 ) -> Result<(), RuntimeError> {
     let database = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&database);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
     let mut id_allocator = IdAllocator::new(Hash([0u8; Hash::LENGTH]));
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);
@@ -349,7 +348,7 @@ fn test_kernel_move_node_via_invoke_with_opened_substate() {
 fn kernel_close_substate_should_fail_if_opened_child_exists() {
     // Arrange
     let database = InMemorySubstateDatabase::standard();
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&database);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
     let mut id_allocator = IdAllocator::new(Hash([0u8; Hash::LENGTH]));
     let mut callback = TestCallbackObject;
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut callback);

--- a/radix-engine-tests/tests/kernel/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel/kernel_open_substate.rs
@@ -21,7 +21,6 @@ use radix_engine::vm::*;
 use radix_engine_interface::api::LockFlags;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_queries::typed_substate_layout::{
     BlueprintVersionKey, PACKAGE_AUTH_TEMPLATE_PARTITION_OFFSET,
 };
@@ -81,7 +80,7 @@ pub fn test_open_substate_of_invisible_package_address() {
         ),
         finalization: Default::default(),
     };
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&database);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
     let mut id_allocator = IdAllocator::new(executable.unique_seed_for_id_allocator());
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
 

--- a/radix-engine-tests/tests/kernel/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel/kernel_open_substate.rs
@@ -80,7 +80,7 @@ pub fn test_open_substate_of_invisible_package_address() {
         ),
         finalization: Default::default(),
     };
-    let mut track = Track::<InMemorySubstateDatabase>::new(&database);
+    let mut track = Track::new(&database);
     let mut id_allocator = IdAllocator::new(executable.unique_seed_for_id_allocator());
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
 

--- a/radix-engine-tests/tests/kernel/panics.rs
+++ b/radix-engine-tests/tests/kernel/panics.rs
@@ -161,7 +161,7 @@ impl<M: SystemCallbackObject> KernelSubstateApi<SystemLockData> for MockKernel<M
         panic1!()
     }
 
-    fn kernel_scan_keys<F: SubstateKeyContent + 'static>(
+    fn kernel_scan_keys<F: SubstateKeyContent>(
         &mut self,
         _: &NodeId,
         _: PartitionNumber,
@@ -170,7 +170,7 @@ impl<M: SystemCallbackObject> KernelSubstateApi<SystemLockData> for MockKernel<M
         panic1!()
     }
 
-    fn kernel_drain_substates<F: SubstateKeyContent + 'static>(
+    fn kernel_drain_substates<F: SubstateKeyContent>(
         &mut self,
         _: &NodeId,
         _: PartitionNumber,

--- a/radix-engine-tests/tests/system/bootstrap.rs
+++ b/radix-engine-tests/tests/system/bootstrap.rs
@@ -265,7 +265,7 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
     } = hooks.into_genesis_receipts();
 
     let total_supply = substate_db
-        .read_substate_typed::<FungibleResourceManagerTotalSupplyFieldSubstate>(
+        .get_substate::<FungibleResourceManagerTotalSupplyFieldSubstate>(
             resource_address,
             MAIN_BASE_PARTITION,
             FungibleResourceManagerField::TotalSupply,

--- a/radix-engine-tests/tests/system/bootstrap.rs
+++ b/radix-engine-tests/tests/system/bootstrap.rs
@@ -13,9 +13,6 @@ use radix_engine::updates::{BabylonSettings, ProtocolBuilder};
 use radix_engine_interface::object_modules::metadata::{MetadataValue, UncheckedUrl};
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_interface::db_key_mapper::{
-    MappedSubstateDatabase, SpreadPrefixKeyMapper,
-};
 use radix_substate_store_queries::typed_substate_layout::*;
 use radix_transactions::prelude::*;
 use scrypto_test::prelude::*;
@@ -268,10 +265,10 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
     } = hooks.into_genesis_receipts();
 
     let total_supply = substate_db
-        .get_mapped::<SpreadPrefixKeyMapper, FungibleResourceManagerTotalSupplyFieldSubstate>(
-            &resource_address.as_node_id(),
+        .read_substate_typed::<FungibleResourceManagerTotalSupplyFieldSubstate>(
+            resource_address,
             MAIN_BASE_PARTITION,
-            &FungibleResourceManagerField::TotalSupply.into(),
+            FungibleResourceManagerField::TotalSupply,
         )
         .unwrap()
         .into_payload()
@@ -310,7 +307,7 @@ fn test_genesis_resource_with_initial_allocation(owned_resource: bool) {
         // check if the metadata exists and is locked
         let reader = SystemDatabaseReader::new(&substate_db);
         let substate = reader
-            .fetch_substate::<SpreadPrefixKeyMapper, KeyValueEntrySubstate<VersionedMetadataEntry>>(
+            .fetch_substate::<KeyValueEntrySubstate<VersionedMetadataEntry>>(
                 created_owner_badge.as_node_id(),
                 METADATA_BASE_PARTITION,
                 &SubstateKey::Map(scrypto_encode("tags").unwrap()),

--- a/radix-engine-tests/tests/system/system_db_checker.rs
+++ b/radix-engine-tests/tests/system/system_db_checker.rs
@@ -5,7 +5,6 @@ use radix_engine::system::checkers::{
 use radix_engine::updates::ProtocolBuilder;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
 use radix_substate_store_interface::interface::*;
 
 #[test]
@@ -15,20 +14,12 @@ fn system_database_checker_should_report_missing_owner_error_on_broken_db() {
     ProtocolBuilder::for_simulator()
         .from_bootstrap_to_latest()
         .commit_each_protocol_update(&mut substate_db);
-    let (node_key, partition_num, sort_key, update) = (
-        SpreadPrefixKeyMapper::to_db_node_key(PACKAGE_PACKAGE.as_node_id()),
-        SpreadPrefixKeyMapper::to_db_partition_num(
-            ROLE_ASSIGNMENT_BASE_PARTITION
-                .at_offset(ROLE_ASSIGNMENT_FIELDS_PARTITION_OFFSET)
-                .unwrap(),
-        ),
-        SpreadPrefixKeyMapper::to_db_sort_key(&SubstateKey::Field(0u8)),
-        DatabaseUpdate::Delete,
+
+    substate_db.delete_substate(
+        PACKAGE_PACKAGE,
+        ROLE_ASSIGNMENT_FIELDS_PARTITION,
+        SubstateKey::Field(0u8),
     );
-    let remove_owner_update = DatabaseUpdates::from_delta_maps(
-        indexmap!(DbPartitionKey {node_key, partition_num} => indexmap!(sort_key => update)),
-    );
-    substate_db.commit(&remove_owner_update);
 
     // Act
     let mut checker = SystemDatabaseChecker::<()>::default();

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -60,7 +60,7 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
         .from_bootstrap_to_latest()
         .commit_each_protocol_update(&mut substate_db);
 
-    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
+    let mut track = Track::new(&substate_db);
     let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
     let native_vm = NativeVm::new_with_extension(Extension);
 
@@ -131,7 +131,7 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
         .from_bootstrap_to_latest()
         .commit_each_protocol_update(&mut substate_db);
 
-    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
+    let mut track = Track::new(&substate_db);
     let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
     let native_vm = NativeVm::new_with_extension(NonStringPanicExtension);
 

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -22,7 +22,6 @@ use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::blueprints::test_utils::invocations::*;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_impls::memory_db::*;
-use radix_substate_store_interface::db_key_mapper::*;
 use radix_transactions::prelude::*;
 use scrypto_test::prelude::LedgerSimulatorBuilder;
 
@@ -61,7 +60,7 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
         .from_bootstrap_to_latest()
         .commit_each_protocol_update(&mut substate_db);
 
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&substate_db);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
     let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
     let native_vm = NativeVm::new_with_extension(Extension);
 
@@ -132,7 +131,7 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
         .from_bootstrap_to_latest()
         .commit_each_protocol_update(&mut substate_db);
 
-    let mut track = Track::<InMemorySubstateDatabase, SpreadPrefixKeyMapper>::new(&substate_db);
+    let mut track = Track::<InMemorySubstateDatabase>::new(&substate_db);
     let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
     let native_vm = NativeVm::new_with_extension(NonStringPanicExtension);
 

--- a/radix-engine/src/kernel/call_frame.rs
+++ b/radix-engine/src/kernel/call_frame.rs
@@ -1220,7 +1220,7 @@ impl<C, L: Clone> CallFrame<C, L> {
         Ok(removed)
     }
 
-    pub fn scan_keys<'f, K: SubstateKeyContent + 'static, S: CommitableSubstateStore, E>(
+    pub fn scan_keys<'f, K: SubstateKeyContent, S: CommitableSubstateStore, E>(
         &mut self,
         substate_io: &'f mut SubstateIO<S>,
         node_id: &NodeId,
@@ -1251,7 +1251,7 @@ impl<C, L: Clone> CallFrame<C, L> {
         Ok(keys)
     }
 
-    pub fn drain_substates<'f, K: SubstateKeyContent + 'static, S: CommitableSubstateStore, E>(
+    pub fn drain_substates<'f, K: SubstateKeyContent, S: CommitableSubstateStore, E>(
         &mut self,
         substate_io: &'f mut SubstateIO<S>,
         node_id: &NodeId,

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -960,7 +960,7 @@ where
     }
 
     #[trace_resources]
-    fn kernel_scan_keys<K: SubstateKeyContent + 'static>(
+    fn kernel_scan_keys<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
@@ -997,7 +997,7 @@ where
     }
 
     #[trace_resources(log=limit)]
-    fn kernel_drain_substates<K: SubstateKeyContent + 'static>(
+    fn kernel_drain_substates<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -93,7 +93,7 @@ impl<'h, M: KernelTransactionCallbackObject, S: SubstateDatabase> BootLoader<'h,
             .unwrap_or(KernelBoot::babylon());
 
         // Upper Layer Initialization
-        let system_init_result = M::init(&mut self.track, &executable, self.init.clone());
+        let system_init_result = M::init(&mut self.track, &executable, self.init);
 
         let (mut system, call_frame_inits) = match system_init_result {
             Ok(success) => success,

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -11,7 +11,7 @@ use crate::track::interface::*;
 use crate::track::Track;
 use radix_engine_interface::api::field_api::LockFlags;
 use radix_engine_profiling_derive::trace_resources;
-use radix_substate_store_interface::db_key_mapper::{SpreadPrefixKeyMapper, SubstateKeyContent};
+use radix_substate_store_interface::db_key_mapper::SubstateKeyContent;
 use radix_substate_store_interface::interface::SubstateDatabase;
 use sbor::rust::mem;
 
@@ -45,7 +45,7 @@ impl KernelBoot {
 /// Organizes the radix engine stack to make a function entrypoint available for execution
 pub struct BootLoader<'h, M: KernelTransactionCallbackObject, S: SubstateDatabase> {
     pub id_allocator: IdAllocator,
-    pub track: Track<'h, S, SpreadPrefixKeyMapper>,
+    pub track: Track<'h, S>,
     pub init: M::Init,
     pub phantom: PhantomData<M>,
 }

--- a/radix-engine/src/kernel/kernel_api.rs
+++ b/radix-engine/src/kernel/kernel_api.rs
@@ -135,14 +135,14 @@ pub trait KernelSubstateApi<L> {
         count: u32,
     ) -> Result<Vec<(SortedKey, IndexedScryptoValue)>, RuntimeError>;
 
-    fn kernel_scan_keys<K: SubstateKeyContent + 'static>(
+    fn kernel_scan_keys<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
         count: u32,
     ) -> Result<Vec<SubstateKey>, RuntimeError>;
 
-    fn kernel_drain_substates<K: SubstateKeyContent + 'static>(
+    fn kernel_drain_substates<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -140,7 +140,7 @@ pub trait ExecutionReceipt {
 
 pub trait KernelTransactionCallbackObject: KernelCallbackObject {
     /// Initialization object
-    type Init: Clone;
+    type Init;
     /// The transaction object
     type Executable;
     /// Output to be returned at the end of execution

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -5,10 +5,9 @@ use crate::kernel::kernel_api::KernelInvocation;
 use crate::kernel::kernel_api::{KernelApi, KernelInternalApi};
 use crate::kernel::substate_io::SubstateDevice;
 use crate::track::interface::{IOAccess, NodeSubstates};
-use crate::track::{BootStore, CommitableSubstateStore, StoreCommitInfo, Track};
+use crate::track::*;
 use crate::transaction::ResourcesUsage;
 use radix_engine_interface::api::field_api::LockFlags;
-use radix_substate_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use radix_substate_store_interface::interface::SubstateDatabase;
 
 pub trait CallFrameReferences {
@@ -167,7 +166,7 @@ pub trait KernelTransactionCallbackObject: KernelCallbackObject {
     /// Create final receipt
     fn create_receipt<S: SubstateDatabase>(
         self,
-        track: Track<S, SpreadPrefixKeyMapper>,
+        track: Track<S>,
         result: Result<Self::ExecutionOutput, TransactionExecutionError>,
     ) -> Self::Receipt;
 }

--- a/radix-engine/src/kernel/substate_io.rs
+++ b/radix-engine/src/kernel/substate_io.rs
@@ -586,7 +586,7 @@ impl<'g, S: CommitableSubstateStore + 'g> SubstateIO<'g, S> {
         Ok(removed)
     }
 
-    pub fn scan_keys<K: SubstateKeyContent + 'static, E>(
+    pub fn scan_keys<K: SubstateKeyContent, E>(
         &mut self,
         device: SubstateDevice,
         node_id: &NodeId,
@@ -607,7 +607,7 @@ impl<'g, S: CommitableSubstateStore + 'g> SubstateIO<'g, S> {
         Ok(keys)
     }
 
-    pub fn drain_substates<K: SubstateKeyContent + 'static, E>(
+    pub fn drain_substates<K: SubstateKeyContent, E>(
         &mut self,
         device: SubstateDevice,
         node_id: &NodeId,

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -423,7 +423,7 @@ struct FlashedSubstateDatabase {
 }
 
 impl SubstateDatabase for FlashedSubstateDatabase {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
@@ -449,7 +449,7 @@ impl SubstateDatabase for FlashedSubstateDatabase {
             })
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -27,9 +27,6 @@ use radix_engine_interface::object_modules::metadata::{MetadataValue, UncheckedU
 use radix_engine_interface::object_modules::ModuleConfig;
 use radix_engine_interface::*;
 use radix_substate_store_interface::interface::*;
-use radix_substate_store_interface::{
-    db_key_mapper::SpreadPrefixKeyMapper, interface::SubstateDatabase,
-};
 use radix_transactions::model::*;
 use radix_transactions::prelude::*;
 
@@ -399,7 +396,7 @@ pub fn create_substate_flash_for_genesis() -> FlashReceipt {
         system_updates,
     });
     let flashed_db = FlashedSubstateDatabase {
-        flash_updates: state_updates.create_database_updates::<SpreadPrefixKeyMapper>(),
+        flash_updates: state_updates.create_database_updates(),
     };
     let mut substate_schema_mapper =
         SubstateSchemaMapper::new(SystemDatabaseReader::new(&flashed_db));

--- a/radix-engine/src/system/checkers/kernel_db_checker.rs
+++ b/radix-engine/src/system/checkers/kernel_db_checker.rs
@@ -43,7 +43,7 @@ impl KernelDatabaseChecker {
             }
 
             for (_, value) in
-                substate_db.read_entries_unknown_key(node_id, partition_number, None::<SubstateKey>)
+                substate_db.list_raw_values(node_id, partition_number, None::<SubstateKey>)
             {
                 let value = IndexedScryptoValue::from_vec(value)
                     .map_err(KernelDatabaseCheckError::DecodeError)?;

--- a/radix-engine/src/system/checkers/system_db_checker.rs
+++ b/radix-engine/src/system/checkers/system_db_checker.rs
@@ -82,7 +82,6 @@ pub enum SystemPartitionCheckError {
     MissingKeyValueStoreValueSchema(SystemReaderError),
     InvalidKeyValueStoreKey,
     InvalidKeyValueStoreValue,
-    InvalidFieldKey,
     ContainsFieldWhichShouldNotExist(BlueprintId, NodeId, u8),
     InvalidFieldValue,
     MissingFieldSchema(SystemReaderError),
@@ -488,19 +487,16 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                         return Err(SystemPartitionCheckError::InvalidBootLoaderPartition);
                     }
 
-                    for _ in reader
-                        .substates_iter::<FieldKey>(&node_checker_state.node_id, partition_number)
-                    {
+                    for _ in reader.field_iter(&node_checker_state.node_id, partition_number) {
                         substate_count += 1;
                     }
                 }
                 SystemPartitionDescriptor::TypeInfo => {
-                    for (key, value) in reader
-                        .substates_iter::<FieldKey>(&node_checker_state.node_id, partition_number)
+                    for (key, value) in
+                        reader.field_iter(&node_checker_state.node_id, partition_number)
                     {
-                        match key {
-                            SubstateKey::Field(0u8) => {}
-                            _ => return Err(SystemPartitionCheckError::InvalidTypeInfoKey),
+                        if key != 0 {
+                            return Err(SystemPartitionCheckError::InvalidTypeInfoKey);
                         };
 
                         let _type_info: TypeInfoSubstate = scrypto_decode(&value)
@@ -510,13 +506,9 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                     }
                 }
                 SystemPartitionDescriptor::Schema => {
-                    for (key, value) in reader
-                        .substates_iter::<MapKey>(&node_checker_state.node_id, partition_number)
+                    for (map_key, value) in
+                        reader.map_iter(&node_checker_state.node_id, partition_number)
                     {
-                        let map_key = match key {
-                            SubstateKey::Map(map_key) => map_key,
-                            _ => return Err(SystemPartitionCheckError::InvalidSchemaKey),
-                        };
                         let _schema_hash: Hash = scrypto_decode(&map_key)
                             .map_err(|_| SystemPartitionCheckError::InvalidSchemaKey)?;
 
@@ -538,17 +530,11 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                         .get_kv_store_payload_schema(&type_target, KeyOrValue::Value)
                         .map_err(SystemPartitionCheckError::MissingKeyValueStoreValueSchema)?;
 
-                    for (key, value) in reader
-                        .substates_iter::<MapKey>(&node_checker_state.node_id, partition_number)
+                    for (map_key, value) in
+                        reader.map_iter(&node_checker_state.node_id, partition_number)
                     {
                         // Key Check
                         {
-                            let map_key = match key {
-                                SubstateKey::Map(map_key) => map_key,
-                                _ => {
-                                    return Err(SystemPartitionCheckError::InvalidKeyValueStoreKey)
-                                }
-                            };
                             reader
                                 .validate_payload(
                                     &map_key,
@@ -601,15 +587,9 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
 
                     match object_partition_descriptor {
                         ObjectPartitionDescriptor::Fields => {
-                            for (key, value) in reader.substates_iter::<FieldKey>(
-                                &node_checker_state.node_id,
-                                partition_number,
-                            ) {
-                                let field_index = match key {
-                                    SubstateKey::Field(field_index) => field_index,
-                                    _ => return Err(SystemPartitionCheckError::InvalidFieldKey),
-                                };
-
+                            for (field_index, value) in
+                                reader.field_iter(&node_checker_state.node_id, partition_number)
+                            {
                                 expected_fields.remove(&(module_id, field_index));
                                 if module_id.eq(&ModuleId::Main)
                                     && excluded_fields.contains(&field_index)
@@ -676,19 +656,11 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .map_err(SystemPartitionCheckError::MissingIndexCollectionValueSchema)?
                             };
 
-                            for (key, value) in reader.substates_iter::<MapKey>(
-                                &node_checker_state.node_id,
-                                partition_number,
-                            ) {
+                            for (map_key, value) in
+                                reader.map_iter(&node_checker_state.node_id, partition_number)
+                            {
                                 // Key Check
                                 let key = {
-                                    let map_key = match key {
-                                        SubstateKey::Map(map_key) => map_key,
-                                        _ => return Err(
-                                            SystemPartitionCheckError::InvalidIndexCollectionKey,
-                                        ),
-                                    };
-
                                     reader
                                         .validate_payload(
                                             &map_key,
@@ -760,18 +732,11 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .map_err(SystemPartitionCheckError::MissingKeyValueCollectionValueSchema)?
                             };
 
-                            for (key, value) in reader.substates_iter::<MapKey>(
-                                &node_checker_state.node_id,
-                                partition_number,
-                            ) {
+                            for (map_key, value) in
+                                reader.map_iter(&node_checker_state.node_id, partition_number)
+                            {
                                 // Key check
                                 let key = {
-                                    let map_key = match key {
-                                        SubstateKey::Map(map_key) => map_key,
-                                        _ => return Err(
-                                            SystemPartitionCheckError::InvalidKeyValueCollectionKey,
-                                        ),
-                                    };
                                     reader
                                         .validate_payload(
                                             &map_key,
@@ -832,19 +797,11 @@ impl<A: ApplicationChecker> SystemDatabaseChecker<A> {
                                     .map_err(SystemPartitionCheckError::MissingSortedIndexCollectionValueSchema)?
                             };
 
-                            for (key, value) in reader.substates_iter::<SortedKey>(
-                                &node_checker_state.node_id,
-                                partition_number,
-                            ) {
+                            for (sorted_key, value) in
+                                reader.sorted_iter(&node_checker_state.node_id, partition_number)
+                            {
                                 // Key Check
                                 let key = {
-                                    let sorted_key = match key {
-                                        SubstateKey::Sorted(sorted_key) => sorted_key,
-                                        _ => return Err(
-                                            SystemPartitionCheckError::InvalidSortedIndexCollectionKey,
-                                        ),
-                                    };
-
                                     reader.validate_payload(
                                         &sorted_key.1,
                                         &key_schema,

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2979,7 +2979,7 @@ impl<'a, Y: SystemBasedKernelApi> KernelSubstateApi<SystemLockData> for SystemSe
             .kernel_scan_sorted_substates(node_id, partition_num, limit)
     }
 
-    fn kernel_scan_keys<K: SubstateKeyContent + 'static>(
+    fn kernel_scan_keys<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
@@ -2989,7 +2989,7 @@ impl<'a, Y: SystemBasedKernelApi> KernelSubstateApi<SystemLockData> for SystemSe
             .kernel_scan_keys::<K>(node_id, partition_num, limit)
     }
 
-    fn kernel_drain_substates<K: SubstateKeyContent + 'static>(
+    fn kernel_drain_substates<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -44,7 +44,7 @@ use radix_engine_interface::blueprints::hooks::*;
 use radix_engine_interface::blueprints::identity::IDENTITY_BLUEPRINT;
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::blueprints::transaction_processor::*;
-use radix_substate_store_interface::{db_key_mapper::SpreadPrefixKeyMapper, interface::*};
+use radix_substate_store_interface::interface::*;
 use radix_transactions::model::*;
 
 pub const BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY: FieldKey = 1u8;
@@ -495,7 +495,7 @@ impl<V: SystemCallbackObject> System<V> {
     }
 
     fn finalize_fees_for_commit<S: SubstateDatabase>(
-        track: &mut Track<S, SpreadPrefixKeyMapper>,
+        track: &mut Track<S>,
         fee_reserve: SystemLoanFeeReserve,
         is_success: bool,
     ) -> (
@@ -746,7 +746,7 @@ impl<V: SystemCallbackObject> System<V> {
     }
 
     fn update_transaction_tracker<S: SubstateDatabase>(
-        track: &mut Track<S, SpreadPrefixKeyMapper>,
+        track: &mut Track<S>,
         next_epoch: Epoch,
         intent_hash_nullification: IntentHashNullification,
         is_success: bool,
@@ -1101,7 +1101,7 @@ impl<V: SystemCallbackObject> System<V> {
 
     fn create_commit_receipt<S: SubstateDatabase>(
         outcome: Result<Vec<InstructionOutput>, RuntimeError>,
-        mut track: Track<S, SpreadPrefixKeyMapper>,
+        mut track: Track<S>,
         modules: SystemModuleMixer,
         system_finalization: SystemFinalization,
     ) -> TransactionReceiptV1 {
@@ -1162,8 +1162,7 @@ impl<V: SystemCallbackObject> System<V> {
 
         // Generate state updates from tracked substates
         // Note that this process will prune invalid reads
-        let (new_node_ids, state_updates) =
-            to_state_updates::<SpreadPrefixKeyMapper>(tracked_substates);
+        let (new_node_ids, state_updates) = to_state_updates(tracked_substates);
 
         // Summarizes state updates
         let system_structure =
@@ -1569,7 +1568,7 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
 
     fn create_receipt<S: SubstateDatabase>(
         mut self,
-        track: Track<S, SpreadPrefixKeyMapper>,
+        track: Track<S>,
         interpretation_result: Result<Vec<InstructionOutput>, TransactionExecutionError>,
     ) -> TransactionReceipt {
         // Panic if an error is encountered in the system layer or below. The following code

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -1162,7 +1162,7 @@ impl<V: SystemCallbackObject> System<V> {
 
         // Generate state updates from tracked substates
         // Note that this process will prune invalid reads
-        let (new_node_ids, state_updates) = to_state_updates(tracked_substates);
+        let (new_node_ids, state_updates) = tracked_substates.to_state_updates();
 
         // Summarizes state updates
         let system_structure =

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -398,7 +398,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         };
 
         let iterable: Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + 's> = match schema {
-            BlueprintCollectionSchema::KeyValueStore(..) | BlueprintCollectionSchema::Index(..) => {
+            BlueprintCollectionSchema::KeyValueStore(..) => {
                 let iterable = self
                     .substate_db
                     .read_map_entries_values_typed::<KeyValueEntrySubstate<ScryptoRawValue>>(
@@ -411,6 +411,22 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
                             SubstateKey::Map(map_key),
                             scrypto_encode(&substate.into_value()?).unwrap(),
                         ))
+                    });
+                Box::new(iterable)
+            }
+            BlueprintCollectionSchema::Index(..) => {
+                let iterable = self
+                    .substate_db
+                    .read_map_entries_values_typed::<IndexEntrySubstate<ScryptoRawValue>>(
+                        node_id,
+                        partition_number,
+                        from_substate_key,
+                    )
+                    .map(|(map_key, substate)| {
+                        (
+                            SubstateKey::Map(map_key),
+                            scrypto_encode(&substate.into_value()).unwrap(),
+                        )
                     });
                 Box::new(iterable)
             }

--- a/radix-engine/src/system/system_db_reader.rs
+++ b/radix-engine/src/system/system_db_reader.rs
@@ -2,20 +2,14 @@ use crate::internal_prelude::*;
 use radix_engine_interface::api::{AttachedModuleId, CollectionIndex, ModuleId};
 use radix_engine_interface::blueprints::package::*;
 use radix_engine_interface::types::*;
-use radix_substate_store_interface::db_key_mapper::{
-    MappedCommittableSubstateDatabase, SubstateKeyContent,
-};
+use radix_substate_store_interface::db_key_mapper::SubstateKeyContent;
+use radix_substate_store_interface::interface::*;
 use radix_substate_store_interface::interface::{
     CommittableSubstateDatabase, ListableSubstateDatabase,
-};
-use radix_substate_store_interface::{
-    db_key_mapper::{DatabaseKeyMapper, MappedSubstateDatabase, SpreadPrefixKeyMapper},
-    interface::SubstateDatabase,
 };
 use sbor::{validate_payload_against_schema, LocalTypeId, LocatedValidationError};
 
 use crate::blueprints::package::PackageBlueprintVersionDefinitionEntrySubstate;
-use crate::internal_prelude::{IndexEntrySubstate, SortedIndexEntrySubstate};
 use crate::system::payload_validation::{SchemaOrigin, TypeInfoForValidation, ValidationContext};
 use crate::system::system_substates::FieldSubstate;
 use crate::system::system_substates::KeyValueEntrySubstate;
@@ -122,7 +116,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
     }
 
     pub fn get_type_info(&self, node_id: &NodeId) -> Result<TypeInfoSubstate, SystemReaderError> {
-        self.fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
+        self.fetch_substate::<TypeInfoSubstate>(
             node_id,
             TYPE_INFO_FIELD_PARTITION,
             &TypeInfoField::TypeInfo.into(),
@@ -134,20 +128,19 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         &self,
         package_address: PackageAddress,
     ) -> BTreeMap<BlueprintVersionKey, BlueprintDefinition> {
-        let entries = self.substate_db
-            .list_mapped::<SpreadPrefixKeyMapper, PackageBlueprintVersionDefinitionEntrySubstate, MapKey>(
+        let entries = self
+            .substate_db
+            .read_map_entries_values_typed::<PackageBlueprintVersionDefinitionEntrySubstate>(
                 package_address.as_node_id(),
                 MAIN_BASE_PARTITION
                     .at_offset(PACKAGE_BLUEPRINTS_PARTITION_OFFSET)
                     .unwrap(),
+                None::<SubstateKey>,
             );
 
         let mut blueprints = BTreeMap::new();
         for (key, blueprint_definition) in entries {
-            let bp_version_key: BlueprintVersionKey = match key {
-                SubstateKey::Map(v) => scrypto_decode(&v).unwrap(),
-                _ => panic!("Unexpected"),
-            };
+            let bp_version_key: BlueprintVersionKey = scrypto_decode(&key).unwrap();
 
             blueprints.insert(
                 bp_version_key,
@@ -201,11 +194,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
 
         let substate: FieldSubstate<ScryptoValue> = self
             .substate_db
-            .get_mapped::<SpreadPrefixKeyMapper, _>(
-                node_id,
-                partition_number,
-                &SubstateKey::Field(field_index),
-            )
+            .read_substate_typed(node_id, partition_number, SubstateKey::Field(field_index))
             .ok_or_else(|| SystemReaderError::FieldDoesNotExist)?;
 
         Ok((
@@ -219,14 +208,13 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         node_id: &NodeId,
         key: &K,
     ) -> Option<V> {
-        let substate = self
-            .substate_db
-            .get_mapped::<SpreadPrefixKeyMapper, KeyValueEntrySubstate<V>>(
+        self.substate_db
+            .read_substate_typed::<KeyValueEntrySubstate<V>>(
                 node_id,
                 MAIN_BASE_PARTITION,
-                &SubstateKey::Map(scrypto_encode(key).unwrap()),
-            );
-        substate.and_then(|v| v.into_value())
+                SubstateKey::Map(scrypto_encode(key).unwrap()),
+            )
+            .and_then(|v| v.into_value())
     }
 
     pub fn read_typed_object_field<V: ScryptoDecode>(
@@ -259,11 +247,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
 
         let substate: FieldSubstate<V> = self
             .substate_db
-            .get_mapped::<SpreadPrefixKeyMapper, _>(
-                node_id,
-                partition_number,
-                &SubstateKey::Field(field_index),
-            )
+            .read_substate_typed(node_id, partition_number, SubstateKey::Field(field_index))
             .ok_or_else(|| SystemReaderError::FieldDoesNotExist)?;
 
         Ok(substate.into_payload())
@@ -310,26 +294,26 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         let entry = match collection_key {
             ObjectCollectionKey::KeyValue(_, key) => self
                 .substate_db
-                .get_mapped::<SpreadPrefixKeyMapper, KeyValueEntrySubstate<V>>(
+                .read_substate_typed::<KeyValueEntrySubstate<V>>(
                     node_id,
                     partition_number,
-                    &SubstateKey::Map(scrypto_encode(key).unwrap()),
+                    SubstateKey::Map(scrypto_encode(key).unwrap()),
                 )
                 .and_then(|value| value.into_value()),
             ObjectCollectionKey::Index(_, key) => self
                 .substate_db
-                .get_mapped::<SpreadPrefixKeyMapper, IndexEntrySubstate<V>>(
+                .read_substate_typed::<IndexEntrySubstate<V>>(
                     node_id,
                     partition_number,
-                    &SubstateKey::Map(scrypto_encode(key).unwrap()),
+                    SubstateKey::Map(scrypto_encode(key).unwrap()),
                 )
                 .map(|value| value.into_value()),
             ObjectCollectionKey::SortedIndex(_, sort, key) => self
                 .substate_db
-                .get_mapped::<SpreadPrefixKeyMapper, SortedIndexEntrySubstate<V>>(
+                .read_substate_typed::<SortedIndexEntrySubstate<V>>(
                     node_id,
                     partition_number,
-                    &SubstateKey::Sorted((sort.to_be_bytes(), scrypto_encode(key).unwrap())),
+                    SubstateKey::Sorted((sort.to_be_bytes(), scrypto_encode(key).unwrap())),
                 )
                 .map(|value| value.into_value()),
         };
@@ -351,27 +335,21 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
             _ => return Err(SystemReaderError::NotAKeyValueStore),
         }
 
-        let partition_key =
-            SpreadPrefixKeyMapper::to_db_partition_key(node_id, MAIN_BASE_PARTITION);
-
-        let from_key = from_key.map(|from_key| SpreadPrefixKeyMapper::map_to_db_sort_key(from_key));
-        let iter = self
+        let iterable = self
             .substate_db
-            .list_entries_from(&partition_key, from_key.as_ref())
-            .filter_map(move |entry| {
-                let substate_key = SpreadPrefixKeyMapper::from_db_sort_key::<MapKey>(&entry.0);
-                let key = match substate_key {
-                    SubstateKey::Map(map_key) => map_key,
-                    _ => panic!("Unexpected SubstateKey"),
-                };
-                let value: KeyValueEntrySubstate<ScryptoValue> = scrypto_decode(&entry.1).unwrap();
-                let value = value.into_value()?;
+            .read_map_entries_values_typed::<KeyValueEntrySubstate<ScryptoRawValue>>(
+                node_id,
+                MAIN_BASE_PARTITION,
+                from_key,
+            )
+            .filter_map(move |(map_key, substate)| {
+                let value = substate.into_value()?;
                 let value = scrypto_encode(&value).unwrap();
 
-                Some((key, value))
+                Some((map_key, value))
             });
 
-        Ok(Box::new(iter))
+        Ok(Box::new(iterable))
     }
 
     pub fn collection_iter(
@@ -384,15 +362,15 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
             .map(|x| x.0)
     }
 
-    pub fn collection_iter_advanced(
-        &self,
-        node_id: &NodeId,
+    pub fn collection_iter_advanced<'s, 'x>(
+        &'s self,
+        node_id: &'x NodeId,
         module_id: ModuleId,
         collection_index: CollectionIndex,
-        from_substate_key: Option<&SubstateKey>,
+        from_substate_key: Option<&'x SubstateKey>,
     ) -> Result<
         (
-            Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + '_>,
+            Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + 's>,
             PartitionNumber,
         ),
         SystemReaderError,
@@ -419,38 +397,42 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
             }
         };
 
-        let partition_key = SpreadPrefixKeyMapper::to_db_partition_key(node_id, partition_number);
-        let from_sort_key = from_substate_key
-            .map(|substate_key| SpreadPrefixKeyMapper::to_db_sort_key(substate_key));
-        let iter = self
-            .substate_db
-            .list_entries_from(&partition_key, from_sort_key.as_ref())
-            .filter_map(move |entry| {
-                let key = match schema {
-                    BlueprintCollectionSchema::KeyValueStore(..)
-                    | BlueprintCollectionSchema::Index(..) => {
-                        SpreadPrefixKeyMapper::from_db_sort_key::<MapKey>(&entry.0)
-                    }
-                    BlueprintCollectionSchema::SortedIndex(..) => {
-                        SpreadPrefixKeyMapper::from_db_sort_key::<SortedKey>(&entry.0)
-                    }
-                };
+        let iterable: Box<dyn Iterator<Item = (SubstateKey, Vec<u8>)> + 's> = match schema {
+            BlueprintCollectionSchema::KeyValueStore(..) | BlueprintCollectionSchema::Index(..) => {
+                let iterable = self
+                    .substate_db
+                    .read_map_entries_values_typed::<KeyValueEntrySubstate<ScryptoRawValue>>(
+                        node_id,
+                        partition_number,
+                        from_substate_key,
+                    )
+                    .filter_map(|(map_key, substate)| {
+                        Some((
+                            SubstateKey::Map(map_key),
+                            scrypto_encode(&substate.into_value()?).unwrap(),
+                        ))
+                    });
+                Box::new(iterable)
+            }
+            BlueprintCollectionSchema::SortedIndex(..) => {
+                let iterable = self
+                    .substate_db
+                    .read_sorted_entries_values_typed::<SortedIndexEntrySubstate<ScryptoRawValue>>(
+                        node_id,
+                        partition_number,
+                        from_substate_key,
+                    )
+                    .map(|(key, substate)| {
+                        (
+                            SubstateKey::Sorted(key),
+                            scrypto_encode(&substate.into_value()).unwrap(),
+                        )
+                    });
+                Box::new(iterable)
+            }
+        };
 
-                let value = match schema {
-                    BlueprintCollectionSchema::KeyValueStore(..) => {
-                        let value: KeyValueEntrySubstate<ScryptoValue> =
-                            scrypto_decode(&entry.1).unwrap();
-                        let value = value.into_value()?;
-                        scrypto_encode(&value).unwrap()
-                    }
-                    BlueprintCollectionSchema::SortedIndex(..)
-                    | BlueprintCollectionSchema::Index(..) => entry.1,
-                };
-
-                Some((key, value))
-            });
-
-        Ok((Box::new(iter), partition_number))
+        Ok((iterable, partition_number))
     }
 
     pub fn get_object_info<A: Into<NodeId>>(
@@ -458,7 +440,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         node_id: A,
     ) -> Result<ObjectInfo, SystemReaderError> {
         let type_info = self
-            .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
+            .fetch_substate::<TypeInfoSubstate>(
                 &node_id.into(),
                 TYPE_INFO_FIELD_PARTITION,
                 &TypeInfoField::TypeInfo.into(),
@@ -477,7 +459,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         module_id: ModuleId,
     ) -> Result<BlueprintId, SystemReaderError> {
         let type_info = self
-            .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
+            .fetch_substate::<TypeInfoSubstate>(
                 node_id,
                 TYPE_INFO_FIELD_PARTITION,
                 &TypeInfoField::TypeInfo.into(),
@@ -524,14 +506,19 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         }
 
         let bp_version_key = BlueprintVersionKey::new_default(blueprint_id.blueprint_name.clone());
-        let definition = Rc::new(self
-            .fetch_substate::<SpreadPrefixKeyMapper, PackageBlueprintVersionDefinitionEntrySubstate>(
+        let definition = Rc::new(
+            self.fetch_substate::<PackageBlueprintVersionDefinitionEntrySubstate>(
                 blueprint_id.package_address.as_node_id(),
                 MAIN_BASE_PARTITION
                     .at_offset(PACKAGE_BLUEPRINTS_PARTITION_OFFSET)
                     .unwrap(),
                 &SubstateKey::Map(scrypto_encode(&bp_version_key).unwrap()),
-            ).ok_or_else(|| SystemReaderError::BlueprintDoesNotExist)?.into_value().unwrap().fully_update_and_into_latest_version());
+            )
+            .ok_or_else(|| SystemReaderError::BlueprintDoesNotExist)?
+            .into_value()
+            .unwrap()
+            .fully_update_and_into_latest_version(),
+        );
 
         self.blueprint_cache
             .borrow_mut()
@@ -545,7 +532,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         node_id: &NodeId,
     ) -> Result<KVStoreTypeTarget, SystemReaderError> {
         let type_info = self
-            .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
+            .fetch_substate::<TypeInfoSubstate>(
                 node_id,
                 TYPE_INFO_FIELD_PARTITION,
                 &TypeInfoField::TypeInfo.into(),
@@ -569,7 +556,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         module_id: ModuleId,
     ) -> Result<BlueprintTypeTarget, SystemReaderError> {
         let type_info = self
-            .fetch_substate::<SpreadPrefixKeyMapper, TypeInfoSubstate>(
+            .fetch_substate::<TypeInfoSubstate>(
                 node_id,
                 TYPE_INFO_FIELD_PARTITION,
                 &TypeInfoField::TypeInfo.into(),
@@ -804,14 +791,16 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
             }
         }
 
-        let schema = Rc::new(self
-            .fetch_substate::<SpreadPrefixKeyMapper, KeyValueEntrySubstate<VersionedScryptoSchema>>(
+        let schema = Rc::new(
+            self.fetch_substate::<KeyValueEntrySubstate<VersionedScryptoSchema>>(
                 node_id,
                 SCHEMAS_PARTITION,
                 &SubstateKey::Map(scrypto_encode(schema_hash).unwrap()),
             )
-            .ok_or_else(|| SystemReaderError::SchemaDoesNotExist)?.into_value()
-            .expect("Schema should exist if substate exists"));
+            .ok_or_else(|| SystemReaderError::SchemaDoesNotExist)?
+            .into_value()
+            .expect("Schema should exist if substate exists"),
+        );
 
         self.schema_cache
             .borrow_mut()
@@ -850,7 +839,7 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
     ) -> Result<BlueprintDefinition, SystemReaderError> {
         let bp_version_key = BlueprintVersionKey::new_default(blueprint_id.blueprint_name.clone());
         let definition = self
-            .fetch_substate::<SpreadPrefixKeyMapper, PackageBlueprintVersionDefinitionEntrySubstate>(
+            .fetch_substate::<PackageBlueprintVersionDefinitionEntrySubstate>(
                 blueprint_id.package_address.as_node_id(),
                 MAIN_BASE_PARTITION
                     .at_offset(PACKAGE_BLUEPRINTS_PARTITION_OFFSET)
@@ -888,34 +877,34 @@ impl<'a, S: SubstateDatabase + ?Sized> SystemDatabaseReader<'a, S> {
         )
     }
 
-    pub fn fetch_substate<M: DatabaseKeyMapper, D: ScryptoDecode>(
+    pub fn fetch_substate<D: ScryptoDecode>(
         &self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
         key: &SubstateKey,
     ) -> Option<D> {
         if let Some(result) =
-            self.fetch_substate_from_state_updates::<M, D>(node_id, partition_num, key)
+            self.fetch_substate_from_state_updates::<D>(node_id, partition_num, key)
         {
             // If result can be determined from the state updates.
             result
         } else {
             // Otherwise, read from the substate database.
-            self.fetch_substate_from_database::<M, D>(node_id, partition_num, key)
+            self.fetch_substate_from_database::<D>(node_id, partition_num, key)
         }
     }
 
-    pub fn fetch_substate_from_database<M: DatabaseKeyMapper, D: ScryptoDecode>(
+    pub fn fetch_substate_from_database<D: ScryptoDecode>(
         &self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
         key: &SubstateKey,
     ) -> Option<D> {
         self.substate_db
-            .get_mapped::<M, D>(node_id, partition_num, key)
+            .read_substate_typed::<D>(node_id, partition_num, key)
     }
 
-    pub fn fetch_substate_from_state_updates<M: DatabaseKeyMapper, D: ScryptoDecode>(
+    pub fn fetch_substate_from_state_updates<D: ScryptoDecode>(
         &self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
@@ -1106,13 +1095,11 @@ impl<'a, S: SubstateDatabase> SystemDatabaseReader<'a, S> {
             panic!("substates_iter with overlay not supported.");
         }
 
-        let partition_key = SpreadPrefixKeyMapper::to_db_partition_key(node_id, partition_number);
-        let iter = self.substate_db.list_entries(&partition_key).map(|entry| {
-            let substate_key = SpreadPrefixKeyMapper::from_db_sort_key::<K>(&entry.0);
-            (substate_key, entry.1)
-        });
-
-        Box::new(iter)
+        let iterable = self
+            .substate_db
+            .read_entries::<K>(node_id, partition_number, None::<SubstateKey>)
+            .map(|(k, v)| (k.into_typed_key(), v));
+        Box::new(iterable)
     }
 }
 
@@ -1169,11 +1156,7 @@ impl<'a, S: SubstateDatabase + ListableSubstateDatabase> SystemDatabaseReader<'a
             panic!("partitions_iter with overlay not supported.");
         }
 
-        let iter = self.substate_db.list_partition_keys().map(|partition_key| {
-            let canonical_partition = SpreadPrefixKeyMapper::from_db_partition_key(&partition_key);
-            canonical_partition
-        });
-        Box::new(iter)
+        self.substate_db.read_partition_keys()
     }
 }
 
@@ -1216,11 +1199,11 @@ impl<'a, S: SubstateDatabase + CommittableSubstateDatabase> SystemDatabaseWriter
             PartitionDescription::Physical(partition_number) => *partition_number,
         };
 
-        self.substate_db.put_mapped::<SpreadPrefixKeyMapper, _>(
+        self.substate_db.update_substate_typed(
             node_id,
             partition_number,
-            &SubstateKey::Field(field_index),
-            &FieldSubstate::new_field(value, LockStatus::Unlocked),
+            SubstateKey::Field(field_index),
+            FieldSubstate::new_field(value, LockStatus::Unlocked),
         );
 
         Ok(())

--- a/radix-engine/src/system/system_type_checker.rs
+++ b/radix-engine/src/system/system_type_checker.rs
@@ -459,7 +459,7 @@ impl SystemMapper {
                     FieldTransience::NotTransient => {}
                 }
 
-                let payload: ScryptoValue =
+                let value: ScryptoRawValue =
                     scrypto_decode(&field.value).expect("Checked by payload-schema validation");
 
                 let lock_status = if field.locked {
@@ -468,7 +468,7 @@ impl SystemMapper {
                     LockStatus::Unlocked
                 };
 
-                let substate = FieldSubstate::new_field(payload, lock_status);
+                let substate = FieldSubstate::new_field(value, lock_status);
 
                 let value = IndexedScryptoValue::from_typed(&substate);
                 field_partition.insert(SubstateKey::Field(index), value);
@@ -490,7 +490,7 @@ impl SystemMapper {
 
             for (key, kv_entry) in substates {
                 let kv_entry = if let Some(value) = kv_entry.value {
-                    let value: ScryptoValue = scrypto_decode(&value).unwrap();
+                    let value: ScryptoRawValue = scrypto_decode(&value).unwrap();
                     let kv_entry = if kv_entry.locked {
                         KeyValueEntrySubstate::locked_entry(value)
                     } else {

--- a/radix-engine/src/track/interface.rs
+++ b/radix-engine/src/track/interface.rs
@@ -149,7 +149,7 @@ pub trait CommitableSubstateStore {
     /// Otherwise, behavior is undefined.
     ///
     /// Returns list of substate keys and database access info
-    fn scan_keys<K: SubstateKeyContent + 'static, E, F: FnMut(IOAccess) -> Result<(), E>>(
+    fn scan_keys<K: SubstateKeyContent, E, F: FnMut(IOAccess) -> Result<(), E>>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
@@ -165,7 +165,7 @@ pub trait CommitableSubstateStore {
     /// Otherwise, behavior is undefined.
     ///
     /// Returns list of removed substates with their associated keys and values, as well as database access info
-    fn drain_substates<K: SubstateKeyContent + 'static, E, F: FnMut(IOAccess) -> Result<(), E>>(
+    fn drain_substates<K: SubstateKeyContent, E, F: FnMut(IOAccess) -> Result<(), E>>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,

--- a/radix-engine/src/track/state_updates.rs
+++ b/radix-engine/src/track/state_updates.rs
@@ -1,6 +1,6 @@
 use crate::internal_prelude::*;
 use radix_rust::rust::{iter::*, mem};
-use radix_substate_store_interface::{db_key_mapper::DatabaseKeyMapper, interface::DbSortKey};
+use radix_substate_store_interface::interface::*;
 
 use super::TrackedSubstates;
 
@@ -258,9 +258,7 @@ impl TrackedNode {
     }
 }
 
-pub fn to_state_updates<M: DatabaseKeyMapper + 'static>(
-    tracked: TrackedSubstates,
-) -> (IndexSet<NodeId>, StateUpdates) {
+pub fn to_state_updates(tracked: TrackedSubstates) -> (IndexSet<NodeId>, StateUpdates) {
     let mut new_nodes = index_set_new();
     let mut system_updates = index_map_new();
     for (node_id, tracked_node) in tracked.tracked_nodes {

--- a/radix-engine/src/track/state_updates.rs
+++ b/radix-engine/src/track/state_updates.rs
@@ -2,8 +2,6 @@ use crate::internal_prelude::*;
 use radix_rust::rust::{iter::*, mem};
 use radix_substate_store_interface::interface::*;
 
-use super::TrackedSubstates;
-
 #[derive(Clone, Debug)]
 pub struct RuntimeSubstate {
     pub value: IndexedScryptoValue,
@@ -256,46 +254,6 @@ impl TrackedNode {
             tracked_partition.revert_writes();
         }
     }
-}
-
-pub fn to_state_updates(tracked: TrackedSubstates) -> (IndexSet<NodeId>, StateUpdates) {
-    let mut new_nodes = index_set_new();
-    let mut system_updates = index_map_new();
-    for (node_id, tracked_node) in tracked.tracked_nodes {
-        if tracked_node.is_new {
-            new_nodes.insert(node_id);
-        }
-
-        for (partition_num, tracked_partition) in tracked_node.tracked_partitions {
-            let mut partition_updates = index_map_new();
-            for tracked in tracked_partition.substates.into_values() {
-                let update = match tracked.substate_value {
-                    TrackedSubstateValue::ReadOnly(..) | TrackedSubstateValue::Garbage => None,
-                    TrackedSubstateValue::ReadNonExistAndWrite(substate)
-                    | TrackedSubstateValue::New(substate) => {
-                        Some(DatabaseUpdate::Set(substate.value.into()))
-                    }
-                    TrackedSubstateValue::ReadExistAndWrite(_, write)
-                    | TrackedSubstateValue::WriteOnly(write) => match write {
-                        Write::Delete => Some(DatabaseUpdate::Delete),
-                        Write::Update(substate) => Some(DatabaseUpdate::Set(substate.value.into())),
-                    },
-                };
-                if let Some(update) = update {
-                    partition_updates.insert(tracked.substate_key, update);
-                }
-            }
-            system_updates.insert((node_id.clone(), partition_num), partition_updates);
-        }
-    }
-
-    (
-        new_nodes,
-        StateUpdates::from(LegacyStateUpdates {
-            partition_deletions: tracked.deleted_partitions,
-            system_updates,
-        }),
-    )
 }
 
 pub struct IterationCountedIter<'a, E> {

--- a/radix-engine/src/transaction/state_update_summary.rs
+++ b/radix-engine/src/transaction/state_update_summary.rs
@@ -77,7 +77,7 @@ impl StateUpdateSummary {
                     return false;
                 }
                 let node_previously_existed = base_substate_db
-                    .read_substate(node_id, type_id_partition_number, type_id_substate_key)
+                    .get_raw_substate(node_id, type_id_partition_number, type_id_substate_key)
                     .is_some();
                 return !node_previously_existed;
             })

--- a/radix-engine/src/transaction/state_update_summary.rs
+++ b/radix-engine/src/transaction/state_update_summary.rs
@@ -4,10 +4,7 @@ use crate::system::system_db_reader::SystemDatabaseReader;
 use radix_common::data::scrypto::model::*;
 use radix_common::math::*;
 use radix_engine_interface::types::*;
-use radix_substate_store_interface::db_key_mapper::DatabaseKeyMapper;
-use radix_substate_store_interface::{
-    db_key_mapper::SpreadPrefixKeyMapper, interface::SubstateDatabase,
-};
+use radix_substate_store_interface::interface::*;
 use sbor::rust::prelude::*;
 
 #[derive(Default, Debug, Clone, ScryptoSbor, PartialEq, Eq)]
@@ -80,13 +77,7 @@ impl StateUpdateSummary {
                     return false;
                 }
                 let node_previously_existed = base_substate_db
-                    .get_substate(
-                        &SpreadPrefixKeyMapper::to_db_partition_key(
-                            node_id,
-                            type_id_partition_number,
-                        ),
-                        &SpreadPrefixKeyMapper::to_db_sort_key(&type_id_substate_key),
-                    )
+                    .read_substate(node_id, type_id_partition_number, type_id_substate_key)
                     .is_some();
                 return !node_previously_existed;
             })
@@ -249,7 +240,7 @@ impl<'a, S: SubstateDatabase> BalanceAccounter<'a, S> {
     fn calculate_fungible_vault_balance_change(&self, vault_id: &NodeId) -> Option<BalanceChange> {
         self
             .system_reader
-            .fetch_substate::<SpreadPrefixKeyMapper, FieldSubstate<FungibleVaultBalanceFieldPayload>>(
+            .fetch_substate::<FieldSubstate<FungibleVaultBalanceFieldPayload>>(
                 vault_id,
                 MAIN_BASE_PARTITION,
                 &FungibleVaultField::Balance.into(),
@@ -258,7 +249,7 @@ impl<'a, S: SubstateDatabase> BalanceAccounter<'a, S> {
             .map(|new_balance| {
                 let old_balance = self
                     .system_reader
-                    .fetch_substate_from_database::<SpreadPrefixKeyMapper, FieldSubstate<FungibleVaultBalanceFieldPayload>>(
+                    .fetch_substate_from_database::<FieldSubstate<FungibleVaultBalanceFieldPayload>>(
                         vault_id,
                         MAIN_BASE_PARTITION,
                         &FungibleVaultField::Balance.into(),
@@ -295,9 +286,9 @@ impl<'a, S: SubstateDatabase> BalanceAccounter<'a, S> {
                         for (substate_key, substate_update) in by_substate {
                             let id: NonFungibleLocalId =
                                 scrypto_decode(substate_key.for_map().unwrap()).unwrap();
-                                let previous_value = self
+                            let previous_value = self
                                 .system_reader
-                                .fetch_substate_from_database::<SpreadPrefixKeyMapper, ScryptoValue>(
+                                .fetch_substate_from_database::<ScryptoValue>(
                                     vault_id,
                                     partition_num,
                                     substate_key,

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -3,7 +3,7 @@ use crate::internal_prelude::*;
 use crate::kernel::id_allocator::IdAllocator;
 use crate::kernel::kernel::BootLoader;
 use crate::kernel::kernel_callback_api::*;
-use crate::system::system_callback::{System, SystemInit};
+use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::track::Track;
 use crate::transaction::*;
@@ -296,15 +296,14 @@ where
         }
     }
 
-    pub fn execute(&mut self, executable: V::Executable) -> V::Receipt {
-        let kernel_boot = BootLoader {
+    pub fn execute(self, executable: V::Executable) -> V::Receipt {
+        BootLoader {
             id_allocator: IdAllocator::new(executable.unique_seed_for_id_allocator()),
             track: Track::<_, SpreadPrefixKeyMapper>::new(self.substate_db),
-            init: self.system_init.clone(),
+            init: self.system_init,
             phantom: PhantomData::<V>::default(),
-        };
-
-        kernel_boot.execute(executable)
+        }
+        .execute(executable)
     }
 }
 
@@ -315,12 +314,14 @@ pub fn execute_transaction_with_configuration<S: SubstateDatabase, V: SystemCall
     executable: ExecutableTransaction,
 ) -> TransactionReceipt {
     let system_init = SystemInit {
-        enable_kernel_trace: execution_config.enable_kernel_trace,
-        enable_cost_breakdown: execution_config.enable_cost_breakdown,
-        enable_debug_information: execution_config.enable_debug_information,
-        execution_trace: execution_config.execution_trace,
+        self_init: SystemSelfInit {
+            enable_kernel_trace: execution_config.enable_kernel_trace,
+            enable_cost_breakdown: execution_config.enable_cost_breakdown,
+            enable_debug_information: execution_config.enable_debug_information,
+            execution_trace: execution_config.execution_trace,
+            system_overrides: execution_config.system_overrides.clone(),
+        },
         callback_init: vm_init,
-        system_overrides: execution_config.system_overrides.clone(),
     };
     TransactionExecutor::<_, System<V>>::new(substate_db, system_init).execute(executable)
 }

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -10,7 +10,7 @@ use crate::transaction::*;
 use crate::vm::*;
 use radix_common::constants::*;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
-use radix_substate_store_interface::{db_key_mapper::SpreadPrefixKeyMapper, interface::*};
+use radix_substate_store_interface::interface::*;
 use radix_transactions::model::*;
 
 /// Protocol-defined costing parameters
@@ -299,7 +299,7 @@ where
     pub fn execute(self, executable: V::Executable) -> V::Receipt {
         BootLoader {
             id_allocator: IdAllocator::new(executable.unique_seed_for_id_allocator()),
-            track: Track::<_, SpreadPrefixKeyMapper>::new(self.substate_db),
+            track: Track::new(self.substate_db),
             init: self.system_init,
             phantom: PhantomData::<V>::default(),
         }
@@ -354,11 +354,7 @@ pub fn execute_and_commit_transaction<'s, V: VmInitialize>(
             executable,
         );
     if let TransactionResult::Commit(commit) = &receipt.result {
-        substate_db.commit(
-            &commit
-                .state_updates
-                .create_database_updates::<SpreadPrefixKeyMapper>(),
-        );
+        substate_db.commit(&commit.state_updates.create_database_updates());
     }
     receipt
 }

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -1680,8 +1680,7 @@ mod tests {
     #[derive(ScryptoSbor, ScryptoSborAssertion)]
     #[sbor_assert(
         backwards_compatible(
-            bottlenose = "FILE:node_local_transaction_execution_v1_bottlenose.txt",
-            cuttlefish = "FILE:node_local_transaction_execution_v1_cuttlefish.txt"
+            bottlenose = "FILE:node_local_transaction_execution_v1_cuttlefish.txt"
         ),
         settings(allow_name_changes)
     )]

--- a/radix-engine/src/transaction/transaction_receipt.rs
+++ b/radix-engine/src/transaction/transaction_receipt.rs
@@ -1680,7 +1680,8 @@ mod tests {
     #[derive(ScryptoSbor, ScryptoSborAssertion)]
     #[sbor_assert(
         backwards_compatible(
-            bottlenose = "FILE:node_local_transaction_execution_v1_cuttlefish.txt"
+            bottlenose = "FILE:node_local_transaction_execution_v1_bottlenose.txt",
+            cuttlefish = "FILE:node_local_transaction_execution_v1_cuttlefish.txt"
         ),
         settings(allow_name_changes)
     )]

--- a/radix-engine/src/updates/cuttlefish.rs
+++ b/radix-engine/src/updates/cuttlefish.rs
@@ -89,7 +89,7 @@ fn generate_principal_batch(
 
 fn generate_system_logic_v2_updates<S: SubstateDatabase + ?Sized>(db: &S) -> StateUpdates {
     let system_boot: SystemBoot = db
-        .read_substate_typed(
+        .get_substate(
             TRANSACTION_TRACKER,
             BOOT_LOADER_PARTITION,
             SubstateKey::Field(BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY),

--- a/radix-engine/src/updates/cuttlefish.rs
+++ b/radix-engine/src/updates/cuttlefish.rs
@@ -2,9 +2,6 @@ use super::*;
 use crate::system::system_callback::{
     SystemBoot, VersionedSystemLogic, BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY,
 };
-use radix_substate_store_interface::db_key_mapper::{
-    MappedSubstateDatabase, SpreadPrefixKeyMapper,
-};
 
 #[derive(Clone)]
 pub struct CuttlefishSettings {
@@ -92,10 +89,10 @@ fn generate_principal_batch(
 
 fn generate_system_logic_v2_updates<S: SubstateDatabase + ?Sized>(db: &S) -> StateUpdates {
     let system_boot: SystemBoot = db
-        .get_mapped::<SpreadPrefixKeyMapper, _>(
-            &TRANSACTION_TRACKER.into_node_id(),
+        .read_substate_typed(
+            TRANSACTION_TRACKER,
             BOOT_LOADER_PARTITION,
-            &SubstateKey::Field(BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY),
+            SubstateKey::Field(BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY),
         )
         .unwrap();
 

--- a/radix-engine/src/updates/protocol_builder.rs
+++ b/radix-engine/src/updates/protocol_builder.rs
@@ -299,7 +299,7 @@ impl ProtocolExecutor {
 
     pub fn is_bootstrapped(store: &mut impl SubstateDatabase) -> bool {
         store
-            .read_substate(
+            .get_raw_substate(
                 PACKAGE_PACKAGE,
                 TYPE_INFO_FIELD_PARTITION,
                 TypeInfoField::TypeInfo,

--- a/radix-engine/src/updates/protocol_builder.rs
+++ b/radix-engine/src/updates/protocol_builder.rs
@@ -1,4 +1,3 @@
-use radix_substate_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
 use radix_transactions::{model::*, validation::TransactionValidator};
 
 use crate::{
@@ -66,9 +65,7 @@ impl ProtocolUpdateExecutor {
                 for (transaction_index, transaction) in batch.transactions.into_iter().enumerate() {
                     let receipt = match &transaction {
                         ProtocolUpdateTransactionDetails::FlashV1Transaction(flash) => {
-                            let db_updates = flash
-                                .state_updates
-                                .create_database_updates::<SpreadPrefixKeyMapper>();
+                            let db_updates = flash.state_updates.create_database_updates();
                             let receipt = if H::IS_ENABLED {
                                 let before_store = &*store;
                                 FlashReceipt::from_state_updates(
@@ -302,12 +299,10 @@ impl ProtocolExecutor {
 
     pub fn is_bootstrapped(store: &mut impl SubstateDatabase) -> bool {
         store
-            .get_substate(
-                &SpreadPrefixKeyMapper::to_db_partition_key(
-                    PACKAGE_PACKAGE.as_node_id(),
-                    TYPE_INFO_FIELD_PARTITION,
-                ),
-                &SpreadPrefixKeyMapper::to_db_sort_key(&TypeInfoField::TypeInfo.into()),
+            .read_substate(
+                PACKAGE_PACKAGE,
+                TYPE_INFO_FIELD_PARTITION,
+                TypeInfoField::TypeInfo,
             )
             .is_some()
     }

--- a/radix-substate-store-impls/src/memory_db.rs
+++ b/radix-substate-store-impls/src/memory_db.rs
@@ -15,7 +15,7 @@ impl InMemorySubstateDatabase {
 }
 
 impl SubstateDatabase for InMemorySubstateDatabase {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
@@ -26,7 +26,7 @@ impl SubstateDatabase for InMemorySubstateDatabase {
             .cloned()
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,

--- a/radix-substate-store-impls/src/rocks_db.rs
+++ b/radix-substate-store-impls/src/rocks_db.rs
@@ -43,7 +43,7 @@ impl RocksdbSubstateStore {
 }
 
 impl SubstateDatabase for RocksdbSubstateStore {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
@@ -52,7 +52,7 @@ impl SubstateDatabase for RocksdbSubstateStore {
         self.db.get_cf(self.cf(), &key_bytes).expect("IO Error")
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,

--- a/radix-substate-store-impls/src/rocks_db_with_merkle_tree/mod.rs
+++ b/radix-substate-store-impls/src/rocks_db_with_merkle_tree/mod.rs
@@ -92,7 +92,7 @@ impl RocksDBWithMerkleTreeSubstateStore {
 }
 
 impl SubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
@@ -103,7 +103,7 @@ impl SubstateDatabase for RocksDBWithMerkleTreeSubstateStore {
             .expect("IO Error")
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,

--- a/radix-substate-store-impls/src/state_tree_support.rs
+++ b/radix-substate-store-impls/src/state_tree_support.rs
@@ -44,21 +44,22 @@ impl<D> StateTreeUpdatingDatabase<D> {
 }
 
 impl<D: SubstateDatabase> SubstateDatabase for StateTreeUpdatingDatabase<D> {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
     ) -> Option<DbSubstateValue> {
-        self.underlying.get_substate(partition_key, sort_key)
+        self.underlying
+            .get_raw_substate_by_db_key(partition_key, sort_key)
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,
     ) -> Box<dyn Iterator<Item = PartitionEntry> + '_> {
         self.underlying
-            .list_entries_from(partition_key, from_sort_key)
+            .list_raw_values_from_db_key(partition_key, from_sort_key)
     }
 }
 
@@ -91,7 +92,7 @@ where
         for (db_partition_key, by_db_sort_key) in hashes_from_tree {
             if by_db_sort_key.into_iter().collect::<HashMap<_, _>>()
                 != self
-                    .list_entries(&db_partition_key)
+                    .list_raw_values_from_db_key(&db_partition_key, None)
                     .map(|(db_sort_key, substate_value)| (db_sort_key, hash(substate_value)))
                     .collect::<HashMap<_, _>>()
             {

--- a/radix-substate-store-impls/src/substate_database_overlay.rs
+++ b/radix-substate-store-impls/src/substate_database_overlay.rs
@@ -80,7 +80,7 @@ impl<S: BorrowMut<D>, D: CommittableSubstateDatabase> SubstateDatabaseOverlay<S,
 }
 
 impl<S: Borrow<D>, D: SubstateDatabase> SubstateDatabase for SubstateDatabaseOverlay<S, D> {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key @ DbPartitionKey {
             node_key,
@@ -136,11 +136,11 @@ impl<S: Borrow<D>, D: SubstateDatabase> SubstateDatabase for SubstateDatabaseOve
             OverlayLookupResult::Found(substate_value) => substate_value.cloned(),
             OverlayLookupResult::NotFound => self
                 .get_readable_root()
-                .get_substate(partition_key, sort_key),
+                .get_raw_substate_by_db_key(partition_key, sort_key),
         }
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key @ DbPartitionKey {
             node_key,
@@ -187,7 +187,7 @@ impl<S: Borrow<D>, D: SubstateDatabase> SubstateDatabase for SubstateDatabaseOve
                     Some(StagingPartitionDatabaseUpdates::Delta { substate_updates }) => {
                         let underlying = self
                             .get_readable_root()
-                            .list_entries_from(partition_key, from_sort_key.as_ref());
+                            .list_raw_values_from_db_key(partition_key, from_sort_key.as_ref());
 
                         match from_sort_key {
                             // A `from_sort_key` is specified. Only return sort keys that are larger
@@ -224,14 +224,14 @@ impl<S: Borrow<D>, D: SubstateDatabase> SubstateDatabase for SubstateDatabaseOve
                     // iterator over the data in the root store.
                     None => self
                         .get_readable_root()
-                        .list_entries_from(partition_key, from_sort_key.as_ref()),
+                        .list_raw_values_from_db_key(partition_key, from_sort_key.as_ref()),
                 }
             }
             // Overlay doesn't contain anything for the provided node key. Return an iterator over
             // the data in the root store.
             None => self
                 .get_readable_root()
-                .list_entries_from(partition_key, from_sort_key.as_ref()),
+                .list_raw_values_from_db_key(partition_key, from_sort_key.as_ref()),
         }
     }
 }

--- a/radix-substate-store-interface/src/db_key_mapper.rs
+++ b/radix-substate-store-interface/src/db_key_mapper.rs
@@ -64,7 +64,7 @@ pub trait DatabaseKeyMapper: 'static {
     /// Mapper::from_db_sort_key::<MapKey>(&db_sort_key);
     /// Mapper::from_db_sort_key::<SortedKey>(&db_sort_key);
     /// ```
-    fn from_db_sort_key<K: SubstateKeyContent + 'static>(db_sort_key: &DbSortKey) -> SubstateKey {
+    fn from_db_sort_key<K: SubstateKeyContent>(db_sort_key: &DbSortKey) -> SubstateKey {
         K::from_db_key::<Self>(db_sort_key).into_typed_key()
     }
 

--- a/radix-substate-store-interface/src/interface.rs
+++ b/radix-substate-store-interface/src/interface.rs
@@ -1,4 +1,4 @@
-use super::db_key_mapper::DatabaseKeyMapper;
+use crate::db_key_mapper::*;
 use radix_common::prelude::*;
 
 pub type DbNodeKey = Vec<u8>;
@@ -30,8 +30,13 @@ pub type PartitionEntry = (DbSortKey, DbSubstateValue);
 pub trait CreateDatabaseUpdates {
     type DatabaseUpdates;
 
+    /// Uses the default [`DatabaseKeyMapper`], [`SpreadPrefixKeyMapper`], to express self using database-level key encoding.
+    fn create_database_updates(&self) -> Self::DatabaseUpdates {
+        self.create_database_updates_with_mapper::<SpreadPrefixKeyMapper>()
+    }
+
     /// Uses the given [`DatabaseKeyMapper`] to express self using database-level key encoding.
-    fn create_database_updates<M: DatabaseKeyMapper>(&self) -> Self::DatabaseUpdates;
+    fn create_database_updates_with_mapper<M: DatabaseKeyMapper>(&self) -> Self::DatabaseUpdates;
 }
 
 /// A canonical description of all database updates to be applied.
@@ -43,10 +48,18 @@ pub struct DatabaseUpdates {
     pub node_updates: IndexMap<DbNodeKey, NodeDatabaseUpdates>,
 }
 
+impl DatabaseUpdates {
+    pub fn node_ids(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.node_updates
+            .keys()
+            .map(|key| SpreadPrefixKeyMapper::from_db_node_key(key))
+    }
+}
+
 impl CreateDatabaseUpdates for StateUpdates {
     type DatabaseUpdates = DatabaseUpdates;
 
-    fn create_database_updates<M: DatabaseKeyMapper>(&self) -> DatabaseUpdates {
+    fn create_database_updates_with_mapper<M: DatabaseKeyMapper>(&self) -> DatabaseUpdates {
         DatabaseUpdates {
             node_updates: self
                 .by_node
@@ -54,7 +67,7 @@ impl CreateDatabaseUpdates for StateUpdates {
                 .map(|(node_id, node_state_updates)| {
                     (
                         M::to_db_node_key(node_id),
-                        node_state_updates.create_database_updates::<M>(),
+                        node_state_updates.create_database_updates_with_mapper::<M>(),
                     )
                 })
                 .collect(),
@@ -74,7 +87,7 @@ pub struct NodeDatabaseUpdates {
 impl CreateDatabaseUpdates for NodeStateUpdates {
     type DatabaseUpdates = NodeDatabaseUpdates;
 
-    fn create_database_updates<M: DatabaseKeyMapper>(&self) -> NodeDatabaseUpdates {
+    fn create_database_updates_with_mapper<M: DatabaseKeyMapper>(&self) -> NodeDatabaseUpdates {
         match self {
             NodeStateUpdates::Delta { by_partition } => NodeDatabaseUpdates {
                 partition_updates: by_partition
@@ -82,7 +95,7 @@ impl CreateDatabaseUpdates for NodeStateUpdates {
                     .map(|(partition_num, partition_state_updates)| {
                         (
                             M::to_db_partition_num(*partition_num),
-                            partition_state_updates.create_database_updates::<M>(),
+                            partition_state_updates.create_database_updates_with_mapper::<M>(),
                         )
                     })
                     .collect(),
@@ -132,7 +145,9 @@ impl PartitionDatabaseUpdates {
 impl CreateDatabaseUpdates for PartitionStateUpdates {
     type DatabaseUpdates = PartitionDatabaseUpdates;
 
-    fn create_database_updates<M: DatabaseKeyMapper>(&self) -> PartitionDatabaseUpdates {
+    fn create_database_updates_with_mapper<M: DatabaseKeyMapper>(
+        &self,
+    ) -> PartitionDatabaseUpdates {
         match self {
             PartitionStateUpdates::Delta { by_substate } => PartitionDatabaseUpdates::Delta {
                 substate_updates: by_substate
@@ -140,7 +155,7 @@ impl CreateDatabaseUpdates for PartitionStateUpdates {
                     .map(|(key, update)| (M::to_db_sort_key(key), update.clone()))
                     .collect(),
             },
-            PartitionStateUpdates::Batch(batch) => batch.create_database_updates::<M>(),
+            PartitionStateUpdates::Batch(batch) => batch.create_database_updates_with_mapper::<M>(),
         }
     }
 }
@@ -148,7 +163,9 @@ impl CreateDatabaseUpdates for PartitionStateUpdates {
 impl CreateDatabaseUpdates for BatchPartitionStateUpdate {
     type DatabaseUpdates = PartitionDatabaseUpdates;
 
-    fn create_database_updates<M: DatabaseKeyMapper>(&self) -> PartitionDatabaseUpdates {
+    fn create_database_updates_with_mapper<M: DatabaseKeyMapper>(
+        &self,
+    ) -> PartitionDatabaseUpdates {
         match self {
             BatchPartitionStateUpdate::Reset {
                 new_substate_values,
@@ -205,6 +222,13 @@ impl DatabaseUpdates {
 /// A read interface between Track and a database vendor.
 pub trait SubstateDatabase {
     /// Reads a substate value by its partition and sort key, or [`Option::None`] if missing.
+    ///
+    /// ## Alternatives
+    ///
+    /// It's likely easier to use the [`read_substate`][SubstateDatabaseExtensions::read_substate] or
+    /// [`read_substate_typed`][SubstateDatabaseExtensions::read_substate_typed] methods instead.
+    /// These should exist on the substate database as long as the [`SubstateDatabaseExtensions`] trait
+    /// is in scope.
     fn get_substate(
         &self,
         partition_key: &DbPartitionKey,
@@ -215,6 +239,11 @@ pub trait SubstateDatabase {
     /// from the given [`DbSortKey`]), in a lexicographical order (ascending) of the [`DbSortKey`]s.
     /// Note: If the exact given starting key does not exist, the iteration starts with its
     /// immediate successor.
+    ///
+    /// ## Alternatives
+    ///
+    /// There are lots of methods starting `read_` which allow reading entries more easily.
+    /// These methods are present as long as the [`SubstateDatabaseExtensions`] trait is in scope.
     fn list_entries_from(
         &self,
         partition_key: &DbPartitionKey,
@@ -225,6 +254,11 @@ pub trait SubstateDatabase {
     /// of the [`DbSortKey`]s.
     /// This is a convenience method, equivalent to [`Self::list_entries_from()`] with the starting
     /// key set to [`None`].
+    ///
+    /// ## Alternatives
+    ///
+    /// There are lots of methods starting `read_` which allow reading entries more easily.
+    /// These methods are present as long as the [`SubstateDatabaseExtensions`] trait is in scope.
     fn list_entries(
         &self,
         partition_key: &DbPartitionKey,
@@ -233,14 +267,304 @@ pub trait SubstateDatabase {
     }
 }
 
+impl<T: SubstateDatabase + ?Sized> SubstateDatabaseExtensions for T {}
+
+/// These are a separate trait so that [`SubstateDatabase`] stays object-safe,
+/// and can be used as `dyn SubstateDatabase`.
+///
+/// Generic parameters aren't permitted on object-safe traits.
+pub trait SubstateDatabaseExtensions: SubstateDatabase {
+    fn db_partition_key(
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+    ) -> DbPartitionKey {
+        SpreadPrefixKeyMapper::to_db_partition_key(node_id.as_ref(), partition_number)
+    }
+
+    fn db_sort_key<'a>(substate_key: impl ResolvableSubstateKey<'a>) -> DbSortKey {
+        SpreadPrefixKeyMapper::to_db_sort_key_from_ref(
+            substate_key.into_substate_key_or_ref().as_ref(),
+        )
+    }
+
+    fn optional_db_sort_key<'a>(
+        optional_substate_key: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Option<DbSortKey> {
+        optional_substate_key
+            .into_optional_substate_key_or_ref()
+            .map(|key_or_ref| SpreadPrefixKeyMapper::to_db_sort_key_from_ref(key_or_ref.as_ref()))
+    }
+
+    /// Reads the substate using the default [`SpreadPrefixKeyMapper`].
+    ///
+    /// ## Example use:
+    /// ```ignore
+    /// let is_bootstrapped = store.read_substate(
+    ///     PACKAGE_PACKAGE,
+    ///     TYPE_INFO_FIELD_PARTITION,
+    ///     TypeInfoField::TypeInfo,
+    /// ).is_some();
+    /// ```
+    fn read_substate<'a>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+    ) -> Option<Vec<u8>> {
+        self.get_substate(
+            &Self::db_partition_key(node_id, partition_number),
+            &Self::db_sort_key(substate_key),
+        )
+    }
+
+    /// Reads the substate using the default [`SpreadPrefixKeyMapper`], and then
+    /// decodes the substate value. It panics if the value has a decode error.
+    ///
+    /// ## Example use:
+    /// ```ignore
+    /// let type_info_substate: TypeInfoSubstate = store.read_substate_typed(
+    ///     PACKAGE_PACKAGE,
+    ///     TYPE_INFO_FIELD_PARTITION,
+    ///     TypeInfoField::TypeInfo,
+    /// );
+    /// ```
+    fn read_substate_typed<'a, T: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+    ) -> Option<T> {
+        let raw = self.read_substate(node_id, partition_number, substate_key)?;
+        Some(decode_value(&raw))
+    }
+
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    #[inline]
+    fn read_entries_unknown_key<'a>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (DbSortKey, Vec<u8>)> + '_> {
+        self.list_entries_from(
+            &Self::db_partition_key(node_id, partition_number),
+            Self::optional_db_sort_key(from_substate_key_inclusive).as_ref(),
+        )
+    }
+
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_entries<'a, K: SubstateKeyContent>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (K, Vec<u8>)> + '_> {
+        let iterable = self
+            .list_entries_from(
+                &Self::db_partition_key(node_id, partition_number),
+                Self::optional_db_sort_key(from_substate_key_inclusive).as_ref(),
+            )
+            .map(|(db_sort_key, raw_value)| {
+                (
+                    SpreadPrefixKeyMapper::from_db_sort_key_to_inner::<K>(&db_sort_key),
+                    raw_value,
+                )
+            });
+        Box::new(iterable)
+    }
+
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_entries_values_typed<'a, K: SubstateKeyContent, V: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (K, V)> + '_> {
+        let iterator = self
+            .read_entries_unknown_key(node_id, partition_number, from_substate_key_inclusive)
+            .map(|(db_sort_key, raw_value)| {
+                (
+                    SpreadPrefixKeyMapper::from_db_sort_key_to_inner::<K>(&db_sort_key),
+                    decode_value::<V>(&raw_value),
+                )
+            });
+        Box::new(iterator)
+    }
+
+    /// Leaves the key and value raw.
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_map_entries<'a>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (MapKey, Vec<u8>)> + '_> {
+        self.read_entries::<MapKey>(node_id, partition_number, from_substate_key_inclusive)
+    }
+
+    /// Decodes just the value, leaving the key raw.
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_map_entries_values_typed<'a, V: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (MapKey, V)> + '_> {
+        self.read_entries_values_typed::<MapKey, V>(
+            node_id,
+            partition_number,
+            from_substate_key_inclusive,
+        )
+    }
+
+    /// Decodes both the key and value.
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_map_entries_typed<'a, K: ScryptoDecode, V: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (K, V)> + '_> {
+        let iterator = self
+            .read_map_entries(node_id, partition_number, from_substate_key_inclusive)
+            .map(|(raw_key, raw_value)| (decode_key::<K>(&raw_key), decode_value::<V>(&raw_value)));
+        Box::new(iterator)
+    }
+
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_sorted_entries<'a>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (SortedKey, Vec<u8>)> + '_> {
+        self.read_entries::<SortedKey>(node_id, partition_number, from_substate_key_inclusive)
+    }
+
+    /// Decodes just the value, leaving the key raw.
+    /// Use `from_substate_key_inclusive: None::<SubstateKey>` to read from start.
+    fn read_sorted_entries_values_typed<'a, V: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        from_substate_key_inclusive: impl ResolvableOptionalSubstateKey<'a>,
+    ) -> Box<dyn Iterator<Item = (SortedKey, V)> + '_> {
+        self.read_entries_values_typed::<SortedKey, V>(
+            node_id,
+            partition_number,
+            from_substate_key_inclusive,
+        )
+    }
+}
+
+fn decode_key<K: ScryptoDecode>(raw: &[u8]) -> K {
+    scrypto_decode::<K>(&raw).unwrap_or_else(|err| {
+        panic!(
+            "Expected key to be decodable as {}. Error: {:?}.",
+            core::any::type_name::<K>(),
+            err,
+        )
+    })
+}
+
+fn decode_value<V: ScryptoDecode>(raw: &[u8]) -> V {
+    scrypto_decode::<V>(&raw).unwrap_or_else(|err| {
+        panic!(
+            "Expected value to be decodable as {}. Error: {:?}.",
+            core::any::type_name::<V>(),
+            err,
+        )
+    })
+}
+
 /// A write interface between Track and a database vendor.
 pub trait CommittableSubstateDatabase {
     /// Commits state changes to the database.
     fn commit(&mut self, database_updates: &DatabaseUpdates);
 }
 
+impl<T: CommittableSubstateDatabase + ?Sized> CommittableSubstateDatabaseExtensions for T {}
+
+pub trait CommittableSubstateDatabaseExtensions: CommittableSubstateDatabase {
+    fn update_substate<'a>(
+        &mut self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+        value: Vec<u8>,
+    ) {
+        self.commit(&DatabaseUpdates::from_delta_maps(indexmap!(
+            SpreadPrefixKeyMapper::to_db_partition_key(
+                node_id.as_ref(),
+                partition_number,
+            ) => indexmap!(
+                SpreadPrefixKeyMapper::to_db_sort_key_from_ref(
+                    substate_key.into_substate_key_or_ref().as_ref(),
+                ) => DatabaseUpdate::Set(
+                    value
+                )
+            )
+        )))
+    }
+
+    fn delete_substate<'a>(
+        &mut self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+    ) {
+        self.commit(&DatabaseUpdates::from_delta_maps(indexmap!(
+            SpreadPrefixKeyMapper::to_db_partition_key(
+                node_id.as_ref(),
+                partition_number,
+            ) => indexmap!(
+                SpreadPrefixKeyMapper::to_db_sort_key_from_ref(
+                    substate_key.into_substate_key_or_ref().as_ref(),
+                ) => DatabaseUpdate::Delete,
+            )
+        )))
+    }
+
+    fn update_substate_typed<'a, E: ScryptoEncode>(
+        &mut self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+        value: E,
+    ) {
+        let encoded_value = scrypto_encode(&value).unwrap_or_else(|err| {
+            panic!(
+                "Expected value to be encodable as {}. Error: {:?}.",
+                core::any::type_name::<E>(),
+                err,
+            )
+        });
+        self.update_substate(node_id, partition_number, substate_key, encoded_value)
+    }
+}
+
 /// A partition listing interface between Track and a database vendor.
 pub trait ListableSubstateDatabase {
     /// Iterates over all partition keys, in an arbitrary order.
+    ///
+    /// ## Alternatives
+    /// You likely want to use the [`read_partition_keys`][ListableSubstateDatabaseExtensions::read_partition_keys]
+    /// method instead, which returns an unmapped key. This is available if
+    /// the trait [`ListableSubstateDatabaseExtensions`] is in scope.
     fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_>;
+}
+
+impl<T: ListableSubstateDatabase + ?Sized> ListableSubstateDatabaseExtensions for T {}
+
+/// These are a separate trait so that [`ListableSubstateDatabase`] stays object-safe,
+/// and can be used as `dyn ListableSubstateDatabase`.
+///
+/// Generic parameters aren't permitted on object-safe traits.
+pub trait ListableSubstateDatabaseExtensions: ListableSubstateDatabase {
+    fn read_partition_keys(&self) -> Box<dyn Iterator<Item = (NodeId, PartitionNumber)> + '_> {
+        let iterator = self
+            .list_partition_keys()
+            .map(|key| SpreadPrefixKeyMapper::from_db_partition_key(&key));
+        Box::new(iterator)
+    }
 }

--- a/radix-transaction-scenarios/src/executor.rs
+++ b/radix-transaction-scenarios/src/executor.rs
@@ -6,7 +6,6 @@ use radix_engine::blueprints::consensus_manager::*;
 use radix_engine::system::system_db_reader::*;
 use radix_engine::updates::*;
 use radix_engine::vm::*;
-use radix_substate_store_interface::db_key_mapper::*;
 use radix_substate_store_interface::interface::*;
 use radix_transactions::errors::*;
 use radix_transactions::validation::*;
@@ -322,9 +321,7 @@ where
         );
 
         if let TransactionResult::Commit(commit) = &receipt.result {
-            let database_updates = commit
-                .state_updates
-                .create_database_updates::<SpreadPrefixKeyMapper>();
+            let database_updates = commit.state_updates.create_database_updates();
             self.database.commit(&database_updates);
         };
 

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -208,7 +208,7 @@ where
             |substate_database| Track::new(substate_database),
             |scrypto_vm, database| {
                 let vm_boot = database
-                    .read_substate_typed(
+                    .get_substate(
                         TRANSACTION_TRACKER,
                         BOOT_LOADER_PARTITION,
                         BOOT_LOADER_VM_BOOT_FIELD_KEY,
@@ -415,7 +415,7 @@ impl FlashSubstateDatabase {
 }
 
 impl SubstateDatabase for FlashSubstateDatabase {
-    fn get_substate(
+    fn get_raw_substate_by_db_key(
         &self,
         partition_key: &DbPartitionKey,
         sort_key: &DbSortKey,
@@ -426,7 +426,7 @@ impl SubstateDatabase for FlashSubstateDatabase {
             .cloned()
     }
 
-    fn list_entries_from(
+    fn list_raw_values_from_db_key(
         &self,
         partition_key: &DbPartitionKey,
         from_sort_key: Option<&DbSortKey>,

--- a/scrypto-test/src/environment/types.rs
+++ b/scrypto-test/src/environment/types.rs
@@ -4,7 +4,7 @@
 use crate::prelude::*;
 
 pub type TestVm<'g> = Vm<'g, DefaultWasmEngine, NoExtension>;
-pub type TestTrack<'g, D> = Track<'g, D, SpreadPrefixKeyMapper>;
+pub type TestTrack<'g, D> = Track<'g, D>;
 pub type TestSystemConfig<'g> = System<TestVm<'g>>;
 pub type TestKernel<'g, D> = Kernel<'g, TestSystemConfig<'g>, TestTrack<'g, D>>;
 pub type TestSystemService<'g, D> = SystemService<'g, TestKernel<'g, D>>;

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -460,7 +460,7 @@ impl<'a, M: SystemCallbackObject, Y: KernelApi<CallbackObject = InjectCostingErr
             .kernel_scan_sorted_substates(node_id, partition_num, count)
     }
 
-    fn kernel_scan_keys<K: SubstateKeyContent + 'static>(
+    fn kernel_scan_keys<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,
@@ -470,7 +470,7 @@ impl<'a, M: SystemCallbackObject, Y: KernelApi<CallbackObject = InjectCostingErr
             .kernel_scan_keys::<K>(node_id, partition_num, count)
     }
 
-    fn kernel_drain_substates<K: SubstateKeyContent + 'static>(
+    fn kernel_drain_substates<K: SubstateKeyContent>(
         &mut self,
         node_id: &NodeId,
         partition_num: PartitionNumber,

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -13,7 +13,7 @@ use radix_engine::vm::wasm::DefaultWasmEngine;
 use radix_engine::vm::Vm;
 use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
 use radix_engine_interface::prelude::*;
-use radix_substate_store_interface::db_key_mapper::{SpreadPrefixKeyMapper, SubstateKeyContent};
+use radix_substate_store_interface::db_key_mapper::SubstateKeyContent;
 use radix_substate_store_interface::interface::SubstateDatabase;
 use radix_transactions::model::ExecutableTransaction;
 
@@ -102,7 +102,7 @@ impl<K: SystemCallbackObject> KernelTransactionCallbackObject for InjectCostingE
 
     fn create_receipt<S: SubstateDatabase>(
         self,
-        track: Track<S, SpreadPrefixKeyMapper>,
+        track: Track<S>,
         result: Result<Vec<InstructionOutput>, TransactionExecutionError>,
     ) -> TransactionReceipt {
         self.system.create_receipt(track, result)

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -1215,16 +1215,19 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
 
         let execution_config =
             ExecutionConfig::for_test_transaction().with_kernel_trace(self.with_kernel_trace);
-        let mut executor = TransactionExecutor::<_, InjectSystemCostingError<'_, E>>::new(
+
+        let executor = TransactionExecutor::<_, InjectSystemCostingError<'_, E>>::new(
             &self.database,
             InjectCostingErrorInput {
                 system_input: SystemInit {
-                    enable_kernel_trace: execution_config.enable_kernel_trace,
-                    enable_cost_breakdown: execution_config.enable_cost_breakdown,
-                    enable_debug_information: execution_config.enable_debug_information,
-                    execution_trace: execution_config.execution_trace,
+                    self_init: SystemSelfInit {
+                        enable_kernel_trace: execution_config.enable_kernel_trace,
+                        enable_cost_breakdown: execution_config.enable_cost_breakdown,
+                        enable_debug_information: execution_config.enable_debug_information,
+                        execution_trace: execution_config.execution_trace,
+                        system_overrides: execution_config.system_overrides.clone(),
+                    },
                     callback_init: vm_init,
-                    system_overrides: execution_config.system_overrides.clone(),
                 },
                 error_after_count,
             },

--- a/scrypto-test/src/ledger_simulator/ledger_simulator.rs
+++ b/scrypto-test/src/ledger_simulator/ledger_simulator.rs
@@ -638,7 +638,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
 
     pub fn component_state<T: ScryptoDecode>(&self, component_address: ComponentAddress) -> T {
         let node_id: &NodeId = component_address.as_node_id();
-        let component_state = self.substate_db().read_substate_typed::<FieldSubstate<T>>(
+        let component_state = self.substate_db().get_substate::<FieldSubstate<T>>(
             node_id,
             MAIN_BASE_PARTITION,
             ComponentField::State0,
@@ -679,7 +679,7 @@ impl<E: NativeVmExtension, D: TestDatabase> LedgerSimulator<E, D> {
     pub fn get_fungible_resource_total_supply(&self, resource: ResourceAddress) -> Decimal {
         let total_supply = self
             .substate_db()
-            .read_substate_typed::<FungibleResourceManagerTotalSupplyFieldSubstate>(
+            .get_substate::<FungibleResourceManagerTotalSupplyFieldSubstate>(
                 resource,
                 MAIN_BASE_PARTITION,
                 FungibleResourceManagerField::TotalSupply,


### PR DESCRIPTION
## Summary
* Added `SubstateDatabaseExtensions`, `CommittableSubstateDatabaseExtensions` and `ListableSubstateDatabaseExtensions` (in `radix-substate-store-interface/src/interface.rs`) which give easier interfaces to a substate store. Also replaced `MappedSubstateDatabase` etc with these.
* Removed `SpreadPrefixKeyMapper` where it could be removed in the codebase.

## Testing
Existing tests pass

## Update Recommendations
Make the following changes:
* `substate_database.get_mapped` to `substate_database.read_substate_typed`
* `substate_database.list_mapped` to `substate_database.read_entries_values_typed`.
