### PR TITLE
tweak: Trivial instruction refactors

### DIFF
--- a/radix-transactions/src/model/v1/instruction_v1.rs
+++ b/radix-transactions/src/model/v1/instruction_v1.rs
@@ -12,71 +12,71 @@ impl ManifestInstructionSet for InstructionV1 {
         context: &mut decompiler::DecompilationContext,
     ) -> Result<decompiler::DecompiledInstruction, DecompileError> {
         match self {
-            Self::TakeAllFromWorktop(x) => x.decompile(context),
-            Self::TakeFromWorktop(x) => x.decompile(context),
-            Self::TakeNonFungiblesFromWorktop(x) => x.decompile(context),
-            Self::ReturnToWorktop(x) => x.decompile(context),
-            Self::AssertWorktopContainsAny(x) => x.decompile(context),
-            Self::AssertWorktopContains(x) => x.decompile(context),
-            Self::AssertWorktopContainsNonFungibles(x) => x.decompile(context),
-            Self::PopFromAuthZone(x) => x.decompile(context),
-            Self::PushToAuthZone(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfAmount(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfNonFungibles(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfAll(x) => x.decompile(context),
-            Self::DropAuthZoneProofs(x) => x.decompile(context),
-            Self::DropAuthZoneRegularProofs(x) => x.decompile(context),
-            Self::DropAuthZoneSignatureProofs(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfAmount(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfNonFungibles(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfAll(x) => x.decompile(context),
-            Self::BurnResource(x) => x.decompile(context),
-            Self::CloneProof(x) => x.decompile(context),
-            Self::DropProof(x) => x.decompile(context),
-            Self::CallFunction(x) => x.decompile(context),
-            Self::CallMethod(x) => x.decompile(context),
-            Self::CallRoyaltyMethod(x) => x.decompile(context),
-            Self::CallMetadataMethod(x) => x.decompile(context),
-            Self::CallRoleAssignmentMethod(x) => x.decompile(context),
-            Self::CallDirectVaultMethod(x) => x.decompile(context),
-            Self::DropNamedProofs(x) => x.decompile(context),
-            Self::DropAllProofs(x) => x.decompile(context),
-            Self::AllocateGlobalAddress(x) => x.decompile(context),
+            InstructionV1::TakeFromWorktop(x) => x.decompile(context),
+            InstructionV1::TakeNonFungiblesFromWorktop(x) => x.decompile(context),
+            InstructionV1::TakeAllFromWorktop(x) => x.decompile(context),
+            InstructionV1::ReturnToWorktop(x) => x.decompile(context),
+            InstructionV1::BurnResource(x) => x.decompile(context),
+            InstructionV1::AssertWorktopContainsAny(x) => x.decompile(context),
+            InstructionV1::AssertWorktopContains(x) => x.decompile(context),
+            InstructionV1::AssertWorktopContainsNonFungibles(x) => x.decompile(context),
+            InstructionV1::CreateProofFromBucketOfAmount(x) => x.decompile(context),
+            InstructionV1::CreateProofFromBucketOfNonFungibles(x) => x.decompile(context),
+            InstructionV1::CreateProofFromBucketOfAll(x) => x.decompile(context),
+            InstructionV1::CreateProofFromAuthZoneOfAmount(x) => x.decompile(context),
+            InstructionV1::CreateProofFromAuthZoneOfNonFungibles(x) => x.decompile(context),
+            InstructionV1::CreateProofFromAuthZoneOfAll(x) => x.decompile(context),
+            InstructionV1::CloneProof(x) => x.decompile(context),
+            InstructionV1::DropProof(x) => x.decompile(context),
+            InstructionV1::PushToAuthZone(x) => x.decompile(context),
+            InstructionV1::PopFromAuthZone(x) => x.decompile(context),
+            InstructionV1::DropAuthZoneProofs(x) => x.decompile(context),
+            InstructionV1::DropAuthZoneRegularProofs(x) => x.decompile(context),
+            InstructionV1::DropAuthZoneSignatureProofs(x) => x.decompile(context),
+            InstructionV1::DropNamedProofs(x) => x.decompile(context),
+            InstructionV1::DropAllProofs(x) => x.decompile(context),
+            InstructionV1::CallFunction(x) => x.decompile(context),
+            InstructionV1::CallMethod(x) => x.decompile(context),
+            InstructionV1::CallRoyaltyMethod(x) => x.decompile(context),
+            InstructionV1::CallMetadataMethod(x) => x.decompile(context),
+            InstructionV1::CallRoleAssignmentMethod(x) => x.decompile(context),
+            InstructionV1::CallDirectVaultMethod(x) => x.decompile(context),
+            InstructionV1::AllocateGlobalAddress(x) => x.decompile(context),
         }
     }
 
     fn effect(&self) -> ManifestInstructionEffect {
         match self {
-            Self::TakeAllFromWorktop(x) => x.effect(),
-            Self::TakeFromWorktop(x) => x.effect(),
-            Self::TakeNonFungiblesFromWorktop(x) => x.effect(),
-            Self::ReturnToWorktop(x) => x.effect(),
-            Self::AssertWorktopContainsAny(x) => x.effect(),
-            Self::AssertWorktopContains(x) => x.effect(),
-            Self::AssertWorktopContainsNonFungibles(x) => x.effect(),
-            Self::PopFromAuthZone(x) => x.effect(),
-            Self::PushToAuthZone(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfAmount(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfNonFungibles(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfAll(x) => x.effect(),
-            Self::DropAuthZoneProofs(x) => x.effect(),
-            Self::DropAuthZoneRegularProofs(x) => x.effect(),
-            Self::DropAuthZoneSignatureProofs(x) => x.effect(),
-            Self::CreateProofFromBucketOfAmount(x) => x.effect(),
-            Self::CreateProofFromBucketOfNonFungibles(x) => x.effect(),
-            Self::CreateProofFromBucketOfAll(x) => x.effect(),
-            Self::BurnResource(x) => x.effect(),
-            Self::CloneProof(x) => x.effect(),
-            Self::DropProof(x) => x.effect(),
-            Self::CallFunction(x) => x.effect(),
-            Self::CallMethod(x) => x.effect(),
-            Self::CallRoyaltyMethod(x) => x.effect(),
-            Self::CallMetadataMethod(x) => x.effect(),
-            Self::CallRoleAssignmentMethod(x) => x.effect(),
-            Self::CallDirectVaultMethod(x) => x.effect(),
-            Self::DropNamedProofs(x) => x.effect(),
-            Self::DropAllProofs(x) => x.effect(),
-            Self::AllocateGlobalAddress(x) => x.effect(),
+            InstructionV1::TakeFromWorktop(x) => x.effect(),
+            InstructionV1::TakeNonFungiblesFromWorktop(x) => x.effect(),
+            InstructionV1::TakeAllFromWorktop(x) => x.effect(),
+            InstructionV1::ReturnToWorktop(x) => x.effect(),
+            InstructionV1::BurnResource(x) => x.effect(),
+            InstructionV1::AssertWorktopContainsAny(x) => x.effect(),
+            InstructionV1::AssertWorktopContains(x) => x.effect(),
+            InstructionV1::AssertWorktopContainsNonFungibles(x) => x.effect(),
+            InstructionV1::CreateProofFromBucketOfAmount(x) => x.effect(),
+            InstructionV1::CreateProofFromBucketOfNonFungibles(x) => x.effect(),
+            InstructionV1::CreateProofFromBucketOfAll(x) => x.effect(),
+            InstructionV1::CreateProofFromAuthZoneOfAmount(x) => x.effect(),
+            InstructionV1::CreateProofFromAuthZoneOfNonFungibles(x) => x.effect(),
+            InstructionV1::CreateProofFromAuthZoneOfAll(x) => x.effect(),
+            InstructionV1::CloneProof(x) => x.effect(),
+            InstructionV1::DropProof(x) => x.effect(),
+            InstructionV1::PushToAuthZone(x) => x.effect(),
+            InstructionV1::PopFromAuthZone(x) => x.effect(),
+            InstructionV1::DropAuthZoneProofs(x) => x.effect(),
+            InstructionV1::DropAuthZoneRegularProofs(x) => x.effect(),
+            InstructionV1::DropAuthZoneSignatureProofs(x) => x.effect(),
+            InstructionV1::DropNamedProofs(x) => x.effect(),
+            InstructionV1::DropAllProofs(x) => x.effect(),
+            InstructionV1::CallFunction(x) => x.effect(),
+            InstructionV1::CallMethod(x) => x.effect(),
+            InstructionV1::CallRoyaltyMethod(x) => x.effect(),
+            InstructionV1::CallMetadataMethod(x) => x.effect(),
+            InstructionV1::CallRoleAssignmentMethod(x) => x.effect(),
+            InstructionV1::CallDirectVaultMethod(x) => x.effect(),
+            InstructionV1::AllocateGlobalAddress(x) => x.effect(),
         }
     }
 }
@@ -85,125 +85,108 @@ impl ManifestInstructionSet for InstructionV1 {
 #[sbor(impl_variant_traits)]
 #[sbor_assert(fixed("FILE:instruction_v1_schema.txt"))]
 pub enum InstructionV1 {
-    //==============
-    // Worktop
-    //==============
-    /// Takes resource from worktop.
-    #[sbor(discriminator(INSTRUCTION_TAKE_ALL_FROM_WORKTOP_DISCRIMINATOR))]
-    TakeAllFromWorktop(#[sbor(flatten)] TakeAllFromWorktop),
-
-    /// Takes resource from worktop by the given amount.
-    #[sbor(discriminator(INSTRUCTION_TAKE_FROM_WORKTOP_DISCRIMINATOR))]
+    //===============
+    // Bucket Lifecycle
+    //===============
+    #[sbor(discriminator(TakeFromWorktop::ID))]
     TakeFromWorktop(#[sbor(flatten)] TakeFromWorktop),
 
-    /// Takes resource from worktop by the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_TAKE_NON_FUNGIBLES_FROM_WORKTOP_DISCRIMINATOR))]
+    #[sbor(discriminator(TakeNonFungiblesFromWorktop::ID))]
     TakeNonFungiblesFromWorktop(#[sbor(flatten)] TakeNonFungiblesFromWorktop),
 
-    /// Returns a bucket of resource to worktop.
-    #[sbor(discriminator(INSTRUCTION_RETURN_TO_WORKTOP_DISCRIMINATOR))]
+    #[sbor(discriminator(TakeAllFromWorktop::ID))]
+    TakeAllFromWorktop(#[sbor(flatten)] TakeAllFromWorktop),
+
+    #[sbor(discriminator(ReturnToWorktop::ID))]
     ReturnToWorktop(#[sbor(flatten)] ReturnToWorktop),
 
-    /// Asserts worktop contains any specified resource.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_ANY_DISCRIMINATOR))]
-    AssertWorktopContainsAny(#[sbor(flatten)] AssertWorktopContainsAny),
-
-    /// Asserts worktop contains resource by at least the given amount.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_DISCRIMINATOR))]
-    AssertWorktopContains(#[sbor(flatten)] AssertWorktopContains),
-
-    /// Asserts worktop contains resource by at least the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES_DISCRIMINATOR))]
-    AssertWorktopContainsNonFungibles(#[sbor(flatten)] AssertWorktopContainsNonFungibles),
-
-    //==============
-    // Auth zone
-    //==============
-    /// Takes the last proof from the auth zone.
-    #[sbor(discriminator(INSTRUCTION_POP_FROM_AUTH_ZONE_DISCRIMINATOR))]
-    PopFromAuthZone(#[sbor(flatten)] PopFromAuthZone),
-
-    /// Adds a proof to the auth zone.
-    #[sbor(discriminator(INSTRUCTION_PUSH_TO_AUTH_ZONE_DISCRIMINATOR))]
-    PushToAuthZone(#[sbor(flatten)] PushToAuthZone),
-
-    /// Creates a proof from the auth zone, by the given amount
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_AMOUNT_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfAmount(#[sbor(flatten)] CreateProofFromAuthZoneOfAmount),
-
-    /// Creates a proof from the auth zone, by the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_NON_FUNGIBLES_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfNonFungibles(#[sbor(flatten)] CreateProofFromAuthZoneOfNonFungibles),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_ALL_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfAll(#[sbor(flatten)] CreateProofFromAuthZoneOfAll),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneProofs(#[sbor(flatten)] DropAuthZoneProofs),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_REGULAR_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneRegularProofs(#[sbor(flatten)] DropAuthZoneRegularProofs),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_SIGNATURE_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneSignatureProofs(#[sbor(flatten)] DropAuthZoneSignatureProofs),
-
-    //==============
-    // Named bucket
-    //==============
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_AMOUNT_DISCRIMINATOR))]
-    CreateProofFromBucketOfAmount(#[sbor(flatten)] CreateProofFromBucketOfAmount),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES_DISCRIMINATOR))]
-    CreateProofFromBucketOfNonFungibles(#[sbor(flatten)] CreateProofFromBucketOfNonFungibles),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_ALL_DISCRIMINATOR))]
-    CreateProofFromBucketOfAll(#[sbor(flatten)] CreateProofFromBucketOfAll),
-
-    #[sbor(discriminator(INSTRUCTION_BURN_RESOURCE_DISCRIMINATOR))]
+    #[sbor(discriminator(BurnResource::ID))]
     BurnResource(#[sbor(flatten)] BurnResource),
 
     //==============
-    // Named proof
+    // Resource Assertions
     //==============
-    /// Clones a proof.
-    #[sbor(discriminator(INSTRUCTION_CLONE_PROOF_DISCRIMINATOR))]
+    #[sbor(discriminator(AssertWorktopContainsAny::ID))]
+    AssertWorktopContainsAny(#[sbor(flatten)] AssertWorktopContainsAny),
+
+    #[sbor(discriminator(AssertWorktopContains::ID))]
+    AssertWorktopContains(#[sbor(flatten)] AssertWorktopContains),
+
+    #[sbor(discriminator(AssertWorktopContainsNonFungibles::ID))]
+    AssertWorktopContainsNonFungibles(#[sbor(flatten)] AssertWorktopContainsNonFungibles),
+
+    //==============
+    // Proof Lifecycle
+    //==============
+    #[sbor(discriminator(CreateProofFromBucketOfAmount::ID))]
+    CreateProofFromBucketOfAmount(#[sbor(flatten)] CreateProofFromBucketOfAmount),
+
+    #[sbor(discriminator(CreateProofFromBucketOfNonFungibles::ID))]
+    CreateProofFromBucketOfNonFungibles(#[sbor(flatten)] CreateProofFromBucketOfNonFungibles),
+
+    #[sbor(discriminator(CreateProofFromBucketOfAll::ID))]
+    CreateProofFromBucketOfAll(#[sbor(flatten)] CreateProofFromBucketOfAll),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfAmount::ID))]
+    CreateProofFromAuthZoneOfAmount(#[sbor(flatten)] CreateProofFromAuthZoneOfAmount),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfNonFungibles::ID))]
+    CreateProofFromAuthZoneOfNonFungibles(#[sbor(flatten)] CreateProofFromAuthZoneOfNonFungibles),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfAll::ID))]
+    CreateProofFromAuthZoneOfAll(#[sbor(flatten)] CreateProofFromAuthZoneOfAll),
+
+    #[sbor(discriminator(CloneProof::ID))]
     CloneProof(#[sbor(flatten)] CloneProof),
 
-    /// Drops a proof.
-    #[sbor(discriminator(INSTRUCTION_DROP_PROOF_DISCRIMINATOR))]
+    #[sbor(discriminator(DropProof::ID))]
     DropProof(#[sbor(flatten)] DropProof),
+
+    #[sbor(discriminator(PushToAuthZone::ID))]
+    PushToAuthZone(#[sbor(flatten)] PushToAuthZone),
+
+    #[sbor(discriminator(PopFromAuthZone::ID))]
+    PopFromAuthZone(#[sbor(flatten)] PopFromAuthZone),
+
+    #[sbor(discriminator(DropAuthZoneProofs::ID))]
+    DropAuthZoneProofs(#[sbor(flatten)] DropAuthZoneProofs),
+
+    #[sbor(discriminator(DropAuthZoneRegularProofs::ID))]
+    DropAuthZoneRegularProofs(#[sbor(flatten)] DropAuthZoneRegularProofs),
+
+    #[sbor(discriminator(DropAuthZoneSignatureProofs::ID))]
+    DropAuthZoneSignatureProofs(#[sbor(flatten)] DropAuthZoneSignatureProofs),
+
+    #[sbor(discriminator(DropNamedProofs::ID))]
+    DropNamedProofs(#[sbor(flatten)] DropNamedProofs),
+
+    #[sbor(discriminator(DropAllProofs::ID))]
+    DropAllProofs(#[sbor(flatten)] DropAllProofs),
 
     //==============
     // Invocation
     //==============
-    #[sbor(discriminator(INSTRUCTION_CALL_FUNCTION_DISCRIMINATOR))]
+    #[sbor(discriminator(CallFunction::ID))]
     CallFunction(#[sbor(flatten)] CallFunction),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallMethod::ID))]
     CallMethod(#[sbor(flatten)] CallMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_ROYALTY_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallRoyaltyMethod::ID))]
     CallRoyaltyMethod(#[sbor(flatten)] CallRoyaltyMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_METADATA_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallMetadataMethod::ID))]
     CallMetadataMethod(#[sbor(flatten)] CallMetadataMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_ROLE_ASSIGNMENT_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallRoleAssignmentMethod::ID))]
     CallRoleAssignmentMethod(#[sbor(flatten)] CallRoleAssignmentMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_DIRECT_VAULT_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallDirectVaultMethod::ID))]
     CallDirectVaultMethod(#[sbor(flatten)] CallDirectVaultMethod),
 
     //==============
-    // Complex
+    // Address Allocation
     //==============
-    #[sbor(discriminator(INSTRUCTION_DROP_NAMED_PROOFS_DISCRIMINATOR))]
-    DropNamedProofs(#[sbor(flatten)] DropNamedProofs),
-
-    /// Drops all proofs, both named proofs and auth zone proofs.
-    #[sbor(discriminator(INSTRUCTION_DROP_ALL_PROOFS_DISCRIMINATOR))]
-    DropAllProofs(#[sbor(flatten)] DropAllProofs),
-
-    #[sbor(discriminator(INSTRUCTION_ALLOCATE_GLOBAL_ADDRESS_DISCRIMINATOR))]
+    #[sbor(discriminator(AllocateGlobalAddress::ID))]
     AllocateGlobalAddress(#[sbor(flatten)] AllocateGlobalAddress),
 }

--- a/radix-transactions/src/model/v2/instruction_v2.rs
+++ b/radix-transactions/src/model/v2/instruction_v2.rs
@@ -13,79 +13,79 @@ impl ManifestInstructionSet for InstructionV2 {
         context: &mut DecompilationContext,
     ) -> Result<DecompiledInstruction, DecompileError> {
         match self {
-            Self::TakeAllFromWorktop(x) => x.decompile(context),
-            Self::TakeFromWorktop(x) => x.decompile(context),
-            Self::TakeNonFungiblesFromWorktop(x) => x.decompile(context),
-            Self::ReturnToWorktop(x) => x.decompile(context),
-            Self::AssertWorktopContainsAny(x) => x.decompile(context),
-            Self::AssertWorktopContains(x) => x.decompile(context),
-            Self::AssertWorktopContainsNonFungibles(x) => x.decompile(context),
-            Self::AssertWorktopIsEmpty(x) => x.decompile(context),
-            Self::PopFromAuthZone(x) => x.decompile(context),
-            Self::PushToAuthZone(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfAmount(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfNonFungibles(x) => x.decompile(context),
-            Self::CreateProofFromAuthZoneOfAll(x) => x.decompile(context),
-            Self::DropAuthZoneProofs(x) => x.decompile(context),
-            Self::DropAuthZoneRegularProofs(x) => x.decompile(context),
-            Self::DropAuthZoneSignatureProofs(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfAmount(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfNonFungibles(x) => x.decompile(context),
-            Self::CreateProofFromBucketOfAll(x) => x.decompile(context),
-            Self::BurnResource(x) => x.decompile(context),
-            Self::CloneProof(x) => x.decompile(context),
-            Self::DropProof(x) => x.decompile(context),
-            Self::CallFunction(x) => x.decompile(context),
-            Self::CallMethod(x) => x.decompile(context),
-            Self::CallRoyaltyMethod(x) => x.decompile(context),
-            Self::CallMetadataMethod(x) => x.decompile(context),
-            Self::CallRoleAssignmentMethod(x) => x.decompile(context),
-            Self::CallDirectVaultMethod(x) => x.decompile(context),
-            Self::DropNamedProofs(x) => x.decompile(context),
-            Self::DropAllProofs(x) => x.decompile(context),
-            Self::AllocateGlobalAddress(x) => x.decompile(context),
-            Self::YieldToParent(x) => x.decompile(context),
-            Self::YieldToChild(x) => x.decompile(context),
-            Self::VerifyParent(x) => x.decompile(context),
+            InstructionV2::TakeFromWorktop(x) => x.decompile(context),
+            InstructionV2::TakeNonFungiblesFromWorktop(x) => x.decompile(context),
+            InstructionV2::TakeAllFromWorktop(x) => x.decompile(context),
+            InstructionV2::ReturnToWorktop(x) => x.decompile(context),
+            InstructionV2::BurnResource(x) => x.decompile(context),
+            InstructionV2::AssertWorktopContainsAny(x) => x.decompile(context),
+            InstructionV2::AssertWorktopContains(x) => x.decompile(context),
+            InstructionV2::AssertWorktopContainsNonFungibles(x) => x.decompile(context),
+            InstructionV2::AssertWorktopIsEmpty(x) => x.decompile(context),
+            InstructionV2::CreateProofFromBucketOfAmount(x) => x.decompile(context),
+            InstructionV2::CreateProofFromBucketOfNonFungibles(x) => x.decompile(context),
+            InstructionV2::CreateProofFromBucketOfAll(x) => x.decompile(context),
+            InstructionV2::CreateProofFromAuthZoneOfAmount(x) => x.decompile(context),
+            InstructionV2::CreateProofFromAuthZoneOfNonFungibles(x) => x.decompile(context),
+            InstructionV2::CreateProofFromAuthZoneOfAll(x) => x.decompile(context),
+            InstructionV2::CloneProof(x) => x.decompile(context),
+            InstructionV2::DropProof(x) => x.decompile(context),
+            InstructionV2::PushToAuthZone(x) => x.decompile(context),
+            InstructionV2::PopFromAuthZone(x) => x.decompile(context),
+            InstructionV2::DropAuthZoneProofs(x) => x.decompile(context),
+            InstructionV2::DropAuthZoneRegularProofs(x) => x.decompile(context),
+            InstructionV2::DropAuthZoneSignatureProofs(x) => x.decompile(context),
+            InstructionV2::DropNamedProofs(x) => x.decompile(context),
+            InstructionV2::DropAllProofs(x) => x.decompile(context),
+            InstructionV2::CallFunction(x) => x.decompile(context),
+            InstructionV2::CallMethod(x) => x.decompile(context),
+            InstructionV2::CallRoyaltyMethod(x) => x.decompile(context),
+            InstructionV2::CallMetadataMethod(x) => x.decompile(context),
+            InstructionV2::CallRoleAssignmentMethod(x) => x.decompile(context),
+            InstructionV2::CallDirectVaultMethod(x) => x.decompile(context),
+            InstructionV2::AllocateGlobalAddress(x) => x.decompile(context),
+            InstructionV2::YieldToParent(x) => x.decompile(context),
+            InstructionV2::YieldToChild(x) => x.decompile(context),
+            InstructionV2::VerifyParent(x) => x.decompile(context),
         }
     }
 
     fn effect(&self) -> ManifestInstructionEffect {
         match self {
-            Self::TakeAllFromWorktop(x) => x.effect(),
-            Self::TakeFromWorktop(x) => x.effect(),
-            Self::TakeNonFungiblesFromWorktop(x) => x.effect(),
-            Self::ReturnToWorktop(x) => x.effect(),
-            Self::AssertWorktopContainsAny(x) => x.effect(),
-            Self::AssertWorktopContains(x) => x.effect(),
-            Self::AssertWorktopContainsNonFungibles(x) => x.effect(),
-            Self::AssertWorktopIsEmpty(x) => x.effect(),
-            Self::PopFromAuthZone(x) => x.effect(),
-            Self::PushToAuthZone(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfAmount(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfNonFungibles(x) => x.effect(),
-            Self::CreateProofFromAuthZoneOfAll(x) => x.effect(),
-            Self::DropAuthZoneProofs(x) => x.effect(),
-            Self::DropAuthZoneRegularProofs(x) => x.effect(),
-            Self::DropAuthZoneSignatureProofs(x) => x.effect(),
-            Self::CreateProofFromBucketOfAmount(x) => x.effect(),
-            Self::CreateProofFromBucketOfNonFungibles(x) => x.effect(),
-            Self::CreateProofFromBucketOfAll(x) => x.effect(),
-            Self::BurnResource(x) => x.effect(),
-            Self::CloneProof(x) => x.effect(),
-            Self::DropProof(x) => x.effect(),
-            Self::CallFunction(x) => x.effect(),
-            Self::CallMethod(x) => x.effect(),
-            Self::CallRoyaltyMethod(x) => x.effect(),
-            Self::CallMetadataMethod(x) => x.effect(),
-            Self::CallRoleAssignmentMethod(x) => x.effect(),
-            Self::CallDirectVaultMethod(x) => x.effect(),
-            Self::DropNamedProofs(x) => x.effect(),
-            Self::DropAllProofs(x) => x.effect(),
-            Self::AllocateGlobalAddress(x) => x.effect(),
-            Self::YieldToParent(x) => x.effect(),
-            Self::YieldToChild(x) => x.effect(),
-            Self::VerifyParent(x) => x.effect(),
+            InstructionV2::TakeFromWorktop(x) => x.effect(),
+            InstructionV2::TakeNonFungiblesFromWorktop(x) => x.effect(),
+            InstructionV2::TakeAllFromWorktop(x) => x.effect(),
+            InstructionV2::ReturnToWorktop(x) => x.effect(),
+            InstructionV2::BurnResource(x) => x.effect(),
+            InstructionV2::AssertWorktopContainsAny(x) => x.effect(),
+            InstructionV2::AssertWorktopContains(x) => x.effect(),
+            InstructionV2::AssertWorktopContainsNonFungibles(x) => x.effect(),
+            InstructionV2::AssertWorktopIsEmpty(x) => x.effect(),
+            InstructionV2::CreateProofFromBucketOfAmount(x) => x.effect(),
+            InstructionV2::CreateProofFromBucketOfNonFungibles(x) => x.effect(),
+            InstructionV2::CreateProofFromBucketOfAll(x) => x.effect(),
+            InstructionV2::CreateProofFromAuthZoneOfAmount(x) => x.effect(),
+            InstructionV2::CreateProofFromAuthZoneOfNonFungibles(x) => x.effect(),
+            InstructionV2::CreateProofFromAuthZoneOfAll(x) => x.effect(),
+            InstructionV2::CloneProof(x) => x.effect(),
+            InstructionV2::DropProof(x) => x.effect(),
+            InstructionV2::PushToAuthZone(x) => x.effect(),
+            InstructionV2::PopFromAuthZone(x) => x.effect(),
+            InstructionV2::DropAuthZoneProofs(x) => x.effect(),
+            InstructionV2::DropAuthZoneRegularProofs(x) => x.effect(),
+            InstructionV2::DropAuthZoneSignatureProofs(x) => x.effect(),
+            InstructionV2::DropNamedProofs(x) => x.effect(),
+            InstructionV2::DropAllProofs(x) => x.effect(),
+            InstructionV2::CallFunction(x) => x.effect(),
+            InstructionV2::CallMethod(x) => x.effect(),
+            InstructionV2::CallRoyaltyMethod(x) => x.effect(),
+            InstructionV2::CallMetadataMethod(x) => x.effect(),
+            InstructionV2::CallRoleAssignmentMethod(x) => x.effect(),
+            InstructionV2::CallDirectVaultMethod(x) => x.effect(),
+            InstructionV2::AllocateGlobalAddress(x) => x.effect(),
+            InstructionV2::YieldToParent(x) => x.effect(),
+            InstructionV2::YieldToChild(x) => x.effect(),
+            InstructionV2::VerifyParent(x) => x.effect(),
         }
     }
 }
@@ -93,35 +93,35 @@ impl ManifestInstructionSet for InstructionV2 {
 impl From<InstructionV1> for InstructionV2 {
     fn from(value: InstructionV1) -> Self {
         match value {
-            InstructionV1::TakeAllFromWorktop(x) => x.into(),
             InstructionV1::TakeFromWorktop(x) => x.into(),
             InstructionV1::TakeNonFungiblesFromWorktop(x) => x.into(),
+            InstructionV1::TakeAllFromWorktop(x) => x.into(),
             InstructionV1::ReturnToWorktop(x) => x.into(),
+            InstructionV1::BurnResource(x) => x.into(),
             InstructionV1::AssertWorktopContainsAny(x) => x.into(),
             InstructionV1::AssertWorktopContains(x) => x.into(),
             InstructionV1::AssertWorktopContainsNonFungibles(x) => x.into(),
-            InstructionV1::PopFromAuthZone(x) => x.into(),
-            InstructionV1::PushToAuthZone(x) => x.into(),
-            InstructionV1::CreateProofFromAuthZoneOfAmount(x) => x.into(),
-            InstructionV1::CreateProofFromAuthZoneOfNonFungibles(x) => x.into(),
-            InstructionV1::CreateProofFromAuthZoneOfAll(x) => x.into(),
-            InstructionV1::DropAuthZoneProofs(x) => x.into(),
-            InstructionV1::DropAuthZoneRegularProofs(x) => x.into(),
-            InstructionV1::DropAuthZoneSignatureProofs(x) => x.into(),
             InstructionV1::CreateProofFromBucketOfAmount(x) => x.into(),
             InstructionV1::CreateProofFromBucketOfNonFungibles(x) => x.into(),
             InstructionV1::CreateProofFromBucketOfAll(x) => x.into(),
-            InstructionV1::BurnResource(x) => x.into(),
+            InstructionV1::CreateProofFromAuthZoneOfAmount(x) => x.into(),
+            InstructionV1::CreateProofFromAuthZoneOfNonFungibles(x) => x.into(),
+            InstructionV1::CreateProofFromAuthZoneOfAll(x) => x.into(),
             InstructionV1::CloneProof(x) => x.into(),
             InstructionV1::DropProof(x) => x.into(),
+            InstructionV1::PushToAuthZone(x) => x.into(),
+            InstructionV1::PopFromAuthZone(x) => x.into(),
+            InstructionV1::DropAuthZoneProofs(x) => x.into(),
+            InstructionV1::DropAuthZoneRegularProofs(x) => x.into(),
+            InstructionV1::DropAuthZoneSignatureProofs(x) => x.into(),
+            InstructionV1::DropNamedProofs(x) => x.into(),
+            InstructionV1::DropAllProofs(x) => x.into(),
             InstructionV1::CallFunction(x) => x.into(),
             InstructionV1::CallMethod(x) => x.into(),
             InstructionV1::CallRoyaltyMethod(x) => x.into(),
             InstructionV1::CallMetadataMethod(x) => x.into(),
             InstructionV1::CallRoleAssignmentMethod(x) => x.into(),
             InstructionV1::CallDirectVaultMethod(x) => x.into(),
-            InstructionV1::DropNamedProofs(x) => x.into(),
-            InstructionV1::DropAllProofs(x) => x.into(),
             InstructionV1::AllocateGlobalAddress(x) => x.into(),
         }
     }
@@ -132,37 +132,37 @@ impl TryFrom<InstructionV2> for InstructionV1 {
 
     fn try_from(value: InstructionV2) -> Result<Self, Self::Error> {
         let mapped = match value {
-            InstructionV2::TakeAllFromWorktop(i) => i.into(),
-            InstructionV2::TakeFromWorktop(i) => i.into(),
-            InstructionV2::TakeNonFungiblesFromWorktop(i) => i.into(),
-            InstructionV2::ReturnToWorktop(i) => i.into(),
-            InstructionV2::AssertWorktopContainsAny(i) => i.into(),
-            InstructionV2::AssertWorktopContains(i) => i.into(),
-            InstructionV2::AssertWorktopContainsNonFungibles(i) => i.into(),
+            InstructionV2::TakeFromWorktop(x) => x.into(),
+            InstructionV2::TakeNonFungiblesFromWorktop(x) => x.into(),
+            InstructionV2::TakeAllFromWorktop(x) => x.into(),
+            InstructionV2::ReturnToWorktop(x) => x.into(),
+            InstructionV2::BurnResource(x) => x.into(),
+            InstructionV2::AssertWorktopContainsAny(x) => x.into(),
+            InstructionV2::AssertWorktopContains(x) => x.into(),
+            InstructionV2::AssertWorktopContainsNonFungibles(x) => x.into(),
             InstructionV2::AssertWorktopIsEmpty(_) => return Err(()),
-            InstructionV2::PopFromAuthZone(i) => i.into(),
-            InstructionV2::PushToAuthZone(i) => i.into(),
-            InstructionV2::CreateProofFromAuthZoneOfAmount(i) => i.into(),
-            InstructionV2::CreateProofFromAuthZoneOfNonFungibles(i) => i.into(),
-            InstructionV2::CreateProofFromAuthZoneOfAll(i) => i.into(),
-            InstructionV2::DropAuthZoneProofs(i) => i.into(),
-            InstructionV2::DropAuthZoneRegularProofs(i) => i.into(),
-            InstructionV2::DropAuthZoneSignatureProofs(i) => i.into(),
-            InstructionV2::CreateProofFromBucketOfAmount(i) => i.into(),
-            InstructionV2::CreateProofFromBucketOfNonFungibles(i) => i.into(),
-            InstructionV2::CreateProofFromBucketOfAll(i) => i.into(),
-            InstructionV2::BurnResource(i) => i.into(),
-            InstructionV2::CloneProof(i) => i.into(),
-            InstructionV2::DropProof(i) => i.into(),
-            InstructionV2::CallFunction(i) => i.into(),
-            InstructionV2::CallMethod(i) => i.into(),
-            InstructionV2::CallRoyaltyMethod(i) => i.into(),
-            InstructionV2::CallMetadataMethod(i) => i.into(),
-            InstructionV2::CallRoleAssignmentMethod(i) => i.into(),
-            InstructionV2::CallDirectVaultMethod(i) => i.into(),
-            InstructionV2::DropNamedProofs(i) => i.into(),
-            InstructionV2::DropAllProofs(i) => i.into(),
-            InstructionV2::AllocateGlobalAddress(i) => i.into(),
+            InstructionV2::CreateProofFromBucketOfAmount(x) => x.into(),
+            InstructionV2::CreateProofFromBucketOfNonFungibles(x) => x.into(),
+            InstructionV2::CreateProofFromBucketOfAll(x) => x.into(),
+            InstructionV2::CreateProofFromAuthZoneOfAmount(x) => x.into(),
+            InstructionV2::CreateProofFromAuthZoneOfNonFungibles(x) => x.into(),
+            InstructionV2::CreateProofFromAuthZoneOfAll(x) => x.into(),
+            InstructionV2::CloneProof(x) => x.into(),
+            InstructionV2::DropProof(x) => x.into(),
+            InstructionV2::PushToAuthZone(x) => x.into(),
+            InstructionV2::PopFromAuthZone(x) => x.into(),
+            InstructionV2::DropAuthZoneProofs(x) => x.into(),
+            InstructionV2::DropAuthZoneRegularProofs(x) => x.into(),
+            InstructionV2::DropAuthZoneSignatureProofs(x) => x.into(),
+            InstructionV2::DropNamedProofs(x) => x.into(),
+            InstructionV2::DropAllProofs(x) => x.into(),
+            InstructionV2::CallFunction(x) => x.into(),
+            InstructionV2::CallMethod(x) => x.into(),
+            InstructionV2::CallRoyaltyMethod(x) => x.into(),
+            InstructionV2::CallMetadataMethod(x) => x.into(),
+            InstructionV2::CallRoleAssignmentMethod(x) => x.into(),
+            InstructionV2::CallDirectVaultMethod(x) => x.into(),
+            InstructionV2::AllocateGlobalAddress(x) => x.into(),
             InstructionV2::YieldToParent(_) => return Err(()),
             InstructionV2::YieldToChild(_) => return Err(()),
             InstructionV2::VerifyParent(_) => return Err(()),
@@ -184,141 +184,123 @@ impl TryFrom<InstructionV2> for InstructionV1 {
     )
 )]
 pub enum InstructionV2 {
-    //==============
-    // Worktop
-    //==============
-    /// Takes resource from worktop.
-    #[sbor(discriminator(INSTRUCTION_TAKE_ALL_FROM_WORKTOP_DISCRIMINATOR))]
-    TakeAllFromWorktop(#[sbor(flatten)] TakeAllFromWorktop),
-
-    /// Takes resource from worktop by the given amount.
-    #[sbor(discriminator(INSTRUCTION_TAKE_FROM_WORKTOP_DISCRIMINATOR))]
+    //===============
+    // Bucket Lifecycle
+    //===============
+    #[sbor(discriminator(TakeFromWorktop::ID))]
     TakeFromWorktop(#[sbor(flatten)] TakeFromWorktop),
 
-    /// Takes resource from worktop by the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_TAKE_NON_FUNGIBLES_FROM_WORKTOP_DISCRIMINATOR))]
+    #[sbor(discriminator(TakeNonFungiblesFromWorktop::ID))]
     TakeNonFungiblesFromWorktop(#[sbor(flatten)] TakeNonFungiblesFromWorktop),
 
-    /// Returns a bucket of resource to worktop.
-    #[sbor(discriminator(INSTRUCTION_RETURN_TO_WORKTOP_DISCRIMINATOR))]
+    #[sbor(discriminator(TakeAllFromWorktop::ID))]
+    TakeAllFromWorktop(#[sbor(flatten)] TakeAllFromWorktop),
+
+    #[sbor(discriminator(ReturnToWorktop::ID))]
     ReturnToWorktop(#[sbor(flatten)] ReturnToWorktop),
 
-    /// Asserts worktop contains any specified resource.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_ANY_DISCRIMINATOR))]
-    AssertWorktopContainsAny(#[sbor(flatten)] AssertWorktopContainsAny),
-
-    /// Asserts worktop contains resource by at least the given amount.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_DISCRIMINATOR))]
-    AssertWorktopContains(#[sbor(flatten)] AssertWorktopContains),
-
-    /// Asserts worktop contains resource by at least the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_CONTAINS_NON_FUNGIBLES_DISCRIMINATOR))]
-    AssertWorktopContainsNonFungibles(#[sbor(flatten)] AssertWorktopContainsNonFungibles),
-
-    /// Asserts the worktop contains no amount of any resource.
-    #[sbor(discriminator(INSTRUCTION_ASSERT_WORKTOP_IS_EMPTY_DISCRIMINATOR))]
-    AssertWorktopIsEmpty(#[sbor(flatten)] AssertWorktopIsEmpty),
-
-    //==============
-    // Auth zone
-    //==============
-    /// Takes the last proof from the auth zone.
-    #[sbor(discriminator(INSTRUCTION_POP_FROM_AUTH_ZONE_DISCRIMINATOR))]
-    PopFromAuthZone(#[sbor(flatten)] PopFromAuthZone),
-
-    /// Adds a proof to the auth zone.
-    #[sbor(discriminator(INSTRUCTION_PUSH_TO_AUTH_ZONE_DISCRIMINATOR))]
-    PushToAuthZone(#[sbor(flatten)] PushToAuthZone),
-
-    /// Creates a proof from the auth zone, by the given amount
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_AMOUNT_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfAmount(#[sbor(flatten)] CreateProofFromAuthZoneOfAmount),
-
-    /// Creates a proof from the auth zone, by the given non-fungible IDs.
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_NON_FUNGIBLES_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfNonFungibles(#[sbor(flatten)] CreateProofFromAuthZoneOfNonFungibles),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_AUTH_ZONE_OF_ALL_DISCRIMINATOR))]
-    CreateProofFromAuthZoneOfAll(#[sbor(flatten)] CreateProofFromAuthZoneOfAll),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneProofs(#[sbor(flatten)] DropAuthZoneProofs),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_REGULAR_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneRegularProofs(#[sbor(flatten)] DropAuthZoneRegularProofs),
-
-    #[sbor(discriminator(INSTRUCTION_DROP_AUTH_ZONE_SIGNATURE_PROOFS_DISCRIMINATOR))]
-    DropAuthZoneSignatureProofs(#[sbor(flatten)] DropAuthZoneSignatureProofs),
-
-    //==============
-    // Named bucket
-    //==============
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_AMOUNT_DISCRIMINATOR))]
-    CreateProofFromBucketOfAmount(#[sbor(flatten)] CreateProofFromBucketOfAmount),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES_DISCRIMINATOR))]
-    CreateProofFromBucketOfNonFungibles(#[sbor(flatten)] CreateProofFromBucketOfNonFungibles),
-
-    #[sbor(discriminator(INSTRUCTION_CREATE_PROOF_FROM_BUCKET_OF_ALL_DISCRIMINATOR))]
-    CreateProofFromBucketOfAll(#[sbor(flatten)] CreateProofFromBucketOfAll),
-
-    #[sbor(discriminator(INSTRUCTION_BURN_RESOURCE_DISCRIMINATOR))]
+    #[sbor(discriminator(BurnResource::ID))]
     BurnResource(#[sbor(flatten)] BurnResource),
 
     //==============
-    // Named proof
+    // Resource Assertions
     //==============
-    /// Clones a proof.
-    #[sbor(discriminator(INSTRUCTION_CLONE_PROOF_DISCRIMINATOR))]
+    #[sbor(discriminator(AssertWorktopContainsAny::ID))]
+    AssertWorktopContainsAny(#[sbor(flatten)] AssertWorktopContainsAny),
+
+    #[sbor(discriminator(AssertWorktopContains::ID))]
+    AssertWorktopContains(#[sbor(flatten)] AssertWorktopContains),
+
+    #[sbor(discriminator(AssertWorktopContainsNonFungibles::ID))]
+    AssertWorktopContainsNonFungibles(#[sbor(flatten)] AssertWorktopContainsNonFungibles),
+
+    #[sbor(discriminator(AssertWorktopIsEmpty::ID))]
+    AssertWorktopIsEmpty(#[sbor(flatten)] AssertWorktopIsEmpty),
+
+    //==============
+    // Proof Lifecycle
+    //==============
+    #[sbor(discriminator(CreateProofFromBucketOfAmount::ID))]
+    CreateProofFromBucketOfAmount(#[sbor(flatten)] CreateProofFromBucketOfAmount),
+
+    #[sbor(discriminator(CreateProofFromBucketOfNonFungibles::ID))]
+    CreateProofFromBucketOfNonFungibles(#[sbor(flatten)] CreateProofFromBucketOfNonFungibles),
+
+    #[sbor(discriminator(CreateProofFromBucketOfAll::ID))]
+    CreateProofFromBucketOfAll(#[sbor(flatten)] CreateProofFromBucketOfAll),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfAmount::ID))]
+    CreateProofFromAuthZoneOfAmount(#[sbor(flatten)] CreateProofFromAuthZoneOfAmount),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfNonFungibles::ID))]
+    CreateProofFromAuthZoneOfNonFungibles(#[sbor(flatten)] CreateProofFromAuthZoneOfNonFungibles),
+
+    #[sbor(discriminator(CreateProofFromAuthZoneOfAll::ID))]
+    CreateProofFromAuthZoneOfAll(#[sbor(flatten)] CreateProofFromAuthZoneOfAll),
+
+    #[sbor(discriminator(CloneProof::ID))]
     CloneProof(#[sbor(flatten)] CloneProof),
 
-    /// Drops a proof.
-    #[sbor(discriminator(INSTRUCTION_DROP_PROOF_DISCRIMINATOR))]
+    #[sbor(discriminator(DropProof::ID))]
     DropProof(#[sbor(flatten)] DropProof),
+
+    #[sbor(discriminator(PushToAuthZone::ID))]
+    PushToAuthZone(#[sbor(flatten)] PushToAuthZone),
+
+    #[sbor(discriminator(PopFromAuthZone::ID))]
+    PopFromAuthZone(#[sbor(flatten)] PopFromAuthZone),
+
+    #[sbor(discriminator(DropAuthZoneProofs::ID))]
+    DropAuthZoneProofs(#[sbor(flatten)] DropAuthZoneProofs),
+
+    #[sbor(discriminator(DropAuthZoneRegularProofs::ID))]
+    DropAuthZoneRegularProofs(#[sbor(flatten)] DropAuthZoneRegularProofs),
+
+    #[sbor(discriminator(DropAuthZoneSignatureProofs::ID))]
+    DropAuthZoneSignatureProofs(#[sbor(flatten)] DropAuthZoneSignatureProofs),
+
+    #[sbor(discriminator(DropNamedProofs::ID))]
+    DropNamedProofs(#[sbor(flatten)] DropNamedProofs),
+
+    #[sbor(discriminator(DropAllProofs::ID))]
+    DropAllProofs(#[sbor(flatten)] DropAllProofs),
 
     //==============
     // Invocation
     //==============
-    #[sbor(discriminator(INSTRUCTION_CALL_FUNCTION_DISCRIMINATOR))]
+    #[sbor(discriminator(CallFunction::ID))]
     CallFunction(#[sbor(flatten)] CallFunction),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallMethod::ID))]
     CallMethod(#[sbor(flatten)] CallMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_ROYALTY_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallRoyaltyMethod::ID))]
     CallRoyaltyMethod(#[sbor(flatten)] CallRoyaltyMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_METADATA_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallMetadataMethod::ID))]
     CallMetadataMethod(#[sbor(flatten)] CallMetadataMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_ROLE_ASSIGNMENT_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallRoleAssignmentMethod::ID))]
     CallRoleAssignmentMethod(#[sbor(flatten)] CallRoleAssignmentMethod),
 
-    #[sbor(discriminator(INSTRUCTION_CALL_DIRECT_VAULT_METHOD_DISCRIMINATOR))]
+    #[sbor(discriminator(CallDirectVaultMethod::ID))]
     CallDirectVaultMethod(#[sbor(flatten)] CallDirectVaultMethod),
 
     //==============
-    // Complex
+    // Address Allocation
     //==============
-    #[sbor(discriminator(INSTRUCTION_DROP_NAMED_PROOFS_DISCRIMINATOR))]
-    DropNamedProofs(#[sbor(flatten)] DropNamedProofs),
-
-    /// Drops all proofs, both named proofs and auth zone proofs.
-    #[sbor(discriminator(INSTRUCTION_DROP_ALL_PROOFS_DISCRIMINATOR))]
-    DropAllProofs(#[sbor(flatten)] DropAllProofs),
-
-    #[sbor(discriminator(INSTRUCTION_ALLOCATE_GLOBAL_ADDRESS_DISCRIMINATOR))]
+    #[sbor(discriminator(AllocateGlobalAddress::ID))]
     AllocateGlobalAddress(#[sbor(flatten)] AllocateGlobalAddress),
 
     //==============
     // Interactions with other intents
     //==============
-    #[sbor(discriminator(INSTRUCTION_YIELD_TO_PARENT_DISCRIMINATOR))]
+    #[sbor(discriminator(YieldToParent::ID))]
     YieldToParent(#[sbor(flatten)] YieldToParent),
 
-    #[sbor(discriminator(INSTRUCTION_YIELD_TO_CHILD_DISCRIMINATOR))]
+    #[sbor(discriminator(YieldToChild::ID))]
     YieldToChild(#[sbor(flatten)] YieldToChild),
 
-    #[sbor(discriminator(INSTRUCTION_VERIFY_PARENT_DISCRIMINATOR))]
+    #[sbor(discriminator(VerifyParent::ID))]
     VerifyParent(#[sbor(flatten)] VerifyParent),
 }

--- a/sbor-derive-common/src/categorize.rs
+++ b/sbor-derive-common/src/categorize.rs
@@ -259,8 +259,8 @@ fn handle_impl_variant_trait(
         impl #impl_generics sbor::SborEnumVariantFor<#enum_name #type_generics_turbofish, #sbor_cvk> for #variant_type_name #where_clause {
             const DISCRIMINATOR: u8 = #discriminator;
             #middle
-            type OwnedVariant = sbor::SborFixedEnumVariant<#discriminator, Self::VariantFields>;
-            type BorrowedVariant<'a> = sbor::SborFixedEnumVariant<#discriminator, Self::VariantFieldsRef<'a>>;
+            type OwnedVariant = sbor::SborFixedEnumVariant<{ #discriminator }, Self::VariantFields>;
+            type BorrowedVariant<'a> = sbor::SborFixedEnumVariant<{ #discriminator }, Self::VariantFieldsRef<'a>>;
 
             fn into_enum(self) -> #enum_name {
                 let value = self;


### PR DESCRIPTION
## Summary
Trivial PR to:
* Re-order instructions into a more sensible order.
* Move the discriminators into an ID associated constant of the `ManifestInstruction` trait, to keep them all together nicely.

## Testing
Existing tests pass, including the instruction schema tests.