### PR TITLE
update: Use rust 1.81.0 for cuttlefish

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -13,7 +13,7 @@ runs:
         #   - "rustup default XXXX"
         # * Ensure you update the version in the "radix-clis-scrypto-coverage" step,
         #   or update the comment explaining why a different version is used.
-        toolchain: 1.80.1
+        toolchain: 1.81.0
         default: true
         target: wasm32-unknown-unknown
         components: rustfmt

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,13 +9,13 @@ runs:
       with:
         # IMPORTANT:
         # To update the Rust version, you must update it in five total places (including the toolchain below):
-        # => [README.md - part 1] Update "Install Rust - we recommend to use Rust XXXX"
-        # => [README.md - part 2] Update "rustup default XXXX"
-        # => [action.yml - part 1] Update "toolchain: XXXX" below
-        # => [action.yml - part 2] Update the three lines starting "rustup toolchain install nightly-...`
+        # => [README.md - part 1] Update "Install Rust - we recommend to use Rust X.XX.X"
+        # => [README.md - part 2] Update "rustup default X.XX.X"
+        # => [action.yml - part 1] Update "toolchain: X.XX.X" below
+        # => [action.yml - part 2] Update the three lines starting "rustup toolchain install nightly-202?-??-??"
         #    in the "radix-clis-scrypto-coverage" step, or update the comment explaining why a
         #    different version is used.
-        # => [Dockerfile] Update `ARG RUST_IMAGE_VERSION=` in the deterministic builder
+        # => [Dockerfile] Update "FROM rust:X.XX.X-slim-bookworm AS base-image" in the deterministic builder
         toolchain: 1.81.0
         default: true
         target: wasm32-unknown-unknown

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,12 +7,15 @@ runs:
     - name: Install Rust toolchain
       uses: RDXWorks-actions/toolchain@master
       with:
-        # IMPORTANT: If you update this Rust version:
-        # * Ensure you also update it in the README in two places:
-        #   - "Install Rust - we recommend to use Rust XXXX"
-        #   - "rustup default XXXX"
-        # * Ensure you update the version in the "radix-clis-scrypto-coverage" step,
-        #   or update the comment explaining why a different version is used.
+        # IMPORTANT:
+        # To update the Rust version, you must update it in five total places (including the toolchain below):
+        # => [README.md - part 1] Update "Install Rust - we recommend to use Rust XXXX"
+        # => [README.md - part 2] Update "rustup default XXXX"
+        # => [action.yml - part 1] Update "toolchain: XXXX" below
+        # => [action.yml - part 2] Update the three lines starting "rustup toolchain install nightly-...`
+        #    in the "radix-clis-scrypto-coverage" step, or update the comment explaining why a
+        #    different version is used.
+        # => [Dockerfile] Update `ARG RUST_IMAGE_VERSION=` in the deterministic builder
         toolchain: 1.81.0
         default: true
         target: wasm32-unknown-unknown

--- a/.github/workflows/ci-scrypto-builder.yml
+++ b/.github/workflows/ci-scrypto-builder.yml
@@ -87,5 +87,5 @@ jobs:
       - name: Check WASM size
         run:
           # Expected WASM size, when building with scrypto-builder = ~150kB
-          # + 1kB tolerance = 151 kB (154624 B)
-          bash ./assert_file_size.sh ./test_package/target/wasm32-unknown-unknown/release/everything.wasm 154624
+          # + 2kB tolerance = 152 kB (155648 B)
+          bash ./assert_file_size.sh ./test_package/target/wasm32-unknown-unknown/release/everything.wasm 155648

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Below version includes rust 1.80.1
-ARG RUST_IMAGE_VERSION=@sha256:e8e40c50bfb54c0a76218f480cc69783b908430de87b59619c1dca847fdbd753
+# Below version includes rust 1.81.0
+# To find a new fixed image, search for the version with the -slim-bookworm tag here:
+# https://hub.docker.com/_/rust/tags
+ARG RUST_IMAGE_VERSION=@sha256:9f1bb107f9433aadaeaa07e015070ca7a9708c234685ba8aba7e417cbf144390
 # If you want to use latest version then uncomment next line
 # ARG RUST_IMAGE_VERSION=:slim-bookworm
 # Alternatively you can build docker with argument: --build-arg="RUST_IMAGE_VERSION=:slim-bookworm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-# Below version includes rust 1.81.0
-# To find a new fixed image, search for the version with the -slim-bookworm tag here:
 # https://hub.docker.com/_/rust/tags
-ARG RUST_IMAGE_VERSION=@sha256:9f1bb107f9433aadaeaa07e015070ca7a9708c234685ba8aba7e417cbf144390
-# If you want to use latest version then uncomment next line
-# ARG RUST_IMAGE_VERSION=:slim-bookworm
-# Alternatively you can build docker with argument: --build-arg="RUST_IMAGE_VERSION=:slim-bookworm"
-
-FROM rust${RUST_IMAGE_VERSION} AS base-image
+FROM rust:1.81.0-slim-bookworm AS base-image
 
 RUN apt update && apt install -y \
     cmake=3.25.1-1 \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Documentation: https://docs.radixdlt.com/docs/scrypto-1
 
 ## Installation
 
-1. Install Rust - we recommend to use Rust 1.80.1
+1. Install Rust - we recommend to use Rust 1.81.0
     - Install Rust (if Rust is installed you can skip this step)
      - Windows:
        - Download and install [`rustup-init.exe`](https://win.rustup.rs/x86_64)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Documentation: https://docs.radixdlt.com/docs/scrypto-1
     - Set Rust version
     ```bash
     rustup update
-    rustup default 1.80.1
+    rustup default 1.81.0
     ```
 
 2. Enable `cargo` in the current shell:


### PR DESCRIPTION
## Summary
Updates to use [current stable rust](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html) (1.81.0) for Cuttlefish, which we can then update to in the node.
