### PR TITLE
tweak: `Decimal` and `PreciseDecimal` subunits are no longer `pub`

### DIFF
--- a/radix-common-derive/src/decimal.rs
+++ b/radix-common-derive/src/decimal.rs
@@ -155,14 +155,14 @@ pub fn to_decimal(input: TokenStream) -> Result<TokenStream> {
     let expr = parse::<Expr>(input)?;
 
     let decimal = get_decimal_from_expr(&expr, false)?;
-    let int = decimal.0;
+    let int = decimal.attos();
     let arr = int.to_digits();
     let i0 = arr[0];
     let i1 = arr[1];
     let i2 = arr[2];
 
     Ok(TokenStream::from(quote! {
-        radix_common::math::Decimal(radix_common::math::I192::from_digits([#i0, #i1, #i2]))
+        radix_common::math::Decimal::from_attos(radix_common::math::I192::from_digits([#i0, #i1, #i2]))
     }))
 }
 
@@ -171,7 +171,7 @@ pub fn to_precise_decimal(input: TokenStream) -> Result<TokenStream> {
     let expr = parse::<Expr>(input)?;
 
     let decimal = get_precise_decimal_from_expr(&expr, false)?;
-    let int = decimal.0;
+    let int = decimal.precise_subunits();
     let arr = int.to_digits();
     let i0 = arr[0];
     let i1 = arr[1];
@@ -179,6 +179,6 @@ pub fn to_precise_decimal(input: TokenStream) -> Result<TokenStream> {
     let i3 = arr[3];
 
     Ok(TokenStream::from(quote! {
-        radix_common::math::PreciseDecimal(radix_common::math::I256::from_digits([#i0, #i1, #i2, #i3]))
+        radix_common::math::PreciseDecimal::from_precise_subunits(radix_common::math::I256::from_digits([#i0, #i1, #i2, #i3]))
     }))
 }

--- a/radix-engine-interface/src/blueprints/resource/mod.rs
+++ b/radix-engine-interface/src/blueprints/resource/mod.rs
@@ -34,7 +34,7 @@ use sbor::rust::prelude::*;
 
 pub fn check_fungible_amount(amount: &Decimal, divisibility: u8) -> bool {
     !amount.is_negative()
-        && amount.0 % I192::from(10i128.pow((18 - divisibility).into())) == I192::from(0)
+        && amount.attos() % I192::from(10i128.pow((18 - divisibility).into())) == I192::from(0)
 }
 
 pub fn check_non_fungible_amount(amount: &Decimal) -> Result<u32, ()> {

--- a/radix-engine-monkey-tests/src/lib.rs
+++ b/radix-engine-monkey-tests/src/lib.rs
@@ -66,7 +66,7 @@ impl SystemTestFuzzer {
                 1 => Decimal::ONE,
                 2 => Decimal::MAX,
                 3 => Decimal::MIN,
-                _ => Decimal(I192::ONE),
+                _ => Decimal::ONE_ATTO,
             },
             1 => {
                 let amount = self.rng.gen_range(0u64..u64::MAX);
@@ -80,12 +80,12 @@ impl SystemTestFuzzer {
                 let mut bytes = [0u8; 24];
                 let (start, _end) = bytes.split_at_mut(8);
                 self.rng.fill_bytes(start);
-                Decimal(I192::from_le_bytes(&bytes))
+                Decimal::from_attos(I192::from_le_bytes(&bytes))
             }
             _ => {
                 let mut bytes = [0u8; 24];
                 self.rng.fill_bytes(&mut bytes);
-                Decimal(I192::from_le_bytes(&bytes))
+                Decimal::from_attos(I192::from_le_bytes(&bytes))
             }
         }
     }

--- a/radix-engine-tests/tests/application/common_transactions.rs
+++ b/radix-engine-tests/tests/application/common_transactions.rs
@@ -117,7 +117,7 @@ fn creating_a_fungible_resource_with_initial_supply_succeeds() {
 #[test]
 fn creating_a_fungible_resource_with_max_initial_supply_succeeds() {
     run_manifest(|account_address, address_bech32_encoder| {
-        let initial_supply = Decimal(I192::from(2).pow(152));
+        let initial_supply = Decimal::from_attos(I192::from(2).pow(152));
 
         let manifest = replace_variables!(
             include_workspace_transaction_examples_str!(
@@ -135,7 +135,7 @@ fn creating_a_fungible_resource_with_max_initial_supply_succeeds() {
 #[test]
 fn creating_a_fungible_resource_with_exceeded_initial_supply_fails() {
     run_manifest(|account_address, address_bech32_encoder| {
-        let initial_supply = Decimal(I192::from(2).pow(152) + I192::ONE);
+        let initial_supply = Decimal::from_attos(I192::from(2).pow(152) + I192::ONE);
 
         let manifest = replace_variables!(
             include_workspace_transaction_examples_str!(
@@ -233,7 +233,7 @@ fn minting_of_fungible_resource_max_mint_amount_succeeds() {
          minter_badge_resource_address,
          mintable_fungible_resource_address,
          address_bech32_encoder| {
-            let mint_amount = Decimal(I192::from(2).pow(152));
+            let mint_amount = Decimal::from_attos(I192::from(2).pow(152));
 
             let manifest = replace_variables!(
                 include_workspace_transaction_examples_str!("resources/mint/fungible/mint.rtm"),
@@ -259,7 +259,7 @@ fn minting_of_fungible_resource_exceed_max_mint_amount_fails() {
          minter_badge_resource_address,
          mintable_fungible_resource_address,
          address_bech32_encoder| {
-            let mint_amount = Decimal(I192::from(2).pow(152) + I192::ONE);
+            let mint_amount = Decimal::from_attos(I192::from(2).pow(152) + I192::ONE);
 
             let manifest = replace_variables!(
                 include_workspace_transaction_examples_str!("resources/mint/fungible/mint.rtm"),

--- a/radix-engine-tests/tests/blueprints/pool_arithmetic.rs
+++ b/radix-engine-tests/tests/blueprints/pool_arithmetic.rs
@@ -10,7 +10,7 @@ macro_rules! atto {
     (
         $($tokens: tt)*
     ) => {
-        Decimal(I192::from($($tokens)*))
+        Decimal::from_attos(I192::from($($tokens)*))
     };
 }
 

--- a/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_multi_resource.rs
@@ -744,7 +744,7 @@ fn cant_withdraw_without_proper_signature() {
 #[test]
 fn contribution_of_large_values_should_not_cause_panic() {
     // Arrange
-    let max_mint_amount = Decimal(I192::from(2).pow(152));
+    let max_mint_amount = Decimal::from_attos(I192::from(2).pow(152));
     let mut ledger = TestEnvironment::<3>::new([18, 18, 18]);
 
     // Act
@@ -764,7 +764,7 @@ fn contribution_of_large_values_should_not_cause_panic() {
 #[test]
 fn get_redemption_value_should_not_panic_on_large_values() {
     // Arrange
-    let mint_amount = Decimal(I192::from(2).pow(40));
+    let mint_amount = Decimal::from_attos(I192::from(2).pow(40));
     let mut ledger = TestEnvironment::<3>::new([18, 18, 18]);
     let receipt = ledger.contribute(
         indexmap!(

--- a/radix-engine-tests/tests/blueprints/pool_one_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_one_resource.rs
@@ -660,7 +660,7 @@ pub fn owner_can_update_pool_metadata() {
 #[test]
 fn get_redemption_value_should_not_panic_on_large_values() {
     // Arrange
-    let max_mint_amount = Decimal(I192::from(2).pow(152));
+    let max_mint_amount = Decimal::from_attos(I192::from(2).pow(152));
     let mut ledger = TestEnvironment::new(18);
     let receipt = ledger.contribute(max_mint_amount, true);
     receipt.expect_commit_success();

--- a/radix-engine-tests/tests/blueprints/pool_two_resource.rs
+++ b/radix-engine-tests/tests/blueprints/pool_two_resource.rs
@@ -856,7 +856,7 @@ pub fn contribute_fails_without_proper_authority_present() {
 #[test]
 fn contribution_of_large_values_should_not_cause_panic() {
     // Arrange
-    let max_mint_amount = Decimal(I192::from(2).pow(152));
+    let max_mint_amount = Decimal::from_attos(I192::from(2).pow(152));
     let mut ledger = TestEnvironment::new((18, 18));
 
     let manifest = ManifestBuilder::new()
@@ -898,7 +898,7 @@ fn contribution_of_large_values_should_not_cause_panic() {
 #[test]
 fn get_redemption_value_should_not_panic_on_large_values() {
     // Arrange
-    let mint_amount = Decimal(I192::from(2).pow(60));
+    let mint_amount = Decimal::from_attos(I192::from(2).pow(60));
     let mut ledger = TestEnvironment::new((18, 18));
     let receipt = ledger.contribute(
         (ledger.pool_resource1, mint_amount),
@@ -924,7 +924,7 @@ fn get_redemption_value_should_not_panic_on_large_values() {
 #[test]
 fn contributing_to_a_pool_with_very_large_difference_in_reserves_succeeds() {
     // Arrange
-    let max_mint_amount = Decimal(I192::from(2).pow(152));
+    let max_mint_amount = Decimal::from_attos(I192::from(2).pow(152));
     let mut ledger = TestEnvironment::new((18, 18));
 
     let manifest = ManifestBuilder::new()

--- a/radix-engine-tests/tests/blueprints/validator.rs
+++ b/radix-engine-tests/tests/blueprints/validator.rs
@@ -171,7 +171,7 @@ fn calling_get_redemption_value_on_staked_validator_with_smallest_amount_should_
             .call_method(
                 validator_address,
                 VALIDATOR_GET_REDEMPTION_VALUE_IDENT,
-                manifest_args!(Decimal(I192::ONE)),
+                manifest_args!(Decimal::from_attos(I192::ONE)),
             )
             .build(),
         vec![],

--- a/radix-engine-tests/tests/system/auth_account.rs
+++ b/radix-engine-tests/tests/system/auth_account.rs
@@ -237,7 +237,7 @@ fn can_withdraw_from_my_any_xrd_auth_account_with_no_signature() {
 fn can_withdraw_from_my_any_xrd_auth_account_with_right_amount_of_proof() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let xrd_auth = rule!(require_amount(Decimal(I192::from(1)), XRD));
+    let xrd_auth = rule!(require_amount(Decimal::ONE_ATTO, XRD));
     let account = ledger.new_account_advanced(OwnerRole::Fixed(xrd_auth));
     let (_, _, other_account) = ledger.new_allocated_account();
 
@@ -290,7 +290,7 @@ fn cannot_withdraw_from_my_any_xrd_auth_account_with_less_than_amount_of_proof()
 fn can_update_updatable_owner_role_account() {
     // Arrange
     let mut ledger = LedgerSimulatorBuilder::new().build();
-    let xrd_auth = rule!(require_amount(Decimal(I192::from(1)), XRD));
+    let xrd_auth = rule!(require_amount(Decimal::from_attos(I192::from(1)), XRD));
     let account = ledger.new_account_advanced(OwnerRole::Updatable(xrd_auth));
 
     // Act

--- a/radix-engine-tests/tests/system/royalty_edge_cases.rs
+++ b/radix-engine-tests/tests/system/royalty_edge_cases.rs
@@ -8,7 +8,7 @@ const DECIMAL_MIN: Decimal = Decimal::MIN;
 const DECIMAL_MAX: Decimal = Decimal::MAX;
 
 const DECIMAL_ZERO: Decimal = Decimal::ZERO;
-const DECIMAL_VERY_SMALL: Decimal = Decimal(I192::ONE);
+const DECIMAL_VERY_SMALL: Decimal = Decimal::ONE_ATTO;
 
 const DECIMAL_ONE: Decimal = Decimal::ONE;
 

--- a/radix-engine-tests/tests/vm/decimal.rs
+++ b/radix-engine-tests/tests/vm/decimal.rs
@@ -85,7 +85,7 @@ fn test_dec_macro_valid() {
     assert_eq!(X13, Decimal::MIN);
 
     const X14: Decimal = dec!("0.000000000000000048");
-    assert_eq!(X14, Decimal(I192::from(48)));
+    assert_eq!(X14, Decimal::from_attos(I192::from(48)));
 }
 
 #[test]
@@ -147,6 +147,11 @@ fn test_pdec_macro_valid() {
     const X13: PreciseDecimal =
         pdec!("-57896044618658097711785492504343953926634.992332820282019728792003956564819968");
     assert_eq!(X13, PreciseDecimal::MIN);
+
+    {
+        let x = pdec!("0.000000000000000001");
+        assert_eq!(x, PreciseDecimal::ONE_ATTO);
+    }
 }
 #[test]
 fn test_dec_macro_in_scrypto() {

--- a/radix-engine/src/blueprints/consensus_manager/validator.rs
+++ b/radix-engine/src/blueprints/consensus_manager/validator.rs
@@ -1659,13 +1659,13 @@ fn create_sort_prefix_from_stake(stake: Decimal) -> Result<[u8; 2], RuntimeError
             ApplicationError::ValidatorError(ValidatorError::UnexpectedDecimalComputationError),
         ))?;
 
-    let stake_100k_whole_units = Decimal::from(10)
+    let stake_100k_whole_units = dec!(10)
         .checked_powi(Decimal::SCALE.into())
         .and_then(|power| stake_100k.checked_div(power))
         .ok_or(RuntimeError::ApplicationError(
             ApplicationError::ValidatorError(ValidatorError::UnexpectedDecimalComputationError),
         ))?
-        .0;
+        .attos();
 
     let stake_u16 = if stake_100k_whole_units > I192::from(u16::MAX) {
         u16::MAX

--- a/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -16,7 +16,7 @@ use radix_native_sdk::runtime::Runtime;
 const DIVISIBILITY_MAXIMUM: u8 = 18;
 
 lazy_static! {
-    static ref MAX_MINT_AMOUNT: Decimal = Decimal(I192::from(2).pow(152)); // 2^152 subunits
+    static ref MAX_MINT_AMOUNT: Decimal = Decimal::from_attos(I192::from(2).pow(152)); // 2^152 subunits
 }
 
 declare_native_blueprint_state! {

--- a/radix-transactions/src/model/execution/executable_common.rs
+++ b/radix-transactions/src/model/execution/executable_common.rs
@@ -145,9 +145,11 @@ impl TipSpecifier {
         // * In order to make this math a bit cheaper, we multiply in I192 space to save a division
         match self {
             TipSpecifier::None => Decimal::ZERO,
-            TipSpecifier::Percentage(percentage) => Decimal(I192::from(*percentage) * dec!(0.01).0),
+            TipSpecifier::Percentage(percentage) => {
+                Decimal::from_attos(I192::from(*percentage) * dec!(0.01).attos())
+            }
             TipSpecifier::BasisPoints(basis_points) => {
-                Decimal(I192::from(*basis_points) * dec!(0.0001).0)
+                Decimal::from_attos(I192::from(*basis_points) * dec!(0.0001).attos())
             }
         }
     }


### PR DESCRIPTION
## Summary

* Makes the internal value of `Decimal` / `PreciseDecimal` private - this avoids some gotchas that us and the community have experienced - where they intend to e.g. create 2 from `Decimal(2.into())` but instead get 2 attos.
* Makes some of the functions `const`
* Adds `Decimal::ONE_ATTO`, `PreciseDecimal::ONE_ATTO`, `Decimal::ONE_SUBUNIT` and `PreciseDecimal::ONE_PRECISE_SUBUNIT` constants.

Whilst this is a "breaking change" for people who chose to update to Cuttlefish scrypto, I think it is a low-risk break, in that:
* I imagine it’s very rare for people to actually do this (or actually do this intentionally), so it likely won’t affect too much code in the wild.
* The change is very simple - `Decimal(x)` to `Decimal::from_attos(x)` - and is signposted on the `Decimal` / `PreciseDecimal` rust docs to point users in the right direction

## Testing
Some new tests are added.

## Update Recommendations
* Instead of `Decimal(x)` use `Decimal::from_attos(x)`
* Instead of `PreciseDecimal(x)` use `PreciseDecimal::from_precise_subunits(x)`
* Instead of `decimal.0` use `decimal.attos()`
* Instead of `precise_decimal.0` use `precise_decimal.precise_subunits()`