### PR TITLE
Add base cost to consume_wasm_execution_units host function

### DIFF
--- a/radix-engine-tests/assets/metering/cuttlefish/cost_crypto_utils.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_crypto_utils.csv
@@ -1,18 +1,18 @@
-Total Cost (XRD)                                                           ,            1.04183166606,    100.0%
-- Execution Cost (XRD)                                                     ,                0.6651783,     63.8%
+Total Cost (XRD)                                                           ,            1.05047606606,    100.0%
+- Execution Cost (XRD)                                                     ,                0.6738227,     64.1%
 - Finalization Cost (XRD)                                                  ,                0.0102517,      1.0%
-- Storage Cost (XRD)                                                       ,            0.36640166606,     35.2%
+- Storage Cost (XRD)                                                       ,            0.36640166606,     34.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 13303566,    100.0%
+Execution Cost Breakdown                                                   ,                 13476454,    100.0%
 - AfterInvoke                                                              ,                      518,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     7778,      0.1%
 - Blake2b256Hash                                                           ,                       91,      0.0%
 - Bls12381G2SignatureAggregate                                             ,                   243986,      1.8%
-- Bls12381V1AggregateVerify                                                ,                  2001824,     15.0%
-- Bls12381V1FastAggregateVerify                                            ,                   632277,      4.8%
-- Bls12381V1Verify                                                         ,                   461378,      3.5%
+- Bls12381V1AggregateVerify                                                ,                  2001824,     14.9%
+- Bls12381V1FastAggregateVerify                                            ,                   632277,      4.7%
+- Bls12381V1Verify                                                         ,                   461378,      3.4%
 - CheckReference                                                           ,                    80024,      0.6%
 - CloseSubstate                                                            ,                    18576,      0.1%
 - CreateNode                                                               ,                    13376,      0.1%
@@ -25,27 +25,27 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      0.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  3497709,     26.3%
+- OpenSubstate::GlobalPackage                                              ,                  3497709,     26.0%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    18682,      0.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.3%
 - PinNode                                                                  ,                      180,      0.0%
-- PrepareWasmCode                                                          ,                  2282710,     17.2%
+- PrepareWasmCode                                                          ,                  2282710,     16.9%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                  2353589,     17.7%
+- ReadSubstate                                                             ,                  2353589,     17.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunWasmCode::CryptoScrypto_blake2b_256_hash                              ,                    10010,      0.1%
-- RunWasmCode::CryptoScrypto_bls12381_g2_signature_aggregate               ,                   362018,      2.7%
-- RunWasmCode::CryptoScrypto_bls12381_v1_aggregate_verify                  ,                   253847,      1.9%
-- RunWasmCode::CryptoScrypto_bls12381_v1_fast_aggregate_verify             ,                   211296,      1.6%
-- RunWasmCode::CryptoScrypto_bls12381_v1_verify                            ,                    61708,      0.5%
-- RunWasmCode::CryptoScrypto_ed25519_verify                                ,                    43794,      0.3%
-- RunWasmCode::CryptoScrypto_keccak256_hash                                ,                    10039,      0.1%
-- RunWasmCode::CryptoScrypto_secp256k1_ecdsa_key_recover                   ,                    44649,      0.3%
-- RunWasmCode::CryptoScrypto_secp256k1_ecdsa_verify                        ,                    55047,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
+- RunWasmCode::CryptoScrypto_blake2b_256_hash                              ,                    10811,      0.1%
+- RunWasmCode::CryptoScrypto_bls12381_g2_signature_aggregate               ,                   422162,      3.1%
+- RunWasmCode::CryptoScrypto_bls12381_v1_aggregate_verify                  ,                   295892,      2.2%
+- RunWasmCode::CryptoScrypto_bls12381_v1_fast_aggregate_verify             ,                   246322,      1.8%
+- RunWasmCode::CryptoScrypto_bls12381_v1_verify                            ,                    71202,      0.5%
+- RunWasmCode::CryptoScrypto_ed25519_verify                                ,                    50392,      0.4%
+- RunWasmCode::CryptoScrypto_keccak256_hash                                ,                    10801,      0.1%
+- RunWasmCode::CryptoScrypto_secp256k1_ecdsa_key_recover                   ,                    51211,      0.4%
+- RunWasmCode::CryptoScrypto_secp256k1_ecdsa_verify                        ,                    63252,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - Secp256k1EcdsaKeyRecover                                                 ,                    14705,      0.1%
 - Secp256k1EcdsaVerify                                                     ,                    14705,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%

--- a/radix-engine-tests/assets/metering/cuttlefish/cost_flash_loan.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_flash_loan.csv
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.62267027592,    100.0%
-- Execution Cost (XRD)                                                     ,               0.46223905,     74.2%
+Total Cost (XRD)                                                           ,            0.62384462592,    100.0%
+- Execution Cost (XRD)                                                     ,                0.4634134,     74.3%
 - Finalization Cost (XRD)                                                  ,                0.0322574,      5.2%
-- Storage Cost (XRD)                                                       ,            0.12817382592,     20.6%
+- Storage Cost (XRD)                                                       ,            0.12817382592,     20.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  9244781,    100.0%
+Execution Cost Breakdown                                                   ,                  9268268,    100.0%
 - AfterInvoke                                                              ,                     1884,      0.0%
 - AllocateNodeId                                                           ,                     5141,      0.1%
 - BeforeInvoke                                                             ,                     7694,      0.1%
@@ -21,11 +21,11 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   259797,      2.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47692,      0.5%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   632452,      6.8%
-- OpenSubstate::GlobalPackage                                              ,                  3160161,     34.2%
+- OpenSubstate::GlobalPackage                                              ,                  3160161,     34.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   290575,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                   212121,      2.3%
 - PinNode                                                                  ,                      636,      0.0%
-- PrepareWasmCode                                                          ,                   967836,     10.5%
+- PrepareWasmCode                                                          ,                   967836,     10.4%
 - QueryActor                                                               ,                    10500,      0.1%
 - ReadSubstate                                                             ,                  1325876,     14.3%
 - RunNativeCode::AuthZone_pop                                              ,                    33696,      0.4%
@@ -47,7 +47,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                   116047,      1.3%
 - RunNativeCode::mint_ruid_NonFungibleResourceManager                      ,                    93979,      1.0%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    28382,      0.3%
-- RunNativeCode::on_move_FungibleProof                                     ,                    32360,      0.4%
+- RunNativeCode::on_move_FungibleProof                                     ,                    32360,      0.3%
 - RunNativeCode::put_FungibleBucket                                        ,                    16165,      0.2%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.5%
 - RunNativeCode::take_FungibleBucket                                       ,                    19855,      0.2%
@@ -55,8 +55,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.3%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    46544,      0.5%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.6%
-- RunWasmCode::BasicFlashLoan_repay_loan                                   ,                    75849,      0.8%
-- RunWasmCode::BasicFlashLoan_take_loan                                    ,                    69367,      0.8%
+- RunWasmCode::BasicFlashLoan_repay_loan                                   ,                    88411,      1.0%
+- RunWasmCode::BasicFlashLoan_take_loan                                    ,                    80292,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    18800,      0.2%

--- a/radix-engine-tests/assets/metering/cuttlefish/cost_mint_large_size_nfts_from_manifest.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_mint_large_size_nfts_from_manifest.csv
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,          207.47148013518,    100.0%
-- Execution Cost (XRD)                                                     ,                2.5817327,      1.2%
+Total Cost (XRD)                                                           ,          207.47164268518,    100.0%
+- Execution Cost (XRD)                                                     ,               2.58189525,      1.2%
 - Finalization Cost (XRD)                                                  ,               2.47943445,      1.2%
 - Storage Cost (XRD)                                                       ,          202.41031298518,     97.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 51634654,    100.0%
+Execution Cost Breakdown                                                   ,                 51637905,    100.0%
 - AfterInvoke                                                              ,                     4752,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                  2093962,      4.1%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.1%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                    35917,      0.1%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-engine-tests/assets/metering/cuttlefish/cost_mint_small_size_nfts_from_manifest.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_mint_small_size_nfts_from_manifest.csv
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            6.53950750536,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2901941,      4.4%
+Total Cost (XRD)                                                           ,            6.53967005536,    100.0%
+- Execution Cost (XRD)                                                     ,               0.29035665,      4.4%
 - Finalization Cost (XRD)                                                  ,                2.4964143,     38.2%
 - Storage Cost (XRD)                                                       ,            3.75289910536,     57.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5803882,    100.0%
+Execution Cost Breakdown                                                   ,                  5807133,    100.0%
 - AfterInvoke                                                              ,                     4806,      0.1%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                    10522,      0.2%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.1%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                    36370,      0.6%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-engine-tests/assets/metering/cuttlefish/cost_publish_large_package.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_publish_large_package.csv
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,          304.84429930219,    100.0%
-- Execution Cost (XRD)                                                     ,               4.93879165,      1.6%
+Total Cost (XRD)                                                           ,          304.84446185219,    100.0%
+- Execution Cost (XRD)                                                     ,                4.9389542,      1.6%
 - Finalization Cost (XRD)                                                  ,               0.07669735,      0.0%
 - Storage Cost (XRD)                                                       ,          299.82881030219,     98.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 98775833,    100.0%
+Execution Cost Breakdown                                                   ,                 98779084,    100.0%
 - AfterInvoke                                                              ,                      326,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                  2096226,      2.1%
@@ -34,7 +34,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.0%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.0%
 - RunNativeCode::publish_wasm_advanced                                     ,                 46852012,     47.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      403,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-engine-tests/assets/metering/cuttlefish/cost_radiswap.csv
+++ b/radix-engine-tests/assets/metering/cuttlefish/cost_radiswap.csv
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.56766152273,    100.0%
-- Execution Cost (XRD)                                                     ,               0.36172655,     63.7%
+Total Cost (XRD)                                                           ,            0.56840327273,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3624683,     63.8%
 - Finalization Cost (XRD)                                                  ,                0.0427613,      7.5%
 - Storage Cost (XRD)                                                       ,            0.16317367273,     28.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7234531,    100.0%
+Execution Cost Breakdown                                                   ,                  7249366,    100.0%
 - AfterInvoke                                                              ,                     1444,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.0%
 - BeforeInvoke                                                             ,                     3714,      0.1%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalAccount                                              ,                   656205,      9.1%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   425889,      5.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    44192,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  2430500,     33.6%
+- OpenSubstate::GlobalPackage                                              ,                  2430500,     33.5%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                   657608,      9.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   355473,      4.9%
 - OpenSubstate::InternalGenericComponent                                   ,                   126104,      1.7%
@@ -35,7 +35,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    88128,      1.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.4%
 - RunNativeCode::get_resource_address_FungibleBucket                       ,                    17768,      0.2%
-- RunNativeCode::get_vault_amounts_two_resource_pool                       ,                    47047,      0.7%
+- RunNativeCode::get_vault_amounts_two_resource_pool                       ,                    47047,      0.6%
 - RunNativeCode::lock_fee                                                  ,                   116047,      1.6%
 - RunNativeCode::protected_deposit_two_resource_pool                       ,                    55718,      0.8%
 - RunNativeCode::protected_withdraw_two_resource_pool                      ,                    38847,      0.5%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_advanced_FungibleVault                               ,                    44567,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.8%
-- RunWasmCode::Radiswap_swap                                               ,                    95299,      1.3%
+- RunWasmCode::Radiswap_swap                                               ,                   110134,      1.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    13120,      0.2%

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -176,9 +176,25 @@ impl FeeTable {
         _export_name: &str,
         wasm_execution_units: u32,
     ) -> u32 {
-        // From `costing::spin_loop`, it takes 5.5391 ms for 1918122691 wasm execution units.
-        // Therefore, cost for single unit: 5.5391 *  1000 / 1918122691 * 100 = 0.00028877714
-
+        // W - WASM execution units
+        // C - cost units
+        // c - single cost unit
+        // T - execution time (1 µs = 100 c => 1 ms = 100,000 c)
+        //
+        // Cost units might be expressed as
+        //  C = T * c
+        //
+        // To convert W to C, we need a d.
+        //   C = W / divider
+        //   divider = W / C
+        //   divider = W / (T * c)
+        //
+        // From `costing::spin_loop_v2`, it takes T=960 ms to consume W=274,517,401,207 wasm execution
+        // units (measured at GH benchmark, git rev 1fd85c47ef, EC2 instance type c6a.4xlarge).
+        //   T = 960 ms = 960 * 100,000
+        //   W = 274,517,401,207
+        // Therefore
+        //   divider = 274,517,401,207 / (960 * 100,000) = 2859.556 ~= 3000
         wasm_execution_units / 3000
     }
 

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/001--access-controller-v2-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/001--access-controller-v2-instantiate.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.94481573742,    100.0%
-- Execution Cost (XRD)                                                     ,               0.32974775,     34.9%
+Total Cost (XRD)                                                           ,            0.94522588742,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3301579,     34.9%
 - Finalization Cost (XRD)                                                  ,                0.1960235,     20.7%
-- Storage Cost (XRD)                                                       ,            0.41904448742,     44.4%
+- Storage Cost (XRD)                                                       ,            0.41904448742,     44.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6594955,    100.0%
+Execution Cost Breakdown                                                   ,                  6603158,    100.0%
 - AfterInvoke                                                              ,                      846,      0.0%
 - AllocateNodeId                                                           ,                     3201,      0.0%
 - BeforeInvoke                                                             ,                     5962,      0.1%
@@ -44,8 +44,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      944,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/002--access-controller-v2-deposit-fees-xrd.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/002--access-controller-v2-deposit-fees-xrd.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.41395877987,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27693935,     66.9%
-- Finalization Cost (XRD)                                                  ,               0.03125695,      7.6%
+Total Cost (XRD)                                                           ,            0.41436892987,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2773495,     66.9%
+- Finalization Cost (XRD)                                                  ,               0.03125695,      7.5%
 - Storage Cost (XRD)                                                       ,            0.10576247987,     25.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5538787,    100.0%
+Execution Cost Breakdown                                                   ,                  5546990,    100.0%
 - AfterInvoke                                                              ,                      520,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     1796,      0.0%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      3.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.9%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40746,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2604016,     47.0%
+- OpenSubstate::GlobalPackage                                              ,                  2604016,     46.9%
 - OpenSubstate::InternalFungibleVault                                      ,                   147198,      2.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    48073,      0.9%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.7%
@@ -41,8 +41,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14880,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/001--access-controller-v2-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/001--access-controller-v2-instantiate.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.94481573742 XRD
-├─ Network execution: 0.32974775 XRD, 6594955 execution cost units
+TRANSACTION COST: 0.94522588742 XRD
+├─ Network execution: 0.3301579 XRD, 6603158 execution cost units
 ├─ Network finalization: 0.1960235 XRD, 3920470 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.41904448742 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.94481573742"),
+     amount: Decimal("0.94522588742"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.47240786871"),
+     amount: Decimal("0.47261294371"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.47240786871"),
+     amount: Decimal("0.47261294371"),
    }
 
 STATE UPDATES: 9 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.236203934355"),
+             0u8 => Decimal("0.236306471855"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.05518426258")),
+         LiquidFungibleResource(Decimal("99999999999989999.05477411258")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -432,7 +432,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.47240786871")),
+         LiquidFungibleResource(Decimal("0.47261294371")),
        )
 
 OUTPUTS: 4
@@ -444,13 +444,13 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.94481573742
+   Change: -10000.94522588742
 ├─ Vault: internal_vault_sim1tz3wnsxw770s9kgtfudv4kktz6juv48d7v59qd7exlq98a53knngw6
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.47240786871
+   Change: 0.47261294371
 
 NEW ENTITIES: 2
 └─ Component: accesscontroller_sim1c09uvtxa5efafuetf983dcz5s5d8whtwcxe559kn3ywruchlxh0twh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/002--access-controller-v2-deposit-fees-xrd.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/002--access-controller-v2-deposit-fees-xrd.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.41395877987 XRD
-├─ Network execution: 0.27693935 XRD, 5538787 execution cost units
+TRANSACTION COST: 0.41436892987 XRD
+├─ Network execution: 0.2773495 XRD, 5546990 execution cost units
 ├─ Network finalization: 0.03125695 XRD, 625139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.10576247987 XRD
@@ -32,15 +32,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.41395877987"),
+     amount: Decimal("0.41436892987"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.206979389935"),
+     amount: Decimal("0.207184464935"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.206979389935"),
+     amount: Decimal("0.207184464935"),
    }
 
 STATE UPDATES: 8 entities
@@ -50,7 +50,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.3396936293225"),
+             0u8 => Decimal("0.3398987043225"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -103,7 +103,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979998.64122548271")),
+         LiquidFungibleResource(Decimal("99999999999979998.64040518271")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -142,7 +142,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.679387258645")),
+         LiquidFungibleResource(Decimal("0.679797408645")),
        )
 
 OUTPUTS: 4
@@ -154,12 +154,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.41395877987
+   Change: -10000.41436892987
 ├─ Vault: internal_vault_sim1trlz48lr8t38e6xlc9n304ahr62r8te03exlrh097s495vmk35e6vz
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.206979389935
+   Change: 0.207184464935
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/003--access-controller-v2-lock-fee-and-recover.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/003--access-controller-v2-lock-fee-and-recover.txt
@@ -172,7 +172,7 @@ STATE UPDATES: 5 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.426474117095"),
+             0u8 => Decimal("0.426679192095"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -270,7 +270,7 @@ STATE UPDATES: 5 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.85294823419")),
+         LiquidFungibleResource(Decimal("0.85335838419")),
        )
 
 OUTPUTS: 3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: access-controller-v2
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 04d963aff2e82429 (allowed to change if not deployed to any network)
-Events       : 5194e6ef6d25254a (allowed to change if not deployed to any network)
+State changes: 63374dfe1ebf0cc6 (allowed to change if not deployed to any network)
+Events       : d183b32cb622ca59 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - access_controller_v2_component_address: accesscontroller_sim1c09uvtxa5efafuetf983dcz5s5d8whtwcxe559kn3ywruchlxh0twh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/001--account-authorized-depositors-configure-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/001--account-authorized-depositors-configure-accounts.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.88885487317,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29540385,     33.2%
-- Finalization Cost (XRD)                                                  ,               0.17202235,     19.4%
+Total Cost (XRD)                                                           ,            0.88901742317,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2955664,     33.2%
+- Finalization Cost (XRD)                                                  ,               0.17202235,     19.3%
 - Storage Cost (XRD)                                                       ,            0.42142867317,     47.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5908077,    100.0%
+Execution Cost Breakdown                                                   ,                  5911328,    100.0%
 - AfterInvoke                                                              ,                      868,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.1%
 - BeforeInvoke                                                             ,                     4842,      0.1%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    69040,      1.2%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::set_default_deposit_rule                                  ,                   119482,      2.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1183,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/002--account-authorized-depositors-attempt-deposit-success.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/002--account-authorized-depositors-attempt-deposit-success.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.52560467719,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3526864,     67.1%
+Total Cost (XRD)                                                           ,            0.52601482719,    100.0%
+- Execution Cost (XRD)                                                     ,               0.35309655,     67.1%
 - Finalization Cost (XRD)                                                  ,               0.03625675,      6.9%
 - Storage Cost (XRD)                                                       ,            0.13666152719,     26.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7053728,    100.0%
+Execution Cost Breakdown                                                   ,                  7061931,    100.0%
 - AfterInvoke                                                              ,                      704,      0.0%
 - AllocateNodeId                                                           ,                     2522,      0.0%
 - BeforeInvoke                                                             ,                     3790,      0.1%
@@ -49,8 +49,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.2%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    23880,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.3217417664,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2759654,     85.8%
+Total Cost (XRD)                                                           ,             0.3221519164,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27637555,     85.8%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,             0.0457763664,     14.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5519308,    100.0%
+Execution Cost Breakdown                                                   ,                  5527511,    100.0%
 - AfterInvoke                                                              ,                      386,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     1566,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   127933,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  2589103,     46.9%
+- OpenSubstate::GlobalPackage                                              ,                  2589103,     46.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285342,      5.2%
 - OpenSubstate::InternalFungibleVault                                      ,                   100390,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    36179,      0.7%
@@ -37,8 +37,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.6%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    19200,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.3359765164,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29020015,     86.4%
+Total Cost (XRD)                                                           ,             0.3363866664,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2906103,     86.4%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,             0.0457763664,     13.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5804003,    100.0%
+Execution Cost Breakdown                                                   ,                  5812206,    100.0%
 - AfterInvoke                                                              ,                      566,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     2028,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   130251,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41401,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2604179,     44.9%
+- OpenSubstate::GlobalPackage                                              ,                  2604179,     44.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   405872,      7.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   100390,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    57145,      1.0%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - PrepareWasmCode                                                          ,                   707732,     12.2%
 - QueryActor                                                               ,                     1500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   868704,     15.0%
+- ReadSubstate                                                             ,                   868704,     14.9%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    58066,      1.0%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
@@ -39,8 +39,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    19200,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/001--account-authorized-depositors-configure-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/001--account-authorized-depositors-configure-accounts.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.88885487317 XRD
-├─ Network execution: 0.29540385 XRD, 5908077 execution cost units
+TRANSACTION COST: 0.88901742317 XRD
+├─ Network execution: 0.2955664 XRD, 5911328 execution cost units
 ├─ Network finalization: 0.17202235 XRD, 3440447 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.42142867317 XRD
@@ -47,15 +47,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.88885487317"),
+     amount: Decimal("0.88901742317"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.444427436585"),
+     amount: Decimal("0.444508711585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.444427436585"),
+     amount: Decimal("0.444508711585"),
    }
 
 STATE UPDATES: 9 entities
@@ -65,7 +65,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2222137182925"),
+             0u8 => Decimal("0.2222543557925"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -98,7 +98,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.11114512683")),
+         LiquidFungibleResource(Decimal("99999999999999999.11098257683")),
        )
 ├─ account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw across 6 partitions
   ├─ Partition(2): 2 changes
@@ -434,7 +434,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.444427436585")),
+         LiquidFungibleResource(Decimal("0.444508711585")),
        )
 
 OUTPUTS: 7
@@ -452,13 +452,13 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.88885487317
+   Change: -0.88901742317
 ├─ Vault: internal_vault_sim1tqvjs768h738fh68a8k9g3umfruja74v7fepgqn0zks3d0a05gs4s5
    ResAddr: resource_sim1t5jzke2dmva79yatdnv2tzecqavwatcmgylgpur9a5r7nxgfd664lz
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.444427436585
+   Change: 0.444508711585
 
 NEW ENTITIES: 3
 ├─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/002--account-authorized-depositors-attempt-deposit-success.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/002--account-authorized-depositors-attempt-deposit-success.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52560467719 XRD
-├─ Network execution: 0.3526864 XRD, 7053728 execution cost units
+TRANSACTION COST: 0.52601482719 XRD
+├─ Network execution: 0.35309655 XRD, 7061931 execution cost units
 ├─ Network finalization: 0.03625675 XRD, 725135 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13666152719 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52560467719"),
+     amount: Decimal("0.52601482719"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.262802338595"),
+     amount: Decimal("0.263007413595"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.262802338595"),
+     amount: Decimal("0.263007413595"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.35361488759"),
+             0u8 => Decimal("0.35375806259"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.58554044964")),
+         LiquidFungibleResource(Decimal("99999999999989998.58496774964")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -135,7 +135,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.70722977518")),
+         LiquidFungibleResource(Decimal("0.70751612518")),
        )
 
 OUTPUTS: 5
@@ -148,12 +148,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.52560467719
+   Change: -10000.52601482719
 ├─ Vault: internal_vault_sim1trlmc306p05rqg76se06hkhq9wh2mlkv5m2pmx92gvg0ykly7s4lma
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.262802338595
+   Change: 0.263007413595
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(AssertAccessRuleFailed)
 
-TRANSACTION COST: 0.3217417664 XRD
-├─ Network execution: 0.2759654 XRD, 5519308 execution cost units
+TRANSACTION COST: 0.3221519164 XRD
+├─ Network execution: 0.27637555 XRD, 5527511 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0457763664 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.3217417664"),
+     amount: Decimal("0.3221519164"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.1608708832"),
+     amount: Decimal("0.1610759582"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.1608708832"),
+     amount: Decimal("0.1610759582"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.43405032919"),
+             0u8 => Decimal("0.43429604169"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.26379868324")),
+         LiquidFungibleResource(Decimal("99999999999989998.26281583324")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.86810065838")),
+         LiquidFungibleResource(Decimal("0.86859208338")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.3217417664
+   Change: -0.3221519164
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.1608708832
+   Change: 0.1610759582
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(FungibleResourceManagerError(DropNonEmptyBucket))
 
-TRANSACTION COST: 0.3359765164 XRD
-├─ Network execution: 0.29020015 XRD, 5804003 execution cost units
+TRANSACTION COST: 0.3363866664 XRD
+├─ Network execution: 0.2906103 XRD, 5812206 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0457763664 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.3359765164"),
+     amount: Decimal("0.3363866664"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.1679882582"),
+     amount: Decimal("0.1681933332"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.1679882582"),
+     amount: Decimal("0.1681933332"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.51804445829"),
+             0u8 => Decimal("0.51839270829"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.92782216684")),
+         LiquidFungibleResource(Decimal("99999999999989997.92642916684")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.03608891658")),
+         LiquidFungibleResource(Decimal("1.03678541658")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.3359765164
+   Change: -0.3363866664
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.1679882582
+   Change: 0.1681933332
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: account_authorized_depositors
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 19ccbaaaf7817ccd (allowed to change if not deployed to any network)
-Events       : 941b776a1bd50472 (allowed to change if not deployed to any network)
+State changes: 9ca2a9085bf2bef1 (allowed to change if not deployed to any network)
+Events       : 0a22798ef2a11fc4 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - source_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/001--account-locker-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/001--account-locker-create-accounts.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.67025233325,    100.0%
-- Execution Cost (XRD)                                                     ,               0.22265655,     33.2%
+Total Cost (XRD)                                                           ,            0.67041488325,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2228191,     33.2%
 - Finalization Cost (XRD)                                                  ,               0.13526745,     20.2%
 - Storage Cost (XRD)                                                       ,            0.31232833325,     46.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4453131,    100.0%
+Execution Cost Breakdown                                                   ,                  4456382,    100.0%
 - AfterInvoke                                                              ,                     1030,      0.0%
 - AllocateNodeId                                                           ,                     4462,      0.1%
 - BeforeInvoke                                                             ,                     4270,      0.1%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    50023,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  2198522,     49.4%
+- OpenSubstate::GlobalPackage                                              ,                  2198522,     49.3%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    47680,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
@@ -35,7 +35,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                   137355,      3.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1855,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/002--account-locker-create-account-locker.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/002--account-locker-create-account-locker.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.71703632689,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2633991,     36.7%
+Total Cost (XRD)                                                           ,            0.71719887689,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26356165,     36.7%
 - Finalization Cost (XRD)                                                  ,                 0.146268,     20.4%
 - Storage Cost (XRD)                                                       ,            0.30736922689,     42.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5267982,    100.0%
+Execution Cost Breakdown                                                   ,                  5271233,    100.0%
 - AfterInvoke                                                              ,                      840,      0.0%
 - AllocateNodeId                                                           ,                     3007,      0.1%
 - BeforeInvoke                                                             ,                     3836,      0.1%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      824,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/003--account-locker-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/003--account-locker-create-resources.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.70117770564,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1916238,     27.3%
+Total Cost (XRD)                                                           ,            0.70134025564,    100.0%
+- Execution Cost (XRD)                                                     ,               0.19178635,     27.3%
 - Finalization Cost (XRD)                                                  ,               0.19026375,     27.1%
 - Storage Cost (XRD)                                                       ,            0.31929015564,     45.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3832476,    100.0%
+Execution Cost Breakdown                                                   ,                  3835727,    100.0%
 - AfterInvoke                                                              ,                      454,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.1%
 - BeforeInvoke                                                             ,                     2636,      0.1%
@@ -35,7 +35,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                    54942,      1.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1016,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/004--account-locker-setting-up-account-deposit-rules.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/004--account-locker-setting-up-account-deposit-rules.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.42376999385,    100.0%
-- Execution Cost (XRD)                                                     ,               0.23086785,     54.5%
+Total Cost (XRD)                                                           ,            0.42393254385,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2310304,     54.5%
 - Finalization Cost (XRD)                                                  ,               0.03125435,      7.4%
 - Storage Cost (XRD)                                                       ,            0.16164779385,     38.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4617357,    100.0%
+Execution Cost Breakdown                                                   ,                  4620608,    100.0%
 - AfterInvoke                                                              ,                       94,      0.0%
 - AllocateNodeId                                                           ,                      970,      0.0%
 - BeforeInvoke                                                             ,                     1256,      0.0%
@@ -34,7 +34,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::set_default_deposit_rule                                  ,                    59741,      1.3%
 - RunNativeCode::set_resource_preference                                   ,                   132054,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    37560,      0.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.46517753228,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29578765,     63.6%
+Total Cost (XRD)                                                           ,            0.46534008228,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2959502,     63.6%
 - Finalization Cost (XRD)                                                  ,               0.03625695,      7.8%
 - Storage Cost (XRD)                                                       ,            0.13313293228,     28.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5915753,    100.0%
+Execution Cost Breakdown                                                   ,                  5919004,    100.0%
 - AfterInvoke                                                              ,                      568,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3620,      0.1%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                      264,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      6.0%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   541449,      9.2%
+- ReadSubstate                                                             ,                   541449,      9.1%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -47,7 +47,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25440,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.53579939639,    100.0%
-- Execution Cost (XRD)                                                     ,               0.30566605,     57.0%
+Total Cost (XRD)                                                           ,            0.53596194639,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3058286,     57.1%
 - Finalization Cost (XRD)                                                  ,               0.05151015,      9.6%
 - Storage Cost (XRD)                                                       ,            0.17862319639,     33.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6113321,    100.0%
+Execution Cost Breakdown                                                   ,                  6116572,    100.0%
 - AfterInvoke                                                              ,                      682,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     3706,      0.1%
@@ -47,7 +47,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25440,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
@@ -1,14 +1,14 @@
-Total Cost (XRD)                                                           ,            0.50129634194,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.282381,     56.3%
+Total Cost (XRD)                                                           ,            0.50145889194,    100.0%
+- Execution Cost (XRD)                                                     ,               0.28254355,     56.3%
 - Finalization Cost (XRD)                                                  ,                0.0512594,     10.2%
 - Storage Cost (XRD)                                                       ,            0.16765594194,     33.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5647620,    100.0%
+Execution Cost Breakdown                                                   ,                  5650871,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3302,      0.1%
-- CheckReference                                                           ,                   240076,      4.3%
+- CheckReference                                                           ,                   240076,      4.2%
 - CloseSubstate                                                            ,                    46698,      0.8%
 - CreateNode                                                               ,                    19818,      0.4%
 - DropNode                                                                 ,                    32775,      0.6%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
 - OpenSubstate::GlobalAccount                                              ,                   246095,      4.4%
 - OpenSubstate::GlobalAccountLocker                                        ,                   204622,      3.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   341815,      6.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   341815,      6.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      0.7%
 - OpenSubstate::GlobalPackage                                              ,                  2501664,     44.3%
@@ -46,7 +46,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25440,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.61621290122,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.372817,     60.5%
+Total Cost (XRD)                                                           ,            0.61637545122,    100.0%
+- Execution Cost (XRD)                                                     ,               0.37297955,     60.5%
 - Finalization Cost (XRD)                                                  ,                0.0475112,      7.7%
 - Storage Cost (XRD)                                                       ,            0.19588470122,     31.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7456340,    100.0%
+Execution Cost Breakdown                                                   ,                  7459591,    100.0%
 - AfterInvoke                                                              ,                     1066,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.0%
 - BeforeInvoke                                                             ,                     5694,      0.1%
@@ -49,7 +49,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleBucket                                       ,                    59565,      0.8%
 - RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.5%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    31360,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.61542839676,    100.0%
-- Execution Cost (XRD)                                                     ,               0.33076825,     53.7%
+Total Cost (XRD)                                                           ,            0.61559094676,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3309308,     53.8%
 - Finalization Cost (XRD)                                                  ,                0.0622633,     10.1%
 - Storage Cost (XRD)                                                       ,            0.22239684676,     36.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6615365,    100.0%
+Execution Cost Breakdown                                                   ,                  6618616,    100.0%
 - AfterInvoke                                                              ,                      928,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.1%
 - BeforeInvoke                                                             ,                     4654,      0.1%
@@ -48,7 +48,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    73662,      1.1%
 - RunNativeCode::take_FungibleBucket                                       ,                    59565,      0.9%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    31360,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.51112871523,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3255403,     63.7%
+Total Cost (XRD)                                                           ,            0.51129126523,    100.0%
+- Execution Cost (XRD)                                                     ,               0.32570285,     63.7%
 - Finalization Cost (XRD)                                                  ,                0.0462566,      9.0%
 - Storage Cost (XRD)                                                       ,            0.13933181523,     27.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6510806,    100.0%
+Execution Cost Breakdown                                                   ,                  6514057,    100.0%
 - AfterInvoke                                                              ,                      542,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3634,      0.1%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      7.1%
-- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.4%
+- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    67715,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
@@ -49,7 +49,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.51112871523,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3255403,     63.7%
+Total Cost (XRD)                                                           ,            0.51129126523,    100.0%
+- Execution Cost (XRD)                                                     ,               0.32570285,     63.7%
 - Finalization Cost (XRD)                                                  ,                0.0462566,      9.0%
 - Storage Cost (XRD)                                                       ,            0.13933181523,     27.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6510806,    100.0%
+Execution Cost Breakdown                                                   ,                  6514057,    100.0%
 - AfterInvoke                                                              ,                      542,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3634,      0.1%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      7.1%
-- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.4%
+- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    67715,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
@@ -49,7 +49,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.49630855327,    100.0%
-- Execution Cost (XRD)                                                     ,               0.30804945,     62.1%
+Total Cost (XRD)                                                           ,            0.49647110327,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.308212,     62.1%
 - Finalization Cost (XRD)                                                  ,                 0.046257,      9.3%
 - Storage Cost (XRD)                                                       ,            0.14200210327,     28.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6160989,    100.0%
+Execution Cost Breakdown                                                   ,                  6164240,    100.0%
 - AfterInvoke                                                              ,                      534,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3316,      0.1%
@@ -29,7 +29,7 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                      252,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      5.7%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   576095,      9.4%
+- ReadSubstate                                                             ,                   576095,      9.3%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -48,7 +48,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.71662556101,    100.0%
-- Execution Cost (XRD)                                                     ,                0.4191023,     58.5%
+Total Cost (XRD)                                                           ,            0.71678811101,    100.0%
+- Execution Cost (XRD)                                                     ,               0.41926485,     58.5%
 - Finalization Cost (XRD)                                                  ,                0.0775106,     10.8%
 - Storage Cost (XRD)                                                       ,            0.22001266101,     30.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8382046,    100.0%
+Execution Cost Breakdown                                                   ,                  8385297,    100.0%
 - AfterInvoke                                                              ,                      962,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.0%
 - BeforeInvoke                                                             ,                     5852,      0.1%
@@ -51,7 +51,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_NonFungibleBucket                                    ,                    67842,      0.8%
 - RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.2%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      453,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.66653331381,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3730744,     56.0%
+Total Cost (XRD)                                                           ,            0.66669586381,    100.0%
+- Execution Cost (XRD)                                                     ,               0.37323695,     56.0%
 - Finalization Cost (XRD)                                                  ,               0.07726095,     11.6%
 - Storage Cost (XRD)                                                       ,            0.21619796381,     32.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7461488,    100.0%
+Execution Cost Breakdown                                                   ,                  7464739,    100.0%
 - AfterInvoke                                                              ,                      850,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.0%
 - BeforeInvoke                                                             ,                     4780,      0.1%
@@ -50,7 +50,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                   106062,      1.4%
 - RunNativeCode::take_NonFungibleBucket                                    ,                    67842,      0.9%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      453,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.65617344779,    100.0%
-- Execution Cost (XRD)                                                     ,                0.4121994,     62.8%
-- Finalization Cost (XRD)                                                  ,                0.0672582,     10.3%
+Total Cost (XRD)                                                           ,            0.65633599779,    100.0%
+- Execution Cost (XRD)                                                     ,               0.41236195,     62.8%
+- Finalization Cost (XRD)                                                  ,                0.0672582,     10.2%
 - Storage Cost (XRD)                                                       ,            0.17671584779,     26.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8243988,    100.0%
+Execution Cost Breakdown                                                   ,                  8247239,    100.0%
 - AfterInvoke                                                              ,                      898,      0.0%
 - AllocateNodeId                                                           ,                     3492,      0.0%
 - BeforeInvoke                                                             ,                     5678,      0.1%
@@ -16,7 +16,7 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   944038,     11.5%
+- OpenSubstate::GlobalAccount                                              ,                   944038,     11.4%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.5%
@@ -50,7 +50,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_non_fungibles_NonFungibleBucket                      ,                    69156,      0.8%
 - RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.2%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      453,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.60608120059,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3661715,     60.4%
+Total Cost (XRD)                                                           ,            0.60624375059,    100.0%
+- Execution Cost (XRD)                                                     ,               0.36633405,     60.4%
 - Finalization Cost (XRD)                                                  ,               0.06700855,     11.1%
 - Storage Cost (XRD)                                                       ,            0.17290115059,     28.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7323430,    100.0%
+Execution Cost Breakdown                                                   ,                  7326681,    100.0%
 - AfterInvoke                                                              ,                      786,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     4606,      0.1%
@@ -49,7 +49,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                   106062,      1.4%
 - RunNativeCode::take_non_fungibles_NonFungibleBucket                      ,                    69156,      0.9%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      453,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.46517753228,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29578765,     63.6%
+Total Cost (XRD)                                                           ,            0.46534008228,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2959502,     63.6%
 - Finalization Cost (XRD)                                                  ,               0.03625695,      7.8%
 - Storage Cost (XRD)                                                       ,            0.13313293228,     28.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5915753,    100.0%
+Execution Cost Breakdown                                                   ,                  5919004,    100.0%
 - AfterInvoke                                                              ,                      568,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3620,      0.1%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                      264,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      6.0%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   541449,      9.2%
+- ReadSubstate                                                             ,                   541449,      9.1%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -47,7 +47,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25440,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/018--account-locker-claim-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/018--account-locker-claim-fungibles-by-amount.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.43425317401,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26856355,     61.8%
+Total Cost (XRD)                                                           ,            0.43441572401,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2687261,     61.9%
 - Finalization Cost (XRD)                                                  ,               0.03150765,      7.3%
 - Storage Cost (XRD)                                                       ,            0.13418197401,     30.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5371271,    100.0%
+Execution Cost Breakdown                                                   ,                  5374522,    100.0%
 - AfterInvoke                                                              ,                      676,      0.0%
 - AllocateNodeId                                                           ,                     1940,      0.0%
 - BeforeInvoke                                                             ,                     2138,      0.0%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    20840,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/019--account-locker-claim-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/019--account-locker-claim-non-fungibles-by-amount.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.39575012313,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26998645,     68.2%
+Total Cost (XRD)                                                           ,            0.39591267313,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.270149,     68.2%
 - Finalization Cost (XRD)                                                  ,               0.03125455,      7.9%
 - Storage Cost (XRD)                                                       ,            0.09450912313,     23.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5399729,    100.0%
+Execution Cost Breakdown                                                   ,                  5402980,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     2100,      0.0%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalKeyValueStore                                      ,                   161799,      3.0%
 - OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      3.2%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.6%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     3000,      0.1%
 - ReadSubstate                                                             ,                   523280,      9.7%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::claim_account_locker                                      ,                    69736,      1.3%
-- RunNativeCode::deposit_batch                                             ,                   110731,      2.1%
+- RunNativeCode::deposit_batch                                             ,                   110731,      2.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.4%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/020--account-locker-claim-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/020--account-locker-claim-non-fungibles-by-ids.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.39407684056,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2682178,     68.1%
+Total Cost (XRD)                                                           ,            0.39423939056,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26838035,     68.1%
 - Finalization Cost (XRD)                                                  ,               0.03125455,      7.9%
 - Storage Cost (XRD)                                                       ,            0.09460449056,     24.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5364356,    100.0%
+Execution Cost Breakdown                                                   ,                  5367607,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     2104,      0.0%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.4%
-- OpenSubstate::GlobalPackage                                              ,                  2577705,     48.1%
+- OpenSubstate::GlobalPackage                                              ,                  2577705,     48.0%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    59380,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                   161799,      3.0%
@@ -29,7 +29,7 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                      216,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      6.6%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   523280,      9.8%
+- ReadSubstate                                                             ,                   523280,      9.7%
 - RemoveSubstate                                                           ,                    40717,      0.8%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/021--account-locker-recover-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/021--account-locker-recover-fungibles-by-amount.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.43348299717,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29097445,     67.1%
+Total Cost (XRD)                                                           ,            0.43364554717,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.291137,     67.1%
 - Finalization Cost (XRD)                                                  ,               0.02625565,      6.1%
 - Storage Cost (XRD)                                                       ,            0.11625289717,     26.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5819489,    100.0%
+Execution Cost Breakdown                                                   ,                  5822740,    100.0%
 - AfterInvoke                                                              ,                      616,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3426,      0.1%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   291970,      5.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41352,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2371668,     40.8%
+- OpenSubstate::GlobalPackage                                              ,                  2371668,     40.7%
 - OpenSubstate::InternalFungibleVault                                      ,                   349614,      6.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    75830,      1.3%
 - OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.8%
@@ -46,7 +46,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::recover_account_locker                                    ,                    56273,      1.0%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    29840,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/022--account-locker-recover-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/022--account-locker-recover-non-fungibles-by-amount.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.45502652974,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.302614,     66.5%
+Total Cost (XRD)                                                           ,            0.45518907974,    100.0%
+- Execution Cost (XRD)                                                     ,               0.30277655,     66.5%
 - Finalization Cost (XRD)                                                  ,                 0.036255,      8.0%
 - Storage Cost (XRD)                                                       ,            0.11615752974,     25.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6052280,    100.0%
+Execution Cost Breakdown                                                   ,                  6055531,    100.0%
 - AfterInvoke                                                              ,                      564,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3490,      0.1%
@@ -49,7 +49,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::recover_account_locker                                    ,                    56273,      0.9%
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.1%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/023--account-locker-recover-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/023--account-locker-recover-non-fungibles-by-ids.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.52402928291,    100.0%
-- Execution Cost (XRD)                                                     ,               0.32140535,     61.3%
+Total Cost (XRD)                                                           ,            0.52419183291,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3215679,     61.3%
 - Finalization Cost (XRD)                                                  ,               0.04650745,      8.9%
 - Storage Cost (XRD)                                                       ,            0.15611648291,     29.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6428107,    100.0%
+Execution Cost Breakdown                                                   ,                  6431358,    100.0%
 - AfterInvoke                                                              ,                      628,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
 - BeforeInvoke                                                             ,                     3596,      0.1%
@@ -50,7 +50,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::recover_non_fungibles_account_locker                      ,                    64973,      1.0%
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.0%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/001--account-locker-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/001--account-locker-create-accounts.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.67025233325 XRD
-├─ Network execution: 0.22265655 XRD, 4453131 execution cost units
+TRANSACTION COST: 0.67041488325 XRD
+├─ Network execution: 0.2228191 XRD, 4456382 execution cost units
 ├─ Network finalization: 0.13526745 XRD, 2705349 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31232833325 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.67025233325"),
+     amount: Decimal("0.67041488325"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.335126166625"),
+     amount: Decimal("0.335207441625"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.335126166625"),
+     amount: Decimal("0.335207441625"),
    }
 
 STATE UPDATES: 10 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.1675630833125"),
+             0u8 => Decimal("0.1676037208125"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.32974766675")),
+         LiquidFungibleResource(Decimal("99999999999999999.32958511675")),
        )
 ├─ account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh across 5 partitions
   ├─ Partition(2): 1 change
@@ -418,7 +418,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.335126166625")),
+         LiquidFungibleResource(Decimal("0.335207441625")),
        )
 
 OUTPUTS: 6
@@ -432,10 +432,10 @@ OUTPUTS: 6
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.67025233325
+   Change: -0.67041488325
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.335126166625
+   Change: 0.335207441625
 
 NEW ENTITIES: 5
 ├─ Component: account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/002--account-locker-create-account-locker.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/002--account-locker-create-account-locker.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.71703632689 XRD
-├─ Network execution: 0.2633991 XRD, 5267982 execution cost units
+TRANSACTION COST: 0.71719887689 XRD
+├─ Network execution: 0.26356165 XRD, 5271233 execution cost units
 ├─ Network finalization: 0.146268 XRD, 2925360 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.30736922689 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.71703632689"),
+     amount: Decimal("0.71719887689"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.358518163445"),
+     amount: Decimal("0.358599438445"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.358518163445"),
+     amount: Decimal("0.358599438445"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.346822165035"),
+             0u8 => Decimal("0.346903440035"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.61271133986")),
+         LiquidFungibleResource(Decimal("99999999999999998.61238623986")),
        )
 ├─ locker_sim1dp8g5xtahznlr27t3jagtplg24d5sfqr2r799h3qfl3jpmdxu7wlr3 across 4 partitions
   ├─ Partition(2): 1 change
@@ -350,7 +350,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.69364433007")),
+         LiquidFungibleResource(Decimal("0.69380688007")),
        )
 
 OUTPUTS: 3
@@ -364,13 +364,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.71703632689
+   Change: -0.71719887689
 ├─ Vault: internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f
    ResAddr: resource_sim1tkgvw0yvyt0vpyzrlkw38rplh5pmgny372rcpxp3973df6yfwqttyw
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.358518163445
+   Change: 0.358599438445
 
 NEW ENTITIES: 2
 └─ Component: locker_sim1dp8g5xtahznlr27t3jagtplg24d5sfqr2r799h3qfl3jpmdxu7wlr3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/003--account-locker-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/003--account-locker-create-resources.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.70117770564 XRD
-├─ Network execution: 0.1916238 XRD, 3832476 execution cost units
+TRANSACTION COST: 0.70134025564 XRD
+├─ Network execution: 0.19178635 XRD, 3835727 execution cost units
 ├─ Network finalization: 0.19026375 XRD, 3805275 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31929015564 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.70117770564"),
+     amount: Decimal("0.70134025564"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.35058885282"),
+     amount: Decimal("0.35067012782"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.35058885282"),
+     amount: Decimal("0.35067012782"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.522116591445"),
+             0u8 => Decimal("0.522238503945"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.91153363422")),
+         LiquidFungibleResource(Decimal("99999999999999997.91104598422")),
        )
 ├─ resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk across 4 partitions
   ├─ Partition(5): 1 change
@@ -322,7 +322,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.04423318289")),
+         LiquidFungibleResource(Decimal("1.04447700789")),
        )
 
 OUTPUTS: 3
@@ -333,10 +333,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.70117770564
+   Change: -0.70134025564
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.35058885282
+   Change: 0.35067012782
 
 NEW ENTITIES: 2
 ├─ Resource: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/004--account-locker-setting-up-account-deposit-rules.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/004--account-locker-setting-up-account-deposit-rules.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.42376999385 XRD
-├─ Network execution: 0.23086785 XRD, 4617357 execution cost units
+TRANSACTION COST: 0.42393254385 XRD
+├─ Network execution: 0.2310304 XRD, 4620608 execution cost units
 ├─ Network finalization: 0.03125435 XRD, 625087 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.16164779385 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.42376999385"),
+     amount: Decimal("0.42393254385"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.211884996925"),
+     amount: Decimal("0.211966271925"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.211884996925"),
+     amount: Decimal("0.211966271925"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6280590899075"),
+             0u8 => Decimal("0.6282216399075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -115,13 +115,13 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.48776364037")),
+         LiquidFungibleResource(Decimal("99999999999999997.48711344037")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.256118179815")),
+         LiquidFungibleResource(Decimal("1.256443279815")),
        )
 
 OUTPUTS: 5
@@ -134,9 +134,9 @@ OUTPUTS: 5
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.42376999385
+   Change: -0.42393254385
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.211884996925
+   Change: 0.211966271925
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46517753228 XRD
-├─ Network execution: 0.29578765 XRD, 5915753 execution cost units
+TRANSACTION COST: 0.46534008228 XRD
+├─ Network execution: 0.2959502 XRD, 5919004 execution cost units
 ├─ Network finalization: 0.03625695 XRD, 725139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13313293228 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46517753228"),
+     amount: Decimal("0.46534008228"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.23258876614"),
+     amount: Decimal("0.23267004114"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.23258876614"),
+     amount: Decimal("0.23267004114"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.7443534729775"),
+             0u8 => Decimal("0.7445566604775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.02258610809")),
+         LiquidFungibleResource(Decimal("99999999999999997.02177335809")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -137,7 +137,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.488706945955")),
+         LiquidFungibleResource(Decimal("1.489113320955")),
        )
 
 OUTPUTS: 5
@@ -150,12 +150,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46517753228
+   Change: -0.46534008228
 ├─ Vault: internal_vault_sim1tq9fel5e3slzv27grm0ym4qpe3c4934d7qttkahkayyngt75577yp4
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.23258876614
+   Change: 0.23267004114
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.53579939639 XRD
-├─ Network execution: 0.30566605 XRD, 6113321 execution cost units
+TRANSACTION COST: 0.53596194639 XRD
+├─ Network execution: 0.3058286 XRD, 6116572 execution cost units
 ├─ Network finalization: 0.05151015 XRD, 1030203 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17862319639 XRD
@@ -41,15 +41,15 @@ EVENTS: 9
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.53579939639"),
+     amount: Decimal("0.53596194639"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.267899698195"),
+     amount: Decimal("0.267980973195"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.267899698195"),
+     amount: Decimal("0.267980973195"),
    }
 
 STATE UPDATES: 10 entities
@@ -59,7 +59,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.878303322075"),
+             0u8 => Decimal("0.878547147075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -104,7 +104,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.4867867117")),
+         LiquidFungibleResource(Decimal("99999999999999996.4858114117")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -190,7 +190,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.75660664415")),
+         LiquidFungibleResource(Decimal("1.75709429415")),
        )
 
 OUTPUTS: 5
@@ -203,12 +203,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.53579939639
+   Change: -0.53596194639
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.267899698195
+   Change: 0.267980973195
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.50129634194 XRD
-├─ Network execution: 0.282381 XRD, 5647620 execution cost units
+TRANSACTION COST: 0.50145889194 XRD
+├─ Network execution: 0.28254355 XRD, 5650871 execution cost units
 ├─ Network finalization: 0.0512594 XRD, 1025188 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.16765594194 XRD
@@ -36,15 +36,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.50129634194"),
+     amount: Decimal("0.50145889194"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.25064817097"),
+     amount: Decimal("0.25072944597"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.25064817097"),
+     amount: Decimal("0.25072944597"),
    }
 
 STATE UPDATES: 10 entities
@@ -54,7 +54,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.00362740756"),
+             0u8 => Decimal("1.00391187006"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -99,7 +99,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.98549036976")),
+         LiquidFungibleResource(Decimal("99999999999999995.98435251976")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -185,7 +185,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.00725481512")),
+         LiquidFungibleResource(Decimal("2.00782374012")),
        )
 
 OUTPUTS: 5
@@ -198,12 +198,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.50129634194
+   Change: -0.50145889194
 ├─ Vault: internal_vault_sim1tpgwdt3l9whdtw6e7m73xfnp8z34nj5atqh78rqtx7trdpvtl0k7z6
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.25064817097
+   Change: 0.25072944597
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.61621290122 XRD
-├─ Network execution: 0.372817 XRD, 7456340 execution cost units
+TRANSACTION COST: 0.61637545122 XRD
+├─ Network execution: 0.37297955 XRD, 7459591 execution cost units
 ├─ Network finalization: 0.0475112 XRD, 950224 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19588470122 XRD
@@ -59,15 +59,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.61621290122"),
+     amount: Decimal("0.61637545122"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.30810645061"),
+     amount: Decimal("0.30818772561"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.30810645061"),
+     amount: Decimal("0.30818772561"),
    }
 
 STATE UPDATES: 11 entities
@@ -77,7 +77,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.157680632865"),
+             0u8 => Decimal("1.158005732865"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -122,7 +122,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.36927746854")),
+         LiquidFungibleResource(Decimal("99999999999999995.36797706854")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -175,7 +175,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.31536126573")),
+         LiquidFungibleResource(Decimal("2.31601146573")),
        )
 
 OUTPUTS: 5
@@ -188,7 +188,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.61621290122
+   Change: -0.61637545122
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
@@ -200,6 +200,6 @@ BALANCE CHANGES: 5
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.30810645061
+   Change: 0.30818772561
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.61542839676 XRD
-├─ Network execution: 0.33076825 XRD, 6615365 execution cost units
+TRANSACTION COST: 0.61559094676 XRD
+├─ Network execution: 0.3309308 XRD, 6618616 execution cost units
 ├─ Network finalization: 0.0622633 XRD, 1245266 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.22239684676 XRD
@@ -60,15 +60,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.61542839676"),
+     amount: Decimal("0.61559094676"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.30771419838"),
+     amount: Decimal("0.30779547338"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.30771419838"),
+     amount: Decimal("0.30779547338"),
    }
 
 STATE UPDATES: 12 entities
@@ -78,7 +78,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.311537732055"),
+             0u8 => Decimal("1.311903469555"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -123,7 +123,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.75384907178")),
+         LiquidFungibleResource(Decimal("99999999999999994.75238612178")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -221,7 +221,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.62307546411")),
+         LiquidFungibleResource(Decimal("2.62380693911")),
        )
 
 OUTPUTS: 5
@@ -234,7 +234,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.61542839676
+   Change: -0.61559094676
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
@@ -246,6 +246,6 @@ BALANCE CHANGES: 5
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.30771419838
+   Change: 0.30779547338
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.51112871523 XRD
-├─ Network execution: 0.3255403 XRD, 6510806 execution cost units
+TRANSACTION COST: 0.51129126523 XRD
+├─ Network execution: 0.32570285 XRD, 6514057 execution cost units
 ├─ Network finalization: 0.0462566 XRD, 925132 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13933181523 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.51112871523"),
+     amount: Decimal("0.51129126523"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.255564357615"),
+     amount: Decimal("0.255645632615"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.255564357615"),
+     amount: Decimal("0.255645632615"),
    }
 
 STATE UPDATES: 9 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.4393199108625"),
+             0u8 => Decimal("1.4397262858625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.24272035655")),
+         LiquidFungibleResource(Decimal("99999999999999994.24109485655")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -151,7 +151,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.878639821725")),
+         LiquidFungibleResource(Decimal("2.879452571725")),
        )
 
 OUTPUTS: 5
@@ -164,12 +164,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.51112871523
+   Change: -0.51129126523
 ├─ Vault: internal_vault_sim1nz49q5dgwxz5dg2spgwd2vqsfawzywahlw5ztxwpcyjl4p8le2crd6
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.255564357615
+   Change: 0.255645632615
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.51112871523 XRD
-├─ Network execution: 0.3255403 XRD, 6510806 execution cost units
+TRANSACTION COST: 0.51129126523 XRD
+├─ Network execution: 0.32570285 XRD, 6514057 execution cost units
 ├─ Network finalization: 0.0462566 XRD, 925132 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13933181523 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.51112871523"),
+     amount: Decimal("0.51129126523"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.255564357615"),
+     amount: Decimal("0.255645632615"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.255564357615"),
+     amount: Decimal("0.255645632615"),
    }
 
 STATE UPDATES: 9 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.56710208967"),
+             0u8 => Decimal("1.56754910217"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.73159164132")),
+         LiquidFungibleResource(Decimal("99999999999999993.72980359132")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -151,7 +151,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.13420417934")),
+         LiquidFungibleResource(Decimal("3.13509820434")),
        )
 
 OUTPUTS: 5
@@ -164,12 +164,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.51112871523
+   Change: -0.51129126523
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#2#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.255564357615
+   Change: 0.255645632615
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.49630855327 XRD
-├─ Network execution: 0.30804945 XRD, 6160989 execution cost units
+TRANSACTION COST: 0.49647110327 XRD
+├─ Network execution: 0.308212 XRD, 6164240 execution cost units
 ├─ Network finalization: 0.046257 XRD, 925140 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14200210327 XRD
@@ -42,15 +42,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.49630855327"),
+     amount: Decimal("0.49647110327"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.248154276635"),
+     amount: Decimal("0.248235551635"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.248154276635"),
+     amount: Decimal("0.248235551635"),
    }
 
 STATE UPDATES: 9 entities
@@ -60,7 +60,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.6911792279875"),
+             0u8 => Decimal("1.6916668779875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -102,7 +102,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.23528308805")),
+         LiquidFungibleResource(Decimal("99999999999999993.23333248805")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -152,7 +152,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.382358455975")),
+         LiquidFungibleResource(Decimal("3.383333755975")),
        )
 
 OUTPUTS: 5
@@ -165,12 +165,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.49630855327
+   Change: -0.49647110327
 ├─ Vault: internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.248154276635
+   Change: 0.248235551635
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.71662556101 XRD
-├─ Network execution: 0.4191023 XRD, 8382046 execution cost units
+TRANSACTION COST: 0.71678811101 XRD
+├─ Network execution: 0.41926485 XRD, 8385297 execution cost units
 ├─ Network finalization: 0.0775106 XRD, 1550212 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.22001266101 XRD
@@ -77,15 +77,15 @@ EVENTS: 13
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.71662556101"),
+     amount: Decimal("0.71678811101"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.358312780505"),
+     amount: Decimal("0.358394055505"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.358312780505"),
+     amount: Decimal("0.358394055505"),
    }
 
 STATE UPDATES: 11 entities
@@ -95,7 +95,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.87033561824"),
+             0u8 => Decimal("1.87086390574"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -141,7 +141,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.51865752704")),
+         LiquidFungibleResource(Decimal("99999999999999992.51654437704")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -213,7 +213,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.74067123648")),
+         LiquidFungibleResource(Decimal("3.74172781148")),
        )
 
 OUTPUTS: 5
@@ -226,7 +226,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.71662556101
+   Change: -0.71678811101
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#4#}, -{}
@@ -238,6 +238,6 @@ BALANCE CHANGES: 5
    Change: +{#5#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.358312780505
+   Change: 0.358394055505
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.66653331381 XRD
-├─ Network execution: 0.3730744 XRD, 7461488 execution cost units
+TRANSACTION COST: 0.66669586381 XRD
+├─ Network execution: 0.37323695 XRD, 7464739 execution cost units
 ├─ Network finalization: 0.07726095 XRD, 1545219 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.21619796381 XRD
@@ -76,15 +76,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.66653331381"),
+     amount: Decimal("0.66669586381"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.333266656905"),
+     amount: Decimal("0.333347931905"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.333266656905"),
+     amount: Decimal("0.333347931905"),
    }
 
 STATE UPDATES: 11 entities
@@ -94,7 +94,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.0369689466925"),
+             0u8 => Decimal("2.0375378716925"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -140,7 +140,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.85212421323")),
+         LiquidFungibleResource(Decimal("99999999999999991.84984851323")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -212,7 +212,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.073937893385")),
+         LiquidFungibleResource(Decimal("4.075075743385")),
        )
 
 OUTPUTS: 5
@@ -225,7 +225,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.66653331381
+   Change: -0.66669586381
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#7#}, -{}
@@ -237,6 +237,6 @@ BALANCE CHANGES: 5
    Change: +{#8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.333266656905
+   Change: 0.333347931905
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.65617344779 XRD
-├─ Network execution: 0.4121994 XRD, 8243988 execution cost units
+TRANSACTION COST: 0.65633599779 XRD
+├─ Network execution: 0.41236195 XRD, 8247239 execution cost units
 ├─ Network finalization: 0.0672582 XRD, 1345164 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17671584779 XRD
@@ -73,15 +73,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.65617344779"),
+     amount: Decimal("0.65633599779"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.328086723895"),
+     amount: Decimal("0.328167998895"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.328086723895"),
+     amount: Decimal("0.328167998895"),
    }
 
 STATE UPDATES: 10 entities
@@ -91,7 +91,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.20101230864"),
+             0u8 => Decimal("2.20162187114"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -137,7 +137,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.19595076544")),
+         LiquidFungibleResource(Decimal("99999999999999991.19351251544")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -182,7 +182,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.40202461728")),
+         LiquidFungibleResource(Decimal("4.40324374228")),
        )
 
 OUTPUTS: 5
@@ -195,7 +195,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.65617344779
+   Change: -0.65633599779
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#10#}, -{}
@@ -207,6 +207,6 @@ BALANCE CHANGES: 5
    Change: +{#12#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.328086723895
+   Change: 0.328167998895
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.60608120059 XRD
-├─ Network execution: 0.3661715 XRD, 7323430 execution cost units
+TRANSACTION COST: 0.60624375059 XRD
+├─ Network execution: 0.36633405 XRD, 7326681 execution cost units
 ├─ Network finalization: 0.06700855 XRD, 1340171 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17290115059 XRD
@@ -72,15 +72,15 @@ EVENTS: 11
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.60608120059"),
+     amount: Decimal("0.60624375059"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.303040600295"),
+     amount: Decimal("0.303121875295"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.303040600295"),
+     amount: Decimal("0.303121875295"),
    }
 
 STATE UPDATES: 10 entities
@@ -90,7 +90,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.3525326087875"),
+             0u8 => Decimal("2.3531828087875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -136,7 +136,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999990.58986956485")),
+         LiquidFungibleResource(Decimal("99999999999999990.58726876485")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -181,7 +181,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.705065217575")),
+         LiquidFungibleResource(Decimal("4.706365617575")),
        )
 
 OUTPUTS: 5
@@ -194,7 +194,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.60608120059
+   Change: -0.60624375059
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#13#}, -{}
@@ -206,6 +206,6 @@ BALANCE CHANGES: 5
    Change: +{#15#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.303040600295
+   Change: 0.303121875295
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46517753228 XRD
-├─ Network execution: 0.29578765 XRD, 5915753 execution cost units
+TRANSACTION COST: 0.46534008228 XRD
+├─ Network execution: 0.2959502 XRD, 5919004 execution cost units
 ├─ Network finalization: 0.03625695 XRD, 725139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13313293228 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46517753228"),
+     amount: Decimal("0.46534008228"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.23258876614"),
+     amount: Decimal("0.23267004114"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.23258876614"),
+     amount: Decimal("0.23267004114"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.4688269918575"),
+             0u8 => Decimal("2.4695178293575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999990.12469203257")),
+         LiquidFungibleResource(Decimal("99999999999999990.12192868257")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -137,7 +137,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.937653983715")),
+         LiquidFungibleResource(Decimal("4.939035658715")),
        )
 
 OUTPUTS: 5
@@ -150,12 +150,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46517753228
+   Change: -0.46534008228
 ├─ Vault: internal_vault_sim1tpqxdp75lc02x9w24dud57q22t9nu3e4g3cav9zzhestx7fcs3u4gg
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.23258876614
+   Change: 0.23267004114
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/018--account-locker-claim-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/018--account-locker-claim-fungibles-by-amount.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43425317401 XRD
-├─ Network execution: 0.26856355 XRD, 5371271 execution cost units
+TRANSACTION COST: 0.43441572401 XRD
+├─ Network execution: 0.2687261 XRD, 5374522 execution cost units
 ├─ Network finalization: 0.03150765 XRD, 630153 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13418197401 XRD
@@ -41,15 +41,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43425317401"),
+     amount: Decimal("0.43441572401"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.217126587005"),
+     amount: Decimal("0.217207862005"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.217126587005"),
+     amount: Decimal("0.217207862005"),
    }
 
 STATE UPDATES: 8 entities
@@ -59,7 +59,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.57739028536"),
+             0u8 => Decimal("2.57812176036"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -98,7 +98,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.69043885856")),
+         LiquidFungibleResource(Decimal("99999999999999989.68751295856")),
        )
 ├─ internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx across 1 partitions
   └─ Partition(64): 1 change
@@ -139,7 +139,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.15478057072")),
+         LiquidFungibleResource(Decimal("5.15624352072")),
        )
 
 OUTPUTS: 3
@@ -150,7 +150,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.43425317401
+   Change: -0.43441572401
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: -1
@@ -159,6 +159,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.217126587005
+   Change: 0.217207862005
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/019--account-locker-claim-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/019--account-locker-claim-non-fungibles-by-amount.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39575012313 XRD
-├─ Network execution: 0.26998645 XRD, 5399729 execution cost units
+TRANSACTION COST: 0.39591267313 XRD
+├─ Network execution: 0.270149 XRD, 5402980 execution cost units
 ├─ Network finalization: 0.03125455 XRD, 625091 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09450912313 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39575012313"),
+     amount: Decimal("0.39591267313"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.197875061565"),
+     amount: Decimal("0.197956336565"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.197875061565"),
+     amount: Decimal("0.197956336565"),
    }
 
 STATE UPDATES: 7 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.6763278161425"),
+             0u8 => Decimal("2.6770999286425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.29468873543")),
+         LiquidFungibleResource(Decimal("99999999999999989.29160028543")),
        )
 ├─ internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9 across 2 partitions
   ├─ Partition(64): 1 change
@@ -121,7 +121,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.352655632285")),
+         LiquidFungibleResource(Decimal("5.354199857285")),
        )
 
 OUTPUTS: 3
@@ -132,7 +132,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39575012313
+   Change: -0.39591267313
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#13#}
@@ -141,6 +141,6 @@ BALANCE CHANGES: 4
    Change: +{#13#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.197875061565
+   Change: 0.197956336565
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/020--account-locker-claim-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/020--account-locker-claim-non-fungibles-by-ids.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39407684056 XRD
-├─ Network execution: 0.2682178 XRD, 5364356 execution cost units
+TRANSACTION COST: 0.39423939056 XRD
+├─ Network execution: 0.26838035 XRD, 5367607 execution cost units
 ├─ Network finalization: 0.03125455 XRD, 625091 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09460449056 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39407684056"),
+     amount: Decimal("0.39423939056"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.19703842028"),
+     amount: Decimal("0.19711969528"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.19703842028"),
+     amount: Decimal("0.19711969528"),
    }
 
 STATE UPDATES: 7 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.7748470262825"),
+             0u8 => Decimal("2.7756597762825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.90061189487")),
+         LiquidFungibleResource(Decimal("99999999999999988.89736089487")),
        )
 ├─ internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405 across 2 partitions
   ├─ Partition(64): 1 change
@@ -121,7 +121,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.549694052565")),
+         LiquidFungibleResource(Decimal("5.551319552565")),
        )
 
 OUTPUTS: 3
@@ -132,7 +132,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39407684056
+   Change: -0.39423939056
 ├─ Vault: internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#3#}
@@ -141,6 +141,6 @@ BALANCE CHANGES: 4
    Change: +{#3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.19703842028
+   Change: 0.19711969528
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/021--account-locker-recover-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/021--account-locker-recover-fungibles-by-amount.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43348299717 XRD
-├─ Network execution: 0.29097445 XRD, 5819489 execution cost units
+TRANSACTION COST: 0.43364554717 XRD
+├─ Network execution: 0.291137 XRD, 5822740 execution cost units
 ├─ Network finalization: 0.02625565 XRD, 525113 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11625289717 XRD
@@ -37,15 +37,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43348299717"),
+     amount: Decimal("0.43364554717"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.216741498585"),
+     amount: Decimal("0.216822773585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.216741498585"),
+     amount: Decimal("0.216822773585"),
    }
 
 STATE UPDATES: 8 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.883217775575"),
+             0u8 => Decimal("2.884071163075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.4671288977")),
+         LiquidFungibleResource(Decimal("99999999999999988.4637153477")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -112,7 +112,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.76643555115")),
+         LiquidFungibleResource(Decimal("5.76814232615")),
        )
 
 OUTPUTS: 4
@@ -124,7 +124,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.43348299717
+   Change: -0.43364554717
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: -1
@@ -133,6 +133,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.216741498585
+   Change: 0.216822773585
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/022--account-locker-recover-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/022--account-locker-recover-non-fungibles-by-amount.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.45502652974 XRD
-├─ Network execution: 0.302614 XRD, 6052280 execution cost units
+TRANSACTION COST: 0.45518907974 XRD
+├─ Network execution: 0.30277655 XRD, 6055531 execution cost units
 ├─ Network finalization: 0.036255 XRD, 725100 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11615752974 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.45502652974"),
+     amount: Decimal("0.45518907974"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.22751326487"),
+     amount: Decimal("0.22759453987"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.22751326487"),
+     amount: Decimal("0.22759453987"),
    }
 
 STATE UPDATES: 8 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.99697440801"),
+             0u8 => Decimal("2.99786843301"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.01210236796")),
+         LiquidFungibleResource(Decimal("99999999999999988.00852626796")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -127,7 +127,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.99394881602")),
+         LiquidFungibleResource(Decimal("5.99573686602")),
        )
 
 OUTPUTS: 4
@@ -139,7 +139,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.45502652974
+   Change: -0.45518907974
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#7#}
@@ -148,6 +148,6 @@ BALANCE CHANGES: 4
    Change: +{#7#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.22751326487
+   Change: 0.22759453987
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/023--account-locker-recover-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/023--account-locker-recover-non-fungibles-by-ids.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52402928291 XRD
-├─ Network execution: 0.32140535 XRD, 6428107 execution cost units
+TRANSACTION COST: 0.52419183291 XRD
+├─ Network execution: 0.3215679 XRD, 6431358 execution cost units
 ├─ Network finalization: 0.04650745 XRD, 930149 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.15611648291 XRD
@@ -49,15 +49,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52402928291"),
+     amount: Decimal("0.52419183291"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.262014641455"),
+     amount: Decimal("0.262095916455"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.262014641455"),
+     amount: Decimal("0.262095916455"),
    }
 
 STATE UPDATES: 9 entities
@@ -67,7 +67,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("3.1279817287375"),
+             0u8 => Decimal("3.1289163912375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -106,7 +106,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999987.48807308505")),
+         LiquidFungibleResource(Decimal("99999999999999987.48433443505")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -160,7 +160,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("6.255963457475")),
+         LiquidFungibleResource(Decimal("6.257832782475")),
        )
 
 OUTPUTS: 4
@@ -172,7 +172,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.52402928291
+   Change: -0.52419183291
 ├─ Vault: internal_vault_sim1nrxkgnug32kd87wny27junyc3s9dey2a7ulpylsz9tz3gjql8cwcjf
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#15#}
@@ -181,6 +181,6 @@ BALANCE CHANGES: 4
    Change: +{#15#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.262014641455
+   Change: 0.262095916455
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: account_locker
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 8ca0a4503efd9644 (allowed to change if not deployed to any network)
-Events       : 02c2fb5be437a178 (allowed to change if not deployed to any network)
+State changes: 785bf373e6fcc24a (allowed to change if not deployed to any network)
+Events       : 2ef2b3e2e73a100b (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - badge_holder_account: account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/001--create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/001--create-accounts.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.66101676762,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3380931,     51.1%
+Total Cost (XRD)                                                           ,            0.66142691762,    100.0%
+- Execution Cost (XRD)                                                     ,               0.33850325,     51.2%
 - Finalization Cost (XRD)                                                  ,                0.0812626,     12.3%
-- Storage Cost (XRD)                                                       ,            0.24166106762,     36.6%
+- Storage Cost (XRD)                                                       ,            0.24166106762,     36.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6761862,    100.0%
+Execution Cost Breakdown                                                   ,                  6770065,    100.0%
 - AfterInvoke                                                              ,                      904,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.1%
 - BeforeInvoke                                                             ,                     3326,      0.0%
@@ -45,8 +45,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      742,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/001--create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/001--create-accounts.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.66101676762 XRD
-├─ Network execution: 0.3380931 XRD, 6761862 execution cost units
+TRANSACTION COST: 0.66142691762 XRD
+├─ Network execution: 0.33850325 XRD, 6770065 execution cost units
 ├─ Network finalization: 0.0812626 XRD, 1625252 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.24166106762 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.66101676762"),
+     amount: Decimal("0.66142691762"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.33050838381"),
+     amount: Decimal("0.33071345881"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.33050838381"),
+     amount: Decimal("0.33071345881"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.165254191905"),
+             0u8 => Decimal("0.165356729405"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.33898323238")),
+         LiquidFungibleResource(Decimal("99999999999989999.33857308238")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -266,7 +266,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.33050838381")),
+         LiquidFungibleResource(Decimal("0.33071345881")),
        )
 
 OUTPUTS: 7
@@ -281,13 +281,13 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.66101676762
+   Change: -10000.66142691762
 ├─ Vault: internal_vault_sim1trj4jx6nhjzx3jshetvefjfkrys34c2f3uw5j5vzydyltn5s5rce95
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.33050838381
+   Change: 0.33071345881
 
 NEW ENTITIES: 2
 ├─ Component: account_sim1c9efznpk7w0xwdav45jj944cj677hcqj9el3atswwfw4dt84z3pun5

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/002--trivial_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/002--trivial_subintent.txt
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2039595030975"),
+             0u8 => Decimal("0.2040620405975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -70,7 +70,7 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.407919006195")),
+         LiquidFungibleResource(Decimal("0.408124081195")),
        )
 
 OUTPUTS: 2

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/003--with_timestamp_range.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/003--with_timestamp_range.txt
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2371386465425"),
+             0u8 => Decimal("0.2372411840425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -66,7 +66,7 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.474277293085")),
+         LiquidFungibleResource(Decimal("0.474482368085")),
        )
 
 OUTPUTS: 1

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/004--depth_four_transaction.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/004--depth_four_transaction.txt
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.288334446665"),
+             0u8 => Decimal("0.288436984165"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -78,7 +78,7 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.57666889333")),
+         LiquidFungibleResource(Decimal("0.57687396833")),
        )
 
 OUTPUTS: 2

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/005--transaction_with_complex_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/005--transaction_with_complex_subintent.txt
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.341536406105"),
+             0u8 => Decimal("0.341638943605"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -66,7 +66,7 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.68307281221")),
+         LiquidFungibleResource(Decimal("0.68327788721")),
        )
 
 BALANCE CHANGES: 2

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: basic_subintents
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 4e3c88d00319c870 (allowed to change if not deployed to any network)
-Events       : 3623f04c0569d07a (allowed to change if not deployed to any network)
+State changes: 920b36bf96552aaa (allowed to change if not deployed to any network)
+Events       : 53c64f0ed69d62e3 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - parent_account: account_sim1c9efznpk7w0xwdav45jj944cj677hcqj9el3atswwfw4dt84z3pun5

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/001--fungible-max-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/001--fungible-max-div-create.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.68786245819,    100.0%
-- Execution Cost (XRD)                                                     ,               0.25280995,     36.8%
+Total Cost (XRD)                                                           ,            0.68802500819,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2529725,     36.8%
 - Finalization Cost (XRD)                                                  ,               0.13626635,     19.8%
 - Storage Cost (XRD)                                                       ,            0.29878615819,     43.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5056199,    100.0%
+Execution Cost Breakdown                                                   ,                  5059450,    100.0%
 - AfterInvoke                                                              ,                      716,      0.0%
 - AllocateNodeId                                                           ,                     2813,      0.1%
 - BeforeInvoke                                                             ,                     3538,      0.1%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.7%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      846,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/002--fungible-max-div-mint.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/002--fungible-max-div-mint.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.29179799273,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20798815,     71.3%
+Total Cost (XRD)                                                           ,            0.29196054273,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2081507,     71.3%
 - Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
 - Storage Cost (XRD)                                                       ,            0.06780624273,     23.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4159763,    100.0%
+Execution Cost Breakdown                                                   ,                  4163014,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1382,      0.0%
@@ -17,8 +17,8 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      6.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
 - OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.2%
 - OpenSubstate::InternalGenericComponent                                   ,                    42563,      1.0%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/003--fungible-max-div-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/003--fungible-max-div-burn.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.29849867199,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2068687,     69.3%
+Total Cost (XRD)                                                           ,            0.29866122199,    100.0%
+- Execution Cost (XRD)                                                     ,               0.20703125,     69.3%
 - Finalization Cost (XRD)                                                  ,                0.0160036,      5.4%
 - Storage Cost (XRD)                                                       ,            0.07562637199,     25.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4137374,    100.0%
+Execution Cost Breakdown                                                   ,                  4140625,    100.0%
 - AfterInvoke                                                              ,                      378,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1456,      0.0%
@@ -24,7 +24,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalGenericComponent                                   ,                    43504,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.6%
+- PrepareWasmCode                                                          ,                   353866,      8.5%
 - QueryActor                                                               ,                     2500,      0.1%
 - ReadSubstate                                                             ,                   483874,     11.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17840,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/004--fungible-max-div-transfer-32-times.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/004--fungible-max-div-transfer-32-times.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            2.01447265695,    100.0%
-- Execution Cost (XRD)                                                     ,               0.80039025,     39.7%
+Total Cost (XRD)                                                           ,            2.01463520695,    100.0%
+- Execution Cost (XRD)                                                     ,                0.8005528,     39.7%
 - Finalization Cost (XRD)                                                  ,               0.08254785,      4.1%
 - Storage Cost (XRD)                                                       ,            1.13153455695,     56.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 16007805,    100.0%
+Execution Cost Breakdown                                                   ,                 16011056,    100.0%
 - AfterInvoke                                                              ,                     8446,      0.1%
 - AllocateNodeId                                                           ,                    24056,      0.2%
 - BeforeInvoke                                                             ,                    28576,      0.2%
@@ -46,7 +46,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
 - RunNativeCode::try_deposit_or_abort                                      ,                  3135616,     19.6%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/005--fungible-max-div-freeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/005--fungible-max-div-freeze-withdraw.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.19198286004,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1359137,     70.8%
+Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.3%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2718274,    100.0%
+Execution Cost Breakdown                                                   ,                  2721525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/006--fungible-max-div-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/006--fungible-max-div-freeze-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.19198286004,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1359137,     70.8%
+Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.3%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2718274,    100.0%
+Execution Cost Breakdown                                                   ,                  2721525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/007--fungible-max-div-freeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/007--fungible-max-div-freeze-burn.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.19198286004,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1359137,     70.8%
+Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.3%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2718274,    100.0%
+Execution Cost Breakdown                                                   ,                  2721525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/008--fungible-max-div-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/008--fungible-max-div-recall-frozen-vault.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.30009958853,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20556725,     68.5%
+Total Cost (XRD)                                                           ,            0.30026213853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2057298,     68.5%
 - Finalization Cost (XRD)                                                  ,               0.02100405,      7.0%
 - Storage Cost (XRD)                                                       ,            0.07352828853,     24.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4111345,    100.0%
+Execution Cost Breakdown                                                   ,                  4114596,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalPackage                                              ,                  1776336,     43.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      7.0%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
 - OpenSubstate::InternalFungibleVault                                      ,                   260945,      6.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/009--fungible-max-div-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/009--fungible-max-div-unfreeze-withdraw.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.1920901949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1358303,     70.7%
+Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
 - Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2716606,    100.0%
+Execution Cost Breakdown                                                   ,                  2719857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.2%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/010--fungible-max-div-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/010--fungible-max-div-unfreeze-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.1920901949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1358303,     70.7%
+Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
 - Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2716606,    100.0%
+Execution Cost Breakdown                                                   ,                  2719857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.2%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/011--fungible-max-div-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/011--fungible-max-div-unfreeze-burn.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.1920901949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1358303,     70.7%
+Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
 - Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2716606,    100.0%
+Execution Cost Breakdown                                                   ,                  2719857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.2%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/012--fungible-max-div-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/012--fungible-max-div-recall-unfrozen-vault.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.29109843853,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20156655,     69.2%
+Total Cost (XRD)                                                           ,            0.29126098853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2017291,     69.3%
 - Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.07352828853,     25.3%
+- Storage Cost (XRD)                                                       ,            0.07352828853,     25.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4031331,    100.0%
+Execution Cost Breakdown                                                   ,                  4034582,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.1%
+- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.0%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      7.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.1%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      3.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/013--fungible-max-div-freeze-withdraw-again.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/013--fungible-max-div-freeze-withdraw-again.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.19198286004,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1359137,     70.8%
+Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.3%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2718274,    100.0%
+Execution Cost Breakdown                                                   ,                  2721525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/014--fungible-min-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/014--fungible-min-div-create.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.58241920439,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2403144,     41.3%
+Total Cost (XRD)                                                           ,            0.58258175439,    100.0%
+- Execution Cost (XRD)                                                     ,               0.24047695,     41.3%
 - Finalization Cost (XRD)                                                  ,               0.10626115,     18.2%
 - Storage Cost (XRD)                                                       ,            0.23584365439,     40.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4806288,    100.0%
+Execution Cost Breakdown                                                   ,                  4809539,    100.0%
 - AfterInvoke                                                              ,                      582,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     2518,      0.1%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - MoveModule                                                               ,                     3920,      0.1%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   134252,      2.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  2488148,     51.8%
+- OpenSubstate::GlobalPackage                                              ,                  2488148,     51.7%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      8.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    97340,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    50613,      1.1%
@@ -40,7 +40,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      475,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/015--fungible-min-div-mint-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/015--fungible-min-div-mint-correct-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.29179799273,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20798815,     71.3%
+Total Cost (XRD)                                                           ,            0.29196054273,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2081507,     71.3%
 - Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
 - Storage Cost (XRD)                                                       ,            0.06780624273,     23.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4159763,    100.0%
+Execution Cost Breakdown                                                   ,                  4163014,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1382,      0.0%
@@ -17,8 +17,8 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      6.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
 - OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.2%
 - OpenSubstate::InternalGenericComponent                                   ,                    42563,      1.0%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/016--fungible-min-div-mint-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/016--fungible-min-div-mint-wrong-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.16578667938,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1308822,     78.9%
+Total Cost (XRD)                                                           ,            0.16594922938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13104475,     79.0%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.03490447938,     21.1%
+- Storage Cost (XRD)                                                       ,            0.03490447938,     21.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2617644,    100.0%
+Execution Cost Breakdown                                                   ,                  2620895,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      478,      0.0%
@@ -17,7 +17,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   207059,      7.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.7%
-- OpenSubstate::GlobalPackage                                              ,                  1216522,     46.5%
+- OpenSubstate::GlobalPackage                                              ,                  1216522,     46.4%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.4%
 - OpenSubstate::InternalGenericComponent                                   ,                     4538,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.6%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/017--fungible-min-div-transfer-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/017--fungible-min-div-transfer-correct-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.40596197083,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2377521,     58.6%
+Total Cost (XRD)                                                           ,            0.40612452083,    100.0%
+- Execution Cost (XRD)                                                     ,               0.23791465,     58.6%
 - Finalization Cost (XRD)                                                  ,               0.03650745,      9.0%
 - Storage Cost (XRD)                                                       ,            0.13170242083,     32.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4755042,    100.0%
+Execution Cost Breakdown                                                   ,                  4758293,    100.0%
 - AfterInvoke                                                              ,                      504,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     1764,      0.0%
@@ -36,9 +36,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.6%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.5%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    18960,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/018--fungible-min-div-transfer-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/018--fungible-min-div-transfer-wrong-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.21006701182,    100.0%
-- Execution Cost (XRD)                                                     ,               0.16486285,     78.5%
+Total Cost (XRD)                                                           ,            0.21022956182,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1650254,     78.5%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,            0.04520416182,     21.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3297257,    100.0%
+Execution Cost Breakdown                                                   ,                  3300508,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      672,      0.0%
@@ -25,12 +25,12 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                       84,      0.0%
 - PrepareWasmCode                                                          ,                   353866,     10.7%
 - QueryActor                                                               ,                     1500,      0.0%
-- ReadSubstate                                                             ,                   427023,     13.0%
+- ReadSubstate                                                             ,                   427023,     12.9%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.3%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    18960,      0.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/019--fungible-min-div-create-proof-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/019--fungible-min-div-create-proof-correct-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.26085126042,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1984876,     76.1%
+Total Cost (XRD)                                                           ,            0.26101381042,    100.0%
+- Execution Cost (XRD)                                                     ,               0.19865015,     76.1%
 - Finalization Cost (XRD)                                                  ,               0.01525215,      5.8%
-- Storage Cost (XRD)                                                       ,            0.04711151042,     18.1%
+- Storage Cost (XRD)                                                       ,            0.04711151042,     18.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3969752,    100.0%
+Execution Cost Breakdown                                                   ,                  3973003,    100.0%
 - AfterInvoke                                                              ,                      246,      0.0%
 - AllocateNodeId                                                           ,                     1164,      0.0%
 - BeforeInvoke                                                             ,                     2256,      0.1%
@@ -16,7 +16,7 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164784,      4.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164784,      4.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      1.0%
 - OpenSubstate::GlobalPackage                                              ,                  1898289,     47.8%
@@ -38,7 +38,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.4%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    16760,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/020--fungible-min-div-create-proof-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/020--fungible-min-div-create-proof-wrong-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.20042050317,    100.0%
-- Execution Cost (XRD)                                                     ,               0.16046155,     80.1%
+Total Cost (XRD)                                                           ,            0.20058305317,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1606241,     80.1%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,            0.03995895317,     19.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3209231,    100.0%
+Execution Cost Breakdown                                                   ,                  3212482,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      736,      0.0%
@@ -17,7 +17,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164139,      5.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  1431122,     44.6%
+- OpenSubstate::GlobalPackage                                              ,                  1431122,     44.5%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      8.9%
 - OpenSubstate::InternalFungibleVault                                      ,                   133423,      4.2%
 - OpenSubstate::InternalGenericComponent                                   ,                     6237,      0.2%
@@ -28,9 +28,9 @@ Execution Cost Breakdown                                                   ,    
 - ReadSubstate                                                             ,                   425123,     13.2%
 - RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.9%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      1.2%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    16760,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/021--fungible-min-div-recall-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/021--fungible-min-div-recall-correct-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.29109843853,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20156655,     69.2%
+Total Cost (XRD)                                                           ,            0.29126098853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2017291,     69.3%
 - Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.07352828853,     25.3%
+- Storage Cost (XRD)                                                       ,            0.07352828853,     25.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4031331,    100.0%
+Execution Cost Breakdown                                                   ,                  4034582,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.1%
+- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.0%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      7.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.1%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      3.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/022--fungible-min-div-recall-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/022--fungible-min-div-recall-wrong-granularity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.1683664692,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1264048,     75.1%
+Total Cost (XRD)                                                           ,             0.1685290192,    100.0%
+- Execution Cost (XRD)                                                     ,               0.12656735,     75.1%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,             0.0419616692,     24.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2528096,    100.0%
+Execution Cost Breakdown                                                   ,                  2531347,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      482,      0.0%
@@ -17,7 +17,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   243851,      9.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.7%
-- OpenSubstate::GlobalPackage                                              ,                  1084341,     42.9%
+- OpenSubstate::GlobalPackage                                              ,                  1084341,     42.8%
 - OpenSubstate::InternalFungibleVault                                      ,                    93947,      3.7%
 - OpenSubstate::InternalGenericComponent                                   ,                     4538,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.6%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.6%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.8%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      1.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/001--fungible-max-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/001--fungible-max-div-create.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.68786245819 XRD
-├─ Network execution: 0.25280995 XRD, 5056199 execution cost units
+TRANSACTION COST: 0.68802500819 XRD
+├─ Network execution: 0.2529725 XRD, 5059450 execution cost units
 ├─ Network finalization: 0.13626635 XRD, 2725327 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.29878615819 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.68786245819"),
+     amount: Decimal("0.68802500819"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.343931229095"),
+     amount: Decimal("0.344012504095"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.343931229095"),
+     amount: Decimal("0.344012504095"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.1719656145475"),
+             0u8 => Decimal("0.1720062520475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.31213754181")),
+         LiquidFungibleResource(Decimal("99999999999999999.31197499181")),
        )
 ├─ resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09 across 4 partitions
   ├─ Partition(5): 1 change
@@ -326,7 +326,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.343931229095")),
+         LiquidFungibleResource(Decimal("0.344012504095")),
        )
 
 OUTPUTS: 3
@@ -340,13 +340,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.68786245819
+   Change: -0.68802500819
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 100000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.343931229095
+   Change: 0.344012504095
 
 NEW ENTITIES: 2
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/002--fungible-max-div-mint.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/002--fungible-max-div-mint.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29179799273 XRD
-├─ Network execution: 0.20798815 XRD, 4159763 execution cost units
+TRANSACTION COST: 0.29196054273 XRD
+├─ Network execution: 0.2081507 XRD, 4163014 execution cost units
 ├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06780624273 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29179799273"),
+     amount: Decimal("0.29196054273"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145898996365"),
+     amount: Decimal("0.145980271365"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145898996365"),
+     amount: Decimal("0.145980271365"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.24491511273"),
+             0u8 => Decimal("0.24499638773"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.02033954908")),
+         LiquidFungibleResource(Decimal("99999999999999999.02001444908")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.48983022546")),
+         LiquidFungibleResource(Decimal("0.48999277546")),
        )
 
 OUTPUTS: 3
@@ -103,12 +103,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29179799273
+   Change: -0.29196054273
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145898996365
+   Change: 0.145980271365
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/003--fungible-max-div-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/003--fungible-max-div-burn.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29849867199 XRD
-├─ Network execution: 0.2068687 XRD, 4137374 execution cost units
+TRANSACTION COST: 0.29866122199 XRD
+├─ Network execution: 0.20703125 XRD, 4140625 execution cost units
 ├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07562637199 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29849867199"),
+     amount: Decimal("0.29866122199"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.149249335995"),
+     amount: Decimal("0.149330610995"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.149249335995"),
+     amount: Decimal("0.149330610995"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.3195397807275"),
+             0u8 => Decimal("0.3196616932275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.72184087709")),
+         LiquidFungibleResource(Decimal("99999999999999998.72135322709")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.639079561455")),
+         LiquidFungibleResource(Decimal("0.639323386455")),
        )
 
 OUTPUTS: 4
@@ -104,12 +104,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29849867199
+   Change: -0.29866122199
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: -10
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.149249335995
+   Change: 0.149330610995
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/004--fungible-max-div-transfer-32-times.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/004--fungible-max-div-transfer-32-times.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 2.01447265695 XRD
-├─ Network execution: 0.80039025 XRD, 16007805 execution cost units
+TRANSACTION COST: 2.01463520695 XRD
+├─ Network execution: 0.8005528 XRD, 16011056 execution cost units
 ├─ Network finalization: 0.08254785 XRD, 1650957 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.13153455695 XRD
@@ -326,15 +326,15 @@ EVENTS: 73
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("2.01447265695"),
+     amount: Decimal("2.01463520695"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.007236328475"),
+     amount: Decimal("1.007317603475"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.007236328475"),
+     amount: Decimal("1.007317603475"),
    }
 
 STATE UPDATES: 8 entities
@@ -344,7 +344,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.823157944965"),
+             0u8 => Decimal("0.823320494965"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -377,7 +377,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.70736822014")),
+         LiquidFungibleResource(Decimal("99999999999999996.70671802014")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -523,7 +523,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.64631588993")),
+         LiquidFungibleResource(Decimal("1.64664098993")),
        )
 
 OUTPUTS: 67
@@ -598,7 +598,7 @@ OUTPUTS: 67
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -2.01447265695
+   Change: -2.01463520695
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: -0.032
@@ -607,7 +607,7 @@ BALANCE CHANGES: 4
    Change: 0.032
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.007236328475
+   Change: 1.007317603475
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/005--fungible-max-div-freeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/005--fungible-max-div-freeze-withdraw.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19198286004 XRD
-├─ Network execution: 0.1359137 XRD, 2718274 execution cost units
+TRANSACTION COST: 0.19214541004 XRD
+├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19198286004"),
+     amount: Decimal("0.19214541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.871153659975"),
+             0u8 => Decimal("0.871356847475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.5153853601")),
+         LiquidFungibleResource(Decimal("99999999999999996.5145726101")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.74230731995")),
+         LiquidFungibleResource(Decimal("1.74271369495")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19198286004
+   Change: -0.19214541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09599143002
+   Change: 0.09607270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/006--fungible-max-div-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/006--fungible-max-div-freeze-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19198286004 XRD
-├─ Network execution: 0.1359137 XRD, 2718274 execution cost units
+TRANSACTION COST: 0.19214541004 XRD
+├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19198286004"),
+     amount: Decimal("0.19214541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.919149374985"),
+             0u8 => Decimal("0.919393199985"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.32340250006")),
+         LiquidFungibleResource(Decimal("99999999999999996.32242720006")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.83829874997")),
+         LiquidFungibleResource(Decimal("1.83878639997")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19198286004
+   Change: -0.19214541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09599143002
+   Change: 0.09607270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/007--fungible-max-div-freeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/007--fungible-max-div-freeze-burn.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19198286004 XRD
-├─ Network execution: 0.1359137 XRD, 2718274 execution cost units
+TRANSACTION COST: 0.19214541004 XRD
+├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19198286004"),
+     amount: Decimal("0.19214541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.967145089995"),
+             0u8 => Decimal("0.967429552495"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.13141964002")),
+         LiquidFungibleResource(Decimal("99999999999999996.13028179002")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.93429017999")),
+         LiquidFungibleResource(Decimal("1.93485910499")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19198286004
+   Change: -0.19214541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09599143002
+   Change: 0.09607270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/008--fungible-max-div-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/008--fungible-max-div-recall-frozen-vault.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30009958853 XRD
-├─ Network execution: 0.20556725 XRD, 4111345 execution cost units
+TRANSACTION COST: 0.30026213853 XRD
+├─ Network execution: 0.2057298 XRD, 4114596 execution cost units
 ├─ Network finalization: 0.02100405 XRD, 420081 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30009958853"),
+     amount: Decimal("0.30026213853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.150049794265"),
+     amount: Decimal("0.150131069265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.150049794265"),
+     amount: Decimal("0.150131069265"),
    }
 
 STATE UPDATES: 7 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.0421699871275"),
+             0u8 => Decimal("1.0424950871275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,7 +86,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.83132005149")),
+         LiquidFungibleResource(Decimal("99999999999999995.83001965149")),
        )
 ├─ internal_vault_sim1trl737k2t8f0y32gd9p4pdm4rkszwtgmd9rknragf3rgegns5pts2p across 1 partitions
   └─ Partition(64): 1 change
@@ -98,7 +98,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.084339974255")),
+         LiquidFungibleResource(Decimal("2.084990174255")),
        )
 
 OUTPUTS: 3
@@ -112,12 +112,12 @@ BALANCE CHANGES: 4
    Change: -1
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30009958853
+   Change: -0.30026213853
 ├─ Vault: internal_vault_sim1trl737k2t8f0y32gd9p4pdm4rkszwtgmd9rknragf3rgegns5pts2p
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.150049794265
+   Change: 0.150131069265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/009--fungible-max-div-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/009--fungible-max-div-unfreeze-withdraw.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1920901949 XRD
-├─ Network execution: 0.1358303 XRD, 2716606 execution cost units
+TRANSACTION COST: 0.1922527449 XRD
+├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1920901949"),
+     amount: Decimal("0.1922527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.0901925358525"),
+             0u8 => Decimal("1.0905582733525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.63922985659")),
+         LiquidFungibleResource(Decimal("99999999999999995.63776690659")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.180385071705")),
+         LiquidFungibleResource(Decimal("2.181116546705")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1920901949
+   Change: -0.1922527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09604509745
+   Change: 0.09612637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/010--fungible-max-div-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/010--fungible-max-div-unfreeze-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1920901949 XRD
-├─ Network execution: 0.1358303 XRD, 2716606 execution cost units
+TRANSACTION COST: 0.1922527449 XRD
+├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1920901949"),
+     amount: Decimal("0.1922527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.1382150845775"),
+             0u8 => Decimal("1.1386214595775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.44713966169")),
+         LiquidFungibleResource(Decimal("99999999999999995.44551416169")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.276430169155")),
+         LiquidFungibleResource(Decimal("2.277242919155")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1920901949
+   Change: -0.1922527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09604509745
+   Change: 0.09612637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/011--fungible-max-div-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/011--fungible-max-div-unfreeze-burn.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1920901949 XRD
-├─ Network execution: 0.1358303 XRD, 2716606 execution cost units
+TRANSACTION COST: 0.1922527449 XRD
+├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1920901949"),
+     amount: Decimal("0.1922527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09604509745"),
+     amount: Decimal("0.09612637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.1862376333025"),
+             0u8 => Decimal("1.1866846458025"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.25504946679")),
+         LiquidFungibleResource(Decimal("99999999999999995.25326141679")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.372475266605")),
+         LiquidFungibleResource(Decimal("2.373369291605")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1920901949
+   Change: -0.1922527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09604509745
+   Change: 0.09612637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/012--fungible-max-div-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/012--fungible-max-div-recall-unfrozen-vault.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29109843853 XRD
-├─ Network execution: 0.20156655 XRD, 4031331 execution cost units
+TRANSACTION COST: 0.29126098853 XRD
+├─ Network execution: 0.2017291 XRD, 4034582 execution cost units
 ├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29109843853"),
+     amount: Decimal("0.29126098853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145549219265"),
+     amount: Decimal("0.145630494265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145549219265"),
+     amount: Decimal("0.145630494265"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.259012242935"),
+             0u8 => Decimal("1.259499892935"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,13 +86,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.96395102826")),
+         LiquidFungibleResource(Decimal("99999999999999994.96200042826")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.51802448587")),
+         LiquidFungibleResource(Decimal("2.51899978587")),
        )
 
 OUTPUTS: 3
@@ -103,9 +103,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29109843853
+   Change: -0.29126098853
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145549219265
+   Change: 0.145630494265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/013--fungible-max-div-freeze-withdraw-again.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/013--fungible-max-div-freeze-withdraw-again.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19198286004 XRD
-├─ Network execution: 0.1359137 XRD, 2718274 execution cost units
+TRANSACTION COST: 0.19214541004 XRD
+├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19198286004"),
+     amount: Decimal("0.19214541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09599143002"),
+     amount: Decimal("0.09607270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.307007957945"),
+             0u8 => Decimal("1.307536245445"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.77196816822")),
+         LiquidFungibleResource(Decimal("99999999999999994.76985501822")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.61401591589")),
+         LiquidFungibleResource(Decimal("2.61507249089")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19198286004
+   Change: -0.19214541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09599143002
+   Change: 0.09607270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/014--fungible-min-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/014--fungible-min-div-create.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.58241920439 XRD
-├─ Network execution: 0.2403144 XRD, 4806288 execution cost units
+TRANSACTION COST: 0.58258175439 XRD
+├─ Network execution: 0.24047695 XRD, 4809539 execution cost units
 ├─ Network finalization: 0.10626115 XRD, 2125223 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.23584365439 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.58241920439"),
+     amount: Decimal("0.58258175439"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.291209602195"),
+     amount: Decimal("0.291290877195"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.291209602195"),
+     amount: Decimal("0.291290877195"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.4526127590425"),
+             0u8 => Decimal("1.4531816840425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.18954896383")),
+         LiquidFungibleResource(Decimal("99999999999999994.18727326383")),
        )
 ├─ resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96 across 4 partitions
   ├─ Partition(5): 1 change
@@ -233,7 +233,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.905225518085")),
+         LiquidFungibleResource(Decimal("2.906363368085")),
        )
 
 OUTPUTS: 3
@@ -247,13 +247,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.58241920439
+   Change: -0.58258175439
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: 100000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.291209602195
+   Change: 0.291290877195
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/015--fungible-min-div-mint-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/015--fungible-min-div-mint-correct-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29179799273 XRD
-├─ Network execution: 0.20798815 XRD, 4159763 execution cost units
+TRANSACTION COST: 0.29196054273 XRD
+├─ Network execution: 0.2081507 XRD, 4163014 execution cost units
 ├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06780624273 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29179799273"),
+     amount: Decimal("0.29196054273"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145898996365"),
+     amount: Decimal("0.145980271365"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145898996365"),
+     amount: Decimal("0.145980271365"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.525562257225"),
+             0u8 => Decimal("1.526171819725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.8977509711")),
+         LiquidFungibleResource(Decimal("99999999999999993.8953127211")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.05112451445")),
+         LiquidFungibleResource(Decimal("3.05234363945")),
        )
 
 OUTPUTS: 3
@@ -103,12 +103,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29179799273
+   Change: -0.29196054273
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: 166
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145898996365
+   Change: 0.145980271365
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/016--fungible-min-div-mint-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/016--fungible-min-div-mint-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(FungibleResourceManagerError(InvalidAmount(1.1, 0)))
 
-TRANSACTION COST: 0.16578667938 XRD
-├─ Network execution: 0.1308822 XRD, 2617644 execution cost units
+TRANSACTION COST: 0.16594922938 XRD
+├─ Network execution: 0.13104475 XRD, 2620895 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.16578667938"),
+     amount: Decimal("0.16594922938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08289333969"),
+     amount: Decimal("0.08297461469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08289333969"),
+     amount: Decimal("0.08297461469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.56700892707"),
+             0u8 => Decimal("1.56765912707"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.73196429172")),
+         LiquidFungibleResource(Decimal("99999999999999993.72936349172")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.13401785414")),
+         LiquidFungibleResource(Decimal("3.13531825414")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.16578667938
+   Change: -0.16594922938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08289333969
+   Change: 0.08297461469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/017--fungible-min-div-transfer-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/017--fungible-min-div-transfer-correct-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.40596197083 XRD
-├─ Network execution: 0.2377521 XRD, 4755042 execution cost units
+TRANSACTION COST: 0.40612452083 XRD
+├─ Network execution: 0.23791465 XRD, 4758293 execution cost units
 ├─ Network finalization: 0.03650745 XRD, 730149 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13170242083 XRD
@@ -38,15 +38,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.40596197083"),
+     amount: Decimal("0.40612452083"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.202980985415"),
+     amount: Decimal("0.203062260415"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.202980985415"),
+     amount: Decimal("0.203062260415"),
    }
 
 STATE UPDATES: 8 entities
@@ -56,7 +56,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.6684994197775"),
+             0u8 => Decimal("1.6691902572775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -89,7 +89,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.32600232089")),
+         LiquidFungibleResource(Decimal("99999999999999993.32323897089")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -142,7 +142,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.336998839555")),
+         LiquidFungibleResource(Decimal("3.338380514555")),
        )
 
 OUTPUTS: 3
@@ -153,7 +153,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.40596197083
+   Change: -0.40612452083
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: -234
@@ -162,6 +162,6 @@ BALANCE CHANGES: 4
    Change: 234
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.202980985415
+   Change: 0.203062260415
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/018--fungible-min-div-transfer-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/018--fungible-min-div-transfer-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(0.0001)))
 
-TRANSACTION COST: 0.21006701182 XRD
-├─ Network execution: 0.16486285 XRD, 3297257 execution cost units
+TRANSACTION COST: 0.21022956182 XRD
+├─ Network execution: 0.1650254 XRD, 3300508 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04520416182 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.21006701182"),
+     amount: Decimal("0.21022956182"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10503350591"),
+     amount: Decimal("0.10511478091"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10503350591"),
+     amount: Decimal("0.10511478091"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.7210161727325"),
+             0u8 => Decimal("1.7217476477325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.11593530907")),
+         LiquidFungibleResource(Decimal("99999999999999993.11300940907")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.442032345465")),
+         LiquidFungibleResource(Decimal("3.443495295465")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.21006701182
+   Change: -0.21022956182
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10503350591
+   Change: 0.10511478091
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/019--fungible-min-div-create-proof-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/019--fungible-min-div-create-proof-correct-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.26085126042 XRD
-├─ Network execution: 0.1984876 XRD, 3969752 execution cost units
+TRANSACTION COST: 0.26101381042 XRD
+├─ Network execution: 0.19865015 XRD, 3973003 execution cost units
 ├─ Network finalization: 0.01525215 XRD, 305043 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04711151042 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.26085126042"),
+     amount: Decimal("0.26101381042"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.13042563021"),
+     amount: Decimal("0.13050690521"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.13042563021"),
+     amount: Decimal("0.13050690521"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.7862289878375"),
+             0u8 => Decimal("1.7870011003375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.85508404865")),
+         LiquidFungibleResource(Decimal("99999999999999992.85199559865")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -79,7 +79,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.572457975675")),
+         LiquidFungibleResource(Decimal("3.574002200675")),
        )
 
 OUTPUTS: 2
@@ -89,9 +89,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.26085126042
+   Change: -0.26101381042
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.13042563021
+   Change: 0.13050690521
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/020--fungible-min-div-create-proof-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/020--fungible-min-div-create-proof-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(0.0001)))
 
-TRANSACTION COST: 0.20042050317 XRD
-├─ Network execution: 0.16046155 XRD, 3209231 execution cost units
+TRANSACTION COST: 0.20058305317 XRD
+├─ Network execution: 0.1606241 XRD, 3212482 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03995895317 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20042050317"),
+     amount: Decimal("0.20058305317"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.100210251585"),
+     amount: Decimal("0.100291526585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.100210251585"),
+     amount: Decimal("0.100291526585"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.83633411363"),
+             0u8 => Decimal("1.83714686363"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.65466354548")),
+         LiquidFungibleResource(Decimal("99999999999999992.65141254548")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.67266822726")),
+         LiquidFungibleResource(Decimal("3.67429372726")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20042050317
+   Change: -0.20058305317
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.100210251585
+   Change: 0.100291526585
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/021--fungible-min-div-recall-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/021--fungible-min-div-recall-correct-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29109843853 XRD
-├─ Network execution: 0.20156655 XRD, 4031331 execution cost units
+TRANSACTION COST: 0.29126098853 XRD
+├─ Network execution: 0.2017291 XRD, 4034582 execution cost units
 ├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29109843853"),
+     amount: Decimal("0.29126098853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145549219265"),
+     amount: Decimal("0.145630494265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145549219265"),
+     amount: Decimal("0.145630494265"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9091087232625"),
+             0u8 => Decimal("1.9099621107625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,13 +86,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.36356510695")),
+         LiquidFungibleResource(Decimal("99999999999999992.36015155695")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.818217446525")),
+         LiquidFungibleResource(Decimal("3.819924221525")),
        )
 
 OUTPUTS: 3
@@ -103,9 +103,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29109843853
+   Change: -0.29126098853
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145549219265
+   Change: 0.145630494265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/022--fungible-min-div-recall-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/022--fungible-min-div-recall-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(123.12321)))
 
-TRANSACTION COST: 0.1683664692 XRD
-├─ Network execution: 0.1264048 XRD, 2528096 execution cost units
+TRANSACTION COST: 0.1685290192 XRD
+├─ Network execution: 0.12656735 XRD, 2531347 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0419616692 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1683664692"),
+     amount: Decimal("0.1685290192"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.0841832346"),
+     amount: Decimal("0.0842645096"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.0841832346"),
+     amount: Decimal("0.0842645096"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9512003405625"),
+             0u8 => Decimal("1.9520943655625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.19519863775")),
+         LiquidFungibleResource(Decimal("99999999999999992.19162253775")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.902400681125")),
+         LiquidFungibleResource(Decimal("3.904188731125")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1683664692
+   Change: -0.1685290192
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.0841832346
+   Change: 0.0842645096
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: fungible_resource
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 5f8731c4b3d3b573 (allowed to change if not deployed to any network)
-Events       : ad1cf70007eef78b (allowed to change if not deployed to any network)
+State changes: 59159dd195d775a3 (allowed to change if not deployed to any network)
+Events       : cdfdf4f81788e605 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - user_account_1: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/costings/001--global_n_owned_emitting_events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/costings/001--global_n_owned_emitting_events.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,           31.11874008773,    100.0%
-- Execution Cost (XRD)                                                     ,               0.73828155,      2.4%
+Total Cost (XRD)                                                           ,           31.11940278773,    100.0%
+- Execution Cost (XRD)                                                     ,               0.73894425,      2.4%
 - Finalization Cost (XRD)                                                  ,                0.1288607,      0.4%
 - Storage Cost (XRD)                                                       ,           30.25159783773,     97.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14765631,    100.0%
+Execution Cost Breakdown                                                   ,                 14778885,    100.0%
 - AfterInvoke                                                              ,                      530,      0.0%
 - AllocateNodeId                                                           ,                     2619,      0.0%
 - BeforeInvoke                                                             ,                   174964,      1.2%
@@ -34,10 +34,10 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
 - RunNativeCode::publish_wasm_advanced                                     ,                  4176881,     28.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
-- RunWasmCode::GlobalBp_emit_event                                         ,                    13600,      0.1%
-- RunWasmCode::GlobalBp_new                                                ,                    47465,      0.3%
-- RunWasmCode::OwnedBp_emit_event                                          ,                    10305,      0.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::GlobalBp_emit_event                                         ,                    15145,      0.1%
+- RunWasmCode::GlobalBp_new                                                ,                    55165,      0.4%
+- RunWasmCode::OwnedBp_emit_event                                          ,                    11063,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      776,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/receipts/001--global_n_owned_emitting_events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/receipts/001--global_n_owned_emitting_events.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 31.11874008773 XRD
-├─ Network execution: 0.73828155 XRD, 14765631 execution cost units
+TRANSACTION COST: 31.11940278773 XRD
+├─ Network execution: 0.73894425 XRD, 14778885 execution cost units
 ├─ Network finalization: 0.1288607 XRD, 2577214 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 30.25159783773 XRD
@@ -24,15 +24,15 @@ EVENTS: 7
    Event: GlobalBpEvent
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("31.11874008773"),
+     amount: Decimal("31.11940278773"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("15.559370043865"),
+     amount: Decimal("15.559701393865"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("15.559370043865"),
+     amount: Decimal("15.559701393865"),
    }
 
 STATE UPDATES: 9 entities
@@ -42,7 +42,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("7.7796850219325"),
+             0u8 => Decimal("7.7798506969325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,7 +75,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999968.88125991227")),
+         LiquidFungibleResource(Decimal("99999999999999968.88059721227")),
        )
 ├─ package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96 across 11 partitions
   ├─ Partition(1): 2 changes
@@ -687,7 +687,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("15.559370043865")),
+         LiquidFungibleResource(Decimal("15.559701393865")),
        )
 
 OUTPUTS: 4
@@ -699,10 +699,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -31.11874008773
+   Change: -31.11940278773
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 15.559370043865
+   Change: 15.559701393865
 
 NEW ENTITIES: 2
 └─ Package: package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: global_n_owned
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 8b185a122796d1f7 (allowed to change if not deployed to any network)
-Events       : 011d0ff4510ec313 (allowed to change if not deployed to any network)
+State changes: 7411e81fdf13949b (allowed to change if not deployed to any network)
+Events       : 13e773bed3504059 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - global_n_owned_package_address: package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/costings/001--kv-store-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/costings/001--kv-store-with-remote-type.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            37.0786903014,    100.0%
-- Execution Cost (XRD)                                                     ,               0.73703315,      2.0%
+Total Cost (XRD)                                                           ,            37.0793026514,    100.0%
+- Execution Cost (XRD)                                                     ,                0.7376455,      2.0%
 - Finalization Cost (XRD)                                                  ,                0.1039411,      0.3%
 - Storage Cost (XRD)                                                       ,            36.2377160514,     97.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14740663,    100.0%
+Execution Cost Breakdown                                                   ,                 14752910,    100.0%
 - AfterInvoke                                                              ,                      460,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                   208346,      1.4%
@@ -33,9 +33,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                    54942,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunNativeCode::publish_wasm_advanced                                     ,                  4918202,     33.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
-- RunWasmCode::KVStore_create_key_value_store_with_remote_type             ,                    54973,      0.4%
+- RunNativeCode::publish_wasm_advanced                                     ,                  4918202,     33.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::KVStore_create_key_value_store_with_remote_type             ,                    63969,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/receipts/001--kv-store-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/receipts/001--kv-store-with-remote-type.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 37.0786903014 XRD
-├─ Network execution: 0.73703315 XRD, 14740663 execution cost units
+TRANSACTION COST: 37.0793026514 XRD
+├─ Network execution: 0.7376455 XRD, 14752910 execution cost units
 ├─ Network finalization: 0.1039411 XRD, 2078822 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 36.2377160514 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("37.0786903014"),
+     amount: Decimal("37.0793026514"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("18.5393451507"),
+     amount: Decimal("18.5396513257"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("18.5393451507"),
+     amount: Decimal("18.5396513257"),
    }
 
 STATE UPDATES: 9 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("9.26967257535"),
+             0u8 => Decimal("9.26982566285"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999962.9213096986")),
+         LiquidFungibleResource(Decimal("99999999999999962.9206973486")),
        )
 ├─ package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt across 11 partitions
   ├─ Partition(1): 1 change
@@ -427,7 +427,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("18.5393451507")),
+         LiquidFungibleResource(Decimal("18.5396513257")),
        )
 
 OUTPUTS: 4
@@ -439,10 +439,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -37.0786903014
+   Change: -37.0793026514
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 18.5393451507
+   Change: 18.5396513257
 
 NEW ENTITIES: 2
 └─ Package: package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: kv_store_with_remote_type
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: f0d65cf28cabfcbe (allowed to change if not deployed to any network)
-Events       : 76f4fe0cba4a7992 (allowed to change if not deployed to any network)
+State changes: 0530e08a0fbeee57 (allowed to change if not deployed to any network)
+Events       : 3e12393f8656767b (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - kv_store_with_remote_type_package_address: package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/001--max_transaction-publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/001--max_transaction-publish-package.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            43.9742614389,    100.0%
-- Execution Cost (XRD)                                                     ,               0.83703315,      1.9%
+Total Cost (XRD)                                                           ,            43.9747960389,    100.0%
+- Execution Cost (XRD)                                                     ,               0.83756775,      1.9%
 - Finalization Cost (XRD)                                                  ,               0.10458285,      0.2%
 - Storage Cost (XRD)                                                       ,            43.0326454389,     97.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 16740663,    100.0%
+Execution Cost Breakdown                                                   ,                 16751355,    100.0%
 - AfterInvoke                                                              ,                      460,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                   248008,      1.5%
@@ -33,13 +33,13 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                    54942,      0.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunNativeCode::publish_wasm_advanced                                     ,                  5802440,     34.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
-- RunWasmCode::MaxTransaction_new                                          ,                    46462,      0.3%
+- RunNativeCode::publish_wasm_advanced                                     ,                  5802440,     34.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::MaxTransaction_new                                          ,                    53903,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      788,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  4947640,     29.6%
+- ValidateTxPayload                                                        ,                  4947640,     29.5%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     6922,      0.0%
 Finalization Cost Breakdown                                                ,                  2091657,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/002--max_transaction-with-large-events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/002--max_transaction-with-large-events.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,          799.32719144787,    100.0%
-- Execution Cost (XRD)                                                     ,                 1.046472,      0.1%
+Total Cost (XRD)                                                           ,          799.32746029787,    100.0%
+- Execution Cost (XRD)                                                     ,               1.04674085,      0.1%
 - Finalization Cost (XRD)                                                  ,                0.1784497,      0.0%
 - Storage Cost (XRD)                                                       ,          798.10226974787,     99.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20929440,    100.0%
+Execution Cost Breakdown                                                   ,                 20934817,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      644,      0.0%
@@ -12,7 +12,7 @@ Execution Cost Breakdown                                                   ,    
 - CloseSubstate                                                            ,                    11352,      0.1%
 - CreateNode                                                               ,                     6032,      0.0%
 - DropNode                                                                 ,                    10841,      0.1%
-- EmitEvent                                                                ,                 16839736,     80.5%
+- EmitEvent                                                                ,                 16839736,     80.4%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
@@ -29,8 +29,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
-- RunWasmCode::MaxTransaction_max_events                                   ,                    13798,      0.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
+- RunWasmCode::MaxTransaction_max_events                                   ,                    15924,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    11960,      0.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/003--max_transaction-with-large-state-updates.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/003--max_transaction-with-large-state-updates.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,         4205.56759160162,    100.0%
-- Execution Cost (XRD)                                                     ,               4.78799965,      0.1%
+Total Cost (XRD)                                                           ,         4205.56802035162,    100.0%
+- Execution Cost (XRD)                                                     ,                4.7884284,      0.1%
 - Finalization Cost (XRD)                                                  ,                0.6707546,      0.0%
 - Storage Cost (XRD)                                                       ,         4200.10883735162,     99.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 95759993,    100.0%
+Execution Cost Breakdown                                                   ,                 95768568,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      630,      0.0%
@@ -29,8 +29,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.0%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.0%
-- RunWasmCode::MaxTransaction_max_state_updates                            ,                    40394,      0.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.0%
+- RunWasmCode::MaxTransaction_max_state_updates                            ,                    45718,      0.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    11600,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/001--max_transaction-publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/001--max_transaction-publish-package.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 43.9742614389 XRD
-├─ Network execution: 0.83703315 XRD, 16740663 execution cost units
+TRANSACTION COST: 43.9747960389 XRD
+├─ Network execution: 0.83756775 XRD, 16751355 execution cost units
 ├─ Network finalization: 0.10458285 XRD, 2091657 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 43.0326454389 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("43.9742614389"),
+     amount: Decimal("43.9747960389"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("21.98713071945"),
+     amount: Decimal("21.98739801945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("21.98713071945"),
+     amount: Decimal("21.98739801945"),
    }
 
 STATE UPDATES: 9 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("10.993565359725"),
+             0u8 => Decimal("10.993699009725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999956.0257385611")),
+         LiquidFungibleResource(Decimal("99999999999999956.0252039611")),
        )
 ├─ package_sim1ph5xhxsxn2ekenmudd0p5rmsjggmzkxcd8eu3pjjame6f2mxc0jwmn across 11 partitions
   ├─ Partition(1): 1 change
@@ -521,7 +521,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("21.98713071945")),
+         LiquidFungibleResource(Decimal("21.98739801945")),
        )
 
 OUTPUTS: 4
@@ -533,10 +533,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -43.9742614389
+   Change: -43.9747960389
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 21.98713071945
+   Change: 21.98739801945
 
 NEW ENTITIES: 2
 └─ Package: package_sim1ph5xhxsxn2ekenmudd0p5rmsjggmzkxcd8eu3pjjame6f2mxc0jwmn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/003--max_transaction-with-large-state-updates.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/003--max_transaction-with-large-state-updates.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 4205.56759160162 XRD
-├─ Network execution: 4.78799965 XRD, 95759993 execution cost units
+TRANSACTION COST: 4205.56802035162 XRD
+├─ Network execution: 4.7884284 XRD, 95768568 execution cost units
 ├─ Network finalization: 0.6707546 XRD, 13415092 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 4200.10883735162 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("4205.56759160162"),
+     amount: Decimal("4205.56802035162"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("2102.78379580081"),
+     amount: Decimal("2102.78401017581"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("2102.78379580081"),
+     amount: Decimal("2102.78401017581"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1262.2172611220975"),
+             0u8 => Decimal("1262.2175691720975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -73,7 +73,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999994951.13095551161")),
+         LiquidFungibleResource(Decimal("99999999999994951.12972331161")),
        )
 ├─ internal_keyvaluestore_sim1krwy3nu9853y0gqa3kpcrrvjx9je56r3pm53wcwmy6m5ahsx3l8rev across 1 partitions
   └─ Partition(64): 21 changes
@@ -123,7 +123,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2524.434522244195")),
+         LiquidFungibleResource(Decimal("2524.435138344195")),
        )
 
 OUTPUTS: 2
@@ -133,9 +133,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -4205.56759160162
+   Change: -4205.56802035162
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 2102.78379580081
+   Change: 2102.78401017581
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: max_transaction
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 0b72c2d3e74a6013 (allowed to change if not deployed to any network)
-Events       : 1358a6ea2351b6f7 (allowed to change if not deployed to any network)
+State changes: 70a6763aea82c40d (allowed to change if not deployed to any network)
+Events       : 492eacef54b910dc (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - component_with_large_state: component_sim1crawpnl7k2d2vlv9q730c3g2yrj59hpc0hzhy24v48qrw6lhxecxcg

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/001--maya-router-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/001--maya-router-create-accounts.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.39881102299,    100.0%
-- Execution Cost (XRD)                                                     ,               0.19616945,     49.2%
+Total Cost (XRD)                                                           ,            0.39897357299,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.196332,     49.2%
 - Finalization Cost (XRD)                                                  ,                 0.060258,     15.1%
 - Storage Cost (XRD)                                                       ,            0.14238357299,     35.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3923389,    100.0%
+Execution Cost Breakdown                                                   ,                  3926640,    100.0%
 - AfterInvoke                                                              ,                      454,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.1%
 - BeforeInvoke                                                             ,                     2020,      0.1%
@@ -35,7 +35,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                    54942,      1.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      742,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/002--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/002--faucet-top-up.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.43698665544,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2905265,     66.5%
-- Finalization Cost (XRD)                                                  ,                0.0312563,      7.2%
-- Storage Cost (XRD)                                                       ,            0.11520385544,     26.4%
+Total Cost (XRD)                                                           ,            0.43739680544,    100.0%
+- Execution Cost (XRD)                                                     ,               0.29093665,     66.5%
+- Finalization Cost (XRD)                                                  ,                0.0312563,      7.1%
+- Storage Cost (XRD)                                                       ,            0.11520385544,     26.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5810530,    100.0%
+Execution Cost Breakdown                                                   ,                  5818733,    100.0%
 - AfterInvoke                                                              ,                      520,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     1796,      0.0%
@@ -20,7 +20,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      3.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2602605,     44.8%
+- OpenSubstate::GlobalPackage                                              ,                  2602605,     44.7%
 - OpenSubstate::InternalFungibleVault                                      ,                   106652,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    49147,      0.8%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.5%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - PrepareWasmCode                                                          ,                   707732,     12.2%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   869143,     15.0%
+- ReadSubstate                                                             ,                   869143,     14.9%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
@@ -40,8 +40,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
 - RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.7%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14880,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/003--maya-router-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/003--maya-router-create-resources.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.06948032912,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2796739,     26.2%
+Total Cost (XRD)                                                           ,            1.06964287912,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27983645,     26.2%
 - Finalization Cost (XRD)                                                  ,                0.2572747,     24.1%
 - Storage Cost (XRD)                                                       ,            0.53253172912,     49.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5593478,    100.0%
+Execution Cost Breakdown                                                   ,                  5596729,    100.0%
 - AfterInvoke                                                              ,                     1080,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.1%
 - BeforeInvoke                                                             ,                     5462,      0.1%
@@ -40,7 +40,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.9%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      864,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/004--maya-router-publish-and-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/004--maya-router-publish-and-instantiate.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            68.2978544291,    100.0%
-- Execution Cost (XRD)                                                     ,                1.2583043,      1.8%
+Total Cost (XRD)                                                           ,            68.2986730791,    100.0%
+- Execution Cost (XRD)                                                     ,               1.25912295,      1.8%
 - Finalization Cost (XRD)                                                  ,               0.15169575,      0.2%
 - Storage Cost (XRD)                                                       ,            66.8878543791,     97.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 25166086,    100.0%
+Execution Cost Breakdown                                                   ,                 25182459,    100.0%
 - AfterInvoke                                                              ,                      710,      0.0%
 - AllocateNodeId                                                           ,                     3201,      0.0%
 - BeforeInvoke                                                             ,                   410742,      1.6%
@@ -37,8 +37,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::instantiate_account_locker                                ,                    49102,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
 - RunNativeCode::publish_wasm_advanced                                     ,                  9388601,     37.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
-- RunWasmCode::MayaRouter_instantiate                                      ,                    82650,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
+- RunWasmCode::MayaRouter_instantiate                                      ,                    95772,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1163,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/001--maya-router-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/001--maya-router-create-accounts.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39881102299 XRD
-├─ Network execution: 0.19616945 XRD, 3923389 execution cost units
+TRANSACTION COST: 0.39897357299 XRD
+├─ Network execution: 0.196332 XRD, 3926640 execution cost units
 ├─ Network finalization: 0.060258 XRD, 1205160 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14238357299 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39881102299"),
+     amount: Decimal("0.39897357299"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.199405511495"),
+     amount: Decimal("0.199486786495"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.199405511495"),
+     amount: Decimal("0.199486786495"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.0997027557475"),
+             0u8 => Decimal("0.0997433932475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.60118897701")),
+         LiquidFungibleResource(Decimal("99999999999999999.60102642701")),
        )
 ├─ account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy across 5 partitions
   ├─ Partition(2): 1 change
@@ -211,7 +211,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.199405511495")),
+         LiquidFungibleResource(Decimal("0.199486786495")),
        )
 
 OUTPUTS: 3
@@ -222,10 +222,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39881102299
+   Change: -0.39897357299
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.199405511495
+   Change: 0.199486786495
 
 NEW ENTITIES: 2
 ├─ Component: account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/002--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/002--faucet-top-up.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43698665544 XRD
-├─ Network execution: 0.2905265 XRD, 5810530 execution cost units
+TRANSACTION COST: 0.43739680544 XRD
+├─ Network execution: 0.29093665 XRD, 5818733 execution cost units
 ├─ Network finalization: 0.0312563 XRD, 625126 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11520385544 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43698665544"),
+     amount: Decimal("0.43739680544"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.21849332772"),
+     amount: Decimal("0.21869840272"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.21849332772"),
+     amount: Decimal("0.21869840272"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2089494196075"),
+             0u8 => Decimal("0.2090925946075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.16420232157")),
+         LiquidFungibleResource(Decimal("99999999999989999.16362962157")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -129,7 +129,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.417898839215")),
+         LiquidFungibleResource(Decimal("0.418185189215")),
        )
 
 OUTPUTS: 4
@@ -141,12 +141,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.43698665544
+   Change: -10000.43739680544
 ├─ Vault: internal_vault_sim1tzd883cmyxpkvj3s540tqfq5dhh887ymjlapc59pdhmf9qh66kqxr3
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.21849332772
+   Change: 0.21869840272
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/003--maya-router-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/003--maya-router-create-resources.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.06948032912 XRD
-├─ Network execution: 0.2796739 XRD, 5593478 execution cost units
+TRANSACTION COST: 1.06964287912 XRD
+├─ Network execution: 0.27983645 XRD, 5596729 execution cost units
 ├─ Network finalization: 0.2572747 XRD, 5145494 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.53253172912 XRD
@@ -50,15 +50,15 @@ EVENTS: 12
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.06948032912"),
+     amount: Decimal("1.06964287912"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.53474016456"),
+     amount: Decimal("0.53482143956"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.53474016456"),
+     amount: Decimal("0.53482143956"),
    }
 
 STATE UPDATES: 10 entities
@@ -68,7 +68,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4763195018875"),
+             0u8 => Decimal("0.4765033143875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -111,7 +111,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.09472199245")),
+         LiquidFungibleResource(Decimal("99999999999989998.09398674245")),
        )
 ├─ resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf across 5 partitions
   ├─ Partition(2): 6 changes
@@ -456,7 +456,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.952639003775")),
+         LiquidFungibleResource(Decimal("0.953006628775")),
        )
 
 OUTPUTS: 4
@@ -474,7 +474,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.06948032912
+   Change: -1.06964287912
 ├─ Vault: internal_vault_sim1tryac3w8efhstsnsygpr8y7dkgjh23eqw8samk73rr69qumddqxnnv
    ResAddr: resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf
    Change: 100000000000
@@ -483,7 +483,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.53474016456
+   Change: 0.53482143956
 
 NEW ENTITIES: 2
 ├─ Resource: resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/004--maya-router-publish-and-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/004--maya-router-publish-and-instantiate.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 68.2978544291 XRD
-├─ Network execution: 1.2583043 XRD, 25166086 execution cost units
+TRANSACTION COST: 68.2986730791 XRD
+├─ Network execution: 1.25912295 XRD, 25182459 execution cost units
 ├─ Network finalization: 0.15169575 XRD, 3033915 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 66.8878543791 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("68.2978544291"),
+     amount: Decimal("68.2986730791"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("34.14892721455"),
+     amount: Decimal("34.14933653955"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("34.14892721455"),
+     amount: Decimal("34.14933653955"),
    }
 
 STATE UPDATES: 10 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("17.5507831091625"),
+             0u8 => Decimal("17.5511715841625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989929.79686756335")),
+         LiquidFungibleResource(Decimal("99999999999989929.79531366335")),
        )
 ├─ package_sim1pha7h60q9p4hx40chf8uxntzs3tqgnd72kfu2akz2lx67hq5e32ex3 across 12 partitions
   ├─ Partition(1): 1 change
@@ -375,7 +375,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("35.101566218325")),
+         LiquidFungibleResource(Decimal("35.102343168325")),
        )
 
 OUTPUTS: 4
@@ -387,10 +387,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -68.2978544291
+   Change: -68.2986730791
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 34.14892721455
+   Change: 34.14933653955
 
 NEW ENTITIES: 3
 └─ Package: package_sim1pha7h60q9p4hx40chf8uxntzs3tqgnd72kfu2akz2lx67hq5e32ex3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: maya_router
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 8ef00407fa8506c5 (allowed to change if not deployed to any network)
-Events       : ba3ae485775f5d72 (allowed to change if not deployed to any network)
+State changes: 96ed194a25f3ef39 (allowed to change if not deployed to any network)
+Events       : d8156132163d1eb7 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - owner_account: account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/001--metadata-create-package-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/001--metadata-create-package-with-metadata.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,           50.38646230485,    100.0%
-- Execution Cost (XRD)                                                     ,               1.03884935,      2.1%
+Total Cost (XRD)                                                           ,           50.38687245485,    100.0%
+- Execution Cost (XRD)                                                     ,                1.0392595,      2.1%
 - Finalization Cost (XRD)                                                  ,                0.2910838,      0.6%
 - Storage Cost (XRD)                                                       ,           49.05652915485,     97.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20776987,    100.0%
+Execution Cost Breakdown                                                   ,                 20785190,    100.0%
 - AfterInvoke                                                              ,                      914,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.0%
 - BeforeInvoke                                                             ,                   295208,      1.4%
@@ -46,8 +46,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.2%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.6%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/002--metadata-create-component-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/002--metadata-create-component-with-metadata.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.82257928628,    100.0%
-- Execution Cost (XRD)                                                     ,               0.71653925,     39.3%
+Total Cost (XRD)                                                           ,            1.82359473628,    100.0%
+- Execution Cost (XRD)                                                     ,                0.7175547,     39.3%
 - Finalization Cost (XRD)                                                  ,               0.22904115,     12.6%
 - Storage Cost (XRD)                                                       ,            0.87699888628,     48.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14330785,    100.0%
+Execution Cost Breakdown                                                   ,                 14351094,    100.0%
 - AfterInvoke                                                              ,                      844,      0.0%
 - AllocateNodeId                                                           ,                     5529,      0.0%
 - BeforeInvoke                                                             ,                     7296,      0.1%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - MoveModule                                                               ,                     1960,      0.0%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.3%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      1.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                  5242541,     36.6%
+- OpenSubstate::GlobalGenericComponent                                     ,                  5242541,     36.5%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    44020,      0.3%
 - OpenSubstate::GlobalPackage                                              ,                  3830264,     26.7%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      2.0%
@@ -44,9 +44,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::set                                                       ,                   667872,      4.7%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
-- RunWasmCode::MetadataTest_new_with_address                               ,                    73344,      0.5%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::MetadataTest_new_with_address                               ,                    85450,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      381,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/003--metadata-create-resource-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/003--metadata-create-resource-with-metadata.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.30572886636,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.361168,     27.7%
+Total Cost (XRD)                                                           ,            1.30613901636,    100.0%
+- Execution Cost (XRD)                                                     ,               0.36157815,     27.7%
 - Finalization Cost (XRD)                                                  ,               0.27202975,     20.8%
 - Storage Cost (XRD)                                                       ,            0.67253111636,     51.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7223360,    100.0%
+Execution Cost Breakdown                                                   ,                  7231563,    100.0%
 - AfterInvoke                                                              ,                      958,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     9258,      0.1%
@@ -45,8 +45,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.7%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      423,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/004--metadata-create-resource-with-metadata-partially-locked.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/004--metadata-create-resource-with-metadata-partially-locked.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.77304721926,    100.0%
-- Execution Cost (XRD)                                                     ,               0.35711055,     46.2%
+Total Cost (XRD)                                                           ,            0.77345736926,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3575207,     46.2%
 - Finalization Cost (XRD)                                                  ,               0.12201425,     15.8%
 - Storage Cost (XRD)                                                       ,            0.29392241926,     38.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7142211,    100.0%
+Execution Cost Breakdown                                                   ,                  7150414,    100.0%
 - AfterInvoke                                                              ,                      958,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     3844,      0.1%
@@ -45,8 +45,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.7%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      423,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/005--metadata-update-initially-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/005--metadata-update-initially-locked-metadata-fails.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.17866137938,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1437569,     80.5%
+Total Cost (XRD)                                                           ,            0.17882392938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14391945,     80.5%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,            0.03490447938,     19.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2875138,    100.0%
+Execution Cost Breakdown                                                   ,                  2878389,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      472,      0.0%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunNativeCode::set                                                       ,                    20871,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/006--metadata-update-updatable-metadata-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/006--metadata-update-updatable-metadata-succeeds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.2187539393,    100.0%
-- Execution Cost (XRD)                                                     ,               0.15461435,     70.7%
+Total Cost (XRD)                                                           ,             0.2189164893,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1547769,     70.7%
 - Finalization Cost (XRD)                                                  ,                0.0155022,      7.1%
 - Storage Cost (XRD)                                                       ,             0.0486373893,     22.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3092287,    100.0%
+Execution Cost Breakdown                                                   ,                  3095538,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      630,      0.0%
@@ -18,7 +18,7 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   364827,     11.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  1501852,     48.6%
+- OpenSubstate::GlobalPackage                                              ,                  1501852,     48.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    11360,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::set                                                       ,                    20871,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14480,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/007--metadata-lock-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/007--metadata-lock-metadata.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.21135074719,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1548047,     73.2%
+Total Cost (XRD)                                                           ,            0.21151329719,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15496725,     73.3%
 - Finalization Cost (XRD)                                                  ,               0.01525195,      7.2%
 - Storage Cost (XRD)                                                       ,            0.04129409719,     19.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3096094,    100.0%
+Execution Cost Breakdown                                                   ,                  3099345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      622,      0.0%
@@ -30,7 +30,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock                                                      ,                    25245,      0.8%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14320,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,               0.46873391,    100.0%
-- Execution Cost (XRD)                                                     ,               0.22198755,     47.4%
+Total Cost (XRD)                                                           ,               0.46889646,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2221501,     47.4%
 - Finalization Cost (XRD)                                                  ,                0.0560115,     11.9%
 - Storage Cost (XRD)                                                       ,               0.19073486,     40.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4439751,    100.0%
+Execution Cost Breakdown                                                   ,                  4443002,    100.0%
 - AfterInvoke                                                              ,                      222,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     2114,      0.0%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.8%
 - RunNativeCode::set                                                       ,                    62613,      1.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.4066273693,    100.0%
-- Execution Cost (XRD)                                                     ,               0.21186395,     52.1%
+Total Cost (XRD)                                                           ,             0.4067899193,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2120265,     52.1%
 - Finalization Cost (XRD)                                                  ,                0.0507586,     12.5%
 - Storage Cost (XRD)                                                       ,             0.1440048193,     35.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4237279,    100.0%
+Execution Cost Breakdown                                                   ,                  4240530,    100.0%
 - AfterInvoke                                                              ,                      216,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1810,      0.0%
@@ -26,7 +26,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalGenericComponent                                   ,                    20149,      0.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      156,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.4%
+- PrepareWasmCode                                                          ,                   353866,      8.3%
 - QueryActor                                                               ,                     1000,      0.0%
 - ReadSubstate                                                             ,                   451054,     10.6%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.8%
 - RunNativeCode::set                                                       ,                    41742,      1.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/010--metadata-update-recently-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/010--metadata-update-recently-locked-metadata-fails.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.17866137938,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1437569,     80.5%
+Total Cost (XRD)                                                           ,            0.17882392938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14391945,     80.5%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
 - Storage Cost (XRD)                                                       ,            0.03490447938,     19.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2875138,    100.0%
+Execution Cost Breakdown                                                   ,                  2878389,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      472,      0.0%
@@ -28,7 +28,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunNativeCode::set                                                       ,                    20871,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/001--metadata-create-package-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/001--metadata-create-package-with-metadata.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 50.38646230485 XRD
-├─ Network execution: 1.03884935 XRD, 20776987 execution cost units
+TRANSACTION COST: 50.38687245485 XRD
+├─ Network execution: 1.0392595 XRD, 20785190 execution cost units
 ├─ Network finalization: 0.2910838 XRD, 5821676 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 49.05652915485 XRD
@@ -37,15 +37,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("50.38646230485"),
+     amount: Decimal("50.38687245485"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("25.193231152425"),
+     amount: Decimal("25.193436227425"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("25.193231152425"),
+     amount: Decimal("25.193436227425"),
    }
 
 STATE UPDATES: 10 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("12.5966155762125"),
+             0u8 => Decimal("12.5967181137125"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989949.61353769515")),
+         LiquidFungibleResource(Decimal("99999999999989949.61312754515")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -853,7 +853,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("25.193231152425")),
+         LiquidFungibleResource(Decimal("25.193436227425")),
        )
 
 OUTPUTS: 5
@@ -866,13 +866,13 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10050.38646230485
+   Change: -10050.38687245485
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 25.193231152425
+   Change: 25.193436227425
 
 NEW ENTITIES: 2
 └─ Package: package_sim1p5pjdx5g7h0ygzc3ev2r5vj3zprctn6vr7p7t3mqvzjp2r6frahcq3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/002--metadata-create-component-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/002--metadata-create-component-with-metadata.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.82257928628 XRD
-├─ Network execution: 0.71653925 XRD, 14330785 execution cost units
+TRANSACTION COST: 1.82359473628 XRD
+├─ Network execution: 0.7175547 XRD, 14351094 execution cost units
 ├─ Network finalization: 0.22904115 XRD, 4580823 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.87699888628 XRD
@@ -313,15 +313,15 @@ EVENTS: 39
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.82257928628"),
+     amount: Decimal("1.82359473628"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.91128964314"),
+     amount: Decimal("0.91179736814"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.91128964314"),
+     amount: Decimal("0.91179736814"),
    }
 
 STATE UPDATES: 8 entities
@@ -331,7 +331,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.0522603977825"),
+             0u8 => Decimal("13.0526167977825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -364,7 +364,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979947.79095840887")),
+         LiquidFungibleResource(Decimal("99999999999979947.78953280887")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -699,7 +699,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("26.104520795565")),
+         LiquidFungibleResource(Decimal("26.105233595565")),
        )
 
 OUTPUTS: 37
@@ -744,13 +744,13 @@ OUTPUTS: 37
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.82257928628
+   Change: -10001.82359473628
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.91128964314
+   Change: 0.91179736814
 
 NEW ENTITIES: 1
 └─ Component: component_sim1cz4djw7ufpm4rjkwnphzxrn2q7kx8k4a0k2l4wqfz0dwfv4fd9znvr

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/003--metadata-create-resource-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/003--metadata-create-resource-with-metadata.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.30572886636 XRD
-├─ Network execution: 0.361168 XRD, 7223360 execution cost units
+TRANSACTION COST: 1.30613901636 XRD
+├─ Network execution: 0.36157815 XRD, 7231563 execution cost units
 ├─ Network finalization: 0.27202975 XRD, 5440595 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.67253111636 XRD
@@ -46,15 +46,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.30572886636"),
+     amount: Decimal("1.30613901636"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.65286443318"),
+     amount: Decimal("0.65306950818"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.65286443318"),
+     amount: Decimal("0.65306950818"),
    }
 
 STATE UPDATES: 10 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.3786926143725"),
+             0u8 => Decimal("13.3791515518725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969946.48522954251")),
+         LiquidFungibleResource(Decimal("99999999999969946.48339379251")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -501,7 +501,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("26.757385228745")),
+         LiquidFungibleResource(Decimal("26.758303103745")),
        )
 
 OUTPUTS: 4
@@ -516,7 +516,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.30572886636
+   Change: -10001.30613901636
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
@@ -525,7 +525,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.65286443318
+   Change: 0.65306950818
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1t5z9e7s76mryajk97lrmpe3cyxy2zaj456y2px85ksu2ts4n6qwa39

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/004--metadata-create-resource-with-metadata-partially-locked.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/004--metadata-create-resource-with-metadata-partially-locked.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.77304721926 XRD
-├─ Network execution: 0.35711055 XRD, 7142211 execution cost units
+TRANSACTION COST: 0.77345736926 XRD
+├─ Network execution: 0.3575207 XRD, 7150414 execution cost units
 ├─ Network finalization: 0.12201425 XRD, 2440285 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.29392241926 XRD
@@ -46,15 +46,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.77304721926"),
+     amount: Decimal("0.77345736926"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.38652360963"),
+     amount: Decimal("0.38672868463"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.38652360963"),
+     amount: Decimal("0.38672868463"),
    }
 
 STATE UPDATES: 10 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.5719544191875"),
+             0u8 => Decimal("13.5725158941875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.71218232325")),
+         LiquidFungibleResource(Decimal("99999999999959945.70993642325")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -272,7 +272,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.143908838375")),
+         LiquidFungibleResource(Decimal("27.145031788375")),
        )
 
 OUTPUTS: 4
@@ -287,7 +287,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.77304721926
+   Change: -10000.77345736926
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
@@ -296,7 +296,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.38652360963
+   Change: 0.38672868463
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1t4xqgmnnrx396mwjwy46844xmq83nrnwtw6uth6pa3uvxs65ltyavt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/005--metadata-update-initially-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/005--metadata-update-initially-locked-metadata-fails.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(KeyValueEntryLocked)
 
-TRANSACTION COST: 0.17866137938 XRD
-├─ Network execution: 0.1437569 XRD, 2875138 execution cost units
+TRANSACTION COST: 0.17882392938 XRD
+├─ Network execution: 0.14391945 XRD, 2878389 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.17866137938"),
+     amount: Decimal("0.17882392938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08933068969"),
+     amount: Decimal("0.08941196469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08933068969"),
+     amount: Decimal("0.08941196469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.6166197640325"),
+             0u8 => Decimal("13.6172218765325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.53352094387")),
+         LiquidFungibleResource(Decimal("99999999999959945.53111249387")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.233239528065")),
+         LiquidFungibleResource(Decimal("27.234443753065")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.17866137938
+   Change: -0.17882392938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08933068969
+   Change: 0.08941196469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/006--metadata-update-updatable-metadata-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/006--metadata-update-updatable-metadata-succeeds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2187539393 XRD
-├─ Network execution: 0.15461435 XRD, 3092287 execution cost units
+TRANSACTION COST: 0.2189164893 XRD
+├─ Network execution: 0.1547769 XRD, 3095538 execution cost units
 ├─ Network finalization: 0.0155022 XRD, 310044 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0486373893 XRD
@@ -23,15 +23,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2187539393"),
+     amount: Decimal("0.2189164893"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10937696965"),
+     amount: Decimal("0.10945824465"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10937696965"),
+     amount: Decimal("0.10945824465"),
    }
 
 STATE UPDATES: 6 entities
@@ -41,7 +41,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.6713082488575"),
+             0u8 => Decimal("13.6719509988575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -82,13 +82,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.31476700457")),
+         LiquidFungibleResource(Decimal("99999999999959945.31219600457")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.342616497715")),
+         LiquidFungibleResource(Decimal("27.343901997715")),
        )
 
 OUTPUTS: 2
@@ -98,9 +98,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2187539393
+   Change: -0.2189164893
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10937696965
+   Change: 0.10945824465
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/007--metadata-lock-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/007--metadata-lock-metadata.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.21135074719 XRD
-├─ Network execution: 0.1548047 XRD, 3096094 execution cost units
+TRANSACTION COST: 0.21151329719 XRD
+├─ Network execution: 0.15496725 XRD, 3099345 execution cost units
 ├─ Network finalization: 0.01525195 XRD, 305039 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04129409719 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.21135074719"),
+     amount: Decimal("0.21151329719"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.105675373595"),
+     amount: Decimal("0.105756648595"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.105675373595"),
+     amount: Decimal("0.105756648595"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.724145935655"),
+             0u8 => Decimal("13.724829323155"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.10341625738")),
+         LiquidFungibleResource(Decimal("99999999999959945.10068270738")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.44829187131")),
+         LiquidFungibleResource(Decimal("27.44965864631")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.21135074719
+   Change: -0.21151329719
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.105675373595
+   Change: 0.105756648595
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46873391 XRD
-├─ Network execution: 0.22198755 XRD, 4439751 execution cost units
+TRANSACTION COST: 0.46889646 XRD
+├─ Network execution: 0.2221501 XRD, 4443002 execution cost units
 ├─ Network finalization: 0.0560115 XRD, 1120230 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19073486 XRD
@@ -37,15 +37,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46873391"),
+     amount: Decimal("0.46889646"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.234366955"),
+     amount: Decimal("0.23444823"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.234366955"),
+     amount: Decimal("0.23444823"),
    }
 
 STATE UPDATES: 6 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.841329413155"),
+             0u8 => Decimal("13.842053438155"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.63468234738")),
+         LiquidFungibleResource(Decimal("99999999999959944.63178624738")),
        )
 ├─ account_sim16xygyhqp3x3awxlz3c5dzrm7jqghgpgs776v4af0yfr7xljqv060nu across 5 partitions
   ├─ Partition(2): 5 changes
@@ -206,7 +206,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.68265882631")),
+         LiquidFungibleResource(Decimal("27.68410687631")),
        )
 
 OUTPUTS: 4
@@ -218,10 +218,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46873391
+   Change: -0.46889646
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.234366955
+   Change: 0.23444823
 
 NEW ENTITIES: 1
 └─ Component: account_sim16xygyhqp3x3awxlz3c5dzrm7jqghgpgs776v4af0yfr7xljqv060nu

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.4066273693 XRD
-├─ Network execution: 0.21186395 XRD, 4237279 execution cost units
+TRANSACTION COST: 0.4067899193 XRD
+├─ Network execution: 0.2120265 XRD, 4240530 execution cost units
 ├─ Network finalization: 0.0507586 XRD, 1015172 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.1440048193 XRD
@@ -30,15 +30,15 @@ EVENTS: 6
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.4066273693"),
+     amount: Decimal("0.4067899193"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.20331368465"),
+     amount: Decimal("0.20339495965"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.20331368465"),
+     amount: Decimal("0.20339495965"),
    }
 
 STATE UPDATES: 6 entities
@@ -48,7 +48,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.94298625548"),
+             0u8 => Decimal("13.94375091798"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -81,7 +81,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.22805497808")),
+         LiquidFungibleResource(Decimal("99999999999959944.22499632808")),
        )
 ├─ account_sim168ydk240yx69yl7zdz2mzkdjc3r5p6n4gwypqsype2d6d942vg95h3 across 5 partitions
   ├─ Partition(2): 4 changes
@@ -193,7 +193,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.88597251096")),
+         LiquidFungibleResource(Decimal("27.88750183596")),
        )
 
 OUTPUTS: 3
@@ -204,10 +204,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.4066273693
+   Change: -0.4067899193
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.20331368465
+   Change: 0.20339495965
 
 NEW ENTITIES: 1
 └─ Component: account_sim168ydk240yx69yl7zdz2mzkdjc3r5p6n4gwypqsype2d6d942vg95h3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/010--metadata-update-recently-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/010--metadata-update-recently-locked-metadata-fails.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(KeyValueEntryLocked)
 
-TRANSACTION COST: 0.17866137938 XRD
-├─ Network execution: 0.1437569 XRD, 2875138 execution cost units
+TRANSACTION COST: 0.17882392938 XRD
+├─ Network execution: 0.14391945 XRD, 2878389 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.17866137938"),
+     amount: Decimal("0.17882392938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08933068969"),
+     amount: Decimal("0.08941196469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08933068969"),
+     amount: Decimal("0.08941196469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.987651600325"),
+             0u8 => Decimal("13.988456900325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.0493935987")),
+         LiquidFungibleResource(Decimal("99999999999959944.0461723987")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.97530320065")),
+         LiquidFungibleResource(Decimal("27.97691380065")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.17866137938
+   Change: -0.17882392938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08933068969
+   Change: 0.08941196469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: metadata
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 2d4da7914b2e5ed1 (allowed to change if not deployed to any network)
-Events       : b4b01623a08c782b (allowed to change if not deployed to any network)
+State changes: 666ba779bc556f93 (allowed to change if not deployed to any network)
+Events       : 870f7c8cd086e0d7 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - user_account_1: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/001--non-fungible-resource-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/001--non-fungible-resource-create.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.86122961999,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27600795,     32.0%
+Total Cost (XRD)                                                           ,            0.86139216999,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2761705,     32.1%
 - Finalization Cost (XRD)                                                  ,               0.16627255,     19.3%
 - Storage Cost (XRD)                                                       ,            0.41894911999,     48.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5520159,    100.0%
+Execution Cost Breakdown                                                   ,                  5523410,    100.0%
 - AfterInvoke                                                              ,                      690,      0.0%
 - AllocateNodeId                                                           ,                     2813,      0.1%
 - BeforeInvoke                                                             ,                     4554,      0.1%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.6%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1105,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/002--non-fungible-resource-create-string.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/002--non-fungible-resource-create-string.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.75135211441,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2634653,     35.1%
+Total Cost (XRD)                                                           ,            0.75151466441,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26362785,     35.1%
 - Finalization Cost (XRD)                                                  ,                0.1362671,     18.1%
 - Storage Cost (XRD)                                                       ,            0.35161971441,     46.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5269306,    100.0%
+Execution Cost Breakdown                                                   ,                  5272557,    100.0%
 - AfterInvoke                                                              ,                      554,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3492,      0.1%
@@ -20,7 +20,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14330,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.8%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.7%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    51081,      1.0%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/003--non-fungible-resource-create-bytes.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/003--non-fungible-resource-create-bytes.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.75710561021,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2634963,     34.8%
+Total Cost (XRD)                                                           ,            0.75726816021,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26365885,     34.8%
 - Finalization Cost (XRD)                                                  ,               0.13626755,     18.0%
 - Storage Cost (XRD)                                                       ,            0.35734176021,     47.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5269926,    100.0%
+Execution Cost Breakdown                                                   ,                  5273177,    100.0%
 - AfterInvoke                                                              ,                      574,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3512,      0.1%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/004--non-fungible-resource-create-ruid.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/004--non-fungible-resource-create-ruid.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.76321259774,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26283175,     34.4%
+Total Cost (XRD)                                                           ,            0.76337514774,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2629943,     34.5%
 - Finalization Cost (XRD)                                                  ,                 0.136268,     17.9%
 - Storage Cost (XRD)                                                       ,            0.36411284774,     47.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5256635,    100.0%
+Execution Cost Breakdown                                                   ,                  5259886,    100.0%
 - AfterInvoke                                                              ,                      604,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3504,      0.1%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14330,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.9%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    51181,      1.0%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/005--non-fungible-resource-mint-32-nfts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/005--non-fungible-resource-mint-32-nfts.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            2.04141269637,    100.0%
-- Execution Cost (XRD)                                                     ,                0.4980885,     24.4%
+Total Cost (XRD)                                                           ,            2.04157524637,    100.0%
+- Execution Cost (XRD)                                                     ,               0.49825105,     24.4%
 - Finalization Cost (XRD)                                                  ,                0.3360679,     16.5%
 - Storage Cost (XRD)                                                       ,            1.20725629637,     59.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  9961770,    100.0%
+Execution Cost Breakdown                                                   ,                  9965021,    100.0%
 - AfterInvoke                                                              ,                      856,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     9500,      0.1%
@@ -39,7 +39,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.0%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.4%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     4832,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/006--non-fungible-resource-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/006--non-fungible-resource-burn.txt
@@ -1,15 +1,15 @@
-Total Cost (XRD)                                                           ,            0.42100291511,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2620007,     62.2%
+Total Cost (XRD)                                                           ,            0.42116546511,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26216325,     62.2%
 - Finalization Cost (XRD)                                                  ,               0.04675475,     11.1%
 - Storage Cost (XRD)                                                       ,            0.11224746511,     26.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5240014,    100.0%
+Execution Cost Breakdown                                                   ,                  5243265,    100.0%
 - AfterInvoke                                                              ,                      678,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     2622,      0.1%
 - CheckReference                                                           ,                    80033,      1.5%
-- CloseSubstate                                                            ,                    49794,      1.0%
+- CloseSubstate                                                            ,                    49794,      0.9%
 - CreateNode                                                               ,                    19982,      0.4%
 - DrainSubstates                                                           ,                   120818,      2.3%
 - DropNode                                                                 ,                    35783,      0.7%
@@ -27,7 +27,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - OpenSubstate::InternalNonFungibleVault                                   ,                   132271,      2.5%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.8%
+- PrepareWasmCode                                                          ,                   353866,      6.7%
 - QueryActor                                                               ,                     4000,      0.1%
 - ReadSubstate                                                             ,                   571028,     10.9%
 - RemoveSubstate                                                           ,                    40717,      0.8%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.2%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.1%
 - RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    24120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/007--non-fungible-resource-transfer.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/007--non-fungible-resource-transfer.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.57087000949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2995224,     52.5%
+Total Cost (XRD)                                                           ,            0.57103255949,    100.0%
+- Execution Cost (XRD)                                                     ,               0.29968495,     52.5%
 - Finalization Cost (XRD)                                                  ,               0.07651195,     13.4%
 - Storage Cost (XRD)                                                       ,            0.19483565949,     34.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5990448,    100.0%
+Execution Cost Breakdown                                                   ,                  5993699,    100.0%
 - AfterInvoke                                                              ,                      586,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
 - BeforeInvoke                                                             ,                     2848,      0.0%
@@ -46,7 +46,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.0%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      522,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/008--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/008--non-fungible-resource-freeze-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.20230061004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14623145,     72.3%
+Total Cost (XRD)                                                           ,            0.20246316004,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.146394,     72.3%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
 - Storage Cost (XRD)                                                       ,            0.04081726004,     20.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2924629,    100.0%
+Execution Cost Breakdown                                                   ,                  2927880,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_NonFungibleVault                                   ,                    36496,      1.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/009--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/009--non-fungible-resource-freeze-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.20230061004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14623145,     72.3%
+Total Cost (XRD)                                                           ,            0.20246316004,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.146394,     72.3%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
 - Storage Cost (XRD)                                                       ,            0.04081726004,     20.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2924629,    100.0%
+Execution Cost Breakdown                                                   ,                  2927880,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::freeze_NonFungibleVault                                   ,                    36496,      1.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/010--non-fungible-resource-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/010--non-fungible-resource-recall-frozen-vault.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.32258731512,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2168157,     67.2%
+Total Cost (XRD)                                                           ,            0.32274986512,    100.0%
+- Execution Cost (XRD)                                                     ,               0.21697825,     67.2%
 - Finalization Cost (XRD)                                                  ,               0.03100355,      9.6%
 - Storage Cost (XRD)                                                       ,            0.07476806512,     23.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4336314,    100.0%
+Execution Cost Breakdown                                                   ,                  4339565,    100.0%
 - AfterInvoke                                                              ,                      298,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1420,      0.0%
@@ -24,7 +24,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    43083,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   171392,      4.0%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   171392,      3.9%
 - PinNode                                                                  ,                      168,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      8.2%
 - QueryActor                                                               ,                     2000,      0.0%
@@ -40,7 +40,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.8%
 - RunNativeCode::recall_non_fungibles                                      ,                    57416,      1.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/011--non-fungible-resource-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/011--non-fungible-resource-unfreeze-withdraw.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.2023645949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1461047,     72.2%
+Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.3%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2922094,    100.0%
+Execution Cost Breakdown                                                   ,                  2925345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.9%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/012--non-fungible-resource-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/012--non-fungible-resource-unfreeze-deposit.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.2023645949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1461047,     72.2%
+Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.3%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2922094,    100.0%
+Execution Cost Breakdown                                                   ,                  2925345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.9%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/013--non-fungible-resource-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/013--non-fungible-resource-unfreeze-burn.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.2023645949,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1461047,     72.2%
+Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
 - Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.3%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2922094,    100.0%
+Execution Cost Breakdown                                                   ,                  2925345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.9%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/014--non-fungible-resource-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/014--non-fungible-resource-recall-unfrozen-vault.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.30372242619,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.212815,     70.1%
+Total Cost (XRD)                                                           ,            0.30388497619,    100.0%
+- Execution Cost (XRD)                                                     ,               0.21297755,     70.1%
 - Finalization Cost (XRD)                                                  ,                0.0210031,      6.9%
 - Storage Cost (XRD)                                                       ,            0.06990432619,     23.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4256300,    100.0%
+Execution Cost Breakdown                                                   ,                  4259551,    100.0%
 - AfterInvoke                                                              ,                      298,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1420,      0.0%
@@ -40,7 +40,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.8%
 - RunNativeCode::recall_non_fungibles                                      ,                    57416,      1.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/015--non-fungible-create-resource-with-supply-with-empty-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/015--non-fungible-create-resource-with-supply-with-empty-data.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.72575947002,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26298495,     36.2%
+Total Cost (XRD)                                                           ,            0.72592202002,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2631475,     36.3%
 - Finalization Cost (XRD)                                                  ,                0.1562636,     21.5%
 - Storage Cost (XRD)                                                       ,            0.30651092002,     42.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5259699,    100.0%
+Execution Cost Breakdown                                                   ,                  5262950,    100.0%
 - AfterInvoke                                                              ,                      592,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     2616,      0.0%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      988,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             1.5461192445,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27146135,     17.6%
+Total Cost (XRD)                                                           ,             1.5462817945,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2716239,     17.6%
 - Finalization Cost (XRD)                                                  ,               0.21131105,     13.7%
 - Storage Cost (XRD)                                                       ,             1.0633468445,     68.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5429227,    100.0%
+Execution Cost Breakdown                                                   ,                  5432478,    100.0%
 - AfterInvoke                                                              ,                      646,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                    10678,      0.2%
@@ -38,12 +38,12 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
 - RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1455,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/017--non-fungible-transfer-metadata-standard-nfs.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/017--non-fungible-transfer-metadata-standard-nfs.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.44436525747,    100.0%
-- Execution Cost (XRD)                                                     ,               0.25657795,     57.7%
+Total Cost (XRD)                                                           ,            0.44452780747,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2567405,     57.8%
 - Finalization Cost (XRD)                                                  ,               0.05150725,     11.6%
 - Storage Cost (XRD)                                                       ,            0.13628005747,     30.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5131559,    100.0%
+Execution Cost Breakdown                                                   ,                  5134810,    100.0%
 - AfterInvoke                                                              ,                      488,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     1868,      0.0%
@@ -19,7 +19,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.4%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    94341,      1.8%
-- OpenSubstate::GlobalPackage                                              ,                  2152801,     42.0%
+- OpenSubstate::GlobalPackage                                              ,                  2152801,     41.9%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   691764,     13.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    54290,      1.1%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.4%
 - RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      302,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/018--non-fungible-create-resource-with-supply-with-complex-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/018--non-fungible-create-resource-with-supply-with-complex-data.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.81695454289,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26887195,     32.9%
+Total Cost (XRD)                                                           ,            0.81711709289,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2690345,     32.9%
 - Finalization Cost (XRD)                                                  ,               0.12627245,     15.5%
 - Storage Cost (XRD)                                                       ,            0.42181014289,     51.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5377439,    100.0%
+Execution Cost Breakdown                                                   ,                  5380690,    100.0%
 - AfterInvoke                                                              ,                      556,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     4370,      0.1%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      700,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/019--non-fungible-mutate-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/019--non-fungible-mutate-data.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.01265223973,    100.0%
-- Execution Cost (XRD)                                                     ,               0.17614035,     17.4%
+Total Cost (XRD)                                                           ,            1.01281478973,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1763029,     17.4%
 - Finalization Cost (XRD)                                                  ,               0.01530295,      1.5%
 - Storage Cost (XRD)                                                       ,            0.82120893973,     81.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3522807,    100.0%
+Execution Cost Breakdown                                                   ,                  3526058,    100.0%
 - AfterInvoke                                                              ,                       82,      0.0%
 - AllocateNodeId                                                           ,                      776,      0.0%
 - BeforeInvoke                                                             ,                     9054,      0.3%
@@ -22,7 +22,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalPackage                                              ,                  1449523,     41.1%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    13522,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.2%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.1%
 - PinNode                                                                  ,                       96,      0.0%
 - PrepareWasmCode                                                          ,                   353866,     10.0%
 - QueryActor                                                               ,                     1000,      0.0%
@@ -31,7 +31,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.3%
 - RunNativeCode::update_non_fungible_data                                  ,                   106206,      3.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                   183160,      5.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/001--non-fungible-resource-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/001--non-fungible-resource-create.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.86122961999 XRD
-├─ Network execution: 0.27600795 XRD, 5520159 execution cost units
+TRANSACTION COST: 0.86139216999 XRD
+├─ Network execution: 0.2761705 XRD, 5523410 execution cost units
 ├─ Network finalization: 0.16627255 XRD, 3325451 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.41894911999 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.86122961999"),
+     amount: Decimal("0.86139216999"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.430614809995"),
+     amount: Decimal("0.430696084995"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.430614809995"),
+     amount: Decimal("0.430696084995"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2153074049975"),
+             0u8 => Decimal("0.2153480424975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.13877038001")),
+         LiquidFungibleResource(Decimal("99999999999999999.13860783001")),
        )
 ├─ resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l across 6 partitions
   ├─ Partition(1): 1 change
@@ -514,7 +514,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.430614809995")),
+         LiquidFungibleResource(Decimal("0.430696084995")),
        )
 
 OUTPUTS: 3
@@ -528,13 +528,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.86122961999
+   Change: -0.86139216999
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.430614809995
+   Change: 0.430696084995
 
 NEW ENTITIES: 2
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/002--non-fungible-resource-create-string.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/002--non-fungible-resource-create-string.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.75135211441 XRD
-├─ Network execution: 0.2634653 XRD, 5269306 execution cost units
+TRANSACTION COST: 0.75151466441 XRD
+├─ Network execution: 0.26362785 XRD, 5272557 execution cost units
 ├─ Network finalization: 0.1362671 XRD, 2725342 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.35161971441 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.75135211441"),
+     amount: Decimal("0.75151466441"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.375676057205"),
+     amount: Decimal("0.375757332205"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.375676057205"),
+     amount: Decimal("0.375757332205"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4031454336"),
+             0u8 => Decimal("0.4032267086"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.3874182656")),
+         LiquidFungibleResource(Decimal("99999999999999998.3870931656")),
        )
 ├─ resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2 across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.8062908672")),
+         LiquidFungibleResource(Decimal("0.8064534172")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.75135211441
+   Change: -0.75151466441
 ├─ Vault: internal_vault_sim1nzzvtpj0tjkaydq997fla88kg90hpn9km9cnev38ltuaalkm6qy48j
    ResAddr: resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2
    Change: +{<my_nft>}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.375676057205
+   Change: 0.375757332205
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/003--non-fungible-resource-create-bytes.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/003--non-fungible-resource-create-bytes.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.75710561021 XRD
-├─ Network execution: 0.2634963 XRD, 5269926 execution cost units
+TRANSACTION COST: 0.75726816021 XRD
+├─ Network execution: 0.26365885 XRD, 5273177 execution cost units
 ├─ Network finalization: 0.13626755 XRD, 2725351 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.35734176021 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.75710561021"),
+     amount: Decimal("0.75726816021"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.378552805105"),
+     amount: Decimal("0.378634080105"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.378552805105"),
+     amount: Decimal("0.378634080105"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.5924218361525"),
+             0u8 => Decimal("0.5925437486525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.63031265539")),
+         LiquidFungibleResource(Decimal("99999999999999997.62982500539")),
        )
 ├─ resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.184843672305")),
+         LiquidFungibleResource(Decimal("1.185087497305")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.75710561021
+   Change: -0.75726816021
 ├─ Vault: internal_vault_sim1npk4ndjw8jn7kav0t2fc69geagkxdpdu7wvvnh4v2p4exwfn6dl0th
    ResAddr: resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs
    Change: +{[00000000000000000000000000000000]}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.378552805105
+   Change: 0.378634080105
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/004--non-fungible-resource-create-ruid.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/004--non-fungible-resource-create-ruid.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.76321259774 XRD
-├─ Network execution: 0.26283175 XRD, 5256635 execution cost units
+TRANSACTION COST: 0.76337514774 XRD
+├─ Network execution: 0.2629943 XRD, 5259886 execution cost units
 ├─ Network finalization: 0.136268 XRD, 2725360 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.36411284774 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.76321259774"),
+     amount: Decimal("0.76337514774"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.38160629887"),
+     amount: Decimal("0.38168757387"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.38160629887"),
+     amount: Decimal("0.38168757387"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.7832249855875"),
+             0u8 => Decimal("0.7833875355875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.86710005765")),
+         LiquidFungibleResource(Decimal("99999999999999996.86644985765")),
        )
 ├─ resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7 across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.566449971175")),
+         LiquidFungibleResource(Decimal("1.566775071175")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.76321259774
+   Change: -0.76337514774
 ├─ Vault: internal_vault_sim1nz6ksuj04dn2dq5waa9jyzfm52erqd74ls0xx2r3rafv8xjs29efp5
    ResAddr: resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7
    Change: +{{01dae3e6299cc23a-5a8ecfea5b6bdb5b-52be14aa0a43c7bc-8498ea430b50b164}}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.38160629887
+   Change: 0.38168757387
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/005--non-fungible-resource-mint-32-nfts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/005--non-fungible-resource-mint-32-nfts.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 2.04141269637 XRD
-├─ Network execution: 0.4980885 XRD, 9961770 execution cost units
+TRANSACTION COST: 2.04157524637 XRD
+├─ Network execution: 0.49825105 XRD, 9965021 execution cost units
 ├─ Network finalization: 0.3360679 XRD, 6721358 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.20725629637 XRD
@@ -128,15 +128,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("2.04141269637"),
+     amount: Decimal("2.04157524637"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.020706348185"),
+     amount: Decimal("1.020787623185"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.020706348185"),
+     amount: Decimal("1.020787623185"),
    }
 
 STATE UPDATES: 7 entities
@@ -146,7 +146,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.29357815968"),
+             0u8 => Decimal("1.29378134718"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -501,7 +501,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.82568736128")),
+         LiquidFungibleResource(Decimal("99999999999999994.82487461128")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -642,7 +642,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.58715631936")),
+         LiquidFungibleResource(Decimal("2.58756269436")),
        )
 
 OUTPUTS: 3
@@ -653,12 +653,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -2.04141269637
+   Change: -2.04157524637
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#100#, #101#, #102#, #103#, #104#, #105#, #106#, #107#, #108#, #109#, #110#, #111#, #112#, #113#, #114#, #115#, #116#, #117#, #118#, #119#, #120#, #121#, #122#, #123#, #124#, #125#, #126#, #127#, #128#, #129#, #130#, #131#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.020706348185
+   Change: 1.020787623185
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/006--non-fungible-resource-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/006--non-fungible-resource-burn.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.42100291511 XRD
-├─ Network execution: 0.2620007 XRD, 5240014 execution cost units
+TRANSACTION COST: 0.42116546511 XRD
+├─ Network execution: 0.26216325 XRD, 5243265 execution cost units
 ├─ Network finalization: 0.04675475 XRD, 935095 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11224746511 XRD
@@ -57,15 +57,15 @@ EVENTS: 10
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.42100291511"),
+     amount: Decimal("0.42116546511"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.210501457555"),
+     amount: Decimal("0.210582732555"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.210501457555"),
+     amount: Decimal("0.210582732555"),
    }
 
 STATE UPDATES: 7 entities
@@ -75,7 +75,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.3988288884575"),
+             0u8 => Decimal("1.3990727134575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -116,7 +116,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.40468444617")),
+         LiquidFungibleResource(Decimal("99999999999999994.40370914617")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -132,7 +132,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.797657776915")),
+         LiquidFungibleResource(Decimal("2.798145426915")),
        )
 
 OUTPUTS: 7
@@ -147,12 +147,12 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.42100291511
+   Change: -0.42116546511
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{}, -{#110#, #126#, #127#}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.210501457555
+   Change: 0.210582732555
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/007--non-fungible-resource-transfer.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/007--non-fungible-resource-transfer.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.57087000949 XRD
-├─ Network execution: 0.2995224 XRD, 5990448 execution cost units
+TRANSACTION COST: 0.57103255949 XRD
+├─ Network execution: 0.29968495 XRD, 5993699 execution cost units
 ├─ Network finalization: 0.07651195 XRD, 1530239 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19483565949 XRD
@@ -46,15 +46,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.57087000949"),
+     amount: Decimal("0.57103255949"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.285435004745"),
+     amount: Decimal("0.285516279745"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.285435004745"),
+     amount: Decimal("0.285516279745"),
    }
 
 STATE UPDATES: 8 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.54154639083"),
+             0u8 => Decimal("1.54183085333"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.83381443668")),
+         LiquidFungibleResource(Decimal("99999999999999993.83267658668")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -250,7 +250,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.08309278166")),
+         LiquidFungibleResource(Decimal("3.08366170666")),
        )
 
 OUTPUTS: 3
@@ -261,7 +261,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.57087000949
+   Change: -0.57103255949
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{}, -{#111#}
@@ -270,7 +270,7 @@ BALANCE CHANGES: 4
    Change: +{#111#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.285435004745
+   Change: 0.285516279745
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/008--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/008--non-fungible-resource-freeze-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.20230061004 XRD
-├─ Network execution: 0.14623145 XRD, 2924629 execution cost units
+TRANSACTION COST: 0.20246316004 XRD
+├─ Network execution: 0.146394 XRD, 2927880 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20230061004"),
+     amount: Decimal("0.20246316004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10115030502"),
+     amount: Decimal("0.10123158002"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10115030502"),
+     amount: Decimal("0.10123158002"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.59212154334"),
+             0u8 => Decimal("1.59244664334"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.63151382664")),
+         LiquidFungibleResource(Decimal("99999999999999993.63021342664")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.18424308668")),
+         LiquidFungibleResource(Decimal("3.18489328668")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20230061004
+   Change: -0.20246316004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10115030502
+   Change: 0.10123158002
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/009--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/009--non-fungible-resource-freeze-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.20230061004 XRD
-├─ Network execution: 0.14623145 XRD, 2924629 execution cost units
+TRANSACTION COST: 0.20246316004 XRD
+├─ Network execution: 0.146394 XRD, 2927880 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20230061004"),
+     amount: Decimal("0.20246316004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10115030502"),
+     amount: Decimal("0.10123158002"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10115030502"),
+     amount: Decimal("0.10123158002"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.64269669585"),
+             0u8 => Decimal("1.64306243335"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.4292132166")),
+         LiquidFungibleResource(Decimal("99999999999999993.4277502666")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.2853933917")),
+         LiquidFungibleResource(Decimal("3.2861248667")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20230061004
+   Change: -0.20246316004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10115030502
+   Change: 0.10123158002
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/010--non-fungible-resource-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/010--non-fungible-resource-recall-frozen-vault.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32258731512 XRD
-├─ Network execution: 0.2168157 XRD, 4336314 execution cost units
+TRANSACTION COST: 0.32274986512 XRD
+├─ Network execution: 0.21697825 XRD, 4339565 execution cost units
 ├─ Network finalization: 0.03100355 XRD, 620071 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07476806512 XRD
@@ -35,15 +35,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32258731512"),
+     amount: Decimal("0.32274986512"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16129365756"),
+     amount: Decimal("0.16137493256"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16129365756"),
+     amount: Decimal("0.16137493256"),
    }
 
 STATE UPDATES: 7 entities
@@ -53,7 +53,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.72334352463"),
+             0u8 => Decimal("1.72374989963"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -94,7 +94,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.10662590148")),
+         LiquidFungibleResource(Decimal("99999999999999993.10500040148")),
        )
 ├─ internal_vault_sim1nq4qqp48us7mydmk7sfmjasfku00yzampszkkte00xx434qwtdfu3z across 2 partitions
   ├─ Partition(64): 1 change
@@ -111,7 +111,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.44668704926")),
+         LiquidFungibleResource(Decimal("3.44749979926")),
        )
 
 OUTPUTS: 3
@@ -125,12 +125,12 @@ BALANCE CHANGES: 4
    Change: +{}, -{#120#}
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32258731512
+   Change: -0.32274986512
 ├─ Vault: internal_vault_sim1nq4qqp48us7mydmk7sfmjasfku00yzampszkkte00xx434qwtdfu3z
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#120#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16129365756
+   Change: 0.16137493256
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/011--non-fungible-resource-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/011--non-fungible-resource-unfreeze-withdraw.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2023645949 XRD
-├─ Network execution: 0.1461047 XRD, 2922094 execution cost units
+TRANSACTION COST: 0.2025271449 XRD
+├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2023645949"),
+     amount: Decimal("0.2025271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.773934673355"),
+             0u8 => Decimal("1.774381685855"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.90426130658")),
+         LiquidFungibleResource(Decimal("99999999999999992.90247325658")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.54786934671")),
+         LiquidFungibleResource(Decimal("3.54876337171")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2023645949
+   Change: -0.2025271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10118229745
+   Change: 0.10126357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/012--non-fungible-resource-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/012--non-fungible-resource-unfreeze-deposit.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2023645949 XRD
-├─ Network execution: 0.1461047 XRD, 2922094 execution cost units
+TRANSACTION COST: 0.2025271449 XRD
+├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2023645949"),
+     amount: Decimal("0.2025271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.82452582208"),
+             0u8 => Decimal("1.82501347208"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.70189671168")),
+         LiquidFungibleResource(Decimal("99999999999999992.69994611168")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.64905164416")),
+         LiquidFungibleResource(Decimal("3.65002694416")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2023645949
+   Change: -0.2025271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10118229745
+   Change: 0.10126357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/013--non-fungible-resource-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/013--non-fungible-resource-unfreeze-burn.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2023645949 XRD
-├─ Network execution: 0.1461047 XRD, 2922094 execution cost units
+TRANSACTION COST: 0.2025271449 XRD
+├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
 ├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2023645949"),
+     amount: Decimal("0.2025271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10118229745"),
+     amount: Decimal("0.10126357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.875116970805"),
+             0u8 => Decimal("1.875645258305"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.49953211678")),
+         LiquidFungibleResource(Decimal("99999999999999992.49741896678")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.75023394161")),
+         LiquidFungibleResource(Decimal("3.75129051661")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2023645949
+   Change: -0.2025271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10118229745
+   Change: 0.10126357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/014--non-fungible-resource-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/014--non-fungible-resource-recall-unfrozen-vault.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30372242619 XRD
-├─ Network execution: 0.212815 XRD, 4256300 execution cost units
+TRANSACTION COST: 0.30388497619 XRD
+├─ Network execution: 0.21297755 XRD, 4259551 execution cost units
 ├─ Network finalization: 0.0210031 XRD, 420062 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06990432619 XRD
@@ -35,15 +35,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30372242619"),
+     amount: Decimal("0.30388497619"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.151861213095"),
+     amount: Decimal("0.151942488095"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.151861213095"),
+     amount: Decimal("0.151942488095"),
    }
 
 STATE UPDATES: 6 entities
@@ -53,7 +53,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9510475773525"),
+             0u8 => Decimal("1.9516165023525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,13 +97,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.19580969059")),
+         LiquidFungibleResource(Decimal("99999999999999992.19353399059")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.902095154705")),
+         LiquidFungibleResource(Decimal("3.903233004705")),
        )
 
 OUTPUTS: 3
@@ -114,9 +114,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30372242619
+   Change: -0.30388497619
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.151861213095
+   Change: 0.151942488095
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/015--non-fungible-create-resource-with-supply-with-empty-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/015--non-fungible-create-resource-with-supply-with-empty-data.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.72575947002 XRD
-├─ Network execution: 0.26298495 XRD, 5259699 execution cost units
+TRANSACTION COST: 0.72592202002 XRD
+├─ Network execution: 0.2631475 XRD, 5262950 execution cost units
 ├─ Network finalization: 0.1562636 XRD, 3125272 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.30651092002 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.72575947002"),
+     amount: Decimal("0.72592202002"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.36287973501"),
+     amount: Decimal("0.36296101001"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.36287973501"),
+     amount: Decimal("0.36296101001"),
    }
 
 STATE UPDATES: 8 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.1324874448575"),
+             0u8 => Decimal("2.1330970073575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.47005022057")),
+         LiquidFungibleResource(Decimal("99999999999999991.46761197057")),
        )
 ├─ resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx across 6 partitions
   ├─ Partition(1): 1 change
@@ -299,7 +299,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.264974889715")),
+         LiquidFungibleResource(Decimal("4.266194014715")),
        )
 
 OUTPUTS: 3
@@ -313,13 +313,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.72575947002
+   Change: -0.72592202002
 ├─ Vault: internal_vault_sim1nptkpwateyft954ecyn22njkpul50pta3sefh62mwuas6uzlh30042
    ResAddr: resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx
    Change: +{#1#, #2#, #3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.36287973501
+   Change: 0.36296101001
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.5461192445 XRD
-├─ Network execution: 0.27146135 XRD, 5429227 execution cost units
+TRANSACTION COST: 1.5462817945 XRD
+├─ Network execution: 0.2716239 XRD, 5432478 execution cost units
 ├─ Network finalization: 0.21131105 XRD, 4226221 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.0633468445 XRD
@@ -54,15 +54,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.5461192445"),
+     amount: Decimal("1.5462817945"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.77305962225"),
+     amount: Decimal("0.77314089725"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.77305962225"),
+     amount: Decimal("0.77314089725"),
    }
 
 STATE UPDATES: 8 entities
@@ -72,7 +72,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.5190172559825"),
+             0u8 => Decimal("2.5196674559825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.92393097607")),
+         LiquidFungibleResource(Decimal("99999999999999989.92133017607")),
        )
 ├─ resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn across 7 partitions
   ├─ Partition(1): 1 change
@@ -437,7 +437,7 @@ DEXes allow users to trade assets without the need for a trusted third party. Th
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.038034511965")),
+         LiquidFungibleResource(Decimal("5.039334911965")),
        )
 
 OUTPUTS: 3
@@ -451,13 +451,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.5461192445
+   Change: -1.5462817945
 ├─ Vault: internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n
    ResAddr: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn
    Change: +{#1#, #2#, #3#, #4#, #5#, #8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.77305962225
+   Change: 0.77314089725
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/017--non-fungible-transfer-metadata-standard-nfs.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/017--non-fungible-transfer-metadata-standard-nfs.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.44436525747 XRD
-├─ Network execution: 0.25657795 XRD, 5131559 execution cost units
+TRANSACTION COST: 0.44452780747 XRD
+├─ Network execution: 0.2567405 XRD, 5134810 execution cost units
 ├─ Network finalization: 0.05150725 XRD, 1030145 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13628005747 XRD
@@ -50,15 +50,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.44436525747"),
+     amount: Decimal("0.44452780747"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.222182628735"),
+     amount: Decimal("0.222263903735"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.222182628735"),
+     amount: Decimal("0.222263903735"),
    }
 
 STATE UPDATES: 8 entities
@@ -68,7 +68,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.63010857035"),
+             0u8 => Decimal("2.63079940785"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -101,7 +101,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.4795657186")),
+         LiquidFungibleResource(Decimal("99999999999999989.4768023686")),
        )
 ├─ internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n across 2 partitions
   ├─ Partition(64): 1 change
@@ -160,7 +160,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.2602171407")),
+         LiquidFungibleResource(Decimal("5.2615988157")),
        )
 
 OUTPUTS: 3
@@ -171,7 +171,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.44436525747
+   Change: -0.44452780747
 ├─ Vault: internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n
    ResAddr: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn
    Change: +{}, -{#4#, #8#}
@@ -180,6 +180,6 @@ BALANCE CHANGES: 4
    Change: +{#4#, #8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.222182628735
+   Change: 0.222263903735
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/018--non-fungible-create-resource-with-supply-with-complex-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/018--non-fungible-create-resource-with-supply-with-complex-data.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.81695454289 XRD
-├─ Network execution: 0.26887195 XRD, 5377439 execution cost units
+TRANSACTION COST: 0.81711709289 XRD
+├─ Network execution: 0.2690345 XRD, 5380690 execution cost units
 ├─ Network finalization: 0.12627245 XRD, 2525449 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.42181014289 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.81695454289"),
+     amount: Decimal("0.81711709289"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.408477271445"),
+     amount: Decimal("0.408558546445"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.408477271445"),
+     amount: Decimal("0.408558546445"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.8343472060725"),
+             0u8 => Decimal("2.8350786810725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.66261117571")),
+         LiquidFungibleResource(Decimal("99999999999999988.65968527571")),
        )
 ├─ resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm across 6 partitions
   ├─ Partition(1): 1 change
@@ -445,7 +445,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.668694412145")),
+         LiquidFungibleResource(Decimal("5.670157362145")),
        )
 
 OUTPUTS: 3
@@ -459,13 +459,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.81695454289
+   Change: -0.81711709289
 ├─ Vault: internal_vault_sim1nqvpupxfdwtvgqxp8jqddjtrrsd8u984qd6u93uz2mhezkdwsvx9u7
    ResAddr: resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.408477271445
+   Change: 0.408558546445
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/019--non-fungible-mutate-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/019--non-fungible-mutate-data.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.01265223973 XRD
-├─ Network execution: 0.17614035 XRD, 3522807 execution cost units
+TRANSACTION COST: 1.01281478973 XRD
+├─ Network execution: 0.1763029 XRD, 3526058 execution cost units
 ├─ Network finalization: 0.01530295 XRD, 306059 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.82120893973 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.01265223973"),
+     amount: Decimal("1.01281478973"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.506326119865"),
+     amount: Decimal("0.506407394865"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.506326119865"),
+     amount: Decimal("0.506407394865"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("3.087510266005"),
+             0u8 => Decimal("3.088282378505"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,13 +71,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999987.64995893598")),
+         LiquidFungibleResource(Decimal("99999999999999987.64687048598")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("6.17502053201")),
+         LiquidFungibleResource(Decimal("6.17656475701")),
        )
 
 OUTPUTS: 3
@@ -88,9 +88,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.01265223973
+   Change: -1.01281478973
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.506326119865
+   Change: 0.506407394865
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: non_fungible_resource
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: f57bdeceb685429f (allowed to change if not deployed to any network)
-Events       : 0a7729c45f851905 (allowed to change if not deployed to any network)
+State changes: ac7246d0f66c7fd2 (allowed to change if not deployed to any network)
+Events       : 063ccf94870488e7 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - main_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/001--non-fungible-resource-with-remote-type-registration.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/001--non-fungible-resource-with-remote-type-registration.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,           57.47030860011,    100.0%
-- Execution Cost (XRD)                                                     ,               1.02319135,      1.8%
+Total Cost (XRD)                                                           ,           57.47047115011,    100.0%
+- Execution Cost (XRD)                                                     ,                1.0233539,      1.8%
 - Finalization Cost (XRD)                                                  ,                0.1157698,      0.2%
 - Storage Cost (XRD)                                                       ,           56.33134745011,     98.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20463827,    100.0%
+Execution Cost Breakdown                                                   ,                 20467078,    100.0%
 - AfterInvoke                                                              ,                      474,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
 - BeforeInvoke                                                             ,                   337732,      1.7%
@@ -39,7 +39,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.2%
 - RunNativeCode::publish_wasm_advanced                                     ,                  7772235,     38.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/002--non-fungible-resource-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/002--non-fungible-resource-with-remote-type.txt
@@ -1,15 +1,15 @@
-Total Cost (XRD)                                                           ,            0.72592866022,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2698015,     37.2%
+Total Cost (XRD)                                                           ,            0.72609121022,    100.0%
+- Execution Cost (XRD)                                                     ,               0.26996405,     37.2%
 - Finalization Cost (XRD)                                                  ,                0.1362648,     18.8%
 - Storage Cost (XRD)                                                       ,            0.31986236022,     44.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5396030,    100.0%
+Execution Cost Breakdown                                                   ,                  5399281,    100.0%
 - AfterInvoke                                                              ,                      556,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3108,      0.1%
 - CheckReference                                                           ,                    80024,      1.5%
-- CloseSubstate                                                            ,                    35088,      0.7%
+- CloseSubstate                                                            ,                    35088,      0.6%
 - CreateNode                                                               ,                    20448,      0.4%
 - DropNode                                                                 ,                    32027,      0.6%
 - EmitEvent                                                                ,                     2782,      0.1%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      804,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/001--non-fungible-resource-with-remote-type-registration.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/001--non-fungible-resource-with-remote-type-registration.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 57.47030860011 XRD
-├─ Network execution: 1.02319135 XRD, 20463827 execution cost units
+TRANSACTION COST: 57.47047115011 XRD
+├─ Network execution: 1.0233539 XRD, 20467078 execution cost units
 ├─ Network finalization: 0.1157698 XRD, 2315396 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 56.33134745011 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("57.47030860011"),
+     amount: Decimal("57.47047115011"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("28.735154300055"),
+     amount: Decimal("28.735235575055"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("28.735154300055"),
+     amount: Decimal("28.735235575055"),
    }
 
 STATE UPDATES: 8 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("14.3675771500275"),
+             0u8 => Decimal("14.3676177875275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999942.52969139989")),
+         LiquidFungibleResource(Decimal("99999999999999942.52952884989")),
        )
 ├─ package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t across 12 partitions
   ├─ Partition(1): 1 change
@@ -294,7 +294,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("28.735154300055")),
+         LiquidFungibleResource(Decimal("28.735235575055")),
        )
 
 OUTPUTS: 3
@@ -305,10 +305,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -57.47030860011
+   Change: -57.47047115011
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 28.735154300055
+   Change: 28.735235575055
 
 NEW ENTITIES: 2
 └─ Package: package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/002--non-fungible-resource-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/002--non-fungible-resource-with-remote-type.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.72592866022 XRD
-├─ Network execution: 0.2698015 XRD, 5396030 execution cost units
+TRANSACTION COST: 0.72609121022 XRD
+├─ Network execution: 0.26996405 XRD, 5399281 execution cost units
 ├─ Network finalization: 0.1362648 XRD, 2725296 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31986236022 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.72592866022"),
+     amount: Decimal("0.72609121022"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.36296433011"),
+     amount: Decimal("0.36304560511"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.36296433011"),
+     amount: Decimal("0.36304560511"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("14.5490593150825"),
+             0u8 => Decimal("14.5491405900825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999941.80376273967")),
+         LiquidFungibleResource(Decimal("99999999999999941.80343763967")),
        )
 ├─ resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6 across 5 partitions
   ├─ Partition(5): 1 change
@@ -286,7 +286,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("29.098118630165")),
+         LiquidFungibleResource(Decimal("29.098281180165")),
        )
 
 OUTPUTS: 3
@@ -300,13 +300,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.72592866022
+   Change: -0.72609121022
 ├─ Vault: internal_vault_sim1nz2n08mf56scr8xqfyw8cvwq9228edqm6as0sws7puc4j8tcwn2mpt
    ResAddr: resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.36296433011
+   Change: 0.36304560511
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: non_fungible_resource_with_remote_type
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 21dce84c02b3a680 (allowed to change if not deployed to any network)
-Events       : 5b9265bee4e02411 (allowed to change if not deployed to any network)
+State changes: 8beb46bfca7ae878 (allowed to change if not deployed to any network)
+Events       : a451bc9883b7eaa1 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - package_with_registered_types: package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/001--radiswap-create-new-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/001--radiswap-create-new-resources.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.62632758577,    100.0%
-- Execution Cost (XRD)                                                     ,               0.33193405,     20.4%
+Total Cost (XRD)                                                           ,            1.62649013577,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3320966,     20.4%
 - Finalization Cost (XRD)                                                  ,               0.41329385,     25.4%
 - Storage Cost (XRD)                                                       ,            0.88109968577,     54.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6638681,    100.0%
+Execution Cost Breakdown                                                   ,                  6641932,    100.0%
 - AfterInvoke                                                              ,                     1712,      0.0%
 - AllocateNodeId                                                           ,                     5723,      0.1%
 - BeforeInvoke                                                             ,                     9534,      0.1%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.5%
 - RunNativeCode::put_FungibleVault                                         ,                    73662,      1.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1686,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.12200440354,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3436575,     30.6%
+Total Cost (XRD)                                                           ,            1.12216695354,    100.0%
+- Execution Cost (XRD)                                                     ,               0.34382005,     30.6%
 - Finalization Cost (XRD)                                                  ,               0.21777715,     19.4%
 - Storage Cost (XRD)                                                       ,            0.56056975354,     50.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6873150,    100.0%
+Execution Cost Breakdown                                                   ,                  6876401,    100.0%
 - AfterInvoke                                                              ,                      726,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.0%
 - BeforeInvoke                                                             ,                     5456,      0.1%
@@ -45,7 +45,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.5%
 - RunNativeCode::set                                                       ,                   125226,      1.8%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1057,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/003--radiswap-publish-and-create-pools.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/003--radiswap-publish-and-create-pools.txt
@@ -1,16 +1,16 @@
-Total Cost (XRD)                                                           ,           59.02674408717,    100.0%
-- Execution Cost (XRD)                                                     ,               1.42194085,      2.4%
+Total Cost (XRD)                                                           ,           59.02917113717,    100.0%
+- Execution Cost (XRD)                                                     ,                1.4243679,      2.4%
 - Finalization Cost (XRD)                                                  ,                0.4588272,      0.8%
 - Storage Cost (XRD)                                                       ,           57.14597603717,     96.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 28438817,    100.0%
+Execution Cost Breakdown                                                   ,                 28487358,    100.0%
 - AfterInvoke                                                              ,                     2492,      0.0%
 - AllocateNodeId                                                           ,                     9409,      0.0%
 - BeforeInvoke                                                             ,                   347642,      1.2%
 - CheckReference                                                           ,                   200075,      0.7%
 - CloseSubstate                                                            ,                   104103,      0.4%
-- CreateNode                                                               ,                   924410,      3.3%
+- CreateNode                                                               ,                   924410,      3.2%
 - DropNode                                                                 ,                   121164,      0.4%
 - EmitEvent                                                                ,                     8480,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
@@ -51,9 +51,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.4%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.1%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
-- RunWasmCode::Radiswap_new                                                ,                   229606,      0.8%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
+- RunWasmCode::Radiswap_new                                                ,                   269944,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     2917,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/004--radiswap-add-liquidity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/004--radiswap-add-liquidity.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            1.29214966567,    100.0%
-- Execution Cost (XRD)                                                     ,                0.7885356,     61.0%
+Total Cost (XRD)                                                           ,            1.29336321567,    100.0%
+- Execution Cost (XRD)                                                     ,               0.78974915,     61.1%
 - Finalization Cost (XRD)                                                  ,               0.10602725,      8.2%
-- Storage Cost (XRD)                                                       ,            0.39758681567,     30.8%
+- Storage Cost (XRD)                                                       ,            0.39758681567,     30.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 15770712,    100.0%
+Execution Cost Breakdown                                                   ,                 15794983,    100.0%
 - AfterInvoke                                                              ,                     3932,      0.0%
 - AllocateNodeId                                                           ,                     9603,      0.1%
 - BeforeInvoke                                                             ,                    10406,      0.1%
@@ -20,7 +20,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                  1028596,      6.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                   135757,      0.9%
 - OpenSubstate::GlobalPackage                                              ,                  4405038,     27.9%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1065784,      6.8%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1065784,      6.7%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                   653312,      4.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   725060,      4.6%
 - OpenSubstate::InternalGenericComponent                                   ,                   400119,      2.5%
@@ -49,9 +49,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_advanced_FungibleBucket                              ,                    93100,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
 - RunNativeCode::withdraw                                                  ,                   173553,      1.1%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
-- RunWasmCode::Radiswap_add_liquidity                                      ,                   101406,      0.6%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::Radiswap_add_liquidity                                      ,                   117474,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    39200,      0.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/005--radiswap-distribute-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/005--radiswap-distribute-tokens.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            3.42739163564,    100.0%
-- Execution Cost (XRD)                                                     ,               1.14335665,     33.4%
+Total Cost (XRD)                                                           ,            3.42780178564,    100.0%
+- Execution Cost (XRD)                                                     ,                1.1437668,     33.4%
 - Finalization Cost (XRD)                                                  ,               0.43886595,     12.8%
 - Storage Cost (XRD)                                                       ,            1.84516903564,     53.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 22867133,    100.0%
+Execution Cost Breakdown                                                   ,                 22875336,    100.0%
 - AfterInvoke                                                              ,                     8528,      0.0%
 - AllocateNodeId                                                           ,                    21631,      0.1%
 - BeforeInvoke                                                             ,                    23866,      0.1%
@@ -47,8 +47,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                   806683,      3.5%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   485028,      2.1%
 - RunNativeCode::withdraw                                                  ,                  1041318,      4.6%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.1%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1113,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/006--radiswap-swap-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/006--radiswap-swap-tokens.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.60013484589,    100.0%
-- Execution Cost (XRD)                                                     ,                0.4173805,     69.5%
-- Finalization Cost (XRD)                                                  ,               0.03750975,      6.3%
+Total Cost (XRD)                                                           ,            0.60103684589,    100.0%
+- Execution Cost (XRD)                                                     ,                0.4182825,     69.6%
+- Finalization Cost (XRD)                                                  ,               0.03750975,      6.2%
 - Storage Cost (XRD)                                                       ,            0.14524459589,     24.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8347610,    100.0%
+Execution Cost Breakdown                                                   ,                  8365650,    100.0%
 - AfterInvoke                                                              ,                     1432,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.0%
 - BeforeInvoke                                                             ,                     3698,      0.0%
@@ -18,10 +18,10 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   339206,      4.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    87882,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  2992927,     35.9%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   530957,      6.4%
+- OpenSubstate::GlobalPackage                                              ,                  2992927,     35.8%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   530957,      6.3%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                   657608,      7.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   438878,      5.3%
+- OpenSubstate::InternalFungibleVault                                      ,                   438878,      5.2%
 - OpenSubstate::InternalGenericComponent                                   ,                   125725,      1.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.5%
 - PinNode                                                                  ,                      408,      0.0%
@@ -42,10 +42,10 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.6%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.5%
 - RunNativeCode::take_advanced_FungibleVault                               ,                    44567,      0.5%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.5%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.4%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
-- RunWasmCode::Radiswap_swap                                               ,                    95093,      1.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
+- RunWasmCode::Radiswap_swap                                               ,                   109882,      1.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    22200,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/007--radiswap-remove-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/007--radiswap-remove-tokens.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             0.6665682726,    100.0%
-- Execution Cost (XRD)                                                     ,               0.44498675,     66.8%
+Total Cost (XRD)                                                           ,             0.6671455226,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.445564,     66.8%
 - Finalization Cost (XRD)                                                  ,                0.0480128,      7.2%
 - Storage Cost (XRD)                                                       ,             0.1735687226,     26.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8899735,    100.0%
+Execution Cost Breakdown                                                   ,                  8911280,    100.0%
 - AfterInvoke                                                              ,                     1654,      0.0%
 - AllocateNodeId                                                           ,                     3977,      0.0%
 - BeforeInvoke                                                             ,                     4284,      0.0%
@@ -43,9 +43,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::redeem_two_resource_pool                                  ,                   135373,      1.5%
 - RunNativeCode::take_FungibleVault                                        ,                   127371,      1.4%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.4%
-- RunNativeCode::withdraw                                                  ,                    57851,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
-- RunWasmCode::Radiswap_remove_liquidity                                   ,                    53469,      0.6%
+- RunNativeCode::withdraw                                                  ,                    57851,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
+- RunWasmCode::Radiswap_remove_liquidity                                   ,                    61763,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    22680,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/008--radiswap-set-two-way-linking.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/008--radiswap-set-two-way-linking.txt
@@ -1,14 +1,14 @@
-Total Cost (XRD)                                                           ,            1.82107864961,    100.0%
-- Execution Cost (XRD)                                                     ,                0.6531704,     35.9%
+Total Cost (XRD)                                                           ,            1.82124119961,    100.0%
+- Execution Cost (XRD)                                                     ,               0.65333295,     35.9%
 - Finalization Cost (XRD)                                                  ,                0.1830488,     10.1%
 - Storage Cost (XRD)                                                       ,            0.98485944961,     54.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 13063408,    100.0%
+Execution Cost Breakdown                                                   ,                 13066659,    100.0%
 - AfterInvoke                                                              ,                     1212,      0.0%
 - AllocateNodeId                                                           ,                     7081,      0.1%
 - BeforeInvoke                                                             ,                    11868,      0.1%
-- CheckReference                                                           ,                   320115,      2.5%
+- CheckReference                                                           ,                   320115,      2.4%
 - CloseSubstate                                                            ,                   140481,      1.1%
 - CreateNode                                                               ,                    62852,      0.5%
 - DropNode                                                                 ,                   113003,      0.9%
@@ -42,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_move_NonFungibleProof                                  ,                    17108,      0.1%
 - RunNativeCode::set                                                       ,                   647001,      5.0%
 - RunNativeCode::unlock_non_fungibles_NonFungibleVault                     ,                    34403,      0.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/001--radiswap-create-new-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/001--radiswap-create-new-resources.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.62632758577 XRD
-├─ Network execution: 0.33193405 XRD, 6638681 execution cost units
+TRANSACTION COST: 1.62649013577 XRD
+├─ Network execution: 0.3320966 XRD, 6641932 execution cost units
 ├─ Network finalization: 0.41329385 XRD, 8265877 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.88109968577 XRD
@@ -67,15 +67,15 @@ EVENTS: 16
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.62632758577"),
+     amount: Decimal("1.62649013577"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.813163792885"),
+     amount: Decimal("0.813245067885"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.813163792885"),
+     amount: Decimal("0.813245067885"),
    }
 
 STATE UPDATES: 12 entities
@@ -85,7 +85,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4065818964425"),
+             0u8 => Decimal("0.4066225339425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -118,7 +118,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.37367241423")),
+         LiquidFungibleResource(Decimal("99999999999999998.37350986423")),
        )
 ├─ resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p across 5 partitions
   ├─ Partition(2): 6 changes
@@ -747,7 +747,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.813163792885")),
+         LiquidFungibleResource(Decimal("0.813245067885")),
        )
 
 OUTPUTS: 5
@@ -769,7 +769,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.62632758577
+   Change: -1.62649013577
 ├─ Vault: internal_vault_sim1trjn2fuhqfhkgev8037gydh5gqgwqsfqr4usr0scxm6ledxt343tc4
    ResAddr: resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p
    Change: 100000000000
@@ -781,7 +781,7 @@ BALANCE CHANGES: 5
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.813163792885
+   Change: 0.813245067885
 
 NEW ENTITIES: 4
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.12200440354 XRD
-├─ Network execution: 0.3436575 XRD, 6873150 execution cost units
+TRANSACTION COST: 1.12216695354 XRD
+├─ Network execution: 0.34382005 XRD, 6876401 execution cost units
 ├─ Network finalization: 0.21777715 XRD, 4355543 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.56056975354 XRD
@@ -87,15 +87,15 @@ EVENTS: 14
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.12200440354"),
+     amount: Decimal("1.12216695354"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.56100220177"),
+     amount: Decimal("0.56108347677"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.56100220177"),
+     amount: Decimal("0.56108347677"),
    }
 
 STATE UPDATES: 8 entities
@@ -105,7 +105,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6870829973275"),
+             0u8 => Decimal("0.6871642723275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -138,7 +138,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.25166801069")),
+         LiquidFungibleResource(Decimal("99999999999999997.25134291069")),
        )
 ├─ resource_sim1ngtf8aw0v8l0wsy0clun8j7wggkmdy5gc7zhyrdy0m4sw98zny9y7n across 7 partitions
   ├─ Partition(1): 1 change
@@ -494,7 +494,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.374165994655")),
+         LiquidFungibleResource(Decimal("1.374328544655")),
        )
 
 OUTPUTS: 9
@@ -514,13 +514,13 @@ OUTPUTS: 9
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.12200440354
+   Change: -1.12216695354
 ├─ Vault: internal_vault_sim1nq62dyu2curupg4unfaytkchtc9q70lg7ckfje4nxthrzpan8fsqtu
    ResAddr: resource_sim1ngtf8aw0v8l0wsy0clun8j7wggkmdy5gc7zhyrdy0m4sw98zny9y7n
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.56100220177
+   Change: 0.56108347677
 
 NEW ENTITIES: 2
 └─ Component: account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/003--radiswap-publish-and-create-pools.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/003--radiswap-publish-and-create-pools.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 59.02674408717 XRD
-├─ Network execution: 1.42194085 XRD, 28438817 execution cost units
+TRANSACTION COST: 59.02917113717 XRD
+├─ Network execution: 1.4243679 XRD, 28487358 execution cost units
 ├─ Network finalization: 0.4588272 XRD, 9176544 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 57.14597603717 XRD
@@ -101,15 +101,15 @@ EVENTS: 17
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("59.02674408717"),
+     amount: Decimal("59.02917113717"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("29.513372043585"),
+     amount: Decimal("29.514585568585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("29.513372043585"),
+     amount: Decimal("29.514585568585"),
    }
 
 STATE UPDATES: 22 entities
@@ -119,7 +119,7 @@ STATE UPDATES: 22 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("15.44376901912"),
+             0u8 => Decimal("15.44445705662"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -152,7 +152,7 @@ STATE UPDATES: 22 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989938.22492392352")),
+         LiquidFungibleResource(Decimal("99999999999989938.22217177352")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -1175,7 +1175,7 @@ STATE UPDATES: 22 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("30.88753803824")),
+         LiquidFungibleResource(Decimal("30.88891411324")),
        )
 
 OUTPUTS: 7
@@ -1190,13 +1190,13 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10059.02674408717
+   Change: -10059.02917113717
 ├─ Vault: internal_vault_sim1tr4r3rur7229t56xpcz0s2cakhxydhjv44pmhu7gf5xkyws0jdzwya
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 29.513372043585
+   Change: 29.514585568585
 
 NEW ENTITIES: 7
 └─ Package: package_sim1p5wscdljf6s7yc0v5u9kjfaqmxk4ccqugvqfd58aazyrlk89u0dgsn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/004--radiswap-add-liquidity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/004--radiswap-add-liquidity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.29214966567 XRD
-├─ Network execution: 0.7885356 XRD, 15770712 execution cost units
+TRANSACTION COST: 1.29336321567 XRD
+├─ Network execution: 0.78974915 XRD, 15794983 execution cost units
 ├─ Network finalization: 0.10602725 XRD, 2120545 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.39758681567 XRD
@@ -139,15 +139,15 @@ EVENTS: 27
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.29214966567"),
+     amount: Decimal("1.29336321567"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.646074832835"),
+     amount: Decimal("0.646681607835"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.646074832835"),
+     amount: Decimal("0.646681607835"),
    }
 
 STATE UPDATES: 20 entities
@@ -157,7 +157,7 @@ STATE UPDATES: 20 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("15.7668064355375"),
+             0u8 => Decimal("15.7677978605375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -202,7 +202,7 @@ STATE UPDATES: 20 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979936.93277425785")),
+         LiquidFungibleResource(Decimal("99999999999979936.92880855785")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -334,7 +334,7 @@ STATE UPDATES: 20 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("31.533612871075")),
+         LiquidFungibleResource(Decimal("31.535595721075")),
        )
 
 OUTPUTS: 12
@@ -360,7 +360,7 @@ OUTPUTS: 12
 BALANCE CHANGES: 11
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.29214966567
+   Change: -10001.29336321567
 ├─ Vault: internal_vault_sim1trjn2fuhqfhkgev8037gydh5gqgwqsfqr4usr0scxm6ledxt343tc4
    ResAddr: resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p
    Change: -7000
@@ -390,6 +390,6 @@ BALANCE CHANGES: 11
    Change: 6324.555320336758663998
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.646074832835
+   Change: 0.646681607835
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/005--radiswap-distribute-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/005--radiswap-distribute-tokens.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 3.42739163564 XRD
-├─ Network execution: 1.14335665 XRD, 22867133 execution cost units
+TRANSACTION COST: 3.42780178564 XRD
+├─ Network execution: 1.1437668 XRD, 22875336 execution cost units
 ├─ Network finalization: 0.43886595 XRD, 8777319 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.84516903564 XRD
@@ -429,15 +429,15 @@ EVENTS: 98
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("3.42739163564"),
+     amount: Decimal("3.42780178564"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.71369581782"),
+     amount: Decimal("1.71390089282"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.71369581782"),
+     amount: Decimal("1.71390089282"),
    }
 
 STATE UPDATES: 34 entities
@@ -447,7 +447,7 @@ STATE UPDATES: 34 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.6236543444475"),
+             0u8 => Decimal("16.6247483069475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -480,7 +480,7 @@ STATE UPDATES: 34 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969933.50538262221")),
+         LiquidFungibleResource(Decimal("99999999999969933.50100677221")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -1434,7 +1434,7 @@ STATE UPDATES: 34 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.247308688895")),
+         LiquidFungibleResource(Decimal("33.249496613895")),
        )
 
 OUTPUTS: 24
@@ -1466,7 +1466,7 @@ OUTPUTS: 24
 BALANCE CHANGES: 26
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10003.42739163564
+   Change: -10003.42780178564
 ├─ Vault: internal_vault_sim1tzqt799quvgq2ddm4253zqupswy9ekqn7fmm6szn7z47rsxfv685g6
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 9001
@@ -1541,7 +1541,7 @@ BALANCE CHANGES: 26
    Change: 333
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.71369581782
+   Change: 1.71390089282
 
 NEW ENTITIES: 3
 ├─ Component: account_sim168j3paqgngj74yzaljq4n422rtsmupaec3wnqq5425fd85cnd8xmdz

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/006--radiswap-swap-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/006--radiswap-swap-tokens.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.60013484589 XRD
-├─ Network execution: 0.4173805 XRD, 8347610 execution cost units
+TRANSACTION COST: 0.60103684589 XRD
+├─ Network execution: 0.4182825 XRD, 8365650 execution cost units
 ├─ Network finalization: 0.03750975 XRD, 750195 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14524459589 XRD
@@ -63,15 +63,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.60013484589"),
+     amount: Decimal("0.60103684589"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.300067422945"),
+     amount: Decimal("0.300518422945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.300067422945"),
+     amount: Decimal("0.300518422945"),
    }
 
 STATE UPDATES: 10 entities
@@ -81,7 +81,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.77368805592"),
+             0u8 => Decimal("16.77500751842"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -120,7 +120,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969932.90524777632")),
+         LiquidFungibleResource(Decimal("99999999999969932.89996992632")),
        )
 ├─ internal_vault_sim1tq3ux37tj8mw4yx26j2uv0r0qxkdlcy0uhs0n6e2tjle20uk8pm2np across 1 partitions
   └─ Partition(64): 1 change
@@ -150,7 +150,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.54737611184")),
+         LiquidFungibleResource(Decimal("33.55001503684")),
        )
 
 OUTPUTS: 5
@@ -163,7 +163,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 6
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.60013484589
+   Change: -0.60103684589
 ├─ Vault: internal_vault_sim1tq3ux37tj8mw4yx26j2uv0r0qxkdlcy0uhs0n6e2tjle20uk8pm2np
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -100
@@ -178,6 +178,6 @@ BALANCE CHANGES: 6
    Change: 69.30693069306930693
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.300067422945
+   Change: 0.300518422945
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/007--radiswap-remove-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/007--radiswap-remove-tokens.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.6665682726 XRD
-├─ Network execution: 0.44498675 XRD, 8899735 execution cost units
+TRANSACTION COST: 0.6671455226 XRD
+├─ Network execution: 0.445564 XRD, 8911280 execution cost units
 ├─ Network finalization: 0.0480128 XRD, 960256 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.1735687226 XRD
@@ -77,15 +77,15 @@ EVENTS: 15
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.6665682726"),
+     amount: Decimal("0.6671455226"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.3332841363"),
+     amount: Decimal("0.3335727613"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.3332841363"),
+     amount: Decimal("0.3335727613"),
    }
 
 STATE UPDATES: 12 entities
@@ -95,7 +95,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.94033012407"),
+             0u8 => Decimal("16.94179389907"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -140,7 +140,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969932.23867950372")),
+         LiquidFungibleResource(Decimal("99999999999969932.23282440372")),
        )
 ├─ internal_vault_sim1tp7shj4lnak2yuvqn5nr634kf354ddz0un56qsxl68j32aku5crjeu across 1 partitions
   └─ Partition(64): 1 change
@@ -176,7 +176,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.88066024814")),
+         LiquidFungibleResource(Decimal("33.88358779814")),
        )
 
 OUTPUTS: 5
@@ -192,7 +192,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 7
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.6665682726
+   Change: -0.6671455226
 ├─ Vault: internal_vault_sim1tp7shj4lnak2yuvqn5nr634kf354ddz0un56qsxl68j32aku5crjeu
    ResAddr: resource_sim1t5d6cc8v4sdv4wlwzf2qngh74028lumvd2ftes7tq7vnass85ap5m5
    Change: -100
@@ -210,6 +210,6 @@ BALANCE CHANGES: 7
    Change: 82.837626389512430492
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.3332841363
+   Change: 0.3335727613
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/008--radiswap-set-two-way-linking.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/008--radiswap-set-two-way-linking.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.82107864961 XRD
-├─ Network execution: 0.6531704 XRD, 13063408 execution cost units
+TRANSACTION COST: 1.82124119961 XRD
+├─ Network execution: 0.65333295 XRD, 13066659 execution cost units
 ├─ Network finalization: 0.1830488 XRD, 3660976 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.98485944961 XRD
@@ -274,15 +274,15 @@ EVENTS: 35
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.82107864961"),
+     amount: Decimal("1.82124119961"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.910539324805"),
+     amount: Decimal("0.910620599805"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.910539324805"),
+     amount: Decimal("0.910620599805"),
    }
 
 STATE UPDATES: 13 entities
@@ -292,7 +292,7 @@ STATE UPDATES: 13 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("17.3955997864725"),
+             0u8 => Decimal("17.3971041989725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -551,7 +551,7 @@ STATE UPDATES: 13 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969930.41760085411")),
+         LiquidFungibleResource(Decimal("99999999999969930.41158320411")),
        )
 ├─ account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd across 1 partitions
   └─ Partition(2): 1 change
@@ -583,7 +583,7 @@ STATE UPDATES: 13 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("34.791199572945")),
+         LiquidFungibleResource(Decimal("34.794208397945")),
        )
 
 OUTPUTS: 33
@@ -624,9 +624,9 @@ OUTPUTS: 33
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.82107864961
+   Change: -1.82124119961
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.910539324805
+   Change: 0.910620599805
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: radiswap
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: c88cfb41d5471d30 (allowed to change if not deployed to any network)
-Events       : 3e9f329a2e6a484a (allowed to change if not deployed to any network)
+State changes: dc0465eaf0114ef3 (allowed to change if not deployed to any network)
+Events       : cb94cc3eab1e4990 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - radiswap_dapp_definition_account: account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/001--royalties--publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/001--royalties--publish-package.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,           31.47003411469,    100.0%
-- Execution Cost (XRD)                                                     ,                0.6181983,      2.0%
+Total Cost (XRD)                                                           ,           31.47019666469,    100.0%
+- Execution Cost (XRD)                                                     ,               0.61836085,      2.0%
 - Finalization Cost (XRD)                                                  ,                0.0783874,      0.2%
 - Storage Cost (XRD)                                                       ,           30.77344841469,     97.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 12363966,    100.0%
+Execution Cost Breakdown                                                   ,                 12367217,    100.0%
 - AfterInvoke                                                              ,                      326,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                   182304,      1.5%
@@ -36,7 +36,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.4%
 - RunNativeCode::publish_wasm_advanced                                     ,                  4351685,     35.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      403,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/002--royalties--instantiate-components.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/002--royalties--instantiate-components.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,             1.0449135481,    100.0%
-- Execution Cost (XRD)                                                     ,               0.36352375,     34.8%
-- Finalization Cost (XRD)                                                  ,                0.2360239,     22.6%
-- Storage Cost (XRD)                                                       ,             0.4453658981,     42.6%
+Total Cost (XRD)                                                           ,             1.0473229481,    100.0%
+- Execution Cost (XRD)                                                     ,               0.36593315,     34.9%
+- Finalization Cost (XRD)                                                  ,                0.2360239,     22.5%
+- Storage Cost (XRD)                                                       ,             0.4453658981,     42.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7270475,    100.0%
+Execution Cost Breakdown                                                   ,                  7318663,    100.0%
 - AfterInvoke                                                              ,                     1030,      0.0%
 - AllocateNodeId                                                           ,                     4074,      0.1%
 - BeforeInvoke                                                             ,                     4174,      0.1%
@@ -19,24 +19,24 @@ Execution Cost Breakdown                                                   ,    
 - MoveModule                                                               ,                    11760,      0.2%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   136104,      1.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    46666,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3403443,     46.8%
+- OpenSubstate::GlobalPackage                                              ,                  3403443,     46.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    95017,      1.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    42997,      0.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - PinNode                                                                  ,                      396,      0.0%
-- PrepareWasmCode                                                          ,                  1188958,     16.4%
+- PrepareWasmCode                                                          ,                  1188958,     16.2%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryCostingModule                                                       ,                     1500,      0.0%
 - QueryFeeReserve                                                          ,                     1500,      0.0%
-- ReadSubstate                                                             ,                  1315744,     18.1%
+- ReadSubstate                                                             ,                  1315744,     18.0%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::create                                                    ,                   154473,      2.1%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   106710,      1.5%
 - RunNativeCode::create_with_data                                          ,                    82413,      1.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.6%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.3%
-- RunWasmCode::RoyaltiesBp_new                                             ,                   286473,      3.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
+- RunWasmCode::RoyaltiesBp_new                                             ,                   331410,      4.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1245,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/003--royalties--set-components-royalty.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/003--royalties--set-components-royalty.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.35937313381,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1832873,     51.0%
+Total Cost (XRD)                                                           ,            0.35953568381,    100.0%
+- Execution Cost (XRD)                                                     ,               0.18344985,     51.0%
 - Finalization Cost (XRD)                                                  ,                0.0552553,     15.4%
 - Storage Cost (XRD)                                                       ,            0.12083053381,     33.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3665746,    100.0%
+Execution Cost Breakdown                                                   ,                  3668997,    100.0%
 - AfterInvoke                                                              ,                      124,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     2254,      0.1%
@@ -23,7 +23,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::InternalGenericComponent                                   ,                    18682,      0.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.1%
 - PinNode                                                                  ,                      180,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      9.7%
+- PrepareWasmCode                                                          ,                   353866,      9.6%
 - QueryActor                                                               ,                     1000,      0.0%
 - QueryCostingModule                                                       ,                     4500,      0.1%
 - QueryFeeReserve                                                          ,                     4500,      0.1%
@@ -32,7 +32,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
 - RunNativeCode::set_royalty                                               ,                   153756,      4.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    45680,      1.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/004--royalties--call_all_components_all_methods.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/004--royalties--call_all_components_all_methods.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,   347.667634537889999992,    100.0%
-- Execution Cost (XRD)                                                     ,                0.5693587,      0.2%
+Total Cost (XRD)                                                           ,   347.667986987889999992,    100.0%
+- Execution Cost (XRD)                                                     ,               0.56971115,      0.2%
 - Finalization Cost (XRD)                                                  ,                0.0102517,      0.0%
 - Storage Cost (XRD)                                                       ,            0.08802413789,      0.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,   346.999999999999999992,     99.8%
-Execution Cost Breakdown                                                   ,                 11387174,    100.0%
+Execution Cost Breakdown                                                   ,                 11394223,    100.0%
 - AfterInvoke                                                              ,                      124,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     1666,      0.0%
@@ -25,14 +25,14 @@ Execution Cost Breakdown                                                   ,    
 - PinNode                                                                  ,                      180,      0.0%
 - PrepareWasmCode                                                          ,                  2859142,     25.1%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                  2955944,     26.0%
+- ReadSubstate                                                             ,                  2955944,     25.9%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.2%
-- RunWasmCode::RoyaltiesBp_method_with_no_package_royalty                  ,                    23736,      0.2%
-- RunWasmCode::RoyaltiesBp_method_with_usd_package_royalty                 ,                    23736,      0.2%
-- RunWasmCode::RoyaltiesBp_method_with_xrd_package_royalty                 ,                    23736,      0.2%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
+- RunWasmCode::RoyaltiesBp_method_with_no_package_royalty                  ,                    25002,      0.2%
+- RunWasmCode::RoyaltiesBp_method_with_usd_package_royalty                 ,                    25002,      0.2%
+- RunWasmCode::RoyaltiesBp_method_with_xrd_package_royalty                 ,                    25002,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    33920,      0.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/001--royalties--publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/001--royalties--publish-package.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 31.47003411469 XRD
-├─ Network execution: 0.6181983 XRD, 12363966 execution cost units
+TRANSACTION COST: 31.47019666469 XRD
+├─ Network execution: 0.61836085 XRD, 12367217 execution cost units
 ├─ Network finalization: 0.0783874 XRD, 1567748 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 30.77344841469 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("31.47003411469"),
+     amount: Decimal("31.47019666469"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("15.735017057345"),
+     amount: Decimal("15.735098332345"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("15.735017057345"),
+     amount: Decimal("15.735098332345"),
    }
 
 STATE UPDATES: 7 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("7.8675085286725"),
+             0u8 => Decimal("7.8675491661725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999968.52996588531")),
+         LiquidFungibleResource(Decimal("99999999999999968.52980333531")),
        )
 ├─ package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z across 11 partitions
   ├─ Partition(1): 1 change
@@ -307,7 +307,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("15.735017057345")),
+         LiquidFungibleResource(Decimal("15.735098332345")),
        )
 
 OUTPUTS: 3
@@ -318,10 +318,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -31.47003411469
+   Change: -31.47019666469
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 15.735017057345
+   Change: 15.735098332345
 
 NEW ENTITIES: 1
 └─ Package: package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/002--royalties--instantiate-components.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/002--royalties--instantiate-components.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.0449135481 XRD
-├─ Network execution: 0.36352375 XRD, 7270475 execution cost units
+TRANSACTION COST: 1.0473229481 XRD
+├─ Network execution: 0.36593315 XRD, 7318663 execution cost units
 ├─ Network finalization: 0.2360239 XRD, 4720478 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.4453658981 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.0449135481"),
+     amount: Decimal("1.0473229481"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.52245677405"),
+     amount: Decimal("0.52366147405"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.52245677405"),
+     amount: Decimal("0.52366147405"),
    }
 
 STATE UPDATES: 11 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.1287369156975"),
+             0u8 => Decimal("8.1293799031975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999967.48505233721")),
+         LiquidFungibleResource(Decimal("99999999999999967.48248038721")),
        )
 ├─ component_sim1cr7guww2kc22r6vnk8ffep9sv2aphp0mg6hdngg8x2shzf2xn90zmw across 6 partitions
   ├─ Partition(3): 1 change
@@ -475,7 +475,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.257473831395")),
+         LiquidFungibleResource(Decimal("16.258759806395")),
        )
 
 OUTPUTS: 4
@@ -487,10 +487,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.0449135481
+   Change: -1.0473229481
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.52245677405
+   Change: 0.52366147405
 
 NEW ENTITIES: 3
 ├─ Component: component_sim1cr7guww2kc22r6vnk8ffep9sv2aphp0mg6hdngg8x2shzf2xn90zmw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/003--royalties--set-components-royalty.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/003--royalties--set-components-royalty.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.35937313381 XRD
-├─ Network execution: 0.1832873 XRD, 3665746 execution cost units
+TRANSACTION COST: 0.35953568381 XRD
+├─ Network execution: 0.18344985 XRD, 3668997 execution cost units
 ├─ Network finalization: 0.0552553 XRD, 1105106 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.12083053381 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.35937313381"),
+     amount: Decimal("0.35953568381"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.179686566905"),
+     amount: Decimal("0.179767841905"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.179686566905"),
+     amount: Decimal("0.179767841905"),
    }
 
 STATE UPDATES: 8 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.21858019915"),
+             0u8 => Decimal("8.21926382415"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -121,13 +121,13 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999967.1256792034")),
+         LiquidFungibleResource(Decimal("99999999999999967.1229447034")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.4371603983")),
+         LiquidFungibleResource(Decimal("16.4385276483")),
        )
 
 OUTPUTS: 10
@@ -145,9 +145,9 @@ OUTPUTS: 10
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.35937313381
+   Change: -0.35953568381
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.179686566905
+   Change: 0.179767841905
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/004--royalties--call_all_components_all_methods.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/004--royalties--call_all_components_all_methods.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 347.667634537889999992 XRD
-├─ Network execution: 0.5693587 XRD, 11387174 execution cost units
+TRANSACTION COST: 347.667986987889999992 XRD
+├─ Network execution: 0.56971115 XRD, 11394223 execution cost units
 ├─ Network finalization: 0.0102517 XRD, 205034 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08802413789 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("347.667634537889999992"),
+     amount: Decimal("347.667986987889999992"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.333817268945"),
+     amount: Decimal("0.333993493945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.333817268945"),
+     amount: Decimal("0.333993493945"),
    }
 
 STATE UPDATES: 8 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.3854888336225"),
+             0u8 => Decimal("8.3862605711225"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999619.458044665510000008")),
+         LiquidFungibleResource(Decimal("99999999999999619.454957715510000008")),
        )
 ├─ internal_vault_sim1tqce6jxy9gwd6trwftkdhksyt4gfq348rypqeq00s40k7jk3z5r2ke across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.770977667245")),
+         LiquidFungibleResource(Decimal("16.772521142245")),
        )
 
 OUTPUTS: 10
@@ -121,7 +121,7 @@ OUTPUTS: 10
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -347.667634537889999992
+   Change: -347.667986987889999992
 ├─ Vault: internal_vault_sim1tqce6jxy9gwd6trwftkdhksyt4gfq348rypqeq00s40k7jk3z5r2ke
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 142.999999999999999998
@@ -133,6 +133,6 @@ BALANCE CHANGES: 5
    Change: 149.999999999999999994
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.333817268945
+   Change: 0.333993493945
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: royalties
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 621767f0d2edb87e (allowed to change if not deployed to any network)
-Events       : 999331c952a301fa (allowed to change if not deployed to any network)
+State changes: d34978a2783e9354 (allowed to change if not deployed to any network)
+Events       : 8fb9a668425950d7 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - royalty_package_address: package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/001--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/001--faucet-top-up.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.57187005924,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3324622,     58.1%
+Total Cost (XRD)                                                           ,            0.57228020924,    100.0%
+- Execution Cost (XRD)                                                     ,               0.33287235,     58.2%
 - Finalization Cost (XRD)                                                  ,                0.0612615,     10.7%
-- Storage Cost (XRD)                                                       ,            0.17814635924,     31.2%
+- Storage Cost (XRD)                                                       ,            0.17814635924,     31.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6649244,    100.0%
+Execution Cost Breakdown                                                   ,                  6657447,    100.0%
 - AfterInvoke                                                              ,                      654,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     2816,      0.0%
@@ -21,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      2.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3181935,     47.9%
+- OpenSubstate::GlobalPackage                                              ,                  3181935,     47.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      7.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   106652,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    55774,      0.8%
@@ -45,8 +45,8 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
 - RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.5%
-- RunWasmCode::Faucet_free                                                 ,                    34815,      0.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/002--transfer--try_deposit_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/002--transfer--try_deposit_or_abort.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.52864231178,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2720081,     51.5%
+Total Cost (XRD)                                                           ,            0.52880486178,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27217065,     51.5%
 - Finalization Cost (XRD)                                                  ,               0.06151245,     11.6%
 - Storage Cost (XRD)                                                       ,            0.19512176178,     36.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5440162,    100.0%
+Execution Cost Breakdown                                                   ,                  5443413,    100.0%
 - AfterInvoke                                                              ,                      686,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     2964,      0.1%
@@ -20,7 +20,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   175335,      3.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2494754,     45.9%
+- OpenSubstate::GlobalPackage                                              ,                  2494754,     45.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   772151,     14.2%
 - OpenSubstate::InternalFungibleVault                                      ,                   181670,      3.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    66591,      1.2%
@@ -43,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
 - RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.8%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.1%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/003--transfer--try_deposit_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/003--transfer--try_deposit_or_refund.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.33535054196,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2213986,     66.0%
+Total Cost (XRD)                                                           ,            0.33551309196,    100.0%
+- Execution Cost (XRD)                                                     ,               0.22156115,     66.0%
 - Finalization Cost (XRD)                                                  ,                0.0212548,      6.3%
 - Storage Cost (XRD)                                                       ,            0.09269714196,     27.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4427972,    100.0%
+Execution Cost Breakdown                                                   ,                  4431223,    100.0%
 - AfterInvoke                                                              ,                      490,      0.0%
 - AllocateNodeId                                                           ,                     1649,      0.0%
 - BeforeInvoke                                                             ,                     1844,      0.0%
@@ -37,7 +37,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      2.0%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    21240,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/004--transfer--try_deposit_batch_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/004--transfer--try_deposit_batch_or_abort.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.32569284845,    100.0%
-- Execution Cost (XRD)                                                     ,               0.21717685,     66.7%
+Total Cost (XRD)                                                           ,            0.32585539845,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2173394,     66.7%
 - Finalization Cost (XRD)                                                  ,                0.0212548,      6.5%
 - Storage Cost (XRD)                                                       ,            0.08726119845,     26.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4343537,    100.0%
+Execution Cost Breakdown                                                   ,                  4346788,    100.0%
 - AfterInvoke                                                              ,                      440,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1662,      0.0%
@@ -37,7 +37,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    18960,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/005--transfer--try_deposit_batch_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/005--transfer--try_deposit_batch_or_refund.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.32860431588,    100.0%
-- Execution Cost (XRD)                                                     ,               0.21999295,     66.9%
+Total Cost (XRD)                                                           ,            0.32876686588,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2201555,     67.0%
 - Finalization Cost (XRD)                                                  ,                0.0212548,      6.5%
 - Storage Cost (XRD)                                                       ,            0.08735656588,     26.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4399859,    100.0%
+Execution Cost Breakdown                                                   ,                  4403110,    100.0%
 - AfterInvoke                                                              ,                      442,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1664,      0.0%
@@ -16,9 +16,9 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1860098,     42.3%
+- OpenSubstate::GlobalPackage                                              ,                  1860098,     42.2%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     13.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    53048,      1.2%
@@ -37,7 +37,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
 - RunNativeCode::try_deposit_batch_or_refund                               ,                    97532,      2.2%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    19000,      0.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/006--self-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/006--self-transfer--deposit_batch.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.30051241957,    100.0%
-- Execution Cost (XRD)                                                     ,               0.19852275,     66.1%
+Total Cost (XRD)                                                           ,            0.30067496957,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1986853,     66.1%
 - Finalization Cost (XRD)                                                  ,               0.01625435,      5.4%
 - Storage Cost (XRD)                                                       ,            0.08573531957,     28.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3970455,    100.0%
+Execution Cost Breakdown                                                   ,                  3973706,    100.0%
 - AfterInvoke                                                              ,                      440,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1630,      0.0%
@@ -16,12 +16,12 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   168812,      4.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   168812,      4.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalPackage                                              ,                  1780095,     44.8%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   290024,      7.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   180065,      4.5%
-- OpenSubstate::InternalGenericComponent                                   ,                    53605,      1.4%
+- OpenSubstate::InternalGenericComponent                                   ,                    53605,      1.3%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      192,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      8.9%
@@ -37,7 +37,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.1%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    18320,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/007--multi-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/007--multi-transfer--deposit_batch.txt
@@ -1,10 +1,10 @@
-Total Cost (XRD)                                                           ,            0.62406191304,    100.0%
-- Execution Cost (XRD)                                                     ,               0.31545795,     50.5%
+Total Cost (XRD)                                                           ,            0.62422446304,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3156205,     50.6%
 - Finalization Cost (XRD)                                                  ,                0.0675151,     10.8%
 - Storage Cost (XRD)                                                       ,            0.24108886304,     38.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6309159,    100.0%
+Execution Cost Breakdown                                                   ,                  6312410,    100.0%
 - AfterInvoke                                                              ,                     1008,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.1%
 - BeforeInvoke                                                             ,                     3926,      0.1%
@@ -20,7 +20,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   182274,      2.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2508568,     39.8%
+- OpenSubstate::GlobalPackage                                              ,                  2508568,     39.7%
 - OpenSubstate::GlobalPreallocatedEd25519Account                           ,                   487127,      7.7%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   575968,      9.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   271533,      4.3%
@@ -44,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_FungibleVault                                        ,                    84914,      1.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   242514,      3.8%
 - RunNativeCode::withdraw                                                  ,                   115702,      1.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    24589,      0.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/001--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/001--faucet-top-up.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.57187005924 XRD
-├─ Network execution: 0.3324622 XRD, 6649244 execution cost units
+TRANSACTION COST: 0.57228020924 XRD
+├─ Network execution: 0.33287235 XRD, 6657447 execution cost units
 ├─ Network finalization: 0.0612615 XRD, 1225230 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17814635924 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.57187005924"),
+     amount: Decimal("0.57228020924"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.28593502962"),
+     amount: Decimal("0.28614010462"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.28593502962"),
+     amount: Decimal("0.28614010462"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.14296751481"),
+             0u8 => Decimal("0.14307005231"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.42812994076")),
+         LiquidFungibleResource(Decimal("99999999999989999.42771979076")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -222,7 +222,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.28593502962")),
+         LiquidFungibleResource(Decimal("0.28614010462")),
        )
 
 OUTPUTS: 4
@@ -234,13 +234,13 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.57187005924
+   Change: -10000.57228020924
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.28593502962
+   Change: 0.28614010462
 
 NEW ENTITIES: 1
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/002--transfer--try_deposit_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/002--transfer--try_deposit_or_abort.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52864231178 XRD
-├─ Network execution: 0.2720081 XRD, 5440162 execution cost units
+TRANSACTION COST: 0.52880486178 XRD
+├─ Network execution: 0.27217065 XRD, 5443413 execution cost units
 ├─ Network finalization: 0.06151245 XRD, 1230249 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19512176178 XRD
@@ -38,15 +38,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52864231178"),
+     amount: Decimal("0.52880486178"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.26432115589"),
+     amount: Decimal("0.26440243089"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.26432115589"),
+     amount: Decimal("0.26440243089"),
    }
 
 STATE UPDATES: 8 entities
@@ -56,7 +56,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.275128092755"),
+             0u8 => Decimal("0.275271267755"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -89,7 +89,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.89948762898")),
+         LiquidFungibleResource(Decimal("99999999999989998.89891492898")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -229,7 +229,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.55025618551")),
+         LiquidFungibleResource(Decimal("0.55054253551")),
        )
 
 OUTPUTS: 4
@@ -241,7 +241,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.52864231178
+   Change: -0.52880486178
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -250,7 +250,7 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.26432115589
+   Change: 0.26440243089
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/003--transfer--try_deposit_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/003--transfer--try_deposit_or_refund.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.33535054196 XRD
-├─ Network execution: 0.2213986 XRD, 4427972 execution cost units
+TRANSACTION COST: 0.33551309196 XRD
+├─ Network execution: 0.22156115 XRD, 4431223 execution cost units
 ├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09269714196 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.33535054196"),
+     amount: Decimal("0.33551309196"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16767527098"),
+     amount: Decimal("0.16775654598"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16767527098"),
+     amount: Decimal("0.16775654598"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.358965728245"),
+             0u8 => Decimal("0.359149540745"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.56413708702")),
+         LiquidFungibleResource(Decimal("99999999999989998.56340183702")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.71793145649")),
+         LiquidFungibleResource(Decimal("0.71829908149")),
        )
 
 OUTPUTS: 4
@@ -115,7 +115,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.33535054196
+   Change: -0.33551309196
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -124,6 +124,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16767527098
+   Change: 0.16775654598
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/004--transfer--try_deposit_batch_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/004--transfer--try_deposit_batch_or_abort.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32569284845 XRD
-├─ Network execution: 0.21717685 XRD, 4343537 execution cost units
+TRANSACTION COST: 0.32585539845 XRD
+├─ Network execution: 0.2173394 XRD, 4346788 execution cost units
 ├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08726119845 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32569284845"),
+     amount: Decimal("0.32585539845"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.162846424225"),
+     amount: Decimal("0.162927699225"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.162846424225"),
+     amount: Decimal("0.162927699225"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4403889403575"),
+             0u8 => Decimal("0.4406133903575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.23844423857")),
+         LiquidFungibleResource(Decimal("99999999999989998.23754643857")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.880777880715")),
+         LiquidFungibleResource(Decimal("0.881226780715")),
        )
 
 OUTPUTS: 3
@@ -114,7 +114,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32569284845
+   Change: -0.32585539845
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -123,6 +123,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.162846424225
+   Change: 0.162927699225
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/005--transfer--try_deposit_batch_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/005--transfer--try_deposit_batch_or_refund.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32860431588 XRD
-├─ Network execution: 0.21999295 XRD, 4399859 execution cost units
+TRANSACTION COST: 0.32876686588 XRD
+├─ Network execution: 0.2201555 XRD, 4403110 execution cost units
 ├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08735656588 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32860431588"),
+     amount: Decimal("0.32876686588"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16430215794"),
+     amount: Decimal("0.16438343294"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16430215794"),
+     amount: Decimal("0.16438343294"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.5225400193275"),
+             0u8 => Decimal("0.5228051068275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.90983992269")),
+         LiquidFungibleResource(Decimal("99999999999989997.90877957269")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.045080038655")),
+         LiquidFungibleResource(Decimal("1.045610213655")),
        )
 
 OUTPUTS: 3
@@ -114,7 +114,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32860431588
+   Change: -0.32876686588
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -123,6 +123,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16430215794
+   Change: 0.16438343294
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/006--self-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/006--self-transfer--deposit_batch.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30051241957 XRD
-├─ Network execution: 0.19852275 XRD, 3970455 execution cost units
+TRANSACTION COST: 0.30067496957 XRD
+├─ Network execution: 0.1986853 XRD, 3973706 execution cost units
 ├─ Network finalization: 0.01625435 XRD, 325087 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08573531957 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30051241957"),
+     amount: Decimal("0.30067496957"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.150256209785"),
+     amount: Decimal("0.150337484785"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.150256209785"),
+     amount: Decimal("0.150337484785"),
    }
 
 STATE UPDATES: 6 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.59766812422"),
+             0u8 => Decimal("0.59797384922"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.60932750312")),
+         LiquidFungibleResource(Decimal("99999999999989997.60810460312")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -97,7 +97,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.19533624844")),
+         LiquidFungibleResource(Decimal("1.19594769844")),
        )
 
 OUTPUTS: 3
@@ -108,9 +108,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30051241957
+   Change: -0.30067496957
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.150256209785
+   Change: 0.150337484785
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/007--multi-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/007--multi-transfer--deposit_batch.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.62406191304 XRD
-├─ Network execution: 0.31545795 XRD, 6309159 execution cost units
+TRANSACTION COST: 0.62422446304 XRD
+├─ Network execution: 0.3156205 XRD, 6312410 execution cost units
 ├─ Network finalization: 0.0675151 XRD, 1350302 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.24108886304 XRD
@@ -56,15 +56,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.62406191304"),
+     amount: Decimal("0.62422446304"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.31203095652"),
+     amount: Decimal("0.31211223152"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.31203095652"),
+     amount: Decimal("0.31211223152"),
    }
 
 STATE UPDATES: 9 entities
@@ -74,7 +74,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.75368360248"),
+             0u8 => Decimal("0.75402996498"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -107,7 +107,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989996.98526559008")),
+         LiquidFungibleResource(Decimal("99999999999989996.98388014008")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -253,7 +253,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.50736720496")),
+         LiquidFungibleResource(Decimal("1.50805992996")),
        )
 
 OUTPUTS: 5
@@ -266,7 +266,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.62406191304
+   Change: -0.62422446304
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -2
@@ -278,7 +278,7 @@ BALANCE CHANGES: 5
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.31203095652
+   Change: 0.31211223152
 
 NEW ENTITIES: 1
 └─ Component: account_sim128cqk4tgnu2trlvmpf242a0lsq4062a2c45hhymr3tly0ps3w57yav

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: transfer_xrd
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 3d5f65532f622546 (allowed to change if not deployed to any network)
-Events       : 104a56ffc7984255 (allowed to change if not deployed to any network)
+State changes: da65b4aa510a0e69 (allowed to change if not deployed to any network)
+Events       : 20a705dc0dc35d27 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - from_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw


### PR DESCRIPTION
## Summary
Added WASM execution unit base to assure simple WASM calls are not being undercharged.

## Motivation

Test | Base | PR | %
-- | -- | -- | --
costing::scrypto_malloc | 592.2±0.84ms | 504.3±2.87ms | -14.84%
costing::scrypto_sbor_decode | 569.5±1.32ms | 500.3±2.76ms | -12.15%
costing::scrypto_sha256 | 392.4±1.20ms | 367.5±1.57ms | -6.35%
costing::spin_loop_v1 | 628.2±5.74ms | 474.9±2.19ms | -24.40%
costing::spin_loop_v2 | 2.7±0.00s | 959.4±0.90ms | -64.47%

Based on the benchmarks on the `base`, the `spin_loop_v2` does not finish within 1 second, despite consuming around 100 million execution cost units. 

It's made possible by iterating an empty code block (except a `br` instruction), where `consume_wasm_execution_units` host function becomes the dominant factor. 

This PR fixes it by introducing a base cost to account for the execution of the host function itself.