### PR TITLE
Clean up spin_loop benchmarks

### DIFF
--- a/radix-engine-tests/assets/blueprints/Cargo.lock
+++ b/radix-engine-tests/assets/blueprints/Cargo.lock
@@ -31,6 +31,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "auth_scenarios"
 version = "1.0.0"
 dependencies = [
@@ -114,6 +125,12 @@ version = "1.0.0"
 dependencies = [
  "scrypto",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cast"
@@ -1112,6 +1129,26 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha256"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "hex",
+ "sha2",
+]
+
+[[package]]
+name = "sha256_in_scrypto"
+version = "1.0.0"
+dependencies = [
+ "scrypto",
+ "sha256",
 ]
 
 [[package]]

--- a/radix-engine-tests/assets/blueprints/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "steal",
     "locker-factory",
     "wasm_limits",
+    "sha256_in_scrypto",
 ]
 resolver = "2"
 

--- a/radix-engine-tests/assets/blueprints/sha256_in_scrypto/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/sha256_in_scrypto/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sha256_in_scrypto"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+scrypto = { path = "../../../../scrypto" }
+sha256 = { version = "1.5.0", default-features = false }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/assets/blueprints/sha256_in_scrypto/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/sha256_in_scrypto/src/lib.rs
@@ -1,0 +1,16 @@
+use scrypto::prelude::*;
+use sha256::digest;
+
+#[blueprint]
+mod s {
+    struct Test {}
+
+    impl Test {
+        pub fn f() {
+            loop {
+                // Avoid loop being optimised away!
+                std::hint::black_box(digest("hello"));
+            }
+        }
+    }
+}

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -191,6 +191,15 @@ fn bench_spin_loop_v1(c: &mut Criterion) {
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
 
+    // The transaction failed, consuming almost all execution cost units.
+    assert!(
+        ledger
+            .execute_manifest(manifest.clone(), [])
+            .fee_summary
+            .total_execution_cost_units_consumed
+            >= 99_000_000
+    );
+
     c.bench_function("costing::spin_loop_v1", |b| {
         b.iter(|| ledger.execute_manifest(manifest.clone(), []))
     });
@@ -215,6 +224,15 @@ fn bench_spin_loop_v2(c: &mut Criterion) {
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
 
+    // The transaction failed, consuming almost all execution cost units.
+    assert!(
+        ledger
+            .execute_manifest(manifest.clone(), [])
+            .fee_summary
+            .total_execution_cost_units_consumed
+            >= 99_000_000
+    );
+
     c.bench_function("costing::spin_loop_v2", |b| {
         b.iter(|| ledger.execute_manifest(manifest.clone(), []))
     });
@@ -231,6 +249,15 @@ fn bench_sha256(c: &mut Criterion) {
         // Now spin-loop to wait for the fee loan to burn through
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
+
+    // The transaction failed, consuming almost all execution cost units.
+    assert!(
+        ledger
+            .execute_manifest(manifest.clone(), [])
+            .fee_summary
+            .total_execution_cost_units_consumed
+            >= 99_000_000
+    );
 
     c.bench_function("costing::sha256", |b| {
         b.iter(|| ledger.execute_manifest(manifest.clone(), []))

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -191,7 +191,7 @@ fn bench_spin_loop_v1(c: &mut Criterion) {
         .call_function(package_address, "Test", "f", manifest_args!())
         .build();
 
-    c.bench_function("costing::spin_loop", |b| {
+    c.bench_function("costing::spin_loop_v1", |b| {
         b.iter(|| ledger.execute_manifest(manifest.clone(), []))
     });
 }

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -197,6 +197,9 @@ fn bench_spin_loop_v1(c: &mut Criterion) {
 }
 
 // Usage: cargo bench --bench costing -- spin_loop_v2
+// Different from spin_loop_v1, this is the smallest possible loop.
+// There is only one instruction `br` per iteration.
+// It's extremely helpful for stress testing the `consume_wasm_execution_units` host function.
 fn bench_spin_loop_v2(c: &mut Criterion) {
     let code = wat2wasm(&include_local_wasm_str!("loop_v2.wat")).unwrap();
     let mut ledger = LedgerSimulatorBuilder::new().build();

--- a/radix-engine-tests/benches/costing.rs
+++ b/radix-engine-tests/benches/costing.rs
@@ -172,7 +172,7 @@ fn bench_validate_secp256k1(c: &mut Criterion) {
 }
 
 // Usage: cargo bench --bench costing -- spin_loop_v1
-// Note that this benchmark replaces the `spin_loop` before this commit, which uses NoOpScryptoRuntime
+// Note that this benchmark replaces the `spin_loop` before this commit, which uses NoOpRuntime
 fn bench_spin_loop_v1(c: &mut Criterion) {
     // Prepare code
     let code =


### PR DESCRIPTION
## Summary

- Replaced `spin_loop` with `spin_loop_v1`, which now uses ScryptoRuntime.
- Removed `spin_loop_v3` (which is redundant to `spin_loop_v1`).
- Added `sha256_in_scrypto` benchmark.