### PR TITLE
update: Tweak info-urls in cuttlefish

### DIFF
--- a/radix-engine/src/updates/cuttlefish.rs
+++ b/radix-engine/src/updates/cuttlefish.rs
@@ -268,119 +268,122 @@ fn generate_cuttlefish_metadata_fix<S: SubstateDatabase + ?Sized>(db: &S) -> Sta
     // We would like to add an `info_url` entry for the various entities that we have. The this is
     // the mapping that we're using.
     let info_url_metadata = [
-        (XRD.into_node_id(), "https://go.radixdlt.com/xrd-info"),
+        (XRD.into_node_id(), "https://www.radixdlt.com/info-url/xrd"),
         (
             SECP256K1_SIGNATURE_RESOURCE.into_node_id(),
-            "https://go.radixdlt.com/secp256k1-signature-resouce-info",
+            "https://www.radixdlt.com/info-url/secp256k1-signature-resource",
         ),
         (
             ED25519_SIGNATURE_RESOURCE.into_node_id(),
-            "https://go.radixdlt.com/ed25519-signature-resource-info",
+            "https://www.radixdlt.com/info-url/ed25519-signature-resource",
         ),
         (
             PACKAGE_OF_DIRECT_CALLER_RESOURCE.into_node_id(),
-            "https://go.radixdlt.com/package-of-direct-caller-resource-info",
+            "https://www.radixdlt.com/info-url/package-of-direct-caller-resource",
         ),
         (
             GLOBAL_CALLER_RESOURCE.into_node_id(),
-            "https://go.radixdlt.com/global-caller-resource-info",
+            "https://www.radixdlt.com/info-url/global-caller-resource",
         ),
         (
             SYSTEM_EXECUTION_RESOURCE.into_node_id(),
-            "https://go.radixdlt.com/system-execution-resource-info",
+            "https://www.radixdlt.com/info-url/system-execution-resource",
         ),
         (
             PACKAGE_OWNER_BADGE.into_node_id(),
-            "https://go.radixdlt.com/package-owner-badge-info",
+            "https://www.radixdlt.com/info-url/package-owner-badge",
         ),
         (
             VALIDATOR_OWNER_BADGE.into_node_id(),
-            "https://go.radixdlt.com/validator-owner-badge-info",
+            "https://www.radixdlt.com/info-url/validator-owner-badge",
         ),
         (
             ACCOUNT_OWNER_BADGE.into_node_id(),
-            "https://go.radixdlt.com/account-owner-badge-info",
+            "https://www.radixdlt.com/info-url/account-owner-badge",
         ),
         (
             IDENTITY_OWNER_BADGE.into_node_id(),
-            "https://go.radixdlt.com/identity-owner-badge-info",
+            "https://www.radixdlt.com/info-url/identity-owner-badge",
         ),
         (
             PACKAGE_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/package-package-info",
+            "https://www.radixdlt.com/info-url/package-package",
         ),
         (
             RESOURCE_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/resource-package-info",
+            "https://www.radixdlt.com/info-url/resource-package",
         ),
         (
             ACCOUNT_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/account-package-info",
+            "https://www.radixdlt.com/info-url/account-package",
         ),
         (
             IDENTITY_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/identity-package-info",
+            "https://www.radixdlt.com/info-url/identity-package",
         ),
         (
             CONSENSUS_MANAGER_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/consensus-manager-package-info",
+            "https://www.radixdlt.com/info-url/consensus-manager-package",
         ),
         (
             ACCESS_CONTROLLER_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/access-controller-package-info",
+            "https://www.radixdlt.com/info-url/access-controller-package",
         ),
         (
             POOL_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/pool-package-info",
+            "https://www.radixdlt.com/info-url/pool-package",
         ),
         (
             TRANSACTION_PROCESSOR_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/transaction-processor-package-info",
+            "https://www.radixdlt.com/info-url/transaction-processor-package",
         ),
         (
             METADATA_MODULE_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/metadata-module-package-info",
+            "https://www.radixdlt.com/info-url/metadata-module-package",
         ),
         (
             ROYALTY_MODULE_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/royalty-module-package-info",
+            "https://www.radixdlt.com/info-url/royalty-module-package",
         ),
         (
             ROLE_ASSIGNMENT_MODULE_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/role-assignment-module-package-info",
+            "https://www.radixdlt.com/info-url/role-assignment-module-package",
         ),
         (
             TEST_UTILS_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/test-utils-package-info",
+            "https://www.radixdlt.com/info-url/test-utils-package",
         ),
         (
             GENESIS_HELPER_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/genesis-helper-package-info",
+            "https://www.radixdlt.com/info-url/genesis-helper-package",
         ),
         (
             FAUCET_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/faucet-package-info",
+            "https://www.radixdlt.com/info-url/faucet-package",
         ),
         (
             TRANSACTION_TRACKER_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/transaction-tracker-package-info",
+            "https://www.radixdlt.com/info-url/transaction-tracker-package",
         ),
         (
             LOCKER_PACKAGE.into_node_id(),
-            "https://go.radixdlt.com/locker-package-info",
+            "https://www.radixdlt.com/info-url/locker-package",
         ),
         (
             CONSENSUS_MANAGER.into_node_id(),
-            "https://go.radixdlt.com/consensus-manager-info",
+            "https://www.radixdlt.com/info-url/consensus-manager",
         ),
         (
             GENESIS_HELPER.into_node_id(),
-            "https://go.radixdlt.com/genesis-helper-info",
+            "https://www.radixdlt.com/info-url/genesis-helper",
         ),
-        (FAUCET.into_node_id(), "https://go.radixdlt.com/faucet-info"),
+        (
+            FAUCET.into_node_id(),
+            "https://www.radixdlt.com/info-url/faucet",
+        ),
         (
             TRANSACTION_TRACKER.into_node_id(),
-            "https://go.radixdlt.com/transaction-tracker-info",
+            "https://www.radixdlt.com/info-url/transaction-tracker",
         ),
     ];
 

--- a/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/protocol_update_summary.txt
+++ b/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/protocol_update_summary.txt
@@ -2,6 +2,6 @@ Name: Cuttlefish
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the protocol update is deployed to a permanent network, else it can cause divergence.
-State changes: e83f7ca5ea352016 (allowed to change if not deployed to any network)
+State changes: f8f14977c0c7cc47 (allowed to change if not deployed to any network)
 Events       : 95a62c573dc22cf0 (allowed to change if not deployed to any network)
 

--- a/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/receipts/00-00-03--cuttlefish-update-metadata.txt
+++ b/radix-transaction-scenarios/generated-protocol-updates/cuttlefish/receipts/00-00-03--cuttlefish-update-metadata.txt
@@ -23,7 +23,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/xrd-info"),
+           Url("https://www.radixdlt.com/info-url/xrd"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxpkcllrxxxxxxxxx003652646977xxxxxxxxxla870l across 1 partitions
@@ -49,7 +49,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/package-of-direct-caller-resource-info"),
+           Url("https://www.radixdlt.com/info-url/package-of-direct-caller-resource"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxglcllrxxxxxxxxx002350006550xxxxxxxxxk5870l across 1 partitions
@@ -75,7 +75,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/global-caller-resource-info"),
+           Url("https://www.radixdlt.com/info-url/global-caller-resource"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxsecpsgxxxxxxxxx004638826440xxxxxxxxxwj8qq5 across 1 partitions
@@ -101,7 +101,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/secp256k1-signature-resouce-info"),
+           Url("https://www.radixdlt.com/info-url/secp256k1-signature-resource"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxx8x44q5 across 1 partitions
@@ -127,7 +127,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/ed25519-signature-resource-info"),
+           Url("https://www.radixdlt.com/info-url/ed25519-signature-resource"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxsystxnxxxxxxxxx002683325037xxxxxxxxxw002k0 across 1 partitions
@@ -153,7 +153,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/system-execution-resource-info"),
+           Url("https://www.radixdlt.com/info-url/system-execution-resource"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxpkgwnrxxxxxxxxx002558553505xxxxxxxxxlah0rl across 1 partitions
@@ -161,7 +161,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/package-owner-badge-info"),
+           Url("https://www.radixdlt.com/info-url/package-owner-badge"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxvdrwnrxxxxxxxxx004365253834xxxxxxxxxjxu0rl across 1 partitions
@@ -169,7 +169,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/validator-owner-badge-info"),
+           Url("https://www.radixdlt.com/info-url/validator-owner-badge"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxaccwnrxxxxxxxxx006664022062xxxxxxxxxrn80rl across 1 partitions
@@ -177,7 +177,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/account-owner-badge-info"),
+           Url("https://www.radixdlt.com/info-url/account-owner-badge"),
          ),
        )
 ├─ resource_sim1nfxxxxxxxxxxdntwnrxxxxxxxxx002876444928xxxxxxxxxnc50rl across 1 partitions
@@ -185,7 +185,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/identity-owner-badge-info"),
+           Url("https://www.radixdlt.com/info-url/identity-owner-badge"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxpackgexxxxxxxxx000726633226xxxxxxxxxlk8hc9 across 1 partitions
@@ -193,7 +193,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/package-package-info"),
+           Url("https://www.radixdlt.com/info-url/package-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxresrcexxxxxxxxx000538436477xxxxxxxxxaj0zg9 across 1 partitions
@@ -201,7 +201,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/resource-package-info"),
+           Url("https://www.radixdlt.com/info-url/resource-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxaccntxxxxxxxxxx000929625493xxxxxxxxxrn8jm6 across 1 partitions
@@ -209,7 +209,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/account-package-info"),
+           Url("https://www.radixdlt.com/info-url/account-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxdntyxxxxxxxxxxx008560783089xxxxxxxxxnc59k6 across 1 partitions
@@ -217,7 +217,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/identity-package-info"),
+           Url("https://www.radixdlt.com/info-url/identity-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxcnsmgrxxxxxxxxx000746305335xxxxxxxxxxc06cl across 1 partitions
@@ -225,7 +225,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/consensus-manager-package-info"),
+           Url("https://www.radixdlt.com/info-url/consensus-manager-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxcntrlrxxxxxxxxx000648572295xxxxxxxxxxc5z0l across 1 partitions
@@ -233,7 +233,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/access-controller-package-info"),
+           Url("https://www.radixdlt.com/info-url/access-controller-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxplxxxxxxxxxxxxx020379220524xxxxxxxxxl5e8k6 across 1 partitions
@@ -241,7 +241,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/pool-package-info"),
+           Url("https://www.radixdlt.com/info-url/pool-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxtxnpxrxxxxxxxxx002962227406xxxxxxxxx4dvqkl across 1 partitions
@@ -249,7 +249,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/transaction-processor-package-info"),
+           Url("https://www.radixdlt.com/info-url/transaction-processor-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxmtdataxxxxxxxxx005246577269xxxxxxxxx9qjump across 1 partitions
@@ -257,7 +257,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/metadata-module-package-info"),
+           Url("https://www.radixdlt.com/info-url/metadata-module-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxryaltyxxxxxxxxx003849573396xxxxxxxxxa0z7mc across 1 partitions
@@ -265,7 +265,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/royalty-module-package-info"),
+           Url("https://www.radixdlt.com/info-url/royalty-module-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxarulesxxxxxxxxx002304462983xxxxxxxxxrgr7fv across 1 partitions
@@ -273,7 +273,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/role-assignment-module-package-info"),
+           Url("https://www.radixdlt.com/info-url/role-assignment-module-package"),
          ),
        )
 ├─ package_sim1phua8spmaxapwq56stduucrvztk92gxzjy9c98h0qemfjec00a6qza across 1 partitions
@@ -281,7 +281,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/test-utils-package-info"),
+           Url("https://www.radixdlt.com/info-url/test-utils-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxgenssxxxxxxxxxx004372642773xxxxxxxxxkjv3q6 across 1 partitions
@@ -289,7 +289,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/genesis-helper-package-info"),
+           Url("https://www.radixdlt.com/info-url/genesis-helper-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxfaucetxxxxxxxxx000034355863xxxxxxxxxhkrefh across 1 partitions
@@ -297,7 +297,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/faucet-package-info"),
+           Url("https://www.radixdlt.com/info-url/faucet-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxtxtrakxxxxxxxxx000595975309xxxxxxxxx4d5zd2 across 1 partitions
@@ -305,7 +305,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/transaction-tracker-package-info"),
+           Url("https://www.radixdlt.com/info-url/transaction-tracker-package"),
          ),
        )
 ├─ package_sim1pkgxxxxxxxxxlckerxxxxxxxxxx000208064247xxxxxxxxxpnfcn6 across 1 partitions
@@ -313,7 +313,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/locker-package-info"),
+           Url("https://www.radixdlt.com/info-url/locker-package"),
          ),
        )
 ├─ consensusmanager_sim1scxxxxxxxxxxcnsmgrxxxxxxxxx000999665565xxxxxxxxxxc06cl across 1 partitions
@@ -321,7 +321,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/consensus-manager-info"),
+           Url("https://www.radixdlt.com/info-url/consensus-manager"),
          ),
        )
 ├─ component_sim1cptxxxxxxxxxgenssxxxxxxxxxx000977302539xxxxxxxxxkjv3q6 across 1 partitions
@@ -329,7 +329,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/genesis-helper-info"),
+           Url("https://www.radixdlt.com/info-url/genesis-helper"),
          ),
        )
 ├─ component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh across 1 partitions
@@ -337,7 +337,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/faucet-info"),
+           Url("https://www.radixdlt.com/info-url/faucet"),
          ),
        )
 └─ transactiontracker_sim1stxxxxxxxxxxtxtrakxxxxxxxxx006844685494xxxxxxxxx4d5zd2 across 1 partitions
@@ -345,7 +345,7 @@ STATE UPDATES: 30 entities
     └─ Set: "info_url"
        Value: LOCKED MetadataEntryEntryPayload::V1(
          GenericMetadataValue::Url(
-           Url("https://go.radixdlt.com/transaction-tracker-info"),
+           Url("https://www.radixdlt.com/info-url/transaction-tracker"),
          ),
        )
 

--- a/update-protocol-updates.sh
+++ b/update-protocol-updates.sh
@@ -1,4 +1,3 @@
 set -ex
 
 cargo test --package radix-transaction-scenarios --lib -- runners::dumper::test::update_all_generated_protocol_update_receipts --exact --ignored --nocapture
-cargo test --package radix-transaction-scenarios --lib -- runners::dumper::test::update_all_generated_scenarios --exact --ignored --nocapture


### PR DESCRIPTION
## Summary
Updates the `info-url` metadata in Cuttlefish to a new URL scheme.

## Testing
Existing tests pass.