### PR TITLE
fix: made locker package visible in scrypto-test

### DIFF
--- a/scrypto-test/src/environment/constants.rs
+++ b/scrypto-test/src/environment/constants.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// Defines the set of Nodes that all test [`CallFrame`]s have visibility to when they're first
 /// created. This contains all of the well-known addresses of nodes.
-pub(super) const GLOBAL_VISIBLE_NODES: [NodeId; 28] = [
+pub(super) const GLOBAL_VISIBLE_NODES: [NodeId; 29] = [
     XRD.into_node_id(),
     SECP256K1_SIGNATURE_RESOURCE.into_node_id(),
     ED25519_SIGNATURE_RESOURCE.into_node_id(),
@@ -20,6 +20,7 @@ pub(super) const GLOBAL_VISIBLE_NODES: [NodeId; 28] = [
     CONSENSUS_MANAGER_PACKAGE.into_node_id(),
     ACCESS_CONTROLLER_PACKAGE.into_node_id(),
     POOL_PACKAGE.into_node_id(),
+    LOCKER_PACKAGE.into_node_id(),
     TRANSACTION_PROCESSOR_PACKAGE.into_node_id(),
     METADATA_MODULE_PACKAGE.into_node_id(),
     ROYALTY_MODULE_PACKAGE.into_node_id(),


### PR DESCRIPTION
Using TestEnvironment in combination with packages that made use of the AccountLocker wasn't possible. Now it is.

## Summary
```
Packages that made use of the AccountLocker weren't testable using the TestEnvironment. With this fix they are.
```

## Details
```
I reckon it was just an omission, but it could be there was a reason for leaving out the AccountLocker from being used in the TestEnvironment. Feel free to ignore if it messes with the rest of the code base. 

It seems the AccountLocker package wasn't visible, as it hadn't been added to the GLOBAL_VISIBLE_NODES in the environment constants. All I did was add it.
```

## Testing
```
Not a lot, only test I've done is try to publish a package that makes use of the AccountLocker using the TestEnvironment. Before the fix it didn't work:

KernelError(CallFrameError(CreateFrameError(PassMessageError(GlobalRefNotFound(NodeId("0d906318c6318c6fe2d9198c6318c6318cf7bd4f3bf55557c6318c6318c6")))))).

After the fix, it does work.
```