### PR TITLE
Add direct method handling in the `TypedInvocation` generation macro.

### DIFF
--- a/radix-engine-tests/tests/application/static_resource_movements_visitor.rs
+++ b/radix-engine-tests/tests/application/static_resource_movements_visitor.rs
@@ -586,6 +586,26 @@ fn two_buckets_with_separate_histories_are_combined() {
     );
 }
 
+#[test]
+fn static_analysis_on_a_vault_direct_method_succeeds() {
+    // Arrange
+    let manifest = ManifestBuilder::new()
+        .call_direct_access_method(
+            vault_id(1),
+            VAULT_FREEZE_IDENT,
+            VaultFreezeManifestInput {
+                to_freeze: VaultFreezeFlags::all(),
+            },
+        )
+        .build();
+
+    // Act
+    let rtn = statically_analyze(&manifest);
+
+    // Act
+    assert!(rtn.is_ok());
+}
+
 fn account_address(id: u64) -> ComponentAddress {
     unsafe {
         ComponentAddress::new_unchecked(node_id(EntityType::GlobalPreallocatedEd25519Account, id).0)
@@ -594,6 +614,10 @@ fn account_address(id: u64) -> ComponentAddress {
 
 fn component_address(id: u64) -> ComponentAddress {
     unsafe { ComponentAddress::new_unchecked(node_id(EntityType::GlobalGenericComponent, id).0) }
+}
+
+fn vault_id(id: u64) -> InternalAddress {
+    unsafe { InternalAddress::new_unchecked(node_id(EntityType::InternalFungibleVault, id).0) }
 }
 
 fn fungible_resource_address(id: u64) -> ResourceAddress {

--- a/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
@@ -291,6 +291,15 @@ macro_rules! define_manifest_typed_invocation {
                         $(
                             $(
                                 TypedManifestNativeInvocation::[<$blueprint_ident BlueprintInvocation>](
+                                    [<$blueprint_ident BlueprintInvocation>]::DirectMethod(
+                                        [<$blueprint_ident BlueprintDirectMethod>]::$direct_method_ident($input)
+                                    )
+                                ) => $action,
+                            )*
+                        )*
+                        $(
+                            $(
+                                TypedManifestNativeInvocation::[<$blueprint_ident BlueprintInvocation>](
                                     [<$blueprint_ident BlueprintInvocation>]::Function(
                                         [<$blueprint_ident BlueprintFunction>]::$function_ident($input)
                                     )


### PR DESCRIPTION
## Summary

Fixed a bug in the static resource analyzer where `DirectMethod`s were not being considered in one of the match statements generated by the macro which lead to unreachable code being reached.