### PR TITLE
refactor: Streamline engine init

### DIFF
--- a/radix-common/src/types/node_and_substate.rs
+++ b/radix-common/src/types/node_and_substate.rs
@@ -307,6 +307,16 @@ impl<'a> SubstateKeyOrRef<'a> {
 
 pub trait ResolvableSubstateKey<'a>: Sized {
     fn into_substate_key_or_ref(self) -> SubstateKeyOrRef<'a>;
+    fn into_substate_key(self) -> SubstateKey {
+        match self.into_substate_key_or_ref() {
+            SubstateKeyOrRef::Owned(key) => key,
+            SubstateKeyOrRef::Borrowed(SubstateKeyRef::Field(key)) => SubstateKey::Field(*key),
+            SubstateKeyOrRef::Borrowed(SubstateKeyRef::Map(key)) => SubstateKey::Map(key.clone()),
+            SubstateKeyOrRef::Borrowed(SubstateKeyRef::Sorted(key)) => {
+                SubstateKey::Sorted(key.clone())
+            }
+        }
+    }
 }
 
 impl<'a> ResolvableSubstateKey<'a> for &'a SubstateKey {

--- a/radix-engine-tests/tests/application/stake_reconciliation.rs
+++ b/radix-engine-tests/tests/application/stake_reconciliation.rs
@@ -89,7 +89,7 @@ fn test_stake_reconciliation() {
     //     let partition_num = PartitionNumber(1);
     //     let substate_key = SubstateKey::Map(ScryptoRawPayload::from_valid_payload(vec![92, 32, 7, 32, 220, 0, 156, 5, 6, 83, 96, 189, 222, 100, 29, 145, 160, 147, 193, 127, 71, 54, 135, 62, 103, 35, 126, 168, 230, 117, 203, 71, 36, 132, 155, 157]));
     //     let value_from_database: ScryptoRawValue = ledger.substate_db()
-    //         .read_substate_typed(&node_id, partition_num, substate_key)
+    //         .get_raw_substate(&node_id, partition_num, substate_key)
     //         .unwrap();
     //     let substate_value = value_from_database.into_payload_bytes();
     //     let state_updates = StateUpdates {

--- a/radix-engine-tests/tests/kernel/kernel_open_substate.rs
+++ b/radix-engine-tests/tests/kernel/kernel_open_substate.rs
@@ -1,31 +1,7 @@
-use radix_common::prelude::*;
-use radix_engine::errors::{CallFrameError, KernelError, RuntimeError};
-use radix_engine::kernel::call_frame::OpenSubstateError;
-use radix_engine::kernel::id_allocator::IdAllocator;
-use radix_engine::kernel::kernel::Kernel;
-use radix_engine::kernel::kernel_api::KernelSubstateApi;
-use radix_engine::system::system_callback::{System, SystemLockData, VersionedSystemLogic};
-use radix_engine::system::system_modules::auth::AuthModule;
-use radix_engine::system::system_modules::costing::{
-    CostingModule, CostingModuleConfig, FeeTable, SystemLoanFeeReserve,
-};
-use radix_engine::system::system_modules::execution_trace::ExecutionTraceModule;
 use radix_engine::system::system_modules::kernel_trace::KernelTraceModule;
 use radix_engine::system::system_modules::limits::LimitsModule;
 use radix_engine::system::system_modules::transaction_runtime::TransactionRuntimeModule;
-use radix_engine::system::system_modules::{EnabledModules, SystemModuleMixer};
-use radix_engine::track::Track;
-use radix_engine::updates::ProtocolBuilder;
-use radix_engine::vm::wasm::DefaultWasmEngine;
-use radix_engine::vm::*;
-use radix_engine_interface::api::LockFlags;
-use radix_engine_interface::prelude::*;
-use radix_substate_store_impls::memory_db::InMemorySubstateDatabase;
-use radix_substate_store_queries::typed_substate_layout::{
-    BlueprintVersionKey, PACKAGE_AUTH_TEMPLATE_PARTITION_OFFSET,
-};
-use radix_transactions::prelude::*;
-use scrypto_test::prelude::UniqueTransaction;
+use scrypto_test::prelude::*;
 
 #[test]
 pub fn test_open_substate_of_invisible_package_address() {
@@ -46,17 +22,14 @@ pub fn test_open_substate_of_invisible_package_address() {
         .commit_each_protocol_update(&mut database);
 
     // Create kernel
-    let mut system = System {
-        versioned_system_logic: VersionedSystemLogic::V1,
-        blueprint_cache: NonIterMap::new(),
-        auth_cache: NonIterMap::new(),
-        schema_cache: NonIterMap::new(),
-        callback: Vm {
+    let mut system = System::new(
+        SystemVersion::latest(),
+        Vm {
             scrypto_vm: &scrypto_vm,
             native_vm,
             vm_boot: VmBoot::latest(),
         },
-        modules: SystemModuleMixer::new(
+        SystemModuleMixer::new(
             EnabledModules::for_test_transaction(),
             KernelTraceModule,
             TransactionRuntimeModule::new(
@@ -78,8 +51,8 @@ pub fn test_open_substate_of_invisible_package_address() {
             },
             ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
         ),
-        finalization: Default::default(),
-    };
+        SystemFinalization::no_nullifications(),
+    );
     let mut track = Track::new(&database);
     let mut id_allocator = IdAllocator::new(executable.unique_seed_for_id_allocator());
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);

--- a/radix-engine-tests/tests/vm/native_vm.rs
+++ b/radix-engine-tests/tests/vm/native_vm.rs
@@ -65,17 +65,14 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
     let native_vm = NativeVm::new_with_extension(Extension);
 
     let intent_hash = Hash([0; 32]);
-    let mut system = System {
-        versioned_system_logic: VersionedSystemLogic::V1,
-        blueprint_cache: NonIterMap::new(),
-        auth_cache: NonIterMap::new(),
-        schema_cache: NonIterMap::new(),
-        callback: Vm {
+    let mut system = System::new(
+        SystemVersion::latest(),
+        Vm {
             scrypto_vm: &scrypto_vm,
             native_vm,
             vm_boot: VmBoot::latest(),
         },
-        modules: SystemModuleMixer::new(
+        SystemModuleMixer::new(
             EnabledModules::for_notarized_transaction(),
             KernelTraceModule,
             TransactionRuntimeModule::new(NetworkDefinition::simulator(), intent_hash),
@@ -94,8 +91,8 @@ fn panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
             },
             ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
         ),
-        finalization: Default::default(),
-    };
+        SystemFinalization::no_nullifications(),
+    );
 
     let mut id_allocator = IdAllocator::new(intent_hash);
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);
@@ -136,17 +133,14 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
     let native_vm = NativeVm::new_with_extension(NonStringPanicExtension);
 
     let intent_hash = Hash([0; 32]);
-    let mut system = System {
-        versioned_system_logic: VersionedSystemLogic::V1,
-        blueprint_cache: NonIterMap::new(),
-        auth_cache: NonIterMap::new(),
-        schema_cache: NonIterMap::new(),
-        callback: Vm {
+    let mut system = System::new(
+        SystemVersion::latest(),
+        Vm {
             scrypto_vm: &scrypto_vm,
             native_vm,
             vm_boot: VmBoot::latest(),
         },
-        modules: SystemModuleMixer::new(
+        SystemModuleMixer::new(
             EnabledModules::for_notarized_transaction(),
             KernelTraceModule,
             TransactionRuntimeModule::new(NetworkDefinition::simulator(), intent_hash),
@@ -165,8 +159,8 @@ fn any_panics_can_be_caught_in_the_native_vm_and_converted_into_results() {
             },
             ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
         ),
-        finalization: Default::default(),
-    };
+        SystemFinalization::no_nullifications(),
+    );
 
     let mut id_allocator = IdAllocator::new(intent_hash);
     let mut kernel = Kernel::new_no_refs(&mut track, &mut id_allocator, &mut system);

--- a/radix-engine/src/init.rs
+++ b/radix-engine/src/init.rs
@@ -1,0 +1,3 @@
+pub trait InitializationParameters {
+    type For;
+}

--- a/radix-engine/src/lib.rs
+++ b/radix-engine/src/lib.rs
@@ -35,9 +35,12 @@ pub mod vm;
 /// Protocol updates
 pub mod updates;
 
+pub mod init;
+
 pub(crate) mod internal_prelude {
     pub use crate::blueprints::internal_prelude::*;
     pub use crate::errors::*;
+    pub use crate::init::*;
     pub use crate::system::system_substates::*;
     pub use crate::{
         dispatch, event_schema, function_schema, method_auth_template, roles_template,

--- a/radix-engine/src/system/bootstrap.rs
+++ b/radix-engine/src/system/bootstrap.rs
@@ -338,7 +338,7 @@ pub fn create_system_bootstrap_flash(
                 native_code_id.to_be_bytes().to_vec(),
                 system_instructions,
                 false,
-                &VmBoot::babylon(),
+                &VmBoot::babylon_genesis(),
             )
             .unwrap_or_else(|err| {
                 panic!(

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -57,46 +57,115 @@ pub struct SystemParameters {
     pub limit_parameters: LimitParameters,
 }
 
+impl SystemParameters {
+    pub fn latest(network_definition: NetworkDefinition) -> Self {
+        Self::bottlenose(network_definition)
+    }
+
+    pub fn bottlenose(network_definition: NetworkDefinition) -> Self {
+        Self {
+            network_definition,
+            costing_module_config: CostingModuleConfig::bottlenose(),
+            costing_parameters: CostingParameters::babylon_genesis(),
+            limit_parameters: LimitParameters::babylon_genesis(),
+        }
+    }
+
+    pub fn babylon_genesis(network_definition: NetworkDefinition) -> Self {
+        Self {
+            network_definition,
+            costing_module_config: CostingModuleConfig::babylon_genesis(),
+            costing_parameters: CostingParameters::babylon_genesis(),
+            limit_parameters: LimitParameters::babylon_genesis(),
+        }
+    }
+}
+
 pub type SystemBootSubstate = SystemBoot;
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum SystemBoot {
     V1(SystemParameters),
-    V2(VersionedSystemLogic, SystemParameters),
+    V2(SystemVersion, SystemParameters),
 }
 
 impl SystemBoot {
-    pub fn babylon_genesis(network_definition: NetworkDefinition) -> Self {
-        SystemBoot::V1(SystemParameters {
-            network_definition,
-            costing_parameters: CostingParameters::babylon_genesis(),
-            costing_module_config: CostingModuleConfig::babylon_genesis(),
-            limit_parameters: LimitParameters::babylon_genesis(),
-        })
+    /// Loads system boot from the database, or resolves a fallback..
+    ///
+    /// # Panics
+    /// This method panics if the database is pre-bottlenose and the execution config
+    /// does not specify a network definition.
+    pub fn load(substate_db: &impl SubstateDatabase, execution_config: &ExecutionConfig) -> Self {
+        substate_db
+            .get_substate(
+                TRANSACTION_TRACKER,
+                BOOT_LOADER_PARTITION,
+                BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY,
+            )
+            .unwrap_or_else(|| {
+                let overrides = execution_config.system_overrides.as_ref();
+                let network_definition = overrides.and_then(|o| o.network_definition.as_ref())
+                    .expect("Before bottlenose, no SystemBoot substate exists, so a network_definition must be provided in the SystemOverrides of the ExecutionConfig.");
+                SystemBoot::babylon_genesis(network_definition.clone())
+            })
     }
 
-    fn system_logic_version(&self) -> VersionedSystemLogic {
+    pub fn latest(network_definition: NetworkDefinition) -> Self {
+        Self::cuttlefish(network_definition)
+    }
+
+    pub fn cuttlefish(network_definition: NetworkDefinition) -> Self {
+        SystemBoot::V2(
+            SystemVersion::V2,
+            SystemParameters::bottlenose(network_definition),
+        )
+    }
+
+    pub fn cuttlefish_for_previous_parameters(parameters: SystemParameters) -> Self {
+        SystemBoot::V2(SystemVersion::V2, parameters)
+    }
+
+    pub fn bottlenose(network_definition: NetworkDefinition) -> Self {
+        SystemBoot::V1(SystemParameters::bottlenose(network_definition))
+    }
+
+    pub fn babylon_genesis(network_definition: NetworkDefinition) -> Self {
+        SystemBoot::V1(SystemParameters::babylon_genesis(network_definition))
+    }
+
+    pub fn system_version(&self) -> SystemVersion {
         match self {
-            Self::V1(..) => VersionedSystemLogic::V1,
-            Self::V2(logic, _) => *logic,
+            Self::V1(..) => SystemVersion::V1,
+            Self::V2(version, _) => *version,
+        }
+    }
+
+    pub fn into_parameters(self) -> SystemParameters {
+        match self {
+            Self::V1(parameters) => parameters,
+            Self::V2(_, parameters) => parameters,
         }
     }
 }
 
 /// System logic which may change given a protocol version
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ScryptoSbor)]
-pub enum VersionedSystemLogic {
+pub enum SystemVersion {
     V1,
     V2,
 }
 
-impl VersionedSystemLogic {
+impl SystemVersion {
+    pub const fn latest() -> Self {
+        Self::V2
+    }
+
     fn create_auth_module(
         &self,
         executable: &ExecutableTransaction,
     ) -> Result<AuthModule, RejectionReason> {
         let auth_module = match self {
-            VersionedSystemLogic::V1 => {
+            SystemVersion::V1 => {
                 // This isn't exactly a necessary check as node logic should protect against this
                 // but keep it here for sanity
                 let intent = if executable.intents().len() != 1 {
@@ -106,7 +175,7 @@ impl VersionedSystemLogic {
                 };
                 AuthModule::new_with_transaction_processor_auth_zone(intent.auth_zone_init.clone())
             }
-            VersionedSystemLogic::V2 => AuthModule::new(),
+            SystemVersion::V2 => AuthModule::new(),
         };
 
         Ok(auth_module)
@@ -119,7 +188,7 @@ impl VersionedSystemLogic {
         global_address_reservations: Vec<GlobalAddressReservation>,
     ) -> Result<Vec<InstructionOutput>, RuntimeError> {
         let output = match self {
-            VersionedSystemLogic::V1 => {
+            SystemVersion::V1 => {
                 let mut system_service = SystemService::new(api);
                 let intent = executable
                     .intents()
@@ -140,7 +209,7 @@ impl VersionedSystemLogic {
                 let output: Vec<InstructionOutput> = scrypto_decode(&rtn).unwrap();
                 output
             }
-            VersionedSystemLogic::V2 => {
+            SystemVersion::V2 => {
                 let mut txn_threads =
                     MultiThreadedTxnProcessor::init(executable, global_address_reservations, api)?;
                 txn_threads.execute(api)?;
@@ -162,13 +231,13 @@ impl VersionedSystemLogic {
 
     pub fn should_consume_cost_units<Y: SystemBasedKernelApi>(&self, api: &mut Y) -> bool {
         match self {
-            VersionedSystemLogic::V1 => {
+            SystemVersion::V1 => {
                 // Skip client-side costing requested by TransactionProcessor
                 if api.kernel_get_current_depth() == 1 {
                     return false;
                 }
             }
-            VersionedSystemLogic::V2 => {}
+            SystemVersion::V2 => {}
         }
 
         true
@@ -253,9 +322,36 @@ impl<V: SystemCallbackObject, K: KernelInternalApi<System = System<V>>> SystemBa
     type SystemCallback = V;
 }
 
-pub struct SystemInit<V> {
+pub struct SystemInit<I: InitializationParameters<For: SystemCallbackObject<Init = I>>> {
     pub self_init: SystemSelfInit,
-    pub callback_init: V,
+    pub callback_init: I,
+}
+
+impl<I: InitializationParameters<For: SystemCallbackObject<Init = I>>> SystemInit<I> {
+    /// This is expected to follow up with a match statement and a call to `v1` / `v2`
+    /// etc, to select the correct concrete generic.
+    pub fn load(
+        substate_db: &impl SubstateDatabase,
+        execution_config: ExecutionConfig,
+        callback_init: I,
+    ) -> Self {
+        let system_boot = SystemBoot::load(substate_db, &execution_config);
+        let self_init = SystemSelfInit::new(
+            execution_config,
+            system_boot.system_version(),
+            system_boot.into_parameters(),
+        );
+        Self {
+            self_init,
+            callback_init,
+        }
+    }
+}
+
+impl<I: InitializationParameters<For: SystemCallbackObject<Init = I>>> InitializationParameters
+    for SystemInit<I>
+{
+    type For = System<I::For>;
 }
 
 pub struct SystemSelfInit {
@@ -265,12 +361,32 @@ pub struct SystemSelfInit {
     pub execution_trace: Option<usize>,
     pub enable_debug_information: bool,
 
-    // An override of system configuration
+    // Configuration
+    pub system_parameters: SystemParameters,
+    pub system_logic_version: SystemVersion,
     pub system_overrides: Option<SystemOverrides>,
 }
 
+impl SystemSelfInit {
+    pub fn new(
+        execution_config: ExecutionConfig,
+        system_logic_version: SystemVersion,
+        system_parameters: SystemParameters,
+    ) -> Self {
+        Self {
+            enable_kernel_trace: execution_config.enable_kernel_trace,
+            enable_cost_breakdown: execution_config.enable_cost_breakdown,
+            enable_debug_information: execution_config.enable_debug_information,
+            execution_trace: execution_config.execution_trace,
+            system_overrides: execution_config.system_overrides,
+            system_logic_version,
+            system_parameters,
+        }
+    }
+}
+
 pub struct System<V: SystemCallbackObject> {
-    pub versioned_system_logic: VersionedSystemLogic,
+    pub versioned_system_logic: SystemVersion,
     pub callback: V,
     pub blueprint_cache: NonIterMap<CanonicalBlueprintId, Rc<BlueprintDefinition>>,
     pub schema_cache: NonIterMap<SchemaHash, Rc<VersionedScryptoSchema>>,
@@ -290,12 +406,36 @@ impl<V: SystemCallbackObject> HasModules for System<V> {
     }
 }
 
-#[derive(Default)]
 pub struct SystemFinalization {
-    intent_nullifications: Vec<IntentHashNullification>,
+    pub intent_nullifications: Vec<IntentHashNullification>,
+}
+
+impl SystemFinalization {
+    pub fn no_nullifications() -> Self {
+        Self {
+            intent_nullifications: vec![],
+        }
+    }
 }
 
 impl<V: SystemCallbackObject> System<V> {
+    pub fn new(
+        versioned_system_logic: SystemVersion,
+        callback: V,
+        modules: SystemModuleMixer,
+        finalization: SystemFinalization,
+    ) -> Self {
+        Self {
+            callback,
+            blueprint_cache: NonIterMap::new(),
+            auth_cache: NonIterMap::new(),
+            schema_cache: NonIterMap::new(),
+            modules,
+            finalization,
+            versioned_system_logic,
+        }
+    }
+
     fn on_move_node<Y: SystemBasedKernelApi>(
         node_id: &NodeId,
         is_moving_down: bool,
@@ -746,14 +886,14 @@ impl<V: SystemCallbackObject> System<V> {
     fn update_transaction_tracker<S: SubstateDatabase>(
         track: &mut Track<S>,
         next_epoch: Epoch,
-        intent_hash_nullification: IntentHashNullification,
+        intent_hash_nullifications: Vec<IntentHashNullification>,
         is_success: bool,
     ) {
         // NOTE: In the case of system transactions, we could skip most of this...
         //       except for backwards compatibility, we can't!
 
         // Read the intent hash store
-        let transaction_tracker = track
+        let mut transaction_tracker = track
             .read_substate(
                 TRANSACTION_TRACKER.as_node_id(),
                 MAIN_BASE_PARTITION,
@@ -762,59 +902,53 @@ impl<V: SystemCallbackObject> System<V> {
             .unwrap()
             .as_typed::<FieldSubstate<TransactionTrackerSubstate>>()
             .unwrap()
-            .into_payload();
+            .into_payload()
+            .into_v1();
 
-        let mut transaction_tracker = transaction_tracker.into_v1();
-
-        let mark_intent_result = match intent_hash_nullification {
-            IntentHashNullification::TransactionIntent {
-                intent_hash,
-                expiry_epoch,
-                ..
-            } => Some((intent_hash.into_hash(), expiry_epoch)),
-            IntentHashNullification::Subintent {
-                intent_hash,
-                expiry_epoch,
-                ..
-            } => {
-                // Only write subintent nullification on success.
-                // Subintents can't pay fees, so this isn't a problem.
-                if is_success {
-                    Some((intent_hash.into_hash(), expiry_epoch))
-                } else {
-                    None
+        for intent_hash_nullification in intent_hash_nullifications {
+            let (intent_hash, expiry_epoch) = match intent_hash_nullification {
+                IntentHashNullification::TransactionIntent {
+                    intent_hash,
+                    expiry_epoch,
+                    ..
+                } => (intent_hash.into_hash(), expiry_epoch),
+                IntentHashNullification::Subintent {
+                    intent_hash,
+                    expiry_epoch,
+                    ..
+                } => {
+                    // Don't write subintent nullification on failure.
+                    // Subintents can't pay fees, so this isn't abusable.
+                    if !is_success {
+                        continue;
+                    }
+                    (intent_hash.into_hash(), expiry_epoch)
                 }
-            }
-            IntentHashNullification::System => None,
-        };
+            };
 
-        if let Some((intent_hash, expiry_epoch)) = mark_intent_result {
+            let partition_number = transaction_tracker.partition_for_expiry_epoch(expiry_epoch)
+                .expect("Validation of the max expiry epoch window should ensure that the expiry epoch is in range for the transaction tracker");
+
             // Update the status of the intent hash
-            if let Some(partition_number) =
-                transaction_tracker.partition_for_expiry_epoch(expiry_epoch)
-            {
-                track
-                    .set_substate(
-                        TRANSACTION_TRACKER.into_node_id(),
-                        PartitionNumber(partition_number),
-                        SubstateKey::Map(scrypto_encode(&intent_hash).unwrap()),
-                        IndexedScryptoValue::from_typed(&KeyValueEntrySubstate::V1(
-                            KeyValueEntrySubstateV1 {
-                                value: Some(if is_success {
-                                    TransactionStatus::V1(TransactionStatusV1::CommittedSuccess)
-                                } else {
-                                    TransactionStatus::V1(TransactionStatusV1::CommittedFailure)
-                                }),
-                                // TODO: maybe make it immutable, but how does this affect partition deletion?
-                                lock_status: LockStatus::Unlocked,
-                            },
-                        )),
-                        &mut |_| -> Result<(), ()> { Ok(()) },
-                    )
-                    .unwrap();
-            } else {
-                panic!("No partition for an expiry epoch")
-            }
+            track
+                .set_substate(
+                    TRANSACTION_TRACKER.into_node_id(),
+                    PartitionNumber(partition_number),
+                    SubstateKey::Map(scrypto_encode(&intent_hash).unwrap()),
+                    IndexedScryptoValue::from_typed(&KeyValueEntrySubstate::V1(
+                        KeyValueEntrySubstateV1 {
+                            value: Some(if is_success {
+                                TransactionStatus::V1(TransactionStatusV1::CommittedSuccess)
+                            } else {
+                                TransactionStatus::V1(TransactionStatusV1::CommittedFailure)
+                            }),
+                            // TODO: maybe make it immutable, but how does this affect partition deletion?
+                            lock_status: LockStatus::Unlocked,
+                        },
+                    )),
+                    &mut |_| -> Result<(), ()> { Ok(()) },
+                )
+                .unwrap();
         }
 
         // Check if all intent hashes in the first epoch have expired, based on the `next_epoch`.
@@ -939,7 +1073,7 @@ impl<V: SystemCallbackObject> System<V> {
     fn reference_check(
         references: &IndexSet<Reference>,
         modules: &mut SystemModuleMixer,
-        store: &mut (impl BootStore + CommitableSubstateStore),
+        store: &mut impl CommitableSubstateStore,
     ) -> Result<(IndexSet<GlobalAddress>, IndexSet<InternalAddress>), BootloadingError> {
         let mut global_addresses = indexset!();
         let mut direct_accesses = indexset!();
@@ -984,7 +1118,7 @@ impl<V: SystemCallbackObject> System<V> {
     fn build_call_frame_inits_with_reference_check(
         intents: &Vec<ExecutableIntent>,
         modules: &mut SystemModuleMixer,
-        store: &mut (impl BootStore + CommitableSubstateStore),
+        store: &mut impl CommitableSubstateStore,
     ) -> Result<Vec<CallFrameInit<Actor>>, BootloadingError> {
         let mut init_call_frames = vec![];
         for intent in intents {
@@ -1134,14 +1268,12 @@ impl<V: SystemCallbackObject> System<V> {
 
         // Update intent hash status
         if let Some(next_epoch) = Self::read_epoch_uncosted(&mut track) {
-            for intent_nullification in system_finalization.intent_nullifications {
-                Self::update_transaction_tracker(
-                    &mut track,
-                    next_epoch,
-                    intent_nullification,
-                    is_success,
-                );
-            }
+            Self::update_transaction_tracker(
+                &mut track,
+                next_epoch,
+                system_finalization.intent_nullifications,
+                is_success,
+            );
         }
 
         // Finalize events and logs
@@ -1253,30 +1385,11 @@ impl<V: SystemCallbackObject> System<V> {
     }
 
     fn resolve_modules(
-        store: &mut impl BootStore,
         executable: &ExecutableTransaction,
         init_input: SystemSelfInit,
-    ) -> Result<(VersionedSystemLogic, SystemModuleMixer), TransactionReceipt> {
-        let system_boot = store
-            .read_boot_substate(
-                TRANSACTION_TRACKER.as_node_id(),
-                BOOT_LOADER_PARTITION,
-                &SubstateKey::Field(BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY),
-            )
-            .map(|v| scrypto_decode(v.as_slice()).unwrap())
-            .unwrap_or_else(|| {
-                let overrides = init_input.system_overrides.as_ref();
-                let network_definition = overrides.and_then(|o| o.network_definition.as_ref())
-                    .expect("Before bottlenose, no SystemBoot substate exists, so a network_definition must be provided in the SystemOverrides of the ExecutionConfig.");
-                SystemBoot::babylon_genesis(network_definition.clone())
-            });
-
-        let system_logic_version = system_boot.system_logic_version();
-        let mut system_parameters = match system_boot {
-            SystemBoot::V1(system_parameters) | SystemBoot::V2(_, system_parameters) => {
-                system_parameters
-            }
-        };
+    ) -> Result<SystemModuleMixer, TransactionReceiptV1> {
+        let mut system_parameters = init_input.system_parameters;
+        let system_logic_version = init_input.system_logic_version;
 
         let mut enabled_modules = {
             let mut enabled_modules = EnabledModules::AUTH | EnabledModules::TRANSACTION_RUNTIME;
@@ -1369,20 +1482,21 @@ impl<V: SystemCallbackObject> System<V> {
             costing_module,
             ExecutionTraceModule::new(init_input.execution_trace.unwrap_or(0)),
         );
-        Ok((system_logic_version, module_mixer))
+
+        Ok(module_mixer)
     }
 }
 
-impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
+impl<V: SystemCallbackObject> KernelTransactionExecutor for System<V> {
     type Init = SystemInit<V::Init>;
     type Executable = ExecutableTransaction;
     type ExecutionOutput = Vec<InstructionOutput>;
     type Receipt = TransactionReceipt;
 
-    fn init<S: BootStore + CommitableSubstateStore>(
-        store: &mut S,
+    fn init(
+        store: &mut impl CommitableSubstateStore,
         executable: &ExecutableTransaction,
-        init_input: SystemInit<V::Init>,
+        init_input: Self::Init,
     ) -> Result<(Self, Vec<CallFrameInit<Actor>>), Self::Receipt> {
         // Dump executable
         #[cfg(not(feature = "alloc"))]
@@ -1390,11 +1504,11 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
             Self::print_executable(executable);
         }
 
-        let (logic_version, mut modules) =
-            Self::resolve_modules(store, executable, init_input.self_init)?;
+        let logic_version = init_input.self_init.system_logic_version;
+        let mut modules = Self::resolve_modules(executable, init_input.self_init)?;
 
         // NOTE: Have to use match pattern rather than map_err to appease the borrow checker
-        let callback = match V::init(store, init_input.callback_init) {
+        let callback = match V::init(init_input.callback_init) {
             Ok(callback) => callback,
             Err(error) => return Err(Self::create_rejection_receipt(error, modules)),
         };
@@ -1405,10 +1519,9 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
         }
 
         // Perform runtime validation.
-        // TODO: the following assumptions can be removed with better interface.
-        // We are assuming that intent hash store is ready when epoch manager is ready.
-        let current_epoch = Self::read_epoch_uncosted(store);
-        if let Some(current_epoch) = current_epoch {
+        // NOTE: The epoch doesn't exist yet on the very first transaction, so we skip this
+        if let Some(current_epoch) = Self::read_epoch_uncosted(store) {
+            // We are assuming that intent hash store is ready when epoch manager is ready.
             if let Some(range) = executable.overall_epoch_range() {
                 let epoch_validation_result = Self::validate_epoch_range(
                     current_epoch,
@@ -1454,7 +1567,6 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
                         )
                     }
                 }
-                IntentHashNullification::System => Ok(()),
             };
             match intent_hash_validation_result {
                 Ok(()) => {}
@@ -1471,26 +1583,23 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
             Err(error) => return Err(Self::create_rejection_receipt(error, modules)),
         };
 
-        let system = System {
-            versioned_system_logic: logic_version,
-            blueprint_cache: NonIterMap::new(),
-            auth_cache: NonIterMap::new(),
-            schema_cache: NonIterMap::new(),
+        let system = System::new(
+            logic_version,
             callback,
             modules,
-            finalization: SystemFinalization {
+            SystemFinalization {
                 intent_nullifications: executable
                     .intent_hash_nullifications()
                     .iter()
                     .cloned()
                     .collect(),
             },
-        };
+        );
 
         Ok((system, call_frame_inits))
     }
 
-    fn start<Y: SystemBasedKernelApi>(
+    fn execute<Y: SystemBasedKernelApi>(
         api: &mut Y,
         executable: ExecutableTransaction,
     ) -> Result<Vec<InstructionOutput>, RuntimeError> {
@@ -1519,7 +1628,7 @@ impl<V: SystemCallbackObject> KernelTransactionCallbackObject for System<V> {
         Ok(output)
     }
 
-    fn finish(&mut self, info: StoreCommitInfo) -> Result<(), RuntimeError> {
+    fn finalize(&mut self, info: StoreCommitInfo) -> Result<(), RuntimeError> {
         self.modules.on_teardown()?;
 
         // Note that if a transactions fails during this phase, the costing is

--- a/radix-engine/src/system/system_callback_api.rs
+++ b/radix-engine/src/system/system_callback_api.rs
@@ -2,17 +2,16 @@ use crate::errors::RuntimeError;
 use crate::internal_prelude::*;
 use crate::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
 use crate::system::system_callback::*;
-use crate::track::BootStore;
 use radix_engine_interface::api::SystemApi;
 use radix_engine_interface::blueprints::package::PackageExport;
 
 /// Callback object invoked by the system layer
 pub trait SystemCallbackObject: Sized {
     /// Initialization Object
-    type Init: Clone;
+    type Init: InitializationParameters<For = Self>;
 
     /// Initialize and create the callback object above the system
-    fn init<S: BootStore>(store: &S, init_input: Self::Init) -> Result<Self, BootloadingError>;
+    fn init(init_input: Self::Init) -> Result<Self, BootloadingError>;
 
     /// Invoke a function
     fn invoke<

--- a/radix-engine/src/track/interface.rs
+++ b/radix-engine/src/track/interface.rs
@@ -35,20 +35,6 @@ pub enum TrackedSubstateInfo {
     Unmodified,
 }
 
-/// The interface to be used during boot loading
-/// This interface is different from the CommitableSubstateStore in
-/// that these reads should not be tracked / costed since it will
-/// cause a protocol break.
-pub trait BootStore {
-    /// Read a substate from the store
-    fn read_boot_substate(
-        &self,
-        node_id: &NodeId,
-        partition_num: PartitionNumber,
-        substate_key: &SubstateKey,
-    ) -> Option<IndexedScryptoValue>;
-}
-
 /// Represents the interface between Radix Engine and Track.
 ///
 /// In practice, we will likely end up with only one implementation.

--- a/radix-engine/src/track/track.rs
+++ b/radix-engine/src/track/track.rs
@@ -4,7 +4,6 @@ use crate::track::interface::{
     CommitableSubstateStore, IOAccess, NodeSubstates, TrackedSubstateInfo,
 };
 use crate::track::state_updates::*;
-use crate::track::BootStore;
 use radix_engine_interface::types::*;
 use radix_substate_store_interface::db_key_mapper::{SpreadPrefixKeyMapper, SubstateKeyContent};
 use radix_substate_store_interface::interface::DbPartitionKey;
@@ -38,22 +37,6 @@ pub struct MappedTrack<'s, S: SubstateDatabase, M: DatabaseKeyMapper + 'static> 
     transient_substates: TransientSubstates,
 
     phantom_data: PhantomData<M>,
-}
-
-impl<'s, S: SubstateDatabase, M: DatabaseKeyMapper + 'static> BootStore for MappedTrack<'s, S, M> {
-    fn read_boot_substate(
-        &self,
-        node_id: &NodeId,
-        partition_num: PartitionNumber,
-        substate_key: &SubstateKey,
-    ) -> Option<IndexedScryptoValue> {
-        let db_partition_key = M::to_db_partition_key(node_id, partition_num);
-        let db_sort_key = M::to_db_sort_key(&substate_key);
-
-        self.substate_db
-            .get_raw_substate_by_db_key(&db_partition_key, &db_sort_key)
-            .map(|e| IndexedScryptoValue::from_vec(e).expect("Failed to decode substate"))
-    }
 }
 
 /// Records all the substates that have been read or written into, and all the partitions to delete.

--- a/radix-engine/src/updates/bottlenose.rs
+++ b/radix-engine/src/updates/bottlenose.rs
@@ -8,8 +8,6 @@ use crate::kernel::kernel::*;
 use crate::object_modules::role_assignment::*;
 use crate::system::system_callback::*;
 use crate::system::system_db_reader::*;
-use crate::system::system_modules::costing::CostingModuleConfig;
-use crate::transaction::*;
 use crate::vm::*;
 use radix_engine_interface::blueprints::access_controller::*;
 use radix_engine_interface::blueprints::account::*;
@@ -511,12 +509,7 @@ fn generate_protocol_params_to_state_updates(
                     BOOT_LOADER_PARTITION => PartitionStateUpdates::Delta {
                         by_substate: indexmap! {
                             SubstateKey::Field(BOOT_LOADER_SYSTEM_SUBSTATE_FIELD_KEY) => DatabaseUpdate::Set(
-                                scrypto_encode(&SystemBoot::V1(SystemParameters {
-                                    network_definition,
-                                    costing_module_config: CostingModuleConfig::bottlenose(),
-                                    costing_parameters: CostingParameters::babylon_genesis(),
-                                    limit_parameters: LimitParameters::babylon_genesis(),
-                                })).unwrap()
+                                scrypto_encode(&SystemBoot::bottlenose(network_definition)).unwrap()
                             ),
                         }
                     },

--- a/radix-engine/src/vm/versions.rs
+++ b/radix-engine/src/vm/versions.rs
@@ -8,12 +8,20 @@ pub enum ScryptoVmVersion {
 }
 
 impl ScryptoVmVersion {
-    pub fn latest() -> ScryptoVmVersion {
-        ScryptoVmVersion::V1_1
+    pub const fn latest() -> ScryptoVmVersion {
+        Self::anemone()
     }
 
-    pub fn crypto_utils_added() -> ScryptoVmVersion {
-        ScryptoVmVersion::V1_1
+    pub const fn babylon_genesis() -> ScryptoVmVersion {
+        Self::V1_0
+    }
+
+    pub const fn anemone() -> ScryptoVmVersion {
+        Self::V1_1
+    }
+
+    pub const fn crypto_utils_added() -> ScryptoVmVersion {
+        Self::V1_1
     }
 }
 

--- a/radix-engine/src/vm/vm.rs
+++ b/radix-engine/src/vm/vm.rs
@@ -5,7 +5,6 @@ use crate::kernel::kernel_api::{KernelNodeApi, KernelSubstateApi};
 use crate::system::system_callback::*;
 use crate::system::system_callback_api::SystemCallbackObject;
 use crate::system::system_substates::KeyValueEntrySubstate;
-use crate::track::BootStore;
 use crate::vm::wasm::{ScryptoV1WasmValidator, WasmEngine};
 use crate::vm::{NativeVm, NativeVmExtension, ScryptoVm};
 use radix_engine_interface::api::field_api::LockFlags;
@@ -26,13 +25,28 @@ pub enum VmBoot {
 }
 
 impl VmBoot {
+    /// Loads vm boot from the database, or resolves a fallback.
+    pub fn load(substate_db: &impl SubstateDatabase) -> Self {
+        substate_db
+            .get_substate(
+                TRANSACTION_TRACKER,
+                BOOT_LOADER_PARTITION,
+                BOOT_LOADER_VM_BOOT_FIELD_KEY,
+            )
+            .unwrap_or_else(|| Self::babylon_genesis())
+    }
+
     pub fn latest() -> Self {
+        Self::bottlenose()
+    }
+
+    pub fn bottlenose() -> Self {
         Self::V1 {
-            scrypto_version: ScryptoVmVersion::latest().into(),
+            scrypto_version: ScryptoVmVersion::V1_1.into(),
         }
     }
 
-    pub fn babylon() -> Self {
+    pub fn babylon_genesis() -> Self {
         Self::V1 {
             scrypto_version: ScryptoVmVersion::V1_0.into(),
         }
@@ -66,11 +80,6 @@ pub trait VmInitialize {
     fn get_vm_extension(&self) -> Self::NativeVmExtension;
 
     fn get_scrypto_vm(&self) -> &ScryptoVm<Self::WasmEngine>;
-
-    fn create_vm_init(&self) -> VmInit<Self::WasmEngine, Self::NativeVmExtension> {
-        let vm_extension = self.get_vm_extension();
-        VmInit::new(self.get_scrypto_vm(), vm_extension)
-    }
 }
 
 pub struct VmModules<W: WasmEngine, E: NativeVmExtension> {
@@ -123,22 +132,22 @@ impl<W: WasmEngine, E: NativeVmExtension> VmInitialize for VmModules<W, E> {
 pub struct VmInit<'g, W: WasmEngine, E: NativeVmExtension> {
     pub scrypto_vm: &'g ScryptoVm<W>,
     pub native_vm_extension: E,
+    pub vm_boot: VmBoot,
+}
+
+impl<'g, W: WasmEngine, E: NativeVmExtension> InitializationParameters for VmInit<'g, W, E> {
+    type For = Vm<'g, W, E>;
 }
 
 impl<'g, W: WasmEngine, E: NativeVmExtension> VmInit<'g, W, E> {
-    pub fn new(scrypto_vm: &'g ScryptoVm<W>, native_vm_extension: E) -> Self {
+    pub fn load(
+        substate_db: &impl SubstateDatabase,
+        vm_modules: &'g impl VmInitialize<WasmEngine = W, NativeVmExtension = E>,
+    ) -> Self {
         Self {
-            scrypto_vm,
-            native_vm_extension,
-        }
-    }
-}
-
-impl<'g, W: WasmEngine, E: NativeVmExtension> Clone for VmInit<'g, W, E> {
-    fn clone(&self) -> Self {
-        Self {
-            scrypto_vm: self.scrypto_vm,
-            native_vm_extension: self.native_vm_extension.clone(),
+            scrypto_vm: vm_modules.get_scrypto_vm(),
+            native_vm_extension: vm_modules.get_vm_extension(),
+            vm_boot: VmBoot::load(substate_db),
         }
     }
 }
@@ -152,20 +161,11 @@ pub struct Vm<'g, W: WasmEngine, E: NativeVmExtension> {
 impl<'g, W: WasmEngine + 'g, E: NativeVmExtension> SystemCallbackObject for Vm<'g, W, E> {
     type Init = VmInit<'g, W, E>;
 
-    fn init<S: BootStore>(store: &S, vm_init: VmInit<'g, W, E>) -> Result<Self, BootloadingError> {
-        let vm_boot = store
-            .read_boot_substate(
-                TRANSACTION_TRACKER.as_node_id(),
-                BOOT_LOADER_PARTITION,
-                &SubstateKey::Field(BOOT_LOADER_VM_BOOT_FIELD_KEY),
-            )
-            .map(|v| scrypto_decode(v.as_slice()).unwrap())
-            .unwrap_or(VmBoot::babylon());
-
+    fn init(vm_init: VmInit<'g, W, E>) -> Result<Self, BootloadingError> {
         Ok(Self {
             scrypto_vm: vm_init.scrypto_vm,
             native_vm: NativeVm::new_with_extension(vm_init.native_vm_extension),
-            vm_boot,
+            vm_boot: vm_init.vm_boot,
         })
     }
 

--- a/radix-substate-store-interface/src/interface.rs
+++ b/radix-substate-store-interface/src/interface.rs
@@ -281,7 +281,8 @@ pub trait SubstateDatabaseExtensions: SubstateDatabase {
         )
     }
 
-    /// Gets the substate's value, if it exists, and returns it decoded as `V`.
+    /// Gets the substate's value, if it exists, and returns it decoded as `Some(V)`.
+    /// If it doesn't exist, `None` is returned.
     ///
     /// # Panics
     /// This method panics if:
@@ -303,6 +304,36 @@ pub trait SubstateDatabaseExtensions: SubstateDatabase {
     ) -> Option<V> {
         let raw = self.get_raw_substate(node_id, partition_number, substate_key)?;
         Some(decode_value(&raw))
+    }
+
+    /// Gets the value of a subsate which is expected to exist, returns it decoded as `V`.
+    ///
+    /// # Panics
+    /// This method panics if:
+    /// * The substate doesn't exist in the database.
+    /// * There is an error decoding the value into the `V`.
+    ///
+    /// # Example use:
+    /// ```ignore
+    /// let existing_type_info_substate: TypeInfoSubstate = db.get_existing_substate(
+    ///     PACKAGE_PACKAGE,
+    ///     TYPE_INFO_FIELD_PARTITION,
+    ///     TypeInfoField::TypeInfo,
+    /// )?;
+    /// ```
+    fn get_existing_substate<'a, V: ScryptoDecode>(
+        &self,
+        node_id: impl AsRef<NodeId>,
+        partition_number: PartitionNumber,
+        substate_key: impl ResolvableSubstateKey<'a>,
+    ) -> V {
+        let substate_value = self.get_substate(node_id, partition_number, substate_key);
+        substate_value.unwrap_or_else(|| {
+            panic!(
+                "Expected substate of type {} to already exist.",
+                core::any::type_name::<V>(),
+            )
+        })
     }
 
     // ------------------------------------------------------------------------------------

--- a/radix-substate-store-interface/src/interface.rs
+++ b/radix-substate-store-interface/src/interface.rs
@@ -263,7 +263,7 @@ pub trait SubstateDatabaseExtensions: SubstateDatabase {
     ///
     /// # Example
     /// ```ignore
-    /// let is_bootstrapped = db.read_substate(
+    /// let is_bootstrapped = db.get_raw_substate(
     ///     PACKAGE_PACKAGE,
     ///     TYPE_INFO_FIELD_PARTITION,
     ///     TypeInfoField::TypeInfo,

--- a/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/receipts/00-00-00--cuttlefish-protocol-system-logic-updates.txt
+++ b/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/receipts/00-00-00--cuttlefish-protocol-system-logic-updates.txt
@@ -16,7 +16,7 @@ STATE UPDATES: 1 entity
   └─ Partition(32): 1 change
     └─ Set: SystemBoot
        Value: SystemBoot::V2(
-         VersionedSystemLogic::V2,
+         SystemVersion::V2,
          SystemParameters {
            network_definition: NetworkDefinition {
              id: 242u8,

--- a/radix-transactions/src/model/execution/executable_common.rs
+++ b/radix-transactions/src/model/execution/executable_common.rs
@@ -81,10 +81,6 @@ pub enum IntentHashNullification {
         expiry_epoch: Epoch,
         ignore_duplicate: bool,
     },
-    /// For system transactions which currently need to go through
-    /// nullification process.
-    /// TODO: Cleanup hash nullification and remove this
-    System,
 }
 
 impl IntentHashNullification {
@@ -96,7 +92,6 @@ impl IntentHashNullification {
             IntentHashNullification::Subintent { intent_hash, .. } => {
                 Some(IntentHash::Sub(*intent_hash))
             }
-            IntentHashNullification::System => None,
         }
     }
 }

--- a/radix-transactions/src/model/v1/system_transaction.rs
+++ b/radix-transactions/src/model/v1/system_transaction.rs
@@ -146,7 +146,7 @@ impl PreparedSystemTransactionV1 {
             self.blobs.blobs_by_hash.clone(),
             ExecutionContext {
                 unique_hash: self.hash_for_execution.hash,
-                intent_hash_nullifications: vec![IntentHashNullification::System],
+                intent_hash_nullifications: vec![],
                 epoch_range: None,
                 payload_size: 0,
                 num_of_signature_validations: 0,

--- a/scrypto-test/src/environment/builder.rs
+++ b/scrypto-test/src/environment/builder.rs
@@ -213,7 +213,7 @@ where
                         BOOT_LOADER_PARTITION,
                         BOOT_LOADER_VM_BOOT_FIELD_KEY,
                     )
-                    .unwrap_or(VmBoot::babylon());
+                    .unwrap_or(VmBoot::babylon_genesis());
 
                 let transaction_runtime_module = TransactionRuntimeModule::new(
                     NetworkDefinition::simulator(),
@@ -236,17 +236,14 @@ where
                     on_apply_cost: Default::default(),
                 };
 
-                System {
-                    versioned_system_logic: VersionedSystemLogic::V1,
-                    blueprint_cache: NonIterMap::new(),
-                    auth_cache: NonIterMap::new(),
-                    schema_cache: NonIterMap::new(),
-                    callback: Vm {
+                System::new(
+                    SystemVersion::latest(),
+                    Vm {
                         scrypto_vm,
                         native_vm: native_vm.clone(),
                         vm_boot,
                     },
-                    modules: SystemModuleMixer::new(
+                    SystemModuleMixer::new(
                         EnabledModules::LIMITS
                             | EnabledModules::AUTH
                             | EnabledModules::TRANSACTION_RUNTIME,
@@ -257,8 +254,8 @@ where
                         costing_module,
                         ExecutionTraceModule::new(MAX_EXECUTION_TRACE_DEPTH),
                     ),
-                    finalization: Default::default(),
-                }
+                    SystemFinalization::no_nullifications(),
+                )
             },
             |system_config, track, id_allocator| {
                 Kernel::kernel_create_kernel_for_testing(


### PR DESCRIPTION
## Summary
This PR explores the idea of moved the reading of the boot substates higher up in the boot process, just before we execute, and storing this onto the `XInit` parameter objects, along with any generics, so that the `XInit` can fully specify `X`.

This simplifies [transaction_executor.rs](https://github.com/radixdlt/radixdlt-scrypto/pull/1924/files#diff-796f5fb2614f1a182ebb4c1d13b67f246cd4265f76d2e9f04624e23fbcd3c192) and anywhere else we need to execute transactions with different set-ups.

I've:
* Created utility methods `XInit::load` for loading these `Boot` methods from the Database, and removed the `BootStore` trait.
* The `XInit` fully capture the generics of their corresponding `X` which allows it to be used to _create_ an `X`. This means we don't have to separately provide generics for e.g. `System<Vm<...>>` which make methods harder to use, and make the code uglier. This has allowed e.g. neatening up the abstractions in `InjectCostingError`.

I've also taken the liberty to fix up a few minor areas as part of this PR:
* Got rid of `TransactionExecutor` struct which after various refactors it was a wrapper with no purpose any more
* Renamed `KernelTransactionCallbackObject` to `KernelTransactionExecutor` - could maybe even call it `TransactionExecutor` now.
* Standardized on `V` (for VM) for the `SystemCallbackObject` generic 
* Removed `IntentHashNullification::System`
* Fixed the two test kernel wrappers (`InjectCostingError` and `MockKernel`) to be generic over the type of System it receives, so we don't have to keep updating it if System changes.
* Improved `SystemCallback`
* Minor tweak to API for creating `StateUpdates`.

## Testing
Existing tests pass
