### PR TITLE
fix: Fixes compiler warning in latest compiler.

### DIFF
--- a/radix-engine/src/blueprints/package/package.rs
+++ b/radix-engine/src/blueprints/package/package.rs
@@ -446,11 +446,10 @@ fn validate_auth(
                     }
                 }
 
-                functions
-                    .values()
-                    .map(RoleAssignmentNativePackage::verify_access_rule)
-                    .collect::<Result<_, _>>()
-                    .map_err(PackageError::RoleAssignmentError)?;
+                for access_rule in functions.values() {
+                    RoleAssignmentNativePackage::verify_access_rule(access_rule)
+                        .map_err(PackageError::RoleAssignmentError)?;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
The warning appears newly in new builds of rustc 1.81.0.

The warning arose because we were collecting void results into `_`, where `()` was previously inferred. But now it want to make it explicit. Or in compiler speak:

```text
in edition 2024, the requirement `!: std::iter::FromIterator<()>` will fail
> rustc(dependency_on_unit_never_type_fallback)
```

It was originally written using a `map => collect::<Result<_, _>>() => map_err` pattern in https://github.com/radixdlt/radixdlt-scrypto/commit/c04412b43f63ec6c12df9927834364922c34852f. 

Instead, I decided to rewrite this into a loop which I believe is semantically much cleaner than using a map for this use case, as we're not actually caring what the primary result is, we're just using it to fail early. In my mind the `for` loop is shorter, cleaner and it's faster to read the intent of the code.
