### PR TITLE
test: Add test case for mitigating AllowExisting workaround

### DIFF
--- a/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
+++ b/radix-engine-tests/tests/blueprints/account_deposit_modes.rs
@@ -5,14 +5,15 @@ use radix_engine::transaction::TransactionReceipt;
 use radix_engine_interface::blueprints::account::*;
 use radix_engine_interface::prelude::*;
 use radix_substate_store_queries::typed_substate_layout::AccountError;
+use radix_transactions::manifest::BuildableManifest;
 use radix_transactions::prelude::*;
 use scrypto_test::prelude::{DefaultLedgerSimulator, LedgerSimulatorBuilder};
 
 #[test]
 fn account_deposit_method_is_callable_with_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger.free_tokens_from_faucet_to_account(DepositMethod::Deposit, true);
@@ -25,8 +26,8 @@ fn account_deposit_method_is_callable_with_owner_signature() {
 #[test]
 fn account_deposit_batch_method_is_callable_with_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger.free_tokens_from_faucet_to_account(DepositMethod::DepositBatch, true);
@@ -39,8 +40,8 @@ fn account_deposit_batch_method_is_callable_with_owner_signature() {
 #[test]
 fn account_deposit_method_is_not_callable_with_out_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger.free_tokens_from_faucet_to_account(DepositMethod::Deposit, false);
@@ -53,8 +54,8 @@ fn account_deposit_method_is_not_callable_with_out_owner_signature() {
 #[test]
 fn account_deposit_batch_method_is_not_callable_with_out_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger.free_tokens_from_faucet_to_account(DepositMethod::DepositBatch, false);
@@ -67,8 +68,8 @@ fn account_deposit_batch_method_is_not_callable_with_out_owner_signature() {
 #[test]
 fn account_try_deposit_method_is_callable_with_out_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger.free_tokens_from_faucet_to_account(DepositMethod::TryDeposit, false);
@@ -81,8 +82,8 @@ fn account_try_deposit_method_is_callable_with_out_owner_signature() {
 #[test]
 fn account_try_deposit_batch_or_refund_method_is_callable_without_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt = ledger
@@ -121,8 +122,8 @@ fn account_try_deposit_batch_or_refund_method_is_callable_with_array_of_resource
 #[test]
 fn account_try_deposit_or_abort_method_is_callable_without_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt =
@@ -136,8 +137,8 @@ fn account_try_deposit_or_abort_method_is_callable_without_owner_signature() {
 #[test]
 fn account_try_deposit_batch_or_abort_method_is_callable_without_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt =
@@ -151,8 +152,8 @@ fn account_try_deposit_batch_or_abort_method_is_callable_without_owner_signature
 #[test]
 fn changing_default_deposit_rule_is_callable_with_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt =
@@ -166,8 +167,8 @@ fn changing_default_deposit_rule_is_callable_with_owner_signature() {
 #[test]
 fn changing_default_deposit_rule_is_not_callable_with_out_owner_signature() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         // Act
         let receipt =
@@ -181,8 +182,8 @@ fn changing_default_deposit_rule_is_not_callable_with_out_owner_signature() {
 #[test]
 fn allow_all_allows_for_all_resource_deposits() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
 
         // Act
@@ -197,8 +198,8 @@ fn allow_all_allows_for_all_resource_deposits() {
 #[test]
 fn allow_all_disallows_deposit_of_resource_in_deny_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .add_to_deny_list(resource_address, true)
@@ -216,8 +217,8 @@ fn allow_all_disallows_deposit_of_resource_in_deny_list() {
 #[test]
 fn resource_in_deny_list_could_be_converted_to_resource_in_allow_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .add_to_deny_list(resource_address, true)
@@ -238,8 +239,8 @@ fn resource_in_deny_list_could_be_converted_to_resource_in_allow_list() {
 #[test]
 fn resource_in_deny_list_could_be_removed_from_there() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .add_to_deny_list(resource_address, true)
@@ -260,8 +261,8 @@ fn resource_in_deny_list_could_be_removed_from_there() {
 #[test]
 fn allow_existing_disallows_deposit_of_resources_on_deny_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true)
             .expect_commit_success();
@@ -279,8 +280,8 @@ fn allow_existing_disallows_deposit_of_resources_on_deny_list() {
 #[test]
 fn allow_existing_allows_deposit_of_xrd_if_not_on_deny_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true)
             .expect_commit_success();
@@ -297,8 +298,8 @@ fn allow_existing_allows_deposit_of_xrd_if_not_on_deny_list() {
 #[test]
 fn allow_existing_allows_deposit_of_an_existing_resource() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         let resource_address = ledger.freely_mintable_resource();
         ledger
@@ -321,8 +322,8 @@ fn allow_existing_allows_deposit_of_an_existing_resource() {
 #[test]
 fn allow_existing_allows_deposit_of_an_existing_resource_even_if_account_has_none_of_it() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
 
         let resource_address = ledger.freely_mintable_resource();
         ledger
@@ -346,8 +347,8 @@ fn allow_existing_allows_deposit_of_an_existing_resource_even_if_account_has_non
 #[test]
 fn allow_existing_allows_deposit_of_a_resource_account_does_not_have_if_it_is_on_the_allow_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true)
@@ -368,8 +369,8 @@ fn allow_existing_allows_deposit_of_a_resource_account_does_not_have_if_it_is_on
 #[test]
 fn removing_an_address_from_the_allow_list_removes_it() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true)
@@ -393,8 +394,8 @@ fn removing_an_address_from_the_allow_list_removes_it() {
 #[test]
 fn transitioning_an_address_to_deny_list_works_as_expected() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true)
@@ -418,8 +419,8 @@ fn transitioning_an_address_to_deny_list_works_as_expected() {
 #[test]
 fn disallow_all_does_not_permit_deposit_of_any_resource() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::Reject, true)
             .expect_commit_success();
@@ -436,8 +437,8 @@ fn disallow_all_does_not_permit_deposit_of_any_resource() {
 #[test]
 fn disallow_all_permits_deposit_of_resource_in_allow_list() {
     // Arrange
-    for is_virtual in [true, false] {
-        let mut ledger = AccountDepositModesLedgerSimulator::new(is_virtual);
+    for is_preallocated in [true, false] {
+        let mut ledger = AccountDepositModesLedgerSimulator::new(is_preallocated);
         let resource_address = ledger.freely_mintable_resource();
         ledger
             .transition_default_deposit_rule(DefaultDepositRule::Reject, true)
@@ -455,10 +456,63 @@ fn disallow_all_permits_deposit_of_resource_in_allow_list() {
     }
 }
 
+#[test]
+fn cannot_trick_account_allow_existing_by_adding_empty_bucket_to_account() {
+    // Arrange
+    let mut ledger = AccountDepositModesLedgerSimulator::new(false);
+    ledger.transition_default_deposit_rule(DefaultDepositRule::AllowExisting, true);
+    let account_address = ledger.account_address;
+
+    let bad_resource_address = ledger.freely_mintable_resource();
+
+    // Act - Part 1
+    // The user interacts with a dApp which has an assertion that it only includes XRD...
+    // but unknown to the user, it also deposits a bucket of size 0 - which might
+    // attempt to trick the account into making the resource an "existing resource"
+    // despite the fact it didn't show up on the assertion.
+    let user_manifest = ManifestBuilder::new_v2()
+        .lock_fee_from_faucet()
+        .get_free_xrd_from_faucet()
+        .mint_fungible(bad_resource_address, 0)
+        .assert_worktop_resources_only(
+            ManifestResourceConstraints::new().with_at_least_amount(XRD, Decimal::ONE_ATTO),
+        )
+        .deposit_entire_worktop(account_address)
+        .build();
+    let receipt = ledger.execute_manifest(user_manifest, true);
+    receipt.expect_commit_success();
+
+    // And now, the dApp tries to deposit the resource without the user being present...
+    let malicious_manifest = ManifestBuilder::new_v2()
+        .lock_fee_from_faucet()
+        .mint_fungible(bad_resource_address, dec!(666))
+        .try_deposit_entire_worktop_or_abort(account_address, None)
+        .build();
+    let receipt = ledger.execute_manifest(malicious_manifest, false);
+
+    // Assert
+    let error = receipt.expect_commit_failure().outcome.expect_failure();
+    let matches_result = matches!(
+        error,
+        RuntimeError::ApplicationError(ApplicationError::AccountError(
+            AccountError::NotAllBucketsCouldBeDeposited
+        )),
+    );
+    if !matches_result {
+        panic!("Error is not DepositIsDisallowed {error:?}");
+    }
+
+    // This test currently passes because the **worktop** prevents this issue,
+    // by dropping empty buckets which are put on the worktop.
+    // This is a little indirect for my liking (it feels like the account should
+    // be maintaing its own invariant by not depositing empty buckets), but it's
+    // good enough for now as the worktop can't be tricked into depositing an empty bucket.
+}
+
 struct AccountDepositModesLedgerSimulator {
     ledger: DefaultLedgerSimulator,
     public_key: PublicKey,
-    component_address: ComponentAddress,
+    account_address: ComponentAddress,
 }
 
 impl AccountDepositModesLedgerSimulator {
@@ -467,7 +521,7 @@ impl AccountDepositModesLedgerSimulator {
         let (public_key, _, component_address) = ledger.new_account(preallocated_account);
 
         Self {
-            component_address,
+            account_address: component_address,
             public_key: public_key.into(),
             ledger,
         }
@@ -484,7 +538,7 @@ impl AccountDepositModesLedgerSimulator {
             .mint_fungible(resource_address, 1)
             .take_all_from_worktop(resource_address, "bucket")
             .with_bucket("bucket", |builder, bucket| {
-                deposit_method.call(builder, self.component_address, bucket)
+                deposit_method.call(builder, self.account_address, bucket)
             })
             .build();
         self.execute_manifest(manifest, sign)
@@ -500,7 +554,7 @@ impl AccountDepositModesLedgerSimulator {
             .get_free_xrd_from_faucet()
             .take_all_from_worktop(XRD, "free_tokens")
             .with_bucket("free_tokens", |builder, bucket| {
-                deposit_method.call(builder, self.component_address, bucket)
+                deposit_method.call(builder, self.account_address, bucket)
             })
             .build();
         self.execute_manifest(manifest, sign)
@@ -514,7 +568,7 @@ impl AccountDepositModesLedgerSimulator {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .call_method(
-                self.component_address,
+                self.account_address,
                 ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
                 AccountSetDefaultDepositRuleInput { default },
             )
@@ -531,7 +585,7 @@ impl AccountDepositModesLedgerSimulator {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .call_method(
-                self.component_address,
+                self.account_address,
                 ACCOUNT_SET_RESOURCE_PREFERENCE_IDENT,
                 AccountSetResourcePreferenceInput {
                     resource_address,
@@ -550,7 +604,7 @@ impl AccountDepositModesLedgerSimulator {
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
             .call_method(
-                self.component_address,
+                self.account_address,
                 ACCOUNT_REMOVE_RESOURCE_PREFERENCE_IDENT,
                 AccountRemoveResourcePreferenceInput { resource_address },
             )
@@ -584,7 +638,7 @@ impl AccountDepositModesLedgerSimulator {
                 OwnerRole::None,
                 None,
                 18,
-                self.component_address,
+                self.account_address,
             )
     }
 
@@ -595,10 +649,10 @@ impl AccountDepositModesLedgerSimulator {
 
         let balance = self
             .ledger
-            .get_component_balance(self.component_address, resource_address);
+            .get_component_balance(self.account_address, resource_address);
         let manifest = ManifestBuilder::new()
             .lock_fee_from_faucet()
-            .withdraw_from_account(self.component_address, resource_address, balance)
+            .withdraw_from_account(self.account_address, resource_address, balance)
             .try_deposit_entire_worktop_or_refund(uninstantiated_account, None)
             .build();
 
@@ -608,7 +662,7 @@ impl AccountDepositModesLedgerSimulator {
 
     pub fn execute_manifest(
         &mut self,
-        manifest: TransactionManifestV1,
+        manifest: impl BuildableManifest,
         sign: bool,
     ) -> TransactionReceipt {
         self.ledger.execute_manifest(


### PR DESCRIPTION
## Summary

Described in the test case - but this test checks that an empty bucket can't be used to pass resource assertions and then deposit to an account in a user-signed transaction (unbeknownst to a user in the wallet) in order to get around the `DefaultDepositRule::AllowExisting` setting in a future externally-initiated transaction.

## Details
Just adds the test case. The test currently passes due to behaviour of the worktop, rather than the account, which feels a little indirect for my liking, but it prevents the issue (at least via the manifest, and I'm much less concerned about non-manifest issues, as scrypto code is unlikely to be dealing with asserting against unknown empty buckets or interacting with an account with an `AllowExisting` deposit rule).

## Testing
See new test.
