### PR TITLE
feature: Add a `manifest` method to the v2 transaction builders

### DIFF
--- a/radix-transactions/src/manifest/any_manifest.rs
+++ b/radix-transactions/src/manifest/any_manifest.rs
@@ -202,13 +202,16 @@ impl ReadableManifestBase for AnyManifest {
         }
     }
 
-    fn get_child_subintents(&self) -> &[ChildSubintent] {
-        match self {
-            AnyManifest::V1(m) => m.get_child_subintents(),
-            AnyManifest::SystemV1(m) => m.get_child_subintents(),
-            AnyManifest::V2(m) => m.get_child_subintents(),
-            AnyManifest::SubintentV2(m) => m.get_child_subintents(),
-        }
+    fn get_child_subintent_hashes<'a>(
+        &'a self,
+    ) -> impl ExactSizeIterator<Item = &'a ChildSubintentSpecifier> {
+        let iterator: Box<dyn ExactSizeIterator<Item = &'a ChildSubintentSpecifier>> = match self {
+            AnyManifest::V1(m) => Box::new(m.get_child_subintent_hashes()),
+            AnyManifest::SystemV1(m) => Box::new(m.get_child_subintent_hashes()),
+            AnyManifest::V2(m) => Box::new(m.get_child_subintent_hashes()),
+            AnyManifest::SubintentV2(m) => Box::new(m.get_child_subintent_hashes()),
+        };
+        iterator
     }
 }
 

--- a/radix-transactions/src/manifest/decompiler.rs
+++ b/radix-transactions/src/manifest/decompiler.rs
@@ -135,7 +135,7 @@ pub fn decompile(
             preallocated_address.decompile_as_pseudo_instruction(&mut context)?;
         output_instruction(&mut buf, &context, psuedo_instruction)?;
     }
-    for child_subintent in manifest.get_child_subintents() {
+    for child_subintent in manifest.get_child_subintent_hashes() {
         let psuedo_instruction = child_subintent.decompile_as_pseudo_instruction(&mut context)?;
         output_instruction(&mut buf, &context, psuedo_instruction)?;
     }

--- a/radix-transactions/src/manifest/generator.rs
+++ b/radix-transactions/src/manifest/generator.rs
@@ -2255,6 +2255,10 @@ pub fn generator_error_diagnostics(
             let title = format!("unsupported instruction for this manifest version");
             (title, "unsupported instruction".to_string())
         }
+        GeneratorErrorKind::ManifestBuildError(ManifestBuildError::DuplicateChildSubintentHash) => {
+            let title = format!("child subintents cannot have the same hash");
+            (title, "duplicate hash".to_string())
+        }
         GeneratorErrorKind::ManifestBuildError(
             ManifestBuildError::PreallocatedAddressesUnsupportedByManifestType,
         ) => {

--- a/radix-transactions/src/manifest/manifest_traits.rs
+++ b/radix-transactions/src/manifest/manifest_traits.rs
@@ -67,6 +67,7 @@ pub enum DefaultTestExecutionConfigType {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ManifestBuildError {
+    DuplicateChildSubintentHash,
     ChildSubintentsUnsupportedByManifestType,
     PreallocatedAddressesUnsupportedByManifestType,
 }
@@ -93,8 +94,10 @@ pub trait ReadableManifestBase {
     fn get_preallocated_addresses(&self) -> &[PreAllocatedAddress] {
         &NO_PREALLOCATED_ADDRESSES
     }
-    fn get_child_subintents(&self) -> &[ChildSubintent] {
-        &NO_CHILD_SUBINTENTS
+    fn get_child_subintent_hashes<'a>(
+        &'a self,
+    ) -> impl ExactSizeIterator<Item = &'a ChildSubintentSpecifier> {
+        NO_CHILD_SUBINTENTS.iter()
     }
     fn get_known_object_names_ref(&self) -> ManifestObjectNamesRef;
 }
@@ -133,4 +136,4 @@ impl<T: TypedReadableManifest + ?Sized> ReadableManifest for T {
 }
 
 static NO_PREALLOCATED_ADDRESSES: [PreAllocatedAddress; 0] = [];
-static NO_CHILD_SUBINTENTS: [ChildSubintent; 0] = [];
+static NO_CHILD_SUBINTENTS: [ChildSubintentSpecifier; 0] = [];

--- a/radix-transactions/src/manifest/static_manifest_interpreter.rs
+++ b/radix-transactions/src/manifest/static_manifest_interpreter.rs
@@ -81,7 +81,7 @@ impl<'a, M: ReadableManifest + ?Sized> StaticManifestInterpreter<'a, M> {
         visitor: &mut V,
     ) -> ControlFlow<V::Output> {
         self.handle_preallocated_addresses(visitor, self.manifest.get_preallocated_addresses())?;
-        self.handle_child_subintents(visitor, self.manifest.get_child_subintents())?;
+        self.handle_child_subintents(visitor, self.manifest.get_child_subintent_hashes())?;
         self.handle_blobs(visitor, self.manifest.get_blobs())?;
         for (index, instruction_effect) in self.manifest.iter_instruction_effects().enumerate() {
             self.handle_instruction(visitor, index, instruction_effect)?;
@@ -112,7 +112,7 @@ impl<'a, M: ReadableManifest + ?Sized> StaticManifestInterpreter<'a, M> {
     fn handle_child_subintents<V: ManifestInterpretationVisitor>(
         &mut self,
         visitor: &mut V,
-        child_subintents: &'a [ChildSubintent],
+        child_subintents: impl Iterator<Item = &'a ChildSubintentSpecifier>,
     ) -> ControlFlow<V::Output> {
         for child_subintent in child_subintents {
             self.handle_new_intent(
@@ -360,7 +360,7 @@ impl<'a, M: ReadableManifest + ?Sized> StaticManifestInterpreter<'a, M> {
             }
             InvocationKind::YieldToChild { child_index } => {
                 let index = child_index.0 as usize;
-                if index >= self.manifest.get_child_subintents().len() {
+                if index >= self.manifest.get_child_subintent_hashes().len() {
                     return ControlFlow::Break(
                         ManifestValidationError::ChildIntentNotRegistered(child_index).into(),
                     );

--- a/radix-transactions/src/model/test_transaction.rs
+++ b/radix-transactions/src/model/test_transaction.rs
@@ -51,7 +51,7 @@ impl TestTransactionV2Builder {
         &self,
         instructions: InstructionsV2,
         blobs: BlobsV1,
-        child_intents: ChildIntentsV2,
+        child_intents: ChildSubintentSpecifiersV2,
         proofs: impl IntoIterator<Item = NonFungibleGlobalId>,
     ) -> TestIntentV2 {
         let children_subintent_indices = child_intents

--- a/radix-transactions/src/model/v2/intent_core_v2.rs
+++ b/radix-transactions/src/model/v2/intent_core_v2.rs
@@ -14,7 +14,7 @@ pub struct IntentCoreV2 {
     pub header: IntentHeaderV2,
     pub blobs: BlobsV1,
     pub message: MessageV2,
-    pub children: ChildIntentsV2,
+    pub children: ChildSubintentSpecifiersV2,
     pub instructions: InstructionsV2,
 }
 
@@ -27,7 +27,7 @@ pub struct PreparedIntentCoreV2 {
     pub header: PreparedIntentHeaderV2,
     pub blobs: PreparedBlobsV1,
     pub message: PreparedMessageV2,
-    pub children: PreparedChildIntentsV2,
+    pub children: PreparedChildSubintentSpecifiersV2V2,
     pub instructions: PreparedInstructionsV2,
     pub summary: Summary,
 }

--- a/radix-transactions/src/model/v2/mod.rs
+++ b/radix-transactions/src/model/v2/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-mod child_intents_v2;
+mod child_subintent_hashes_v2;
 mod instruction_v2;
 mod instructions_v2;
 mod intent_core_v2;
@@ -19,7 +19,7 @@ mod transaction_intent_v2;
 mod transaction_manifest_v2;
 mod validated_notarized_transaction_v2;
 
-pub use child_intents_v2::*;
+pub use child_subintent_hashes_v2::*;
 pub use instruction_v2::*;
 pub use instructions_v2::*;
 pub use intent_core_v2::*;

--- a/radix-transactions/src/model/v2/signed_partial_transaction_v2.rs
+++ b/radix-transactions/src/model/v2/signed_partial_transaction_v2.rs
@@ -6,7 +6,7 @@ use crate::internal_prelude::*;
 // See versioned.rs for tests and a demonstration for the calculation of hashes etc
 //=================================================================================
 
-/// An analogue of a [`SignedTransactionIntentV2`], except with a subintent at the root.
+/// An analogue of a [`SignedTransactionIntentV2`], except with a [`SubintentV2`] at the root.
 ///
 /// This is intended to represent a fully signed, incomplete sub-tree of the transaction,
 /// and be a canonical model for building, storing and transferring this signed subtree.

--- a/radix-transactions/src/model/v2/subintent_manifest_v2.rs
+++ b/radix-transactions/src/model/v2/subintent_manifest_v2.rs
@@ -12,7 +12,7 @@ use crate::internal_prelude::*;
 pub struct SubintentManifestV2 {
     pub instructions: Vec<InstructionV2>,
     pub blobs: IndexMap<Hash, Vec<u8>>,
-    pub children: Vec<ChildSubintent>,
+    pub children: IndexSet<ChildSubintentSpecifier>,
     pub object_names: ManifestObjectNames,
 }
 
@@ -25,8 +25,10 @@ impl ReadableManifestBase for SubintentManifestV2 {
         self.blobs.iter()
     }
 
-    fn get_child_subintents(&self) -> &[ChildSubintent] {
-        &self.children
+    fn get_child_subintent_hashes<'a>(
+        &'a self,
+    ) -> impl ExactSizeIterator<Item = &'a ChildSubintentSpecifier> {
+        self.children.iter()
     }
 
     fn get_known_object_names_ref(&self) -> ManifestObjectNamesRef {
@@ -60,7 +62,9 @@ impl BuildableManifest for SubintentManifestV2 {
     }
 
     fn add_child_subintent(&mut self, hash: SubintentHash) -> Result<(), ManifestBuildError> {
-        self.children.push(ChildSubintent { hash });
+        if !self.children.insert(ChildSubintentSpecifier { hash }) {
+            return Err(ManifestBuildError::DuplicateChildSubintentHash);
+        }
         Ok(())
     }
 
@@ -88,11 +92,11 @@ impl SubintentManifestV2 {
         }
     }
 
-    pub fn for_intent(self) -> (InstructionsV2, BlobsV1, ChildIntentsV2) {
+    pub fn for_intent(self) -> (InstructionsV2, BlobsV1, ChildSubintentSpecifiersV2) {
         (
             self.instructions.into(),
             self.blobs.into(),
-            ChildIntentsV2 {
+            ChildSubintentSpecifiersV2 {
                 children: self.children,
             },
         )
@@ -100,11 +104,16 @@ impl SubintentManifestV2 {
 
     pub fn for_intent_with_names(
         self,
-    ) -> (InstructionsV2, BlobsV1, ChildIntentsV2, ManifestObjectNames) {
+    ) -> (
+        InstructionsV2,
+        BlobsV1,
+        ChildSubintentSpecifiersV2,
+        ManifestObjectNames,
+    ) {
         (
             self.instructions.into(),
             self.blobs.into(),
-            ChildIntentsV2 {
+            ChildSubintentSpecifiersV2 {
                 children: self.children,
             },
             self.object_names,

--- a/radix-transactions/src/model/versioned.rs
+++ b/radix-transactions/src/model/versioned.rs
@@ -468,8 +468,10 @@ mod tests {
         (message, expected_hash)
     }
 
-    fn create_childless_child_intents_v2() -> (ChildIntentsV2, Hash) {
-        let children: ChildIntentsV2 = ChildIntentsV2 { children: vec![] };
+    fn create_childless_child_intents_v2() -> (ChildSubintentSpecifiersV2, Hash) {
+        let children: ChildSubintentSpecifiersV2 = ChildSubintentSpecifiersV2 {
+            children: Default::default(),
+        };
         // Concatenation of all hashes
         let empty: [u8; 0] = [];
         let expected_hash = hash(&empty);


### PR DESCRIPTION
## Summary
A few things:
* Adds a `manifest` method to the v2 transaction builders -- for use in sargon
* Renames `ChildIntent` to `ChildSubintentSpecifier`

## Testing
* Existing tests pass
* Trialled using this locally and it worked
