### PR TITLE
test: Add test of system loan limitations

### DIFF
--- a/radix-engine-tests/tests/application/metering.rs
+++ b/radix-engine-tests/tests/application/metering.rs
@@ -906,6 +906,7 @@ fn system_loan_should_cover_very_minimal_lock_fee_in_scrypto_component() {
 
     // Assert and print
     receipt.expect_commit_success();
+    #[cfg(feature = "std")]
     println!(
         "\n{}",
         format_cost_breakdown(&receipt.fee_summary, receipt.fee_details.as_ref().unwrap())

--- a/radix-engine-tests/tests/application/metering.rs
+++ b/radix-engine-tests/tests/application/metering.rs
@@ -839,10 +839,10 @@ fn system_loan_should_cover_very_minimal_lock_fee_in_scrypto_component() {
     let network = NetworkDefinition::simulator();
     let (_, private_key, account_address) = ledger.new_account(true);
 
-    let manifest_dir = std::path::PathBuf::from_str(env!("CARGO_MANIFEST_DIR")).unwrap();
-    let package_dir = manifest_dir.join("assets").join("blueprints").join("fee");
-    let compiled =
-        scrypto_test::prelude::Compile::compile(package_dir, CompileProfile::FastWithTraceLogs);
+    // NOTE: We can't use `PackageLoader::get` here because it builds with `CompileProfile::FastWithTraceLogs`
+    // This test's passing is very borderline, and compiling without optimizations means the test doesn't pass.
+    // Therefore we have to make sure we do build with optimizations:
+    let compiled = Compile::compile(path_local_blueprint!("fee"), CompileProfile::Standard);
     let package_address = ledger.publish_package_simple(compiled);
     let deploy_receipt = ledger.execute_manifest(
         ManifestBuilder::new()

--- a/radix-engine/src/transaction/transaction_executor.rs
+++ b/radix-engine/src/transaction/transaction_executor.rs
@@ -33,6 +33,10 @@ pub struct CostingParameters {
 }
 
 impl CostingParameters {
+    pub fn latest() -> Self {
+        Self::babylon_genesis()
+    }
+
     #[cfg(not(feature = "coverage"))]
     pub fn babylon_genesis() -> Self {
         Self {
@@ -58,6 +62,11 @@ impl CostingParameters {
             state_storage_price: Decimal::zero(),
             archive_storage_price: Decimal::zero(),
         }
+    }
+
+    pub fn with_execution_cost_unit_loan(mut self, loan_units: u32) -> Self {
+        self.execution_cost_unit_loan = loan_units;
+        self
     }
 
     pub fn with_execution_cost_unit_limit(mut self, limit: u32) -> Self {
@@ -147,6 +156,14 @@ impl SystemOverrides {
 
     pub const fn with_network(network_definition: NetworkDefinition) -> Self {
         Self::internal_default(Some(network_definition))
+    }
+
+    pub const fn set_costing_parameters(
+        mut self,
+        costing_parameters: Option<CostingParameters>,
+    ) -> Self {
+        self.costing_parameters = costing_parameters;
+        self
     }
 
     pub fn set_abort_when_loan_repaid(mut self) -> Self {


### PR DESCRIPTION
Add test to verify a system loan just about covers locking a fee in a scrypto component, with a badge check.