### PR TITLE
tweak: Use a visitor pattern for more efficient traversals

### DIFF
--- a/radix-common/src/data/manifest/definitions.rs
+++ b/radix-common/src/data/manifest/definitions.rs
@@ -10,6 +10,7 @@ pub type ManifestDecoder<'a> = VecDecoder<'a, ManifestCustomValueKind>;
 pub type ManifestValueKind = ValueKind<ManifestCustomValueKind>;
 pub type ManifestValue = Value<ManifestCustomValueKind, ManifestCustomValue>;
 pub type ManifestEnumVariantValue = EnumVariantValue<ManifestCustomValueKind, ManifestCustomValue>;
+#[allow(deprecated)]
 pub type ManifestTraverser<'a> = VecTraverser<'a, ManifestCustomTraversal>;
 
 pub trait ManifestCategorize: Categorize<ManifestCustomValueKind> {}

--- a/radix-common/src/data/scrypto/definitions.rs
+++ b/radix-common/src/data/scrypto/definitions.rs
@@ -7,6 +7,7 @@ pub use crate::constants::SCRYPTO_SBOR_V1_PAYLOAD_PREFIX;
 
 pub type ScryptoEncoder<'a> = VecEncoder<'a, ScryptoCustomValueKind>;
 pub type ScryptoDecoder<'a> = VecDecoder<'a, ScryptoCustomValueKind>;
+#[allow(deprecated)]
 pub type ScryptoTraverser<'a> = VecTraverser<'a, ScryptoCustomTraversal>;
 pub type ScryptoValueKind = ValueKind<ScryptoCustomValueKind>;
 pub type ScryptoValue = Value<ScryptoCustomValueKind, ScryptoCustomValue>;

--- a/sbor/src/basic.rs
+++ b/sbor/src/basic.rs
@@ -27,6 +27,7 @@ impl CustomValue<NoCustomValueKind> for NoCustomValue {
 
 pub type BasicEncoder<'a> = VecEncoder<'a, NoCustomValueKind>;
 pub type BasicDecoder<'a> = VecDecoder<'a, NoCustomValueKind>;
+#[allow(deprecated)]
 pub type BasicTraverser<'a> = VecTraverser<'a, NoCustomTraversal>;
 pub type BasicValue = Value<NoCustomValueKind, NoCustomValue>;
 pub type BasicValueKind = ValueKind<NoCustomValueKind>;

--- a/sbor/src/lib.rs
+++ b/sbor/src/lib.rs
@@ -122,5 +122,12 @@ pub(crate) mod internal_prelude {
     pub use crate::prelude::*;
     // These are mostly used for more advanced use cases,
     // so aren't included in the general prelude
+    pub use crate::basic::*;
+    pub use crate::decoder::*;
+    pub use crate::encoder::*;
+    pub use crate::payload_validation::*;
+    pub use crate::schema::*;
+    pub use crate::traversal::*;
     pub use crate::vec_traits::*;
+    pub use core::ops::ControlFlow;
 }

--- a/sbor/src/traversal/typed/typed_traverser.rs
+++ b/sbor/src/traversal/typed/typed_traverser.rs
@@ -44,6 +44,7 @@ pub fn traverse_partial_payload_with_types<'de, 's, E: CustomExtension>(
 /// It validates that the payload matches the given type kinds,
 /// and adds the relevant type index to the events which are output.
 pub struct TypedTraverser<'de, 's, E: CustomExtension> {
+    #[allow(deprecated)]
     traverser: VecTraverser<'de, E::CustomTraversal>,
     state: TypedTraverserState<'s, E>,
 }
@@ -114,6 +115,7 @@ macro_rules! look_up_type {
     };
 }
 
+#[allow(deprecated)] // Allow use of deprecated VecTraverser
 impl<'de, 's, E: CustomExtension> TypedTraverser<'de, 's, E> {
     pub fn new(
         input: &'de [u8],

--- a/sbor/src/traversal/untyped/event_stream_traverser.rs
+++ b/sbor/src/traversal/untyped/event_stream_traverser.rs
@@ -1,0 +1,484 @@
+use crate::internal_prelude::*;
+
+// =================
+// DEPRECATION NOTES
+// =================
+// Once we no longer need this (because we've moved to the visitor model), this opens up
+// a world of further optimisations:
+// * We can change it so that issuing a ControlFlow::Break aborts the process
+// * Can get rid of `NextAction` and Step completely
+//   * And instead, just have standard top-down traversal logic
+//   * We can avoid storing a `resume_action` on the events
+
+/// The `VecTraverser` is for streamed decoding of a payload or single encoded value (tree).
+/// It turns payload decoding into a pull-based event stream.
+///
+/// The caller is responsible for stopping calling `next_event` after an Error or End event.
+#[deprecated = "Use UntypedTraverser which uses the visitor pattern and is more efficient"]
+pub struct VecTraverser<'de, T: CustomTraversal> {
+    untyped_traverser: UntypedTraverser<'de, T>,
+    visitor: EventStreamVisitor<'de, T>,
+}
+
+pub struct VecTraverserConfig {
+    pub max_depth: usize,
+    pub check_exact_end: bool,
+}
+
+#[allow(deprecated)]
+impl<'de, T: CustomTraversal> VecTraverser<'de, T> {
+    pub fn new(
+        input: &'de [u8],
+        expected_start: ExpectedStart<T::CustomValueKind>,
+        config: VecTraverserConfig,
+    ) -> Self {
+        let config = UntypedTraverserConfig {
+            max_depth: config.max_depth,
+            check_exact_end: config.check_exact_end,
+        };
+        let untyped_traverser = UntypedTraverser::<T>::new(input, config);
+        Self {
+            untyped_traverser,
+            visitor: EventStreamVisitor {
+                next_action: SuspendableNextAction::Action(expected_start.into_starting_action()),
+                next_event: None,
+            },
+        }
+    }
+
+    pub fn next_event<'t>(&'t mut self) -> LocatedTraversalEvent<'t, 'de, T> {
+        match self.visitor.next_action {
+            SuspendableNextAction::Action(next_action) => {
+                let location = self
+                    .untyped_traverser
+                    .continue_traversal_from(next_action, &mut self.visitor);
+                LocatedTraversalEvent {
+                    location,
+                    event: self
+                        .visitor
+                        .next_event
+                        .take()
+                        .expect("Visitor always expected to populate an event"),
+                }
+            }
+            SuspendableNextAction::Errored => panic!("Can't get next event as already errored"),
+            SuspendableNextAction::Ended => todo!("Can't get next event as already ended"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::internal_prelude::*;
+
+    #[derive(Categorize, Encode)]
+    #[allow(dead_code)]
+    struct TestStruct {
+        x: u32,
+    }
+
+    #[derive(Categorize, Encode)]
+    #[allow(dead_code)]
+    enum TestEnum {
+        A { x: u32 },
+        B(u32),
+        C,
+    }
+
+    #[test]
+    pub fn test_calculate_value_tree_body_byte_array() {
+        let payload = basic_encode(&BasicValue::Array {
+            element_value_kind: BasicValueKind::Array,
+            elements: vec![BasicValue::Array {
+                element_value_kind: BasicValueKind::U8,
+                elements: vec![BasicValue::U8 { value: 44 }, BasicValue::U8 { value: 55 }],
+            }],
+        })
+        .unwrap();
+        /*
+            91  - prefix
+            32  - value kind: array
+            32  - element value kind: array
+            1   - number of elements: 1
+            7   - element value kind: u8
+            2   - number of elements: u8
+            44  - u8
+            55  - u8
+        */
+        let length = calculate_value_tree_body_byte_length::<NoCustomExtension>(
+            &payload[2..],
+            BasicValueKind::Array,
+            0,
+            100,
+        )
+        .unwrap();
+        assert_eq!(length, 6);
+        let length = calculate_value_tree_body_byte_length::<NoCustomExtension>(
+            &payload[6..],
+            BasicValueKind::U8,
+            0,
+            100,
+        )
+        .unwrap();
+        assert_eq!(length, 1);
+    }
+
+    #[test]
+    pub fn test_exact_events_returned() {
+        let payload = basic_encode(&(
+            2u8,
+            vec![3u8, 7u8],
+            (3u32, indexmap!(16u8 => 18u32)),
+            TestEnum::B(4u32),
+            Vec::<u8>::new(),
+            Vec::<i32>::new(),
+            vec![vec![(-2i64,)]],
+        ))
+        .unwrap();
+
+        let mut traverser = basic_payload_traverser(&payload);
+
+        // Start:
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 7 }),
+            1,
+            1,
+            3,
+        );
+        // First line
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::U8(2), 2, 3, 5);
+        // Second line
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::U8,
+                length: 2,
+            }),
+            2,
+            5,
+            8,
+        );
+        next_event_is_terminal_value_slice(
+            &mut traverser,
+            TerminalValueBatchRef::U8(&[3u8, 7u8]),
+            3,
+            8,
+            10,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::U8,
+                length: 2,
+            }),
+            2,
+            5,
+            10,
+        );
+        // Third line
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 2 }),
+            2,
+            10,
+            12,
+        );
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::U32(3), 3, 12, 17);
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Map(MapHeader {
+                key_value_kind: ValueKind::U8,
+                value_value_kind: ValueKind::U32,
+                length: 1,
+            }),
+            3,
+            17,
+            21,
+        );
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::U8(16), 4, 21, 22);
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::U32(18), 4, 22, 26);
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Map(MapHeader {
+                key_value_kind: ValueKind::U8,
+                value_value_kind: ValueKind::U32,
+                length: 1,
+            }),
+            3,
+            17,
+            26,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 2 }),
+            2,
+            10,
+            26,
+        );
+        // Fourth line
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::EnumVariant(EnumVariantHeader {
+                variant: 1,
+                length: 1,
+            }),
+            2,
+            26,
+            29,
+        );
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::U32(4), 3, 29, 34);
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::EnumVariant(EnumVariantHeader {
+                variant: 1,
+                length: 1,
+            }),
+            2,
+            26,
+            34,
+        );
+        // Fifth line - empty Vec<u8> - no bytes event is output
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::U8,
+                length: 0,
+            }),
+            2,
+            34,
+            37,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::U8,
+                length: 0,
+            }),
+            2,
+            34,
+            37,
+        );
+        // Sixth line - empty Vec<i32>
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::I32,
+                length: 0,
+            }),
+            2,
+            37,
+            40,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::I32,
+                length: 0,
+            }),
+            2,
+            37,
+            40,
+        );
+        // Seventh line - Vec<Vec<(i64)>>
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::Array,
+                length: 1,
+            }),
+            2,
+            40,
+            43,
+        );
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::Tuple,
+                length: 1,
+            }),
+            3,
+            43,
+            45,
+        );
+        next_event_is_container_start_header(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 1 }),
+            4,
+            45,
+            46,
+        );
+        next_event_is_terminal_value(&mut traverser, TerminalValueRef::I64(-2), 5, 46, 55);
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 1 }),
+            4,
+            45,
+            55,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::Tuple,
+                length: 1,
+            }),
+            3,
+            43,
+            55,
+        );
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Array(ArrayHeader {
+                element_value_kind: ValueKind::Array,
+                length: 1,
+            }),
+            2,
+            40,
+            55,
+        );
+
+        // End
+        next_event_is_container_end(
+            &mut traverser,
+            ContainerHeader::Tuple(TupleHeader { length: 7 }),
+            1,
+            1,
+            55,
+        );
+        next_event_is_end(&mut traverser, 55, 55);
+    }
+
+    pub fn next_event_is_container_start_header(
+        traverser: &mut BasicTraverser,
+        expected_header: ContainerHeader<NoCustomTraversal>,
+        expected_depth: usize,
+        expected_start_offset: usize,
+        expected_end_offset: usize,
+    ) {
+        let event = traverser.next_event();
+        let sbor_depth = event.location.ancestor_path.len() + 1;
+        let LocatedTraversalEvent {
+            event: TraversalEvent::ContainerStart(header),
+            location:
+                Location {
+                    start_offset,
+                    end_offset,
+                    ..
+                },
+        } = event
+        else {
+            panic!("Invalid event - expected ContainerStart, was {:?}", event);
+        };
+        assert_eq!(header, expected_header);
+        assert_eq!(sbor_depth, expected_depth);
+        assert_eq!(start_offset, expected_start_offset);
+        assert_eq!(end_offset, expected_end_offset);
+    }
+
+    pub fn next_event_is_container_end(
+        traverser: &mut BasicTraverser,
+        expected_header: ContainerHeader<NoCustomTraversal>,
+        expected_depth: usize,
+        expected_start_offset: usize,
+        expected_end_offset: usize,
+    ) {
+        let event = traverser.next_event();
+        let sbor_depth = event.location.ancestor_path.len() + 1;
+        let LocatedTraversalEvent {
+            event: TraversalEvent::ContainerEnd(header),
+            location:
+                Location {
+                    start_offset,
+                    end_offset,
+                    ..
+                },
+        } = event
+        else {
+            panic!("Invalid event - expected ContainerEnd, was {:?}", event);
+        };
+        assert_eq!(header, expected_header);
+        assert_eq!(sbor_depth, expected_depth);
+        assert_eq!(start_offset, expected_start_offset);
+        assert_eq!(end_offset, expected_end_offset);
+    }
+
+    pub fn next_event_is_terminal_value<'de>(
+        traverser: &mut BasicTraverser<'de>,
+        expected_value: TerminalValueRef<'de, NoCustomTraversal>,
+        expected_child_depth: usize,
+        expected_start_offset: usize,
+        expected_end_offset: usize,
+    ) {
+        let event = traverser.next_event();
+        let sbor_depth = event.location.ancestor_path.len() + 1;
+        let LocatedTraversalEvent {
+            event: TraversalEvent::TerminalValue(value),
+            location:
+                Location {
+                    start_offset,
+                    end_offset,
+                    ..
+                },
+        } = event
+        else {
+            panic!("Invalid event - expected TerminalValue, was {:?}", event);
+        };
+        assert_eq!(value, expected_value);
+        assert_eq!(sbor_depth, expected_child_depth);
+        assert_eq!(start_offset, expected_start_offset);
+        assert_eq!(end_offset, expected_end_offset);
+    }
+
+    pub fn next_event_is_terminal_value_slice<'de>(
+        traverser: &mut BasicTraverser<'de>,
+        expected_value_batch: TerminalValueBatchRef<'de>,
+        expected_child_depth: usize,
+        expected_start_offset: usize,
+        expected_end_offset: usize,
+    ) {
+        let event = traverser.next_event();
+        let sbor_depth = event.location.ancestor_path.len() + 1;
+        let LocatedTraversalEvent {
+            event: TraversalEvent::TerminalValueBatch(value_batch),
+            location:
+                Location {
+                    start_offset,
+                    end_offset,
+                    ..
+                },
+        } = event
+        else {
+            panic!(
+                "Invalid event - expected TerminalValueBatch, was {:?}",
+                event
+            );
+        };
+        assert_eq!(value_batch, expected_value_batch);
+        assert_eq!(sbor_depth, expected_child_depth);
+        assert_eq!(start_offset, expected_start_offset);
+        assert_eq!(end_offset, expected_end_offset);
+    }
+
+    pub fn next_event_is_end(
+        traverser: &mut BasicTraverser,
+        expected_start_offset: usize,
+        expected_end_offset: usize,
+    ) {
+        let event = traverser.next_event();
+        let LocatedTraversalEvent {
+            event: TraversalEvent::End,
+            location:
+                Location {
+                    start_offset,
+                    end_offset,
+                    ..
+                },
+        } = event
+        else {
+            panic!("Invalid event - expected End, was {:?}", event);
+        };
+        assert_eq!(start_offset, expected_start_offset);
+        assert_eq!(end_offset, expected_end_offset);
+        assert!(event.location.ancestor_path.is_empty());
+    }
+}

--- a/sbor/src/traversal/untyped/mod.rs
+++ b/sbor/src/traversal/untyped/mod.rs
@@ -1,5 +1,30 @@
-mod events;
-mod traverser;
+use crate::internal_prelude::*;
 
+mod event_stream_traverser;
+mod events;
+mod traversal_traits;
+mod untyped_traverser;
+mod utility_visitors;
+
+pub use event_stream_traverser::*;
 pub use events::*;
-pub use traverser::*;
+pub use traversal_traits::*;
+pub use untyped_traverser::*;
+pub use utility_visitors::*;
+
+/// Returns the length of the value at the start of the partial payload.
+pub fn calculate_value_tree_body_byte_length<'de, 's, E: CustomExtension>(
+    partial_payload: &'de [u8],
+    value_kind: ValueKind<E::CustomValueKind>,
+    current_depth: usize,
+    depth_limit: usize,
+) -> Result<usize, DecodeError> {
+    let mut traverser = UntypedTraverser::<E::CustomTraversal>::new(
+        partial_payload,
+        UntypedTraverserConfig {
+            max_depth: depth_limit - current_depth,
+            check_exact_end: false,
+        },
+    );
+    traverser.run_from_start(ExpectedStart::ValueBody(value_kind), &mut ValidatingVisitor)
+}

--- a/sbor/src/traversal/untyped/traversal_traits.rs
+++ b/sbor/src/traversal/untyped/traversal_traits.rs
@@ -1,0 +1,111 @@
+use crate::internal_prelude::*;
+use core::ops::ControlFlow;
+
+pub trait CustomTraversal: Copy + Debug + Clone + PartialEq + Eq + 'static {
+    type CustomValueKind: CustomValueKind;
+    type CustomTerminalValueRef<'de>: CustomTerminalValueRef<
+        CustomValueKind = Self::CustomValueKind,
+    >;
+
+    fn read_custom_value_body<'de, R>(
+        custom_value_kind: Self::CustomValueKind,
+        reader: &mut R,
+    ) -> Result<Self::CustomTerminalValueRef<'de>, DecodeError>
+    where
+        R: BorrowingDecoder<'de, Self::CustomValueKind>;
+}
+
+pub trait CustomTerminalValueRef: Debug + Clone + PartialEq + Eq {
+    type CustomValueKind: CustomValueKind;
+
+    fn custom_value_kind(&self) -> Self::CustomValueKind;
+}
+
+// We add this allow so that the placeholder names don't have to start with underscores
+#[allow(unused_variables)]
+pub trait UntypedPayloadVisitor<'de, T: CustomTraversal> {
+    type Output<'t>;
+
+    #[inline]
+    #[must_use]
+    fn on_container_start<'t>(
+        &mut self,
+        details: OnContainerStart<'t, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        ControlFlow::Continue(())
+    }
+
+    #[inline]
+    #[must_use]
+    fn on_terminal_value<'t>(
+        &mut self,
+        details: OnTerminalValue<'t, 'de, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        ControlFlow::Continue(())
+    }
+
+    #[inline]
+    #[must_use]
+    fn on_terminal_value_batch<'t>(
+        &mut self,
+        details: OnTerminalValueBatch<'t, 'de, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        ControlFlow::Continue(())
+    }
+
+    #[inline]
+    #[must_use]
+    fn on_container_end<'t>(
+        &mut self,
+        details: OnContainerEnd<'t, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        ControlFlow::Continue(())
+    }
+
+    #[must_use]
+    fn on_error<'t>(&mut self, details: OnError<'t, T>) -> Self::Output<'t>;
+
+    #[must_use]
+    fn on_traversal_end<'t>(&mut self, details: OnTraversalEnd<'t, T>) -> Self::Output<'t>;
+}
+
+pub struct OnContainerStart<'t, T: CustomTraversal> {
+    pub header: ContainerHeader<T>,
+    pub location: Location<'t, T>,
+    /// If requesting to break, the traversal can be continued with this action.
+    /// This will be optimized out if the visitor doesn't use it.
+    pub resume_action: NextAction<T>,
+}
+
+pub struct OnTerminalValue<'t, 'de, T: CustomTraversal> {
+    pub value: TerminalValueRef<'de, T>,
+    pub location: Location<'t, T>,
+    /// If requesting to break, the traversal can be continued with this action.
+    /// This will be optimized out if the visitor doesn't use it.
+    pub resume_action: NextAction<T>,
+}
+
+pub struct OnTerminalValueBatch<'t, 'de, T: CustomTraversal> {
+    pub value_batch: TerminalValueBatchRef<'de>,
+    pub location: Location<'t, T>,
+    /// If requesting to break, the traversal can be continued with this action.
+    /// This will be optimized out if the visitor doesn't require it.
+    pub resume_action: NextAction<T>,
+}
+
+pub struct OnContainerEnd<'t, T: CustomTraversal> {
+    pub header: ContainerHeader<T>,
+    pub location: Location<'t, T>,
+    /// If requesting to break, the traversal can be continued with this action.
+    /// This will be optimized out if the visitor doesn't require it.
+    pub resume_action: NextAction<T>,
+}
+
+pub struct OnTraversalEnd<'t, T: CustomTraversal> {
+    pub location: Location<'t, T>,
+}
+
+pub struct OnError<'t, T: CustomTraversal> {
+    pub error: DecodeError,
+    pub location: Location<'t, T>,
+}

--- a/sbor/src/traversal/untyped/untyped_traverser.rs
+++ b/sbor/src/traversal/untyped/untyped_traverser.rs
@@ -1,3 +1,5 @@
+use core::ops::ControlFlow;
+
 use super::*;
 use crate::decoder::BorrowingDecoder;
 use crate::rust::prelude::*;
@@ -5,49 +7,11 @@ use crate::rust::str;
 use crate::value_kind::*;
 use crate::*;
 
-/// Returns the length of the value at the start of the partial payload.
-pub fn calculate_value_tree_body_byte_length<'de, 's, E: CustomExtension>(
-    partial_payload: &'de [u8],
-    value_kind: ValueKind<E::CustomValueKind>,
-    current_depth: usize,
-    depth_limit: usize,
-) -> Result<usize, DecodeError> {
-    let mut traverser = VecTraverser::<E::CustomTraversal>::new(
-        partial_payload,
-        ExpectedStart::ValueBody(value_kind),
-        VecTraverserConfig {
-            max_depth: depth_limit - current_depth,
-            check_exact_end: false,
-        },
-    );
-    loop {
-        let next_event = traverser.next_event();
-        match next_event.event {
-            TraversalEvent::End => return Ok(next_event.location.end_offset),
-            TraversalEvent::DecodeError(decode_error) => return Err(decode_error),
-            _ => {}
-        }
-    }
-}
-
-pub trait CustomTraversal: Copy + Debug + Clone + PartialEq + Eq {
-    type CustomValueKind: CustomValueKind;
-    type CustomTerminalValueRef<'de>: CustomTerminalValueRef<
-        CustomValueKind = Self::CustomValueKind,
-    >;
-
-    fn read_custom_value_body<'de, R>(
-        custom_value_kind: Self::CustomValueKind,
-        reader: &mut R,
-    ) -> Result<Self::CustomTerminalValueRef<'de>, DecodeError>
-    where
-        R: BorrowingDecoder<'de, Self::CustomValueKind>;
-}
-
-pub trait CustomTerminalValueRef: Debug + Clone + PartialEq + Eq {
-    type CustomValueKind: CustomValueKind;
-
-    fn custom_value_kind(&self) -> Self::CustomValueKind;
+/// Designed for streamed decoding of a payload or single encoded value (tree).
+pub struct UntypedTraverser<'de, T: CustomTraversal> {
+    decoder: VecDecoder<'de, T::CustomValueKind>,
+    ancestor_path: Vec<AncestorState<T>>,
+    config: UntypedTraverserConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,24 +29,15 @@ pub struct AncestorState<T: CustomTraversal> {
 
 impl<T: CustomTraversal> AncestorState<T> {
     #[inline]
-    fn get_implicit_value_kind_of_current_child(&self) -> Option<ValueKind<T::CustomValueKind>> {
+    pub fn get_implicit_value_kind_of_current_child(
+        &self,
+    ) -> Option<ValueKind<T::CustomValueKind>> {
         self.container_header
             .get_implicit_child_value_kind(self.current_child_index)
     }
 }
 
-/// The `VecTraverser` is for streamed decoding of a payload or single encoded value (tree).
-/// It turns payload decoding into a pull-based event stream.
-///
-/// The caller is responsible for stopping calling `next_event` after an Error or End event.
-pub struct VecTraverser<'de, T: CustomTraversal> {
-    decoder: VecDecoder<'de, T::CustomValueKind>,
-    ancestor_path: Vec<AncestorState<T>>,
-    next_action: NextAction<T>,
-    config: VecTraverserConfig,
-}
-
-pub struct VecTraverserConfig {
+pub struct UntypedTraverserConfig {
     pub max_depth: usize,
     pub check_exact_end: bool,
 }
@@ -103,10 +58,6 @@ pub enum NextAction<T: CustomTraversal> {
     /// The state which is put into after entering parent, and
     /// the default state to return to from below
     ReadNextChildOrExitContainer,
-    Errored,
-    Ended,
-    /// Impossible to observe this value
-    InProgressPlaceholder,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -116,73 +67,89 @@ pub enum ExpectedStart<X: CustomValueKind> {
     ValueBody(ValueKind<X>),
 }
 
-impl<'de, T: CustomTraversal> VecTraverser<'de, T> {
-    pub fn new(
-        input: &'de [u8],
-        expected_start: ExpectedStart<T::CustomValueKind>,
-        config: VecTraverserConfig,
-    ) -> Self {
+impl<X: CustomValueKind> ExpectedStart<X> {
+    pub fn into_starting_action<T: CustomTraversal<CustomValueKind = X>>(self) -> NextAction<T> {
+        match self {
+            ExpectedStart::PayloadPrefix(prefix) => NextAction::ReadPrefix {
+                expected_prefix: prefix,
+            },
+            ExpectedStart::Value => NextAction::ReadRootValue,
+            ExpectedStart::ValueBody(value_kind) => NextAction::ReadRootValueBody {
+                implicit_value_kind: value_kind,
+            },
+        }
+    }
+}
+
+impl<'de, T: CustomTraversal> UntypedTraverser<'de, T> {
+    pub fn new(input: &'de [u8], config: UntypedTraverserConfig) -> Self {
         Self {
-            // Note that the VecTraverser needs to be very low level for performance,
+            // Note that the VecTraverserV2 needs to be very low level for performance,
             // so purposefully doesn't use the depth tracking in the decoder itself.
             // But we set a max depth anyway, for safety.
             decoder: VecDecoder::new(input, config.max_depth),
             ancestor_path: Vec::with_capacity(config.max_depth),
-            next_action: match expected_start {
-                ExpectedStart::PayloadPrefix(prefix) => NextAction::ReadPrefix {
-                    expected_prefix: prefix,
-                },
-                ExpectedStart::Value => NextAction::ReadRootValue,
-                ExpectedStart::ValueBody(value_kind) => NextAction::ReadRootValueBody {
-                    implicit_value_kind: value_kind,
-                },
-            },
             config,
         }
     }
 
-    pub fn next_event<'t>(&'t mut self) -> LocatedTraversalEvent<'t, 'de, T> {
-        let (event, next_action) = Self::step(
-            core::mem::replace(&mut self.next_action, NextAction::InProgressPlaceholder),
-            &self.config,
-            &mut self.decoder,
-            &mut self.ancestor_path,
-        );
-        self.next_action = next_action;
-        event
+    pub fn run_from_start<'t, V: UntypedPayloadVisitor<'de, T>>(
+        &'t mut self,
+        expected_start: ExpectedStart<T::CustomValueKind>,
+        visitor: &mut V,
+    ) -> V::Output<'t> {
+        self.continue_traversal_from(expected_start.into_starting_action(), visitor)
+    }
+
+    /// # Expected behaviour
+    /// Start action should either be an action from ExpectedStart, or a `resume_action` returned
+    /// in a previous event.
+    pub fn continue_traversal_from<'t, V: UntypedPayloadVisitor<'de, T>>(
+        &'t mut self,
+        start_action: NextAction<T>,
+        visitor: &mut V,
+    ) -> V::Output<'t> {
+        let mut action = start_action;
+        loop {
+            // SAFETY: Work around the current borrow checker, which is sound as per this thread:
+            // https://users.rust-lang.org/t/mutable-borrow-in-loop-borrow-checker-query/118081/3
+            // Unsafe syntax borrowed from here: https://docs.rs/polonius-the-crab/latest/polonius_the_crab/
+            // Can remove this once the polonius borrow checker hits stable
+            let ancester_path = unsafe { &mut *(&mut self.ancestor_path as *mut _) };
+            action = match Self::step(
+                action,
+                &self.config,
+                &mut self.decoder,
+                ancester_path,
+                visitor,
+            ) {
+                ControlFlow::Continue(action) => action,
+                ControlFlow::Break(output) => return output,
+            };
+        }
     }
 
     #[inline]
-    fn step<'t, 'd>(
+    fn step<'t, V: UntypedPayloadVisitor<'de, T>>(
         action: NextAction<T>,
-        config: &VecTraverserConfig,
-        decoder: &'d mut VecDecoder<'de, T::CustomValueKind>,
+        config: &UntypedTraverserConfig,
+        decoder: &mut VecDecoder<'de, T::CustomValueKind>,
         ancestor_path: &'t mut Vec<AncestorState<T>>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
         match action {
             NextAction::ReadPrefix { expected_prefix } => {
-                // The reading of the prefix has no associated event, so we perform the prefix check first,
-                // and then proceed to read the root value if it succeeds.
-                let start_offset = decoder.get_offset();
-                match decoder.read_and_check_payload_prefix(expected_prefix) {
-                    Ok(()) => {
-                        // Prefix read successfully. Now read root value.
-                        ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                            .read_value(None)
-                    }
-                    Err(error) => {
-                        ActionHandler::new_with_fixed_offset(ancestor_path, decoder, start_offset)
-                            .complete_with_error(error)
-                    }
-                }
+                Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                    .read_and_check_payload_prefix::<V>(expected_prefix, visitor)
             }
             NextAction::ReadRootValue => {
-                ActionHandler::new_from_current_offset(ancestor_path, decoder).read_value(None)
+                Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                    .read_value(None, visitor)
             }
             NextAction::ReadRootValueBody {
                 implicit_value_kind,
-            } => ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                .read_value(Some(implicit_value_kind)),
+            } => Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                .read_value(Some(implicit_value_kind), visitor),
             NextAction::ReadContainerContentStart {
                 container_header,
                 container_start_offset,
@@ -191,53 +158,55 @@ impl<'de, T: CustomTraversal> VecTraverser<'de, T> {
                 if container_child_size == 0 {
                     // If the container has no children, we immediately container end without ever bothering
                     // adding it as an ancestor.
-                    return ActionHandler::new_with_fixed_offset(
-                        ancestor_path,
-                        decoder,
-                        container_start_offset,
-                    )
-                    .complete_container_end(container_header);
-                }
-
-                // Add ancestor before checking for max depth so that the ancestor stack is
-                // correct if the depth check returns an error
-                ancestor_path.push(AncestorState {
-                    container_header,
-                    container_start_offset,
-                    current_child_index: 0,
-                });
-                // We know we're about to read a child at depth ancestor_path.len() + 1 - so
-                // it's an error if ancestor_path.len() >= config.max_depth.
-                // (We avoid the +1 so that we don't need to worry about overflow).
-                if ancestor_path.len() >= config.max_depth {
-                    return ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                        .complete_with_error(DecodeError::MaxDepthExceeded(config.max_depth));
-                }
-
-                let parent = ancestor_path.last_mut().unwrap();
-                let parent_container = &parent.container_header;
-                let is_byte_array = matches!(
-                    parent_container,
-                    ContainerHeader::Array(ArrayHeader {
-                        element_value_kind: ValueKind::U8,
-                        ..
-                    })
-                );
-                // If it's a byte array, we do a batch-read optimisation
-                if is_byte_array {
-                    // We know this is >= 1 from the above check
-                    let array_length = container_child_size;
-                    let max_index_which_would_be_read = array_length - 1;
-                    // Set current child index before we read so that if we get an error on read
-                    // then it comes through at the max child index we attempted to read.
-                    parent.current_child_index = max_index_which_would_be_read;
-                    ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                        .read_byte_array(array_length)
+                    Locator::with(container_start_offset, ancestor_path, decoder)
+                        .complete_container_end(container_header, visitor)
                 } else {
-                    // NOTE: parent.current_child_index is already 0, so no need to change it
-                    let implicit_value_kind = parent.get_implicit_value_kind_of_current_child();
-                    ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                        .read_value(implicit_value_kind)
+                    // Add ancestor before checking for max depth so that the ancestor stack is
+                    // correct if the depth check returns an error
+                    ancestor_path.push(AncestorState {
+                        container_header,
+                        container_start_offset,
+                        current_child_index: 0,
+                    });
+
+                    // We know we're about to read a child at depth ancestor_path.len() + 1 - so
+                    // it's an error if ancestor_path.len() >= config.max_depth.
+                    // (We avoid the +1 so that we don't need to worry about overflow).
+                    if ancestor_path.len() >= config.max_depth {
+                        let error_output =
+                            Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                                .handle_error(
+                                    DecodeError::MaxDepthExceeded(config.max_depth),
+                                    visitor,
+                                );
+                        return ControlFlow::Break(error_output);
+                    }
+
+                    let parent = ancestor_path.last_mut().unwrap();
+                    let parent_container = &parent.container_header;
+                    let is_byte_array = matches!(
+                        parent_container,
+                        ContainerHeader::Array(ArrayHeader {
+                            element_value_kind: ValueKind::U8,
+                            ..
+                        })
+                    );
+                    // If it's a byte array, we do a batch-read optimisation
+                    if is_byte_array {
+                        // We know this is >= 1 from the above check
+                        let array_length = container_child_size;
+                        let max_index_which_would_be_read = array_length - 1;
+                        // Set current child index before we read so that if we get an error on read
+                        // then it comes through at the max child index we attempted to read.
+                        parent.current_child_index = max_index_which_would_be_read;
+                        Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                            .read_byte_array(array_length, visitor)
+                    } else {
+                        // NOTE: parent.current_child_index is already 0, so no need to change it
+                        let implicit_value_kind = parent.get_implicit_value_kind_of_current_child();
+                        Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                            .read_value(implicit_value_kind, visitor)
+                    }
                 }
             }
             NextAction::ReadNextChildOrExitContainer => {
@@ -255,80 +224,51 @@ impl<'de, T: CustomTraversal> VecTraverser<'de, T> {
                                 ..
                             } = ancestor_path.pop().expect("Parent has just been read");
 
-                            ActionHandler::new_with_fixed_offset(
-                                ancestor_path,
-                                decoder,
-                                container_start_offset,
-                            )
-                            .complete_container_end(container_header)
+                            Locator::with(container_start_offset, ancestor_path, decoder)
+                                .complete_container_end(container_header, visitor)
                         } else {
                             parent.current_child_index = next_child_index;
                             let implicit_value_kind =
                                 parent.get_implicit_value_kind_of_current_child();
-                            ActionHandler::new_from_current_offset(ancestor_path, decoder)
-                                .read_value(implicit_value_kind)
+                            Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                                .read_value(implicit_value_kind, visitor)
                         }
                     }
                     None => {
                         // We are due to read another element and exit but have no parent
                         // This is because we have finished reading the `root` value.
-                        // Therefore we call `end`.
-                        ActionHandler::new_from_current_offset(ancestor_path, decoder).end(config)
+                        let output = Locator::with(decoder.get_offset(), ancestor_path, decoder)
+                            .handle_traversal_end(config.check_exact_end, visitor);
+                        return ControlFlow::Break(output);
                     }
                 }
-            }
-            NextAction::Errored => {
-                panic!("It is unsupported to call `next_event` on a traverser which has returned an error.")
-            }
-            NextAction::Ended => {
-                panic!("It is unsupported to call `next_event` on a traverser which has already emitted an end event.")
-            }
-            NextAction::InProgressPlaceholder => {
-                unreachable!("It is not possible to observe this value - it is a placeholder for rust memory safety.")
             }
         }
     }
 }
 
-macro_rules! handle_error {
-    ($action_handler: expr, $result: expr$(,)?) => {{
-        match $result {
-            Ok(value) => value,
-            Err(error) => {
-                return $action_handler.complete_with_error(error);
-            }
-        }
+macro_rules! handle_result {
+    ($self: expr, $visitor: expr, $result: expr$(,)?) => {{
+        let result = $result;
+        $self.handle_result(result, $visitor)?
     }};
 }
 
 /// This is just an encapsulation to improve code quality by:
 /// * Removing code duplication by capturing the ancestor_path/decoder/start_offset in one place
 /// * Ensuring code correctness by fixing the ancestor path
-struct ActionHandler<'t, 'd, 'de, T: CustomTraversal> {
+struct Locator<'t, 'd, 'de, T: CustomTraversal> {
     ancestor_path: &'t [AncestorState<T>],
     decoder: &'d mut VecDecoder<'de, T::CustomValueKind>,
     start_offset: usize,
 }
 
-impl<'t, 'd, 'de, T: CustomTraversal> ActionHandler<'t, 'd, 'de, T> {
+impl<'t, 'd, 'de, T: CustomTraversal> Locator<'t, 'd, 'de, T> {
     #[inline]
-    fn new_from_current_offset(
-        ancestor_path: &'t [AncestorState<T>],
-        decoder: &'d mut VecDecoder<'de, T::CustomValueKind>,
-    ) -> Self {
-        let start_offset = decoder.get_offset();
-        Self {
-            ancestor_path,
-            decoder,
-            start_offset,
-        }
-    }
-
-    #[inline]
-    fn new_with_fixed_offset(
-        ancestor_path: &'t [AncestorState<T>],
-        decoder: &'d mut VecDecoder<'de, T::CustomValueKind>,
+    fn with(
         start_offset: usize,
+        ancestor_path: &'t [AncestorState<T>],
+        decoder: &'d mut VecDecoder<'de, T::CustomValueKind>,
     ) -> Self {
         Self {
             ancestor_path,
@@ -337,179 +277,266 @@ impl<'t, 'd, 'de, T: CustomTraversal> ActionHandler<'t, 'd, 'de, T> {
         }
     }
 
+    #[must_use]
     #[inline]
-    fn read_value(
+    fn read_and_check_payload_prefix<V: UntypedPayloadVisitor<'de, T>>(
+        self,
+        expected_prefix: u8,
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        handle_result!(
+            self,
+            visitor,
+            self.decoder.read_and_check_payload_prefix(expected_prefix)
+        );
+        ControlFlow::Continue(NextAction::ReadRootValue)
+    }
+
+    #[inline]
+    #[must_use]
+    fn read_value<V: UntypedPayloadVisitor<'de, T>>(
         self,
         implicit_value_kind: Option<ValueKind<T::CustomValueKind>>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
         let value_kind = match implicit_value_kind {
             Some(value_kind) => value_kind,
-            None => handle_error!(self, self.decoder.read_value_kind()),
+            None => handle_result!(self, visitor, self.decoder.read_value_kind()),
         };
-        self.read_value_body(value_kind)
+        self.read_value_body(value_kind, visitor)
     }
 
     #[inline]
-    fn read_byte_array(
+    #[must_use]
+    fn read_byte_array<V: UntypedPayloadVisitor<'de, T>>(
         self,
         array_length: usize,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        let bytes = handle_error!(self, self.decoder.read_slice_from_payload(array_length));
-        self.complete(
-            TraversalEvent::TerminalValueBatch(TerminalValueBatchRef::U8(bytes)),
-            // This is the correct action to ensure we exit the container on the next step
-            NextAction::ReadNextChildOrExitContainer,
-        )
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        let bytes = handle_result!(
+            self,
+            visitor,
+            self.decoder.read_slice_from_payload(array_length)
+        );
+        self.complete_terminal_value_batch(TerminalValueBatchRef::U8(bytes), visitor)
     }
 
     #[inline]
-    fn end(
-        self,
-        config: &VecTraverserConfig,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        if config.check_exact_end {
-            handle_error!(self, self.decoder.check_end());
-        }
-        self.complete(TraversalEvent::End, NextAction::Ended)
-    }
-
-    #[inline]
-    fn read_value_body(
+    #[must_use]
+    fn read_value_body<V: UntypedPayloadVisitor<'de, T>>(
         self,
         value_kind: ValueKind<T::CustomValueKind>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
         match value_kind {
-            ValueKind::Bool => self.read_terminal_value(value_kind, TerminalValueRef::Bool),
-            ValueKind::I8 => self.read_terminal_value(value_kind, TerminalValueRef::I8),
-            ValueKind::I16 => self.read_terminal_value(value_kind, TerminalValueRef::I16),
-            ValueKind::I32 => self.read_terminal_value(value_kind, TerminalValueRef::I32),
-            ValueKind::I64 => self.read_terminal_value(value_kind, TerminalValueRef::I64),
-            ValueKind::I128 => self.read_terminal_value(value_kind, TerminalValueRef::I128),
-            ValueKind::U8 => self.read_terminal_value(value_kind, TerminalValueRef::U8),
-            ValueKind::U16 => self.read_terminal_value(value_kind, TerminalValueRef::U16),
-            ValueKind::U32 => self.read_terminal_value(value_kind, TerminalValueRef::U32),
-            ValueKind::U64 => self.read_terminal_value(value_kind, TerminalValueRef::U64),
-            ValueKind::U128 => self.read_terminal_value(value_kind, TerminalValueRef::U128),
+            ValueKind::Bool => self.read_basic_value(value_kind, TerminalValueRef::Bool, visitor),
+            ValueKind::I8 => self.read_basic_value(value_kind, TerminalValueRef::I8, visitor),
+            ValueKind::I16 => self.read_basic_value(value_kind, TerminalValueRef::I16, visitor),
+            ValueKind::I32 => self.read_basic_value(value_kind, TerminalValueRef::I32, visitor),
+            ValueKind::I64 => self.read_basic_value(value_kind, TerminalValueRef::I64, visitor),
+            ValueKind::I128 => self.read_basic_value(value_kind, TerminalValueRef::I128, visitor),
+            ValueKind::U8 => self.read_basic_value(value_kind, TerminalValueRef::U8, visitor),
+            ValueKind::U16 => self.read_basic_value(value_kind, TerminalValueRef::U16, visitor),
+            ValueKind::U32 => self.read_basic_value(value_kind, TerminalValueRef::U32, visitor),
+            ValueKind::U64 => self.read_basic_value(value_kind, TerminalValueRef::U64, visitor),
+            ValueKind::U128 => self.read_basic_value(value_kind, TerminalValueRef::U128, visitor),
             ValueKind::String => {
-                let length = handle_error!(self, self.decoder.read_size());
-                let bytes = handle_error!(self, self.decoder.read_slice_from_payload(length));
-                let string_body = handle_error!(
-                    self,
-                    str::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8)
-                );
-                self.complete(
-                    TraversalEvent::TerminalValue(TerminalValueRef::String(string_body)),
-                    NextAction::ReadNextChildOrExitContainer,
-                )
+                let length = handle_result!(self, visitor, self.decoder.read_size());
+                let bytes =
+                    handle_result!(self, visitor, self.decoder.read_slice_from_payload(length));
+                let string_decode_result =
+                    str::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8);
+                let string_body = handle_result!(self, visitor, string_decode_result);
+                self.complete_terminal_value(TerminalValueRef::String(string_body), visitor)
             }
             ValueKind::Array => {
-                let element_value_kind = handle_error!(self, self.decoder.read_value_kind());
-                let length = handle_error!(self, self.decoder.read_size());
-                self.complete_container_start(ContainerHeader::Array(ArrayHeader {
-                    element_value_kind,
-                    length,
-                }))
-            }
-            ValueKind::Map => {
-                let key_value_kind = handle_error!(self, self.decoder.read_value_kind());
-                let value_value_kind = handle_error!(self, self.decoder.read_value_kind());
-                let length = handle_error!(self, self.decoder.read_size());
-                self.complete_container_start(ContainerHeader::Map(MapHeader {
-                    key_value_kind,
-                    value_value_kind,
-                    length,
-                }))
-            }
-            ValueKind::Enum => {
-                let variant = handle_error!(self, self.decoder.read_byte());
-                let length = handle_error!(self, self.decoder.read_size());
-                self.complete_container_start(ContainerHeader::EnumVariant(EnumVariantHeader {
-                    variant,
-                    length,
-                }))
-            }
-            ValueKind::Tuple => {
-                let length = handle_error!(self, self.decoder.read_size());
-                self.complete_container_start(ContainerHeader::Tuple(TupleHeader { length }))
-            }
-            ValueKind::Custom(custom_value_kind) => {
-                let custom_value_ref = handle_error!(
-                    self,
-                    T::read_custom_value_body(custom_value_kind, self.decoder)
-                );
-                self.complete(
-                    TraversalEvent::TerminalValue(TerminalValueRef::Custom(custom_value_ref)),
-                    NextAction::ReadNextChildOrExitContainer,
+                let element_value_kind =
+                    handle_result!(self, visitor, self.decoder.read_value_kind());
+                let length = handle_result!(self, visitor, self.decoder.read_size());
+                self.complete_container_start(
+                    ContainerHeader::Array(ArrayHeader {
+                        element_value_kind,
+                        length,
+                    }),
+                    visitor,
                 )
             }
+            ValueKind::Map => {
+                let key_value_kind = handle_result!(self, visitor, self.decoder.read_value_kind());
+                let value_value_kind =
+                    handle_result!(self, visitor, self.decoder.read_value_kind());
+                let length = handle_result!(self, visitor, self.decoder.read_size());
+                self.complete_container_start(
+                    ContainerHeader::Map(MapHeader {
+                        key_value_kind,
+                        value_value_kind,
+                        length,
+                    }),
+                    visitor,
+                )
+            }
+            ValueKind::Enum => {
+                let variant = handle_result!(self, visitor, self.decoder.read_byte());
+                let length = handle_result!(self, visitor, self.decoder.read_size());
+                self.complete_container_start(
+                    ContainerHeader::EnumVariant(EnumVariantHeader { variant, length }),
+                    visitor,
+                )
+            }
+            ValueKind::Tuple => {
+                let length = handle_result!(self, visitor, self.decoder.read_size());
+                self.complete_container_start(
+                    ContainerHeader::Tuple(TupleHeader { length }),
+                    visitor,
+                )
+            }
+            ValueKind::Custom(custom_value_kind) => {
+                let custom_value_ref = handle_result!(
+                    self,
+                    visitor,
+                    T::read_custom_value_body(custom_value_kind, self.decoder)
+                );
+                self.complete_terminal_value(TerminalValueRef::Custom(custom_value_ref), visitor)
+            }
         }
     }
 
     #[inline]
-    fn read_terminal_value<V: Decode<T::CustomValueKind, VecDecoder<'de, T::CustomValueKind>>>(
+    #[must_use]
+    fn read_basic_value<
+        X: Decode<T::CustomValueKind, VecDecoder<'de, T::CustomValueKind>>,
+        V: UntypedPayloadVisitor<'de, T>,
+    >(
         self,
         value_kind: ValueKind<T::CustomValueKind>,
-        value_ref_constructor: impl Fn(V) -> TerminalValueRef<'de, T>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        match V::decode_body_with_value_kind(self.decoder, value_kind) {
-            Ok(value) => self.complete(
-                TraversalEvent::TerminalValue(value_ref_constructor(value)),
-                NextAction::ReadNextChildOrExitContainer,
-            ),
-            Err(error) => self.complete_with_error(error),
-        }
+        value_ref_constructor: impl Fn(X) -> TerminalValueRef<'de, T>,
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        let value = handle_result!(
+            self,
+            visitor,
+            X::decode_body_with_value_kind(self.decoder, value_kind)
+        );
+        self.complete_terminal_value(value_ref_constructor(value), visitor)
     }
 
     #[inline]
-    fn complete_container_start(
+    #[must_use]
+    fn complete_terminal_value<V: UntypedPayloadVisitor<'de, T>>(
+        self,
+        value_ref: TerminalValueRef<'de, T>,
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        let next_action = NextAction::ReadNextChildOrExitContainer;
+        visitor.on_terminal_value(OnTerminalValue {
+            location: self.location(),
+            value: value_ref,
+            resume_action: next_action,
+        })?;
+        ControlFlow::Continue(next_action)
+    }
+
+    #[inline]
+    #[must_use]
+    fn complete_terminal_value_batch<V: UntypedPayloadVisitor<'de, T>>(
+        self,
+        value_batch_ref: TerminalValueBatchRef<'de>,
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        let next_action = NextAction::ReadNextChildOrExitContainer;
+        visitor.on_terminal_value_batch(OnTerminalValueBatch {
+            location: self.location(),
+            value_batch: value_batch_ref,
+            resume_action: next_action,
+        })?;
+        ControlFlow::Continue(next_action)
+    }
+
+    #[inline]
+    #[must_use]
+    fn complete_container_start<V: UntypedPayloadVisitor<'de, T>>(
         self,
         container_header: ContainerHeader<T>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
         let next_action = NextAction::ReadContainerContentStart {
             container_header: container_header.clone(),
             container_start_offset: self.start_offset,
         };
-        self.complete(
-            TraversalEvent::ContainerStart(container_header),
-            next_action,
-        )
+        visitor.on_container_start(OnContainerStart {
+            location: self.location(),
+            header: container_header,
+            resume_action: next_action,
+        })?;
+        ControlFlow::Continue(next_action)
     }
 
     #[inline]
-    fn complete_container_end(
+    #[must_use]
+    fn complete_container_end<V: UntypedPayloadVisitor<'de, T>>(
         self,
         container_header: ContainerHeader<T>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        self.complete(
-            TraversalEvent::ContainerEnd(container_header),
-            // Continue interating the parent
-            NextAction::ReadNextChildOrExitContainer,
-        )
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, NextAction<T>> {
+        let next_action = NextAction::ReadNextChildOrExitContainer;
+        visitor.on_container_end(OnContainerEnd {
+            location: self.location(),
+            header: container_header,
+            resume_action: next_action,
+        })?;
+        ControlFlow::Continue(next_action)
     }
 
     #[inline]
-    fn complete_with_error(
+    #[must_use]
+    fn handle_result<V: UntypedPayloadVisitor<'de, T>, X>(
+        &self,
+        result: Result<X, DecodeError>,
+        visitor: &mut V,
+    ) -> ControlFlow<V::Output<'t>, X> {
+        match result {
+            Ok(value) => ControlFlow::Continue(value),
+            Err(error) => ControlFlow::Break(self.handle_error(error, visitor)),
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    fn handle_traversal_end<V: UntypedPayloadVisitor<'de, T>>(
         self,
+        check_end: bool,
+        visitor: &mut V,
+    ) -> V::Output<'t> {
+        if check_end {
+            if let Err(error) = self.decoder.check_end() {
+                return self.handle_error(error, visitor);
+            }
+        }
+        visitor.on_traversal_end(OnTraversalEnd {
+            location: self.location(),
+        })
+    }
+
+    #[inline]
+    #[must_use]
+    fn handle_error<V: UntypedPayloadVisitor<'de, T>>(
+        &self,
         error: DecodeError,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        self.complete(TraversalEvent::DecodeError(error), NextAction::Errored)
+        visitor: &mut V,
+    ) -> V::Output<'t> {
+        visitor.on_error(OnError {
+            error,
+            location: self.location(),
+        })
     }
 
     #[inline]
-    fn complete(
-        self,
-        traversal_event: TraversalEvent<'de, T>,
-        next_action: NextAction<T>,
-    ) -> (LocatedTraversalEvent<'t, 'de, T>, NextAction<T>) {
-        let located_event = LocatedTraversalEvent {
-            event: traversal_event,
-            location: Location {
-                start_offset: self.start_offset,
-                end_offset: self.decoder.get_offset(),
-                ancestor_path: self.ancestor_path,
-            },
-        };
-        (located_event, next_action)
+    fn location(&self) -> Location<'t, T> {
+        Location {
+            start_offset: self.start_offset,
+            end_offset: self.decoder.get_offset(),
+            ancestor_path: self.ancestor_path,
+        }
     }
 }
 

--- a/sbor/src/traversal/untyped/utility_visitors.rs
+++ b/sbor/src/traversal/untyped/utility_visitors.rs
@@ -1,0 +1,80 @@
+use crate::internal_prelude::*;
+
+pub struct ValidatingVisitor;
+
+impl<'de, T: CustomTraversal + 'static> UntypedPayloadVisitor<'de, T> for ValidatingVisitor {
+    type Output<'t> = Result<usize, DecodeError>;
+
+    fn on_error<'t>(&mut self, details: OnError<'t, T>) -> Self::Output<'t> {
+        Err(details.error)
+    }
+
+    fn on_traversal_end<'t>(&mut self, details: OnTraversalEnd<'t, T>) -> Self::Output<'t> {
+        Ok(details.location.end_offset)
+    }
+}
+
+pub struct EventStreamVisitor<'de, T: CustomTraversal> {
+    pub next_action: SuspendableNextAction<T>,
+    pub next_event: Option<TraversalEvent<'de, T>>,
+}
+
+pub enum SuspendableNextAction<T: CustomTraversal> {
+    Action(NextAction<T>),
+    Errored,
+    Ended,
+}
+
+impl<'de, T: CustomTraversal + 'static> UntypedPayloadVisitor<'de, T>
+    for EventStreamVisitor<'de, T>
+{
+    type Output<'t> = Location<'t, T>;
+
+    fn on_container_start<'t>(
+        &mut self,
+        details: OnContainerStart<'t, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        self.next_action = SuspendableNextAction::Action(details.resume_action);
+        self.next_event = Some(TraversalEvent::ContainerStart(details.header));
+        ControlFlow::Break(details.location)
+    }
+
+    fn on_terminal_value<'t>(
+        &mut self,
+        details: OnTerminalValue<'t, 'de, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        self.next_action = SuspendableNextAction::Action(details.resume_action);
+        self.next_event = Some(TraversalEvent::TerminalValue(details.value));
+        ControlFlow::Break(details.location)
+    }
+
+    fn on_terminal_value_batch<'t>(
+        &mut self,
+        details: OnTerminalValueBatch<'t, 'de, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        self.next_action = SuspendableNextAction::Action(details.resume_action);
+        self.next_event = Some(TraversalEvent::TerminalValueBatch(details.value_batch));
+        ControlFlow::Break(details.location)
+    }
+
+    fn on_container_end<'t>(
+        &mut self,
+        details: OnContainerEnd<'t, T>,
+    ) -> ControlFlow<Self::Output<'t>> {
+        self.next_action = SuspendableNextAction::Action(details.resume_action);
+        self.next_event = Some(TraversalEvent::ContainerEnd(details.header));
+        ControlFlow::Break(details.location)
+    }
+
+    fn on_error<'t>(&mut self, details: OnError<'t, T>) -> Self::Output<'t> {
+        self.next_action = SuspendableNextAction::Errored;
+        self.next_event = Some(TraversalEvent::DecodeError(details.error));
+        details.location
+    }
+
+    fn on_traversal_end<'t>(&mut self, details: OnTraversalEnd<'t, T>) -> Self::Output<'t> {
+        self.next_action = SuspendableNextAction::Ended;
+        self.next_event = Some(TraversalEvent::End);
+        details.location
+    }
+}

--- a/sbor/src/vec_traits.rs
+++ b/sbor/src/vec_traits.rs
@@ -1,7 +1,4 @@
-use crate::{
-    internal_prelude::*, validate_payload_against_schema, CustomExtension, CustomSchema,
-    Decoder as _, Describe, Encoder as _, ValidatableCustomExtension, VecDecoder, VecEncoder,
-};
+use crate::internal_prelude::*;
 
 pub trait VecEncode<X: CustomValueKind>: for<'a> Encode<X, VecEncoder<'a, X>> {}
 impl<X: CustomValueKind, T: for<'a> Encode<X, VecEncoder<'a, X>> + ?Sized> VecEncode<X> for T {}


### PR DESCRIPTION
## Summary
Basically just a side-exploration on my off-day to trial a visitor pattern for SBOR traversals.
And makes VecTraverser use a shim to the new visitor pattern to validate it in tests.

I imagine it makes `VecTraverser` too slow in its current form, so we probably don't want to merge this.

But I'm interested to see if the RawSborValue decoding is significantly faster (I'm hoping it can be, due to various  optimizations which can be done for `calculate_value_tree_body_byte_length` now).

When I have some more down time, I might investigate if we can do the same treatment to `TypedTraverser`, payload validation, etc.

## Details
TBC

## Testing
Existing tests pass... Let's take a look at the benchmark comparison for validation!
