### PR TITLE
Add intent hash to the error code

### DIFF
--- a/radix-engine-tests/tests/system/nullification.rs
+++ b/radix-engine-tests/tests/system/nullification.rs
@@ -29,7 +29,7 @@ fn v2_transaction_intent_gets_nullified_and_cannot_be_replayed() {
     // Assert
     assert_matches!(
         duplicate_receipt.expect_rejection(),
-        &RejectionReason::IntentHashPreviouslyCommitted
+        &RejectionReason::IntentHashPreviouslyCommitted(IntentHash::Transaction(_))
     );
 }
 
@@ -106,6 +106,6 @@ fn v2_subintent_only_gets_nullified_on_success() {
 
     assert_matches!(
         receipt.expect_rejection(),
-        &RejectionReason::IntentHashPreviouslyCommitted
+        &RejectionReason::IntentHashPreviouslyCommitted(IntentHash::Subintent(_))
     );
 }

--- a/radix-engine-tests/tests/system/transaction_tracker.rs
+++ b/radix-engine-tests/tests/system/transaction_tracker.rs
@@ -58,9 +58,11 @@ fn test_transaction_replay_protection() {
         executable.clone(),
         ExecutionConfig::for_notarized_transaction(NetworkDefinition::simulator()),
     );
-    receipt.expect_specific_rejection(|e| match e {
-        RejectionReason::IntentHashPreviouslyCommitted => true,
-        _ => false,
+    receipt.expect_specific_rejection(|e| {
+        matches!(
+            e,
+            RejectionReason::IntentHashPreviouslyCommitted(IntentHash::Transaction(_))
+        )
     });
 
     // 4. Advance to the max epoch (which triggers epoch update)

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -66,14 +66,17 @@ pub enum RejectionReason {
         valid_to_exclusive: Instant,
         current_time: Instant,
     },
-    IntentHashPreviouslyCommitted(IntentHash),
-    IntentHashPreviouslyCancelled(IntentHash),
+    DeprecatedIntentHashPreviouslyCommitted,
+    DeprecatedIntentHashPreviouslyCancelled,
 
     BootloadingError(BootloadingError),
 
     ErrorBeforeLoanAndDeferredCostsRepaid(RuntimeError),
     SuccessButFeeLoanNotRepaid,
     SubintentsNotYetSupported,
+
+    IntentHashPreviouslyCommitted(IntentHash),
+    IntentHashPreviouslyCancelled(IntentHash),
 }
 
 impl From<BootloadingError> for RejectionReason {

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -66,17 +66,14 @@ pub enum RejectionReason {
         valid_to_exclusive: Instant,
         current_time: Instant,
     },
-    DeprecatedIntentHashPreviouslyCommitted,
-    DeprecatedIntentHashPreviouslyCancelled,
+    IntentHashPreviouslyCommitted(IntentHash),
+    IntentHashPreviouslyCancelled(IntentHash),
 
     BootloadingError(BootloadingError),
 
     ErrorBeforeLoanAndDeferredCostsRepaid(RuntimeError),
     SuccessButFeeLoanNotRepaid,
     SubintentsNotYetSupported,
-
-    IntentHashPreviouslyCommitted(IntentHash),
-    IntentHashPreviouslyCancelled(IntentHash),
 }
 
 impl From<BootloadingError> for RejectionReason {

--- a/radix-engine/src/errors.rs
+++ b/radix-engine/src/errors.rs
@@ -34,6 +34,7 @@ use crate::vm::ScryptoVmVersionError;
 use radix_engine_interface::api::object_api::ModuleId;
 use radix_engine_interface::api::{ActorStateHandle, AttachedModuleId};
 use radix_engine_interface::blueprints::package::{BlueprintPartitionType, CanonicalBlueprintId};
+use radix_transactions::model::IntentHash;
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub enum IdAllocationError {
@@ -65,8 +66,8 @@ pub enum RejectionReason {
         valid_to_exclusive: Instant,
         current_time: Instant,
     },
-    IntentHashPreviouslyCommitted,
-    IntentHashPreviouslyCancelled,
+    IntentHashPreviouslyCommitted(IntentHash),
+    IntentHashPreviouslyCancelled(IntentHash),
 
     BootloadingError(BootloadingError),
 


### PR DESCRIPTION
## Summary

This PR adds intent hash to the rejection error code, so clients can know whether transaction intent hash or subintent hash was failing.