### PR TITLE
Add cost for transaction intent hash status

### DIFF
--- a/radix-engine-tests/tests/application/execution_trace.rs
+++ b/radix-engine-tests/tests/application/execution_trace.rs
@@ -1011,7 +1011,7 @@ fn test_execution_trace_for_transaction_v2() {
                         "58d39b18c2cb0885ab8e1da7b25b973ed5489f64e0765696956941aa1cf5",
                     ),
                     resource_address: ResourceAddress(5da66318c6318c61f5a61b4c6318c6318cf794aa8d295f14e6318c6318c6),
-                    amount: -0.33513389042,
+                    amount: -0.34813389042,
                 },
             ],
             1: [

--- a/radix-engine/src/kernel/kernel.rs
+++ b/radix-engine/src/kernel/kernel.rs
@@ -156,7 +156,7 @@ impl<'h, S: SubstateDatabase> BootLoader<'h, S> {
             kernel_boot.always_visible_global_nodes(),
         );
 
-        let (mut system, call_frame_inits, num_of_intent_statuses) = match system_init_result {
+        let (mut system, call_frame_inits) = match system_init_result {
             Ok(success) => success,
             Err(receipt) => return receipt,
         };
@@ -184,9 +184,7 @@ impl<'h, S: SubstateDatabase> BootLoader<'h, S> {
 
             // Finalize state updates based on what has occurred
             let commit_info = kernel.substate_io.store.get_commit_info();
-            kernel
-                .callback
-                .finalize(commit_info, num_of_intent_statuses)?;
+            kernel.callback.finalize(executable, commit_info)?;
 
             Ok(output)
         }()

--- a/radix-engine/src/kernel/kernel_callback_api.rs
+++ b/radix-engine/src/kernel/kernel_callback_api.rs
@@ -166,7 +166,7 @@ pub trait KernelTransactionExecutor: KernelCallbackObject {
         executable: &Self::Executable,
         init: Self::Init,
         always_visible_global_nodes: &'static IndexSet<NodeId>,
-    ) -> Result<(Self, Vec<CallFrameInit<Self::CallFrameData>>, usize), Self::Receipt>;
+    ) -> Result<(Self, Vec<CallFrameInit<Self::CallFrameData>>), Self::Receipt>;
 
     /// Start execution
     fn execute<Y: KernelApi<CallbackObject = Self>>(
@@ -177,8 +177,8 @@ pub trait KernelTransactionExecutor: KernelCallbackObject {
     /// Finish execution
     fn finalize(
         &mut self,
+        executable: &Self::Executable,
         store_commit_info: StoreCommitInfo,
-        num_of_intent_statuses: usize,
     ) -> Result<(), RuntimeError>;
 
     /// Create final receipt

--- a/radix-engine/src/system/system_callback.rs
+++ b/radix-engine/src/system/system_callback.rs
@@ -1588,14 +1588,16 @@ impl<V: SystemCallbackObject> KernelTransactionExecutor for System<V> {
                 }
             }
             .and_then(|_| {
-                if match hash_nullification {
+                let charge_for_nullification_check = match hash_nullification {
                     IntentHashNullification::TransactionIntent { .. }
                     | IntentHashNullification::SimulatedTransactionIntent { .. } => {
                         logic_version.should_charge_for_transaction_intent()
                     }
                     IntentHashNullification::Subintent { .. }
                     | IntentHashNullification::SimulatedSubintent { .. } => true,
-                } {
+                };
+                
+                if charge_for_nullification_check {
                     if let Some(costing) = modules.costing_mut() {
                         return costing
                             .apply_deferred_execution_cost(

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/001--access-controller-v2-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/001--access-controller-v2-instantiate.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.94522588742,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3301579,     34.9%
-- Finalization Cost (XRD)                                                  ,                0.1960235,     20.7%
-- Storage Cost (XRD)                                                       ,            0.41904448742,     44.3%
+Total Cost (XRD)                                                           ,            0.95822588742,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3381579,     35.3%
+- Finalization Cost (XRD)                                                  ,                0.2010235,     21.0%
+- Storage Cost (XRD)                                                       ,            0.41904448742,     43.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6603158,    100.0%
+Execution Cost Breakdown                                                   ,                  6763158,    100.0%
 - AfterInvoke                                                              ,                      846,      0.0%
 - AllocateNodeId                                                           ,                     3201,      0.0%
 - BeforeInvoke                                                             ,                     5962,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
 - CheckReference                                                           ,                    40011,      0.6%
 - CloseSubstate                                                            ,                    45150,      0.7%
 - CreateNode                                                               ,                    29642,      0.4%
@@ -18,23 +19,23 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - MoveModule                                                               ,                     9520,      0.1%
 - OpenSubstate::GlobalAccessController                                     ,                     2227,      0.0%
-- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.7%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      2.6%
+- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    93378,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  3379244,     51.2%
+- OpenSubstate::GlobalPackage                                              ,                  3379244,     50.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   106652,      1.6%
-- OpenSubstate::InternalGenericComponent                                   ,                    57160,      0.9%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.1%
+- OpenSubstate::InternalGenericComponent                                   ,                    57160,      0.8%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.0%
 - PinNode                                                                  ,                      336,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     10.7%
+- PrepareWasmCode                                                          ,                   707732,     10.5%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   927777,     14.1%
+- ReadSubstate                                                             ,                   927777,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
-- RunNativeCode::create                                                    ,                   156297,      2.4%
+- RunNativeCode::create                                                    ,                   156297,      2.3%
 - RunNativeCode::create_NonFungibleResourceManager                         ,                    88856,      1.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.5%
 - RunNativeCode::create_with_data                                          ,                    54942,      0.8%
@@ -52,12 +53,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    24600,      0.4%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    12778,      0.2%
-Finalization Cost Breakdown                                                ,                  3920470,    100.0%
+Finalization Cost Breakdown                                                ,                  4020470,    100.0%
 - CommitEvents                                                             ,                    20030,      0.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccessController                               ,                   700142,     17.9%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.6%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2700228,     68.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      7.7%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.6%
+- CommitStateUpdates::GlobalAccessController                               ,                   700142,     17.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.5%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2700228,     67.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      7.5%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/002--access-controller-v2-deposit-fees-xrd.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/002--access-controller-v2-deposit-fees-xrd.txt
@@ -1,35 +1,36 @@
-Total Cost (XRD)                                                           ,            0.41436892987,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2773495,     66.9%
-- Finalization Cost (XRD)                                                  ,               0.03125695,      7.5%
-- Storage Cost (XRD)                                                       ,            0.10576247987,     25.5%
+Total Cost (XRD)                                                           ,            0.42736892987,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2853495,     66.8%
+- Finalization Cost (XRD)                                                  ,               0.03625695,      8.5%
+- Storage Cost (XRD)                                                       ,            0.10576247987,     24.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5546990,    100.0%
+Execution Cost Breakdown                                                   ,                  5706990,    100.0%
 - AfterInvoke                                                              ,                      520,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     1796,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      2.8%
 - CheckReference                                                           ,                    80023,      1.4%
 - CloseSubstate                                                            ,                    37539,      0.7%
 - CreateNode                                                               ,                    16554,      0.3%
 - DropNode                                                                 ,                    28158,      0.5%
-- EmitEvent                                                                ,                     2796,      0.1%
+- EmitEvent                                                                ,                     2796,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - OpenSubstate::GlobalAccessController                                     ,                    44423,      0.8%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      3.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      3.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40746,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2604016,     46.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   147198,      2.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    48073,      0.9%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.7%
+- OpenSubstate::GlobalPackage                                              ,                  2604016,     45.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   147198,      2.6%
+- OpenSubstate::InternalGenericComponent                                   ,                    48073,      0.8%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.6%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     12.8%
+- PrepareWasmCode                                                          ,                   707732,     12.4%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   868225,     15.7%
+- ReadSubstate                                                             ,                   868225,     15.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
@@ -40,7 +41,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -48,11 +49,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    14880,      0.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    11198,      0.2%
-Finalization Cost Breakdown                                                ,                   625139,    100.0%
-- CommitEvents                                                             ,                    25037,      4.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   725139,    100.0%
+- CommitEvents                                                             ,                    25037,      3.5%
+- CommitIntentStatus                                                       ,                   100000,     13.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccessController                               ,                   100032,     16.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     48.0%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     16.0%
+- CommitStateUpdates::GlobalAccessController                               ,                   100032,     13.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     41.4%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     13.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/003--access-controller-v2-lock-fee-and-recover.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/costings/003--access-controller-v2-lock-fee-and-recover.txt
@@ -1,43 +1,44 @@
-Total Cost (XRD)                                                           ,            0.34712195109,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1143269,     32.9%
-- Finalization Cost (XRD)                                                  ,                0.0265153,      7.6%
-- Storage Cost (XRD)                                                       ,            0.20627975109,     59.4%
+Total Cost (XRD)                                                           ,            0.36012195109,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1223269,     34.0%
+- Finalization Cost (XRD)                                                  ,                0.0315153,      8.8%
+- Storage Cost (XRD)                                                       ,            0.20627975109,     57.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2286538,    100.0%
+Execution Cost Breakdown                                                   ,                  2446538,    100.0%
 - AfterInvoke                                                              ,                       48,      0.0%
 - AllocateNodeId                                                           ,                      970,      0.0%
 - BeforeInvoke                                                             ,                     2434,      0.1%
-- CheckReference                                                           ,                    40012,      1.7%
+- CheckIntentValidity                                                      ,                   160000,      6.5%
+- CheckReference                                                           ,                    40012,      1.6%
 - CloseSubstate                                                            ,                    21156,      0.9%
 - CreateNode                                                               ,                     8836,      0.4%
-- DropNode                                                                 ,                    15706,      0.7%
+- DropNode                                                                 ,                    15706,      0.6%
 - EmitEvent                                                                ,                     4578,      0.2%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccessController                                     ,                   181338,      7.9%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      5.3%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    98222,      4.3%
-- OpenSubstate::GlobalPackage                                              ,                  1115355,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                   128427,      5.6%
-- OpenSubstate::InternalGenericComponent                                   ,                    18124,      0.8%
+- OpenSubstate::GlobalAccessController                                     ,                   181338,      7.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      5.0%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    98222,      4.0%
+- OpenSubstate::GlobalPackage                                              ,                  1115355,     45.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   128427,      5.2%
+- OpenSubstate::InternalGenericComponent                                   ,                    18124,      0.7%
 - PinNode                                                                  ,                      120,      0.0%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   109358,      4.8%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.8%
-- RunNativeCode::initiate_recovery_as_primary                              ,                    62671,      2.7%
-- RunNativeCode::lock_fee                                                  ,                    45243,      2.0%
-- RunNativeCode::lock_recovery_fee                                         ,                    49499,      2.2%
-- RunNativeCode::quick_confirm_primary_role_recovery_proposal              ,                    84572,      3.7%
-- RunNativeCode::set                                                       ,                    81627,      3.6%
+- ReadSubstate                                                             ,                   109358,      4.5%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- RunNativeCode::initiate_recovery_as_primary                              ,                    62671,      2.6%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.8%
+- RunNativeCode::lock_recovery_fee                                         ,                    49499,      2.0%
+- RunNativeCode::quick_confirm_primary_role_recovery_proposal              ,                    84572,      3.5%
+- RunNativeCode::set                                                       ,                    81627,      3.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    43080,      1.9%
+- ValidateTxPayload                                                        ,                    43080,      1.8%
 - VerifyTxSignatures                                                       ,                    21000,      0.9%
-- WriteSubstate                                                            ,                     8266,      0.4%
-Finalization Cost Breakdown                                                ,                   530306,    100.0%
-- CommitEvents                                                             ,                    30196,      5.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     8266,      0.3%
+Finalization Cost Breakdown                                                ,                   630306,    100.0%
+- CommitEvents                                                             ,                    30196,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     15.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccessController                               ,                   400101,     75.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     18.9%
+- CommitStateUpdates::GlobalAccessController                               ,                   400101,     63.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     15.9%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/001--access-controller-v2-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/001--access-controller-v2-instantiate.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.94522588742 XRD
-├─ Network execution: 0.3301579 XRD, 6603158 execution cost units
-├─ Network finalization: 0.1960235 XRD, 3920470 finalization cost units
+TRANSACTION COST: 0.95822588742 XRD
+├─ Network execution: 0.3381579 XRD, 6763158 execution cost units
+├─ Network finalization: 0.2010235 XRD, 4020470 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.41904448742 XRD
 └─ Royalties: 0 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.94522588742"),
+     amount: Decimal("0.95822588742"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.47261294371"),
+     amount: Decimal("0.47911294371"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.47261294371"),
+     amount: Decimal("0.47911294371"),
    }
 
 STATE UPDATES: 9 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.236306471855"),
+             0u8 => Decimal("0.239556471855"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.05477411258")),
+         LiquidFungibleResource(Decimal("99999999999989999.04177411258")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -432,7 +432,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.47261294371")),
+         LiquidFungibleResource(Decimal("0.47911294371")),
        )
 
 OUTPUTS: 4
@@ -444,13 +444,13 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.94522588742
+   Change: -10000.95822588742
 ├─ Vault: internal_vault_sim1tz3wnsxw770s9kgtfudv4kktz6juv48d7v59qd7exlq98a53knngw6
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.47261294371
+   Change: 0.47911294371
 
 NEW ENTITIES: 2
 └─ Component: accesscontroller_sim1c09uvtxa5efafuetf983dcz5s5d8whtwcxe559kn3ywruchlxh0twh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/002--access-controller-v2-deposit-fees-xrd.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/002--access-controller-v2-deposit-fees-xrd.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.41436892987 XRD
-├─ Network execution: 0.2773495 XRD, 5546990 execution cost units
-├─ Network finalization: 0.03125695 XRD, 625139 finalization cost units
+TRANSACTION COST: 0.42736892987 XRD
+├─ Network execution: 0.2853495 XRD, 5706990 execution cost units
+├─ Network finalization: 0.03625695 XRD, 725139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.10576247987 XRD
 └─ Royalties: 0 XRD
@@ -32,15 +32,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.41436892987"),
+     amount: Decimal("0.42736892987"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.207184464935"),
+     amount: Decimal("0.213684464935"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.207184464935"),
+     amount: Decimal("0.213684464935"),
    }
 
 STATE UPDATES: 8 entities
@@ -50,7 +50,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.3398987043225"),
+             0u8 => Decimal("0.3463987043225"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -103,7 +103,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979998.64040518271")),
+         LiquidFungibleResource(Decimal("99999999999979998.61440518271")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -142,7 +142,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.679797408645")),
+         LiquidFungibleResource(Decimal("0.692797408645")),
        )
 
 OUTPUTS: 4
@@ -154,12 +154,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.41436892987
+   Change: -10000.42736892987
 ├─ Vault: internal_vault_sim1trlz48lr8t38e6xlc9n304ahr62r8te03exlrh097s495vmk35e6vz
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.207184464935
+   Change: 0.213684464935
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/003--access-controller-v2-lock-fee-and-recover.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/receipts/003--access-controller-v2-lock-fee-and-recover.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.34712195109 XRD
-├─ Network execution: 0.1143269 XRD, 2286538 execution cost units
-├─ Network finalization: 0.0265153 XRD, 530306 finalization cost units
+TRANSACTION COST: 0.36012195109 XRD
+├─ Network execution: 0.1223269 XRD, 2446538 execution cost units
+├─ Network finalization: 0.0315153 XRD, 630306 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.20627975109 XRD
 └─ Royalties: 0 XRD
@@ -154,15 +154,15 @@ EVENTS: 9
    }
 ├─ Emitter: Method { node: internal_vault_sim1trlz48lr8t38e6xlc9n304ahr62r8te03exlrh097s495vmk35e6vz, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.34712195109"),
+     amount: Decimal("0.36012195109"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.173560975545"),
+     amount: Decimal("0.180060975545"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.173560975545"),
+     amount: Decimal("0.180060975545"),
    }
 
 STATE UPDATES: 5 entities
@@ -172,7 +172,7 @@ STATE UPDATES: 5 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.426679192095"),
+             0u8 => Decimal("0.436429192095"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -264,13 +264,13 @@ STATE UPDATES: 5 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9999.65287804891")),
+         LiquidFungibleResource(Decimal("9999.63987804891")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.85335838419")),
+         LiquidFungibleResource(Decimal("0.87285838419")),
        )
 
 OUTPUTS: 3
@@ -281,9 +281,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1trlz48lr8t38e6xlc9n304ahr62r8te03exlrh097s495vmk35e6vz
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.34712195109
+   Change: -0.36012195109
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.173560975545
+   Change: 0.180060975545
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/access-controller-v2/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: access-controller-v2
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 63374dfe1ebf0cc6 (allowed to change if not deployed to any network)
-Events       : d183b32cb622ca59 (allowed to change if not deployed to any network)
+State changes: c5df769ceeb2f64a (allowed to change if not deployed to any network)
+Events       : 019d79afe43943db (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - access_controller_v2_component_address: accesscontroller_sim1c09uvtxa5efafuetf983dcz5s5d8whtwcxe559kn3ywruchlxh0twh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/001--account-authorized-depositors-configure-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/001--account-authorized-depositors-configure-accounts.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.88901742317,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2955664,     33.2%
-- Finalization Cost (XRD)                                                  ,               0.17202235,     19.3%
-- Storage Cost (XRD)                                                       ,            0.42142867317,     47.4%
+Total Cost (XRD)                                                           ,            0.90201742317,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3035664,     33.7%
+- Finalization Cost (XRD)                                                  ,               0.17702235,     19.6%
+- Storage Cost (XRD)                                                       ,            0.42142867317,     46.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5911328,    100.0%
+Execution Cost Breakdown                                                   ,                  6071328,    100.0%
 - AfterInvoke                                                              ,                      868,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.1%
 - BeforeInvoke                                                             ,                     4842,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.6%
 - CheckReference                                                           ,                    40011,      0.7%
 - CloseSubstate                                                            ,                    49407,      0.8%
 - CreateNode                                                               ,                    33614,      0.6%
@@ -17,18 +18,18 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     7000,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   134251,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   134251,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    45354,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2503545,     42.4%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   981414,     16.6%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    45354,      0.7%
+- OpenSubstate::GlobalPackage                                              ,                  2503545,     41.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   981414,     16.2%
 - OpenSubstate::InternalFungibleVault                                      ,                    96464,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    72834,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      396,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.0%
+- PrepareWasmCode                                                          ,                   353866,      5.8%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   536066,      9.1%
+- ReadSubstate                                                             ,                   536066,      8.8%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -37,11 +38,11 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
 - RunNativeCode::create_with_data                                          ,                    82413,      1.4%
 - RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      1.8%
-- RunNativeCode::deposit_batch                                             ,                   110731,      1.9%
+- RunNativeCode::deposit_batch                                             ,                   110731,      1.8%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::on_virtualize                                             ,                    69040,      1.2%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
+- RunNativeCode::on_virtualize                                             ,                    69040,      1.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::set_default_deposit_rule                                  ,                   119482,      2.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
@@ -49,13 +50,13 @@ Execution Cost Breakdown                                                   ,    
 - SetSubstate                                                              ,                     1183,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    33840,      0.6%
-- VerifyTxSignatures                                                       ,                    21000,      0.4%
+- VerifyTxSignatures                                                       ,                    21000,      0.3%
 - WriteSubstate                                                            ,                    13454,      0.2%
-Finalization Cost Breakdown                                                ,                  3440447,    100.0%
-- CommitEvents                                                             ,                    40056,      1.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  3540447,    100.0%
+- CommitEvents                                                             ,                    40056,      1.1%
+- CommitIntentStatus                                                       ,                   100000,      2.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1600103,     46.5%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.9%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                  1400223,     40.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      8.7%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1600103,     45.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.8%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                  1400223,     39.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      8.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/002--account-authorized-depositors-attempt-deposit-success.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/002--account-authorized-depositors-attempt-deposit-success.txt
@@ -1,38 +1,39 @@
-Total Cost (XRD)                                                           ,            0.52601482719,    100.0%
-- Execution Cost (XRD)                                                     ,               0.35309655,     67.1%
-- Finalization Cost (XRD)                                                  ,               0.03625675,      6.9%
-- Storage Cost (XRD)                                                       ,            0.13666152719,     26.0%
+Total Cost (XRD)                                                           ,            0.53901482719,    100.0%
+- Execution Cost (XRD)                                                     ,               0.36109655,     67.0%
+- Finalization Cost (XRD)                                                  ,               0.04125675,      7.7%
+- Storage Cost (XRD)                                                       ,            0.13666152719,     25.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7061931,    100.0%
+Execution Cost Breakdown                                                   ,                  7221931,    100.0%
 - AfterInvoke                                                              ,                      704,      0.0%
 - AllocateNodeId                                                           ,                     2522,      0.0%
 - BeforeInvoke                                                             ,                     3790,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.2%
 - CheckReference                                                           ,                    80026,      1.1%
 - CloseSubstate                                                            ,                    56115,      0.8%
 - CreateNode                                                               ,                    22920,      0.3%
-- DropNode                                                                 ,                    39333,      0.6%
+- DropNode                                                                 ,                    39333,      0.5%
 - EmitEvent                                                                ,                     2860,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      275,      0.0%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   218165,      3.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   218165,      3.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  2985523,     42.3%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   732102,     10.4%
-- OpenSubstate::InternalFungibleVault                                      ,                   196187,      2.8%
-- OpenSubstate::InternalGenericComponent                                   ,                    75279,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.9%
+- OpenSubstate::GlobalPackage                                              ,                  2985523,     41.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   732102,     10.1%
+- OpenSubstate::InternalFungibleVault                                      ,                   196187,      2.7%
+- OpenSubstate::InternalGenericComponent                                   ,                    75279,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.8%
 - PinNode                                                                  ,                      300,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     10.0%
+- PrepareWasmCode                                                          ,                   707732,      9.8%
 - QueryActor                                                               ,                     4500,      0.1%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   911071,     12.9%
+- ReadSubstate                                                             ,                   911071,     12.6%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.5%
@@ -56,11 +57,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    23880,      0.3%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    15964,      0.2%
-Finalization Cost Breakdown                                                ,                   725135,    100.0%
-- CommitEvents                                                             ,                    25045,      3.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   825135,    100.0%
+- CommitEvents                                                             ,                    25045,      3.0%
+- CommitIntentStatus                                                       ,                   100000,     12.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,     13.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     55.2%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     13.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     12.1%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,     12.1%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     48.5%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     12.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
@@ -1,33 +1,34 @@
-Total Cost (XRD)                                                           ,             0.3221519164,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27637555,     85.8%
+Total Cost (XRD)                                                           ,             0.3301519164,    100.0%
+- Execution Cost (XRD)                                                     ,               0.28437555,     86.1%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,             0.0457763664,     14.2%
+- Storage Cost (XRD)                                                       ,             0.0457763664,     13.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5527511,    100.0%
+Execution Cost Breakdown                                                   ,                  5687511,    100.0%
 - AfterInvoke                                                              ,                      386,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     1566,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      2.8%
 - CheckReference                                                           ,                    80026,      1.4%
-- CloseSubstate                                                            ,                    30702,      0.6%
+- CloseSubstate                                                            ,                    30702,      0.5%
 - CreateNode                                                               ,                    13152,      0.2%
 - DropNode                                                                 ,                    15890,      0.3%
 - EmitEvent                                                                ,                     1112,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   127933,      2.3%
-- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  2589103,     46.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285342,      5.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   127933,      2.2%
+- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
+- OpenSubstate::GlobalPackage                                              ,                  2589103,     45.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285342,      5.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   100390,      1.8%
-- OpenSubstate::InternalGenericComponent                                   ,                    36179,      0.7%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.7%
+- OpenSubstate::InternalGenericComponent                                   ,                    36179,      0.6%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.6%
 - PinNode                                                                  ,                      180,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     12.8%
+- PrepareWasmCode                                                          ,                   707732,     12.4%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   843257,     15.3%
+- ReadSubstate                                                             ,                   843257,     14.8%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
@@ -35,13 +36,13 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.5%
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.6%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    19200,      0.3%
-- VerifyTxSignatures                                                       ,                    14000,      0.3%
+- VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                     7228,      0.1%
 Finalization Cost Breakdown                                                ,                        0,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/costings/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,             0.3363866664,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2906103,     86.4%
+Total Cost (XRD)                                                           ,             0.3443866664,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2986103,     86.7%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,             0.0457763664,     13.6%
+- Storage Cost (XRD)                                                       ,             0.0457763664,     13.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5812206,    100.0%
+Execution Cost Breakdown                                                   ,                  5972206,    100.0%
 - AfterInvoke                                                              ,                      566,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     2028,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      2.7%
 - CheckReference                                                           ,                    40011,      0.7%
 - CloseSubstate                                                            ,                    39087,      0.7%
 - CreateNode                                                               ,                    16558,      0.3%
@@ -15,24 +16,24 @@ Execution Cost Breakdown                                                   ,    
 - EmitEvent                                                                ,                     1732,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
-- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
+- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.7%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   130251,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41401,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2604179,     44.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   405872,      7.0%
+- OpenSubstate::GlobalPackage                                              ,                  2604179,     43.6%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   405872,      6.8%
 - OpenSubstate::InternalFungibleVault                                      ,                   100390,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    57145,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.4%
 - PinNode                                                                  ,                      228,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     12.2%
+- PrepareWasmCode                                                          ,                   707732,     11.9%
 - QueryActor                                                               ,                     1500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   868704,     14.9%
+- ReadSubstate                                                             ,                   868704,     14.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    58066,      1.0%
-- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
-- RunNativeCode::drop_empty_bucket_FungibleResourceManager                 ,                    20469,      0.4%
+- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
+- RunNativeCode::drop_empty_bucket_FungibleResourceManager                 ,                    20469,      0.3%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.5%
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/001--account-authorized-depositors-configure-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/001--account-authorized-depositors-configure-accounts.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.88901742317 XRD
-├─ Network execution: 0.2955664 XRD, 5911328 execution cost units
-├─ Network finalization: 0.17202235 XRD, 3440447 finalization cost units
+TRANSACTION COST: 0.90201742317 XRD
+├─ Network execution: 0.3035664 XRD, 6071328 execution cost units
+├─ Network finalization: 0.17702235 XRD, 3540447 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.42142867317 XRD
 └─ Royalties: 0 XRD
@@ -47,15 +47,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.88901742317"),
+     amount: Decimal("0.90201742317"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.444508711585"),
+     amount: Decimal("0.451008711585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.444508711585"),
+     amount: Decimal("0.451008711585"),
    }
 
 STATE UPDATES: 9 entities
@@ -65,7 +65,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2222543557925"),
+             0u8 => Decimal("0.2255043557925"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -98,7 +98,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.11098257683")),
+         LiquidFungibleResource(Decimal("99999999999999999.09798257683")),
        )
 ├─ account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw across 6 partitions
   ├─ Partition(2): 2 changes
@@ -434,7 +434,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.444508711585")),
+         LiquidFungibleResource(Decimal("0.451008711585")),
        )
 
 OUTPUTS: 7
@@ -452,13 +452,13 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.88901742317
+   Change: -0.90201742317
 ├─ Vault: internal_vault_sim1tqvjs768h738fh68a8k9g3umfruja74v7fepgqn0zks3d0a05gs4s5
    ResAddr: resource_sim1t5jzke2dmva79yatdnv2tzecqavwatcmgylgpur9a5r7nxgfd664lz
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.444508711585
+   Change: 0.451008711585
 
 NEW ENTITIES: 3
 ├─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/002--account-authorized-depositors-attempt-deposit-success.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/002--account-authorized-depositors-attempt-deposit-success.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52601482719 XRD
-├─ Network execution: 0.35309655 XRD, 7061931 execution cost units
-├─ Network finalization: 0.03625675 XRD, 725135 finalization cost units
+TRANSACTION COST: 0.53901482719 XRD
+├─ Network execution: 0.36109655 XRD, 7221931 execution cost units
+├─ Network finalization: 0.04125675 XRD, 825135 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13666152719 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52601482719"),
+     amount: Decimal("0.53901482719"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.263007413595"),
+     amount: Decimal("0.269507413595"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.263007413595"),
+     amount: Decimal("0.269507413595"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.35375806259"),
+             0u8 => Decimal("0.36025806259"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.58496774964")),
+         LiquidFungibleResource(Decimal("99999999999989998.55896774964")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -135,7 +135,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.70751612518")),
+         LiquidFungibleResource(Decimal("0.72051612518")),
        )
 
 OUTPUTS: 5
@@ -148,12 +148,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.52601482719
+   Change: -10000.53901482719
 ├─ Vault: internal_vault_sim1trlmc306p05rqg76se06hkhq9wh2mlkv5m2pmx92gvg0ykly7s4lma
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.263007413595
+   Change: 0.269507413595
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/003--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-present.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(AssertAccessRuleFailed)
 
-TRANSACTION COST: 0.3221519164 XRD
-├─ Network execution: 0.27637555 XRD, 5527511 execution cost units
+TRANSACTION COST: 0.3301519164 XRD
+├─ Network execution: 0.28437555 XRD, 5687511 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0457763664 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.3221519164"),
+     amount: Decimal("0.3301519164"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.1610759582"),
+     amount: Decimal("0.1650759582"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.1610759582"),
+     amount: Decimal("0.1650759582"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.43429604169"),
+             0u8 => Decimal("0.44279604169"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.26281583324")),
+         LiquidFungibleResource(Decimal("99999999999989998.22881583324")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.86859208338")),
+         LiquidFungibleResource(Decimal("0.88559208338")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.3221519164
+   Change: -0.3301519164
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.1610759582
+   Change: 0.1650759582
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/receipts/004--account-authorized-depositors-attempt-deposit-failure-if-badge-is-not-an-authorized-depositor.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(FungibleResourceManagerError(DropNonEmptyBucket))
 
-TRANSACTION COST: 0.3363866664 XRD
-├─ Network execution: 0.2906103 XRD, 5812206 execution cost units
+TRANSACTION COST: 0.3443866664 XRD
+├─ Network execution: 0.2986103 XRD, 5972206 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0457763664 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.3363866664"),
+     amount: Decimal("0.3443866664"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.1681933332"),
+     amount: Decimal("0.1721933332"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.1681933332"),
+     amount: Decimal("0.1721933332"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.51839270829"),
+             0u8 => Decimal("0.52889270829"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.92642916684")),
+         LiquidFungibleResource(Decimal("99999999999989997.88442916684")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.03678541658")),
+         LiquidFungibleResource(Decimal("1.05778541658")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.3363866664
+   Change: -0.3443866664
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.1681933332
+   Change: 0.1721933332
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_authorized_depositors/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: account_authorized_depositors
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 9ca2a9085bf2bef1 (allowed to change if not deployed to any network)
-Events       : 0a22798ef2a11fc4 (allowed to change if not deployed to any network)
+State changes: 42ab9fbe4267f3bf (allowed to change if not deployed to any network)
+Events       : 42c66c7b6b82e813 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - source_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/001--account-locker-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/001--account-locker-create-accounts.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.67041488325,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2228191,     33.2%
-- Finalization Cost (XRD)                                                  ,               0.13526745,     20.2%
-- Storage Cost (XRD)                                                       ,            0.31232833325,     46.6%
+Total Cost (XRD)                                                           ,            0.68341488325,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2308191,     33.8%
+- Finalization Cost (XRD)                                                  ,               0.14026745,     20.5%
+- Storage Cost (XRD)                                                       ,            0.31232833325,     45.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4456382,    100.0%
+Execution Cost Breakdown                                                   ,                  4616382,    100.0%
 - AfterInvoke                                                              ,                     1030,      0.0%
 - AllocateNodeId                                                           ,                     4462,      0.1%
 - BeforeInvoke                                                             ,                     4270,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      3.5%
 - CheckReference                                                           ,                    40011,      0.9%
 - CloseSubstate                                                            ,                    33153,      0.7%
 - CreateNode                                                               ,                    36994,      0.8%
@@ -18,34 +19,34 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - MoveModule                                                               ,                     5600,      0.1%
 - OpenSubstate::GlobalAccount                                              ,                     4700,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.7%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.6%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    50023,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  2198522,     49.3%
+- OpenSubstate::GlobalPackage                                              ,                  2198522,     47.6%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
-- OpenSubstate::InternalGenericComponent                                   ,                    47680,      1.1%
+- OpenSubstate::InternalGenericComponent                                   ,                    47680,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      432,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      7.9%
+- PrepareWasmCode                                                          ,                   353866,      7.7%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   482930,     10.8%
+- ReadSubstate                                                             ,                   482930,     10.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::create                                                    ,                   122960,      2.8%
-- RunNativeCode::create_advanced                                           ,                   409035,      9.2%
-- RunNativeCode::create_with_data                                          ,                   137355,      3.1%
+- RunNativeCode::create                                                    ,                   122960,      2.7%
+- RunNativeCode::create_advanced                                           ,                   409035,      8.9%
+- RunNativeCode::create_with_data                                          ,                   137355,      3.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1855,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    38400,      0.9%
+- ValidateTxPayload                                                        ,                    38400,      0.8%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                    10924,      0.2%
-Finalization Cost Breakdown                                                ,                  2705349,    100.0%
+Finalization Cost Breakdown                                                ,                  2805349,    100.0%
 - CommitEvents                                                             ,                     5007,      0.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                  2500315,     92.4%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.7%
+- CommitStateUpdates::GlobalAccount                                        ,                  2500315,     89.1%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/002--account-locker-create-account-locker.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/002--account-locker-create-account-locker.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.71719887689,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26356165,     36.7%
-- Finalization Cost (XRD)                                                  ,                 0.146268,     20.4%
-- Storage Cost (XRD)                                                       ,            0.30736922689,     42.9%
+Total Cost (XRD)                                                           ,            0.73019887689,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27156165,     37.2%
+- Finalization Cost (XRD)                                                  ,                 0.151268,     20.7%
+- Storage Cost (XRD)                                                       ,            0.30736922689,     42.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5271233,    100.0%
+Execution Cost Breakdown                                                   ,                  5431233,    100.0%
 - AfterInvoke                                                              ,                      840,      0.0%
 - AllocateNodeId                                                           ,                     3007,      0.1%
 - BeforeInvoke                                                             ,                     3836,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
 - CheckReference                                                           ,                    80022,      1.5%
 - CloseSubstate                                                            ,                    40764,      0.8%
 - CreateNode                                                               ,                    26628,      0.5%
@@ -17,31 +18,31 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     6160,      0.1%
-- OpenSubstate::GlobalAccount                                              ,                   366729,      7.0%
+- OpenSubstate::GlobalAccount                                              ,                   366729,      6.8%
 - OpenSubstate::GlobalAccountLocker                                        ,                     2197,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   141654,      2.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   141654,      2.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2783713,     52.8%
+- OpenSubstate::GlobalPackage                                              ,                  2783713,     51.3%
 - OpenSubstate::InternalFungibleVault                                      ,                    96464,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    59999,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      312,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   526969,     10.0%
+- ReadSubstate                                                             ,                   526969,      9.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    49184,      0.9%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
 - RunNativeCode::create_with_data                                          ,                    54942,      1.0%
 - RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      2.0%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::instantiate_simple_account_locker                         ,                    50097,      1.0%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::instantiate_simple_account_locker                         ,                    50097,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      824,      0.0%
@@ -49,12 +50,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    14880,      0.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    11048,      0.2%
-Finalization Cost Breakdown                                                ,                  2925360,    100.0%
-- CommitEvents                                                             ,                    25045,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  3025360,    100.0%
+- CommitEvents                                                             ,                    25045,      0.8%
+- CommitIntentStatus                                                       ,                   100000,      3.3%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,      3.4%
-- CommitStateUpdates::GlobalAccountLocker                                  ,                   700114,     23.9%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1700125,     58.1%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     10.3%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,      3.3%
+- CommitStateUpdates::GlobalAccountLocker                                  ,                   700114,     23.1%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1700125,     56.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.3%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      9.9%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/003--account-locker-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/003--account-locker-create-resources.txt
@@ -1,52 +1,53 @@
-Total Cost (XRD)                                                           ,            0.70134025564,    100.0%
-- Execution Cost (XRD)                                                     ,               0.19178635,     27.3%
-- Finalization Cost (XRD)                                                  ,               0.19026375,     27.1%
-- Storage Cost (XRD)                                                       ,            0.31929015564,     45.5%
+Total Cost (XRD)                                                           ,            0.71434025564,    100.0%
+- Execution Cost (XRD)                                                     ,               0.19978635,     28.0%
+- Finalization Cost (XRD)                                                  ,               0.19526375,     27.3%
+- Storage Cost (XRD)                                                       ,            0.31929015564,     44.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3835727,    100.0%
+Execution Cost Breakdown                                                   ,                  3995727,    100.0%
 - AfterInvoke                                                              ,                      454,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.1%
 - BeforeInvoke                                                             ,                     2636,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      4.0%
 - CheckReference                                                           ,                    40011,      1.0%
 - CloseSubstate                                                            ,                    19221,      0.5%
 - CreateNode                                                               ,                    19096,      0.5%
-- DropNode                                                                 ,                    29440,      0.8%
+- DropNode                                                                 ,                    29440,      0.7%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - MoveModule                                                               ,                     9520,      0.2%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   122934,      3.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   122934,      3.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                     1162,      0.0%
-- OpenSubstate::GlobalPackage                                              ,                  2162909,     56.4%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.4%
-- OpenSubstate::InternalGenericComponent                                   ,                    25026,      0.7%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.1%
+- OpenSubstate::GlobalPackage                                              ,                  2162909,     54.1%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.3%
+- OpenSubstate::InternalGenericComponent                                   ,                    25026,      0.6%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      9.2%
+- PrepareWasmCode                                                          ,                   353866,      8.9%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   474034,     12.4%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
-- RunNativeCode::create                                                    ,                    49184,      1.3%
-- RunNativeCode::create_FungibleResourceManager                            ,                    59493,      1.6%
-- RunNativeCode::create_NonFungibleResourceManager                         ,                    88856,      2.3%
+- ReadSubstate                                                             ,                   474034,     11.9%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
+- RunNativeCode::create                                                    ,                    49184,      1.2%
+- RunNativeCode::create_FungibleResourceManager                            ,                    59493,      1.5%
+- RunNativeCode::create_NonFungibleResourceManager                         ,                    88856,      2.2%
 - RunNativeCode::create_with_data                                          ,                    54942,      1.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1016,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    21440,      0.6%
+- ValidateTxPayload                                                        ,                    21440,      0.5%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                     6540,      0.2%
-Finalization Cost Breakdown                                                ,                  3805275,    100.0%
+Finalization Cost Breakdown                                                ,                  3905275,    100.0%
 - CommitEvents                                                             ,                     5007,      0.1%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1600106,     42.0%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1600106,     41.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.6%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000135,     52.6%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000135,     51.2%
 - CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/004--account-locker-setting-up-account-deposit-rules.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/004--account-locker-setting-up-account-deposit-rules.txt
@@ -1,49 +1,50 @@
-Total Cost (XRD)                                                           ,            0.42393254385,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2310304,     54.5%
-- Finalization Cost (XRD)                                                  ,               0.03125435,      7.4%
-- Storage Cost (XRD)                                                       ,            0.16164779385,     38.1%
+Total Cost (XRD)                                                           ,            0.43693254385,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2390304,     54.7%
+- Finalization Cost (XRD)                                                  ,               0.03625435,      8.3%
+- Storage Cost (XRD)                                                       ,            0.16164779385,     37.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4620608,    100.0%
+Execution Cost Breakdown                                                   ,                  4780608,    100.0%
 - AfterInvoke                                                              ,                       94,      0.0%
 - AllocateNodeId                                                           ,                      970,      0.0%
 - BeforeInvoke                                                             ,                     1256,      0.0%
-- CheckReference                                                           ,                   240081,      5.2%
-- CloseSubstate                                                            ,                    21414,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      3.3%
+- CheckReference                                                           ,                   240081,      5.0%
+- CloseSubstate                                                            ,                    21414,      0.4%
 - CreateNode                                                               ,                     9170,      0.2%
 - DropNode                                                                 ,                    16040,      0.3%
 - EmitEvent                                                                ,                     2864,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                  1139766,     24.7%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   123765,      2.7%
+- OpenSubstate::GlobalAccount                                              ,                  1139766,     23.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   123765,      2.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    44194,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1605688,     34.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    44194,      0.9%
+- OpenSubstate::GlobalPackage                                              ,                  1605688,     33.6%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    19126,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - PinNode                                                                  ,                      120,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      7.7%
+- PrepareWasmCode                                                          ,                   353866,      7.4%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   452696,      9.8%
+- ReadSubstate                                                             ,                   452696,      9.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::add_authorized_depositor                                  ,                    41242,      0.9%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunNativeCode::set_default_deposit_rule                                  ,                    59741,      1.3%
-- RunNativeCode::set_resource_preference                                   ,                   132054,      2.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::set_default_deposit_rule                                  ,                    59741,      1.2%
+- RunNativeCode::set_resource_preference                                   ,                   132054,      2.8%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    37560,      0.8%
 - VerifyTxSignatures                                                       ,                    28000,      0.6%
 - WriteSubstate                                                            ,                     6860,      0.1%
-Finalization Cost Breakdown                                                ,                   625087,    100.0%
-- CommitEvents                                                             ,                    25044,      4.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   725087,    100.0%
+- CommitEvents                                                             ,                    25044,      3.5%
+- CommitIntentStatus                                                       ,                   100000,     13.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   400016,     64.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     16.0%
+- CommitStateUpdates::GlobalAccount                                        ,                   400016,     55.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     13.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.46534008228,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2959502,     63.6%
-- Finalization Cost (XRD)                                                  ,               0.03625695,      7.8%
-- Storage Cost (XRD)                                                       ,            0.13313293228,     28.6%
+Total Cost (XRD)                                                           ,            0.47834008228,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3039502,     63.5%
+- Finalization Cost (XRD)                                                  ,               0.04125695,      8.6%
+- Storage Cost (XRD)                                                       ,            0.13313293228,     27.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5919004,    100.0%
+Execution Cost Breakdown                                                   ,                  6079004,    100.0%
 - AfterInvoke                                                              ,                      568,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3620,      0.1%
-- CheckReference                                                           ,                   240076,      4.1%
+- CheckIntentValidity                                                      ,                   160000,      2.6%
+- CheckReference                                                           ,                   240076,      3.9%
 - CloseSubstate                                                            ,                    49149,      0.8%
 - CreateNode                                                               ,                    19884,      0.3%
 - DropNode                                                                 ,                    34236,      0.6%
@@ -16,36 +17,36 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   611742,     10.3%
+- OpenSubstate::GlobalAccount                                              ,                   611742,     10.1%
 - OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.7%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81370,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  2583852,     43.7%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81370,      1.3%
+- OpenSubstate::GlobalPackage                                              ,                  2583852,     42.5%
 - OpenSubstate::InternalFungibleVault                                      ,                   185999,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    67567,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.0%
+- PrepareWasmCode                                                          ,                   353866,      5.8%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   541449,      9.1%
+- ReadSubstate                                                             ,                   541449,      8.9%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.1%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
+- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.6%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
-- RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
+- RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -53,11 +54,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    25440,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13498,      0.2%
-Finalization Cost Breakdown                                                ,                   725139,    100.0%
-- CommitEvents                                                             ,                    25045,      3.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   825139,    100.0%
+- CommitEvents                                                             ,                    25045,      3.0%
+- CommitIntentStatus                                                       ,                   100000,     12.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     13.8%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     13.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     55.2%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,     12.1%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     12.1%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     12.1%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     48.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,34 +1,35 @@
-Total Cost (XRD)                                                           ,            0.53596194639,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3058286,     57.1%
-- Finalization Cost (XRD)                                                  ,               0.05151015,      9.6%
-- Storage Cost (XRD)                                                       ,            0.17862319639,     33.3%
+Total Cost (XRD)                                                           ,            0.54896194639,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3138286,     57.2%
+- Finalization Cost (XRD)                                                  ,               0.05651015,     10.3%
+- Storage Cost (XRD)                                                       ,            0.17862319639,     32.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6116572,    100.0%
+Execution Cost Breakdown                                                   ,                  6276572,    100.0%
 - AfterInvoke                                                              ,                      682,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     3706,      0.1%
-- CheckReference                                                           ,                   240076,      3.9%
-- CloseSubstate                                                            ,                    52116,      0.9%
-- CreateNode                                                               ,                    21620,      0.4%
+- CheckIntentValidity                                                      ,                   160000,      2.5%
+- CheckReference                                                           ,                   240076,      3.8%
+- CloseSubstate                                                            ,                    52116,      0.8%
+- CreateNode                                                               ,                    21620,      0.3%
 - DropNode                                                                 ,                    35951,      0.6%
 - EmitEvent                                                                ,                     3546,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   451090,      7.4%
+- OpenSubstate::GlobalAccount                                              ,                   451090,      7.2%
 - OpenSubstate::GlobalAccountLocker                                        ,                   204622,      3.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.6%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    82037,      1.3%
-- OpenSubstate::GlobalPackage                                              ,                  2585426,     42.3%
+- OpenSubstate::GlobalPackage                                              ,                  2585426,     41.2%
 - OpenSubstate::InternalFungibleVault                                      ,                   185999,      3.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    74935,      1.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                   201721,      3.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                   201721,      3.2%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.8%
+- PrepareWasmCode                                                          ,                   353866,      5.6%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   547982,      9.0%
+- ReadSubstate                                                             ,                   547982,      8.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -47,18 +48,18 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25440,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    14432,      0.2%
-Finalization Cost Breakdown                                                ,                  1030203,    100.0%
-- CommitEvents                                                             ,                    30068,      2.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1130203,    100.0%
+- CommitEvents                                                             ,                    30068,      2.7%
+- CommitIntentStatus                                                       ,                   100000,      8.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      9.7%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      9.7%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     38.8%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     29.1%
+- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      8.8%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      8.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     35.4%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     26.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
@@ -1,34 +1,35 @@
-Total Cost (XRD)                                                           ,            0.50145889194,    100.0%
-- Execution Cost (XRD)                                                     ,               0.28254355,     56.3%
-- Finalization Cost (XRD)                                                  ,                0.0512594,     10.2%
-- Storage Cost (XRD)                                                       ,            0.16765594194,     33.4%
+Total Cost (XRD)                                                           ,            0.51445889194,    100.0%
+- Execution Cost (XRD)                                                     ,               0.29054355,     56.5%
+- Finalization Cost (XRD)                                                  ,                0.0562594,     10.9%
+- Storage Cost (XRD)                                                       ,            0.16765594194,     32.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5650871,    100.0%
+Execution Cost Breakdown                                                   ,                  5810871,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3302,      0.1%
-- CheckReference                                                           ,                   240076,      4.2%
+- CheckIntentValidity                                                      ,                   160000,      2.8%
+- CheckReference                                                           ,                   240076,      4.1%
 - CloseSubstate                                                            ,                    46698,      0.8%
-- CreateNode                                                               ,                    19818,      0.4%
+- CreateNode                                                               ,                    19818,      0.3%
 - DropNode                                                                 ,                    32775,      0.6%
 - EmitEvent                                                                ,                     2926,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   246095,      4.4%
-- OpenSubstate::GlobalAccountLocker                                        ,                   204622,      3.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   341815,      6.0%
+- OpenSubstate::GlobalAccount                                              ,                   246095,      4.2%
+- OpenSubstate::GlobalAccountLocker                                        ,                   204622,      3.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   341815,      5.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2501664,     44.3%
-- OpenSubstate::InternalFungibleVault                                      ,                   185999,      3.3%
-- OpenSubstate::InternalGenericComponent                                   ,                    65128,      1.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                   201721,      3.6%
+- OpenSubstate::GlobalPackage                                              ,                  2501664,     43.1%
+- OpenSubstate::InternalFungibleVault                                      ,                   185999,      3.2%
+- OpenSubstate::InternalGenericComponent                                   ,                    65128,      1.1%
+- OpenSubstate::InternalKeyValueStore                                      ,                   201721,      3.5%
 - PinNode                                                                  ,                      252,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.3%
+- PrepareWasmCode                                                          ,                   353866,      6.1%
 - QueryActor                                                               ,                     4000,      0.1%
-- ReadSubstate                                                             ,                   535855,      9.5%
+- ReadSubstate                                                             ,                   535855,      9.2%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -38,10 +39,10 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.7%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.7%
-- RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.3%
+- RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
@@ -49,15 +50,15 @@ Execution Cost Breakdown                                                   ,    
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    25440,      0.5%
+- ValidateTxPayload                                                        ,                    25440,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13426,      0.2%
-Finalization Cost Breakdown                                                ,                  1025188,    100.0%
-- CommitEvents                                                             ,                    25053,      2.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1125188,    100.0%
+- CommitEvents                                                             ,                    25053,      2.2%
+- CommitIntentStatus                                                       ,                   100000,      8.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      9.8%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      9.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     39.0%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     29.3%
+- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      8.9%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      8.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     35.6%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     26.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.61637545122,    100.0%
-- Execution Cost (XRD)                                                     ,               0.37297955,     60.5%
-- Finalization Cost (XRD)                                                  ,                0.0475112,      7.7%
-- Storage Cost (XRD)                                                       ,            0.19588470122,     31.8%
+Total Cost (XRD)                                                           ,            0.62937545122,    100.0%
+- Execution Cost (XRD)                                                     ,               0.38097955,     60.5%
+- Finalization Cost (XRD)                                                  ,                0.0525112,      8.3%
+- Storage Cost (XRD)                                                       ,            0.19588470122,     31.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7459591,    100.0%
+Execution Cost Breakdown                                                   ,                  7619591,    100.0%
 - AfterInvoke                                                              ,                     1066,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.0%
 - BeforeInvoke                                                             ,                     5694,      0.1%
-- CheckReference                                                           ,                   320098,      4.3%
+- CheckIntentValidity                                                      ,                   160000,      2.1%
+- CheckReference                                                           ,                   320098,      4.2%
 - CloseSubstate                                                            ,                    81528,      1.1%
 - CreateNode                                                               ,                    33534,      0.4%
 - DropNode                                                                 ,                    58191,      0.8%
@@ -16,19 +17,19 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                  1064834,     14.3%
+- OpenSubstate::GlobalAccount                                              ,                  1064834,     14.0%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   357368,      4.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   357368,      4.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    83371,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  2603962,     34.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   355341,      4.8%
-- OpenSubstate::InternalGenericComponent                                   ,                   132306,      1.8%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.2%
+- OpenSubstate::GlobalPackage                                              ,                  2603962,     34.2%
+- OpenSubstate::InternalFungibleVault                                      ,                   355341,      4.7%
+- OpenSubstate::InternalGenericComponent                                   ,                   132306,      1.7%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.1%
 - PinNode                                                                  ,                      444,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      4.7%
+- PrepareWasmCode                                                          ,                   353866,      4.6%
 - QueryActor                                                               ,                     6500,      0.1%
-- ReadSubstate                                                             ,                   615047,      8.2%
+- ReadSubstate                                                             ,                   615047,      8.1%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
@@ -55,11 +56,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    31360,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    21450,      0.3%
-Finalization Cost Breakdown                                                ,                   950224,    100.0%
-- CommitEvents                                                             ,                    50112,      5.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1050224,    100.0%
+- CommitEvents                                                             ,                    50112,      4.8%
+- CommitIntentStatus                                                       ,                   100000,      9.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     10.5%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     10.5%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   600074,     63.2%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,      9.5%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      9.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   600074,     57.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.61559094676,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3309308,     53.8%
-- Finalization Cost (XRD)                                                  ,                0.0622633,     10.1%
-- Storage Cost (XRD)                                                       ,            0.22239684676,     36.1%
+Total Cost (XRD)                                                           ,            0.62859094676,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3389308,     53.9%
+- Finalization Cost (XRD)                                                  ,                0.0672633,     10.7%
+- Storage Cost (XRD)                                                       ,            0.22239684676,     35.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6618616,    100.0%
+Execution Cost Breakdown                                                   ,                  6778616,    100.0%
 - AfterInvoke                                                              ,                      928,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.1%
 - BeforeInvoke                                                             ,                     4654,      0.1%
-- CheckReference                                                           ,                   320098,      4.8%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
+- CheckReference                                                           ,                   320098,      4.7%
 - CloseSubstate                                                            ,                    71337,      1.1%
 - CreateNode                                                               ,                    30892,      0.5%
 - DropNode                                                                 ,                    52093,      0.8%
@@ -16,19 +17,19 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   249341,      3.8%
-- OpenSubstate::GlobalAccountLocker                                        ,                   287632,      4.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   354213,      5.4%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
+- OpenSubstate::GlobalAccount                                              ,                   249341,      3.7%
+- OpenSubstate::GlobalAccountLocker                                        ,                   287632,      4.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   354213,      5.2%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  2515830,     38.0%
-- OpenSubstate::InternalFungibleVault                                      ,                   355341,      5.4%
-- OpenSubstate::InternalGenericComponent                                   ,                   117621,      1.8%
-- OpenSubstate::InternalKeyValueStore                                      ,                   403535,      6.1%
+- OpenSubstate::GlobalPackage                                              ,                  2515830,     37.1%
+- OpenSubstate::InternalFungibleVault                                      ,                   355341,      5.2%
+- OpenSubstate::InternalGenericComponent                                   ,                   117621,      1.7%
+- OpenSubstate::InternalKeyValueStore                                      ,                   403535,      6.0%
 - PinNode                                                                  ,                      396,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.3%
+- PrepareWasmCode                                                          ,                   353866,      5.2%
 - QueryActor                                                               ,                     5000,      0.1%
-- ReadSubstate                                                             ,                   592797,      9.0%
+- ReadSubstate                                                             ,                   592797,      8.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
@@ -47,19 +48,19 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
 - RunNativeCode::put_FungibleVault                                         ,                    73662,      1.1%
 - RunNativeCode::take_FungibleBucket                                       ,                    59565,      0.9%
-- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
+- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    31360,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    19996,      0.3%
-Finalization Cost Breakdown                                                ,                  1245266,    100.0%
-- CommitEvents                                                             ,                    45113,      3.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1345266,    100.0%
+- CommitEvents                                                             ,                    45113,      3.4%
+- CommitIntentStatus                                                       ,                   100000,      7.4%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      8.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      8.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   600074,     48.2%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     24.1%
+- CommitStateUpdates::GlobalAccountLocker                                  ,                   100011,      7.4%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      7.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.4%
+- CommitStateUpdates::InternalFungibleVault                                ,                   600074,     44.6%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   300041,     22.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.51129126523,    100.0%
-- Execution Cost (XRD)                                                     ,               0.32570285,     63.7%
-- Finalization Cost (XRD)                                                  ,                0.0462566,      9.0%
-- Storage Cost (XRD)                                                       ,            0.13933181523,     27.3%
+Total Cost (XRD)                                                           ,            0.52429126523,    100.0%
+- Execution Cost (XRD)                                                     ,               0.33370285,     63.6%
+- Finalization Cost (XRD)                                                  ,                0.0512566,      9.8%
+- Storage Cost (XRD)                                                       ,            0.13933181523,     26.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6514057,    100.0%
+Execution Cost Breakdown                                                   ,                  6674057,    100.0%
 - AfterInvoke                                                              ,                      542,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3634,      0.1%
-- CheckReference                                                           ,                   240081,      3.7%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
+- CheckReference                                                           ,                   240081,      3.6%
 - CloseSubstate                                                            ,                    50181,      0.8%
 - CreateNode                                                               ,                    19874,      0.3%
 - DropNode                                                                 ,                    34220,      0.5%
@@ -16,39 +17,39 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   611742,      9.4%
-- OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.7%
+- OpenSubstate::GlobalAccount                                              ,                   611742,      9.2%
+- OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.6%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      7.1%
-- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.3%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      6.9%
+- OpenSubstate::GlobalPackage                                              ,                  2822803,     42.3%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    67715,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     6869,      0.1%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.4%
+- PrepareWasmCode                                                          ,                   353866,      5.3%
 - QueryActor                                                               ,                     5000,      0.1%
-- ReadSubstate                                                             ,                   581650,      8.9%
+- ReadSubstate                                                             ,                   581650,      8.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.1%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.9%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
-- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.5%
+- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.4%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.5%
-- RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
-- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
+- RunNativeCode::store_account_locker                                      ,                    62556,      0.9%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.3%
+- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
@@ -56,12 +57,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    25080,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13744,      0.2%
-Finalization Cost Breakdown                                                ,                   925132,    100.0%
-- CommitEvents                                                             ,                    25033,      2.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1025132,    100.0%
+- CommitEvents                                                             ,                    25033,      2.4%
+- CommitIntentStatus                                                       ,                   100000,      9.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     10.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.8%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     21.6%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     21.6%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     32.4%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,      9.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.8%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     19.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     19.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     29.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.51129126523,    100.0%
-- Execution Cost (XRD)                                                     ,               0.32570285,     63.7%
-- Finalization Cost (XRD)                                                  ,                0.0462566,      9.0%
-- Storage Cost (XRD)                                                       ,            0.13933181523,     27.3%
+Total Cost (XRD)                                                           ,            0.52429126523,    100.0%
+- Execution Cost (XRD)                                                     ,               0.33370285,     63.6%
+- Finalization Cost (XRD)                                                  ,                0.0512566,      9.8%
+- Storage Cost (XRD)                                                       ,            0.13933181523,     26.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6514057,    100.0%
+Execution Cost Breakdown                                                   ,                  6674057,    100.0%
 - AfterInvoke                                                              ,                      542,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3634,      0.1%
-- CheckReference                                                           ,                   240081,      3.7%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
+- CheckReference                                                           ,                   240081,      3.6%
 - CloseSubstate                                                            ,                    50181,      0.8%
 - CreateNode                                                               ,                    19874,      0.3%
 - DropNode                                                                 ,                    34220,      0.5%
@@ -16,39 +17,39 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   611742,      9.4%
-- OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.7%
+- OpenSubstate::GlobalAccount                                              ,                   611742,      9.2%
+- OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.6%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      7.1%
-- OpenSubstate::GlobalPackage                                              ,                  2822803,     43.3%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   463748,      6.9%
+- OpenSubstate::GlobalPackage                                              ,                  2822803,     42.3%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    67715,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     6869,      0.1%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.4%
+- PrepareWasmCode                                                          ,                   353866,      5.3%
 - QueryActor                                                               ,                     5000,      0.1%
-- ReadSubstate                                                             ,                   581650,      8.9%
+- ReadSubstate                                                             ,                   581650,      8.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.1%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.9%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
-- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.5%
+- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.4%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.5%
-- RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
-- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
+- RunNativeCode::store_account_locker                                      ,                    62556,      0.9%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.3%
+- RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
@@ -56,12 +57,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    25080,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13744,      0.2%
-Finalization Cost Breakdown                                                ,                   925132,    100.0%
-- CommitEvents                                                             ,                    25033,      2.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1025132,    100.0%
+- CommitEvents                                                             ,                    25033,      2.4%
+- CommitIntentStatus                                                       ,                   100000,      9.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     10.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.8%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     21.6%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     21.6%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     32.4%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,      9.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.8%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     19.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     19.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     29.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.49647110327,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.308212,     62.1%
-- Finalization Cost (XRD)                                                  ,                 0.046257,      9.3%
-- Storage Cost (XRD)                                                       ,            0.14200210327,     28.6%
+Total Cost (XRD)                                                           ,            0.50947110327,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.316212,     62.1%
+- Finalization Cost (XRD)                                                  ,                 0.051257,     10.1%
+- Storage Cost (XRD)                                                       ,            0.14200210327,     27.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6164240,    100.0%
+Execution Cost Breakdown                                                   ,                  6324240,    100.0%
 - AfterInvoke                                                              ,                      534,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3316,      0.1%
-- CheckReference                                                           ,                   240081,      3.9%
+- CheckIntentValidity                                                      ,                   160000,      2.5%
+- CheckReference                                                           ,                   240081,      3.8%
 - CloseSubstate                                                            ,                    47601,      0.8%
 - CreateNode                                                               ,                    19100,      0.3%
 - DropNode                                                                 ,                    32759,      0.5%
@@ -16,20 +17,20 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   246095,      4.0%
-- OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.4%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.7%
+- OpenSubstate::GlobalAccount                                              ,                   246095,      3.9%
+- OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   421613,      6.8%
-- OpenSubstate::GlobalPackage                                              ,                  2740615,     44.5%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.9%
-- OpenSubstate::InternalGenericComponent                                   ,                    65258,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                   241376,      3.9%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   421613,      6.7%
+- OpenSubstate::GlobalPackage                                              ,                  2740615,     43.3%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    65258,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                   241376,      3.8%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     6869,      0.1%
 - PinNode                                                                  ,                      252,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.7%
+- PrepareWasmCode                                                          ,                   353866,      5.6%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   576095,      9.3%
+- ReadSubstate                                                             ,                   576095,      9.1%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
@@ -42,25 +43,25 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
-- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.6%
+- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.5%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    25080,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13362,      0.2%
-Finalization Cost Breakdown                                                ,                   925140,    100.0%
-- CommitEvents                                                             ,                    25042,      2.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1025140,    100.0%
+- CommitEvents                                                             ,                    25042,      2.4%
+- CommitIntentStatus                                                       ,                   100000,      9.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.8%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     21.6%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     21.6%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,     10.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     32.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.8%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   200012,     19.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     19.5%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,      9.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     29.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.71678811101,    100.0%
-- Execution Cost (XRD)                                                     ,               0.41926485,     58.5%
-- Finalization Cost (XRD)                                                  ,                0.0775106,     10.8%
-- Storage Cost (XRD)                                                       ,            0.22001266101,     30.7%
+Total Cost (XRD)                                                           ,            0.72978811101,    100.0%
+- Execution Cost (XRD)                                                     ,               0.42726485,     58.5%
+- Finalization Cost (XRD)                                                  ,                0.0825106,     11.3%
+- Storage Cost (XRD)                                                       ,            0.22001266101,     30.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8385297,    100.0%
+Execution Cost Breakdown                                                   ,                  8545297,    100.0%
 - AfterInvoke                                                              ,                      962,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.0%
 - BeforeInvoke                                                             ,                     5852,      0.1%
-- CheckReference                                                           ,                   320103,      3.8%
+- CheckIntentValidity                                                      ,                   160000,      1.9%
+- CheckReference                                                           ,                   320103,      3.7%
 - CloseSubstate                                                            ,                    81657,      1.0%
 - CreateNode                                                               ,                    33512,      0.4%
 - DropNode                                                                 ,                    58109,      0.7%
@@ -16,20 +17,20 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   944038,     11.3%
+- OpenSubstate::GlobalAccount                                              ,                   944038,     11.0%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      1.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   800131,      9.5%
-- OpenSubstate::GlobalPackage                                              ,                  2842913,     33.9%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   800131,      9.4%
+- OpenSubstate::GlobalPackage                                              ,                  2842913,     33.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.1%
-- OpenSubstate::InternalGenericComponent                                   ,                   131217,      1.6%
-- OpenSubstate::InternalKeyValueStore                                      ,                   241376,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                   131217,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   241376,      2.8%
 - OpenSubstate::InternalNonFungibleVault                                   ,                   177389,      2.1%
 - PinNode                                                                  ,                      444,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      4.2%
+- PrepareWasmCode                                                          ,                   353866,      4.1%
 - QueryActor                                                               ,                     7000,      0.1%
-- ReadSubstate                                                             ,                   655189,      7.8%
+- ReadSubstate                                                             ,                   655189,      7.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.3%
@@ -37,7 +38,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::airdrop_account_locker                                    ,                   120645,      1.4%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      0.9%
 - RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.7%
-- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.5%
+- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.4%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::drop_empty_bucket_NonFungibleResourceManager              ,                    36472,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
@@ -47,9 +48,9 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.1%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
-- RunNativeCode::put_NonFungibleVault                                      ,                   106062,      1.3%
+- RunNativeCode::put_NonFungibleVault                                      ,                   106062,      1.2%
 - RunNativeCode::take_NonFungibleBucket                                    ,                    67842,      0.8%
-- RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.2%
+- RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.1%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -58,12 +59,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    31960,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    22116,      0.3%
-Finalization Cost Breakdown                                                ,                  1550212,    100.0%
-- CommitEvents                                                             ,                    50086,      3.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1650212,    100.0%
+- CommitEvents                                                             ,                    50086,      3.0%
+- CommitIntentStatus                                                       ,                   100000,      6.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.5%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     25.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     12.9%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,      6.5%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   700062,     45.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.1%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     24.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     12.1%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,      6.1%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   700062,     42.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.66669586381,    100.0%
-- Execution Cost (XRD)                                                     ,               0.37323695,     56.0%
-- Finalization Cost (XRD)                                                  ,               0.07726095,     11.6%
-- Storage Cost (XRD)                                                       ,            0.21619796381,     32.4%
+Total Cost (XRD)                                                           ,            0.67969586381,    100.0%
+- Execution Cost (XRD)                                                     ,               0.38123695,     56.1%
+- Finalization Cost (XRD)                                                  ,               0.08226095,     12.1%
+- Storage Cost (XRD)                                                       ,            0.21619796381,     31.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7464739,    100.0%
+Execution Cost Breakdown                                                   ,                  7624739,    100.0%
 - AfterInvoke                                                              ,                      850,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.0%
 - BeforeInvoke                                                             ,                     4780,      0.1%
-- CheckReference                                                           ,                   320103,      4.3%
-- CloseSubstate                                                            ,                    71853,      1.0%
+- CheckIntentValidity                                                      ,                   160000,      2.1%
+- CheckReference                                                           ,                   320103,      4.2%
+- CloseSubstate                                                            ,                    71853,      0.9%
 - CreateNode                                                               ,                    30162,      0.4%
 - DropNode                                                                 ,                    52011,      0.7%
 - EmitEvent                                                                ,                     5264,      0.1%
@@ -20,16 +21,16 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalAccountLocker                                        ,                   167704,      2.2%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   754545,     10.1%
-- OpenSubstate::GlobalPackage                                              ,                  2754781,     36.9%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   754545,      9.9%
+- OpenSubstate::GlobalPackage                                              ,                  2754781,     36.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.4%
-- OpenSubstate::InternalGenericComponent                                   ,                   116446,      1.6%
-- OpenSubstate::InternalKeyValueStore                                      ,                   403188,      5.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   177389,      2.4%
+- OpenSubstate::InternalGenericComponent                                   ,                   116446,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   403188,      5.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   177389,      2.3%
 - PinNode                                                                  ,                      396,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      4.7%
+- PrepareWasmCode                                                          ,                   353866,      4.6%
 - QueryActor                                                               ,                     5500,      0.1%
-- ReadSubstate                                                             ,                   633872,      8.5%
+- ReadSubstate                                                             ,                   633872,      8.3%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
@@ -57,12 +58,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    31960,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    20358,      0.3%
-Finalization Cost Breakdown                                                ,                  1545219,    100.0%
-- CommitEvents                                                             ,                    45093,      2.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1645219,    100.0%
+- CommitEvents                                                             ,                    45093,      2.7%
+- CommitIntentStatus                                                       ,                   100000,      6.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.5%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     25.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     12.9%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,      6.5%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   700062,     45.3%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.1%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     24.3%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     12.2%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100010,      6.1%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   700062,     42.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
@@ -1,41 +1,42 @@
-Total Cost (XRD)                                                           ,            0.65633599779,    100.0%
-- Execution Cost (XRD)                                                     ,               0.41236195,     62.8%
-- Finalization Cost (XRD)                                                  ,                0.0672582,     10.2%
-- Storage Cost (XRD)                                                       ,            0.17671584779,     26.9%
+Total Cost (XRD)                                                           ,            0.66933599779,    100.0%
+- Execution Cost (XRD)                                                     ,               0.42036195,     62.8%
+- Finalization Cost (XRD)                                                  ,                0.0722582,     10.8%
+- Storage Cost (XRD)                                                       ,            0.17671584779,     26.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8247239,    100.0%
+Execution Cost Breakdown                                                   ,                  8407239,    100.0%
 - AfterInvoke                                                              ,                      898,      0.0%
 - AllocateNodeId                                                           ,                     3492,      0.0%
 - BeforeInvoke                                                             ,                     5678,      0.1%
-- CheckReference                                                           ,                   320103,      3.9%
-- CloseSubstate                                                            ,                    79464,      1.0%
+- CheckIntentValidity                                                      ,                   160000,      1.9%
+- CheckReference                                                           ,                   320103,      3.8%
+- CloseSubstate                                                            ,                    79464,      0.9%
 - CreateNode                                                               ,                    31874,      0.4%
 - DropNode                                                                 ,                    56552,      0.7%
 - EmitEvent                                                                ,                     5154,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   944038,     11.4%
+- OpenSubstate::GlobalAccount                                              ,                   944038,     11.2%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   794331,      9.6%
-- OpenSubstate::GlobalPackage                                              ,                  2841339,     34.5%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.2%
-- OpenSubstate::InternalGenericComponent                                   ,                   130197,      1.6%
-- OpenSubstate::InternalKeyValueStore                                      ,                   121442,      1.5%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   255780,      3.1%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   794331,      9.4%
+- OpenSubstate::GlobalPackage                                              ,                  2841339,     33.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.1%
+- OpenSubstate::InternalGenericComponent                                   ,                   130197,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   121442,      1.4%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   255780,      3.0%
 - PinNode                                                                  ,                      432,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      4.3%
+- PrepareWasmCode                                                          ,                   353866,      4.2%
 - QueryActor                                                               ,                     6500,      0.1%
-- ReadSubstate                                                             ,                   649040,      7.9%
+- ReadSubstate                                                             ,                   649040,      7.7%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.3%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
-- RunNativeCode::airdrop_account_locker                                    ,                   120645,      1.5%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.8%
+- RunNativeCode::airdrop_account_locker                                    ,                   120645,      1.4%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.7%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.5%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::drop_empty_bucket_NonFungibleResourceManager              ,                    36472,      0.4%
@@ -43,12 +44,12 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    27162,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    47772,      0.6%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.5%
-- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.2%
+- RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.1%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
 - RunNativeCode::put_NonFungibleVault                                      ,                   106062,      1.3%
 - RunNativeCode::take_non_fungibles_NonFungibleBucket                      ,                    69156,      0.8%
-- RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.2%
+- RunNativeCode::try_deposit_or_refund                                     ,                   264342,      3.1%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -57,11 +58,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    30400,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    21340,      0.3%
-Finalization Cost Breakdown                                                ,                  1345164,    100.0%
-- CommitEvents                                                             ,                    45077,      3.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1445164,    100.0%
+- CommitEvents                                                             ,                    45077,      3.1%
+- CommitIntentStatus                                                       ,                   100000,      6.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.4%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     29.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     14.9%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   600033,     44.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.9%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     27.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     13.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   600033,     41.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
@@ -1,41 +1,42 @@
-Total Cost (XRD)                                                           ,            0.60624375059,    100.0%
-- Execution Cost (XRD)                                                     ,               0.36633405,     60.4%
-- Finalization Cost (XRD)                                                  ,               0.06700855,     11.1%
-- Storage Cost (XRD)                                                       ,            0.17290115059,     28.5%
+Total Cost (XRD)                                                           ,            0.61924375059,    100.0%
+- Execution Cost (XRD)                                                     ,               0.37433405,     60.5%
+- Finalization Cost (XRD)                                                  ,               0.07200855,     11.6%
+- Storage Cost (XRD)                                                       ,            0.17290115059,     27.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7326681,    100.0%
+Execution Cost Breakdown                                                   ,                  7486681,    100.0%
 - AfterInvoke                                                              ,                      786,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     4606,      0.1%
-- CheckReference                                                           ,                   320103,      4.4%
-- CloseSubstate                                                            ,                    69660,      1.0%
+- CheckIntentValidity                                                      ,                   160000,      2.1%
+- CheckReference                                                           ,                   320103,      4.3%
+- CloseSubstate                                                            ,                    69660,      0.9%
 - CreateNode                                                               ,                    28524,      0.4%
 - DropNode                                                                 ,                    50454,      0.7%
 - EmitEvent                                                                ,                     4692,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   249341,      3.4%
-- OpenSubstate::GlobalAccountLocker                                        ,                   167704,      2.3%
+- OpenSubstate::GlobalAccount                                              ,                   249341,      3.3%
+- OpenSubstate::GlobalAccountLocker                                        ,                   167704,      2.2%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   748745,     10.2%
-- OpenSubstate::GlobalPackage                                              ,                  2753207,     37.6%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.5%
-- OpenSubstate::InternalGenericComponent                                   ,                   115426,      1.6%
-- OpenSubstate::InternalKeyValueStore                                      ,                   283254,      3.9%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   255780,      3.5%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   748745,     10.0%
+- OpenSubstate::GlobalPackage                                              ,                  2753207,     36.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.4%
+- OpenSubstate::InternalGenericComponent                                   ,                   115426,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   283254,      3.8%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   255780,      3.4%
 - PinNode                                                                  ,                      384,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      4.8%
+- PrepareWasmCode                                                          ,                   353866,      4.7%
 - QueryActor                                                               ,                     5000,      0.1%
-- ReadSubstate                                                             ,                   627723,      8.6%
+- ReadSubstate                                                             ,                   627723,      8.4%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::airdrop_account_locker                                    ,                   120645,      1.6%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.9%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.8%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.5%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::drop_empty_bucket_NonFungibleResourceManager              ,                    36472,      0.5%
@@ -56,11 +57,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    30400,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    19582,      0.3%
-Finalization Cost Breakdown                                                ,                  1340171,    100.0%
-- CommitEvents                                                             ,                    40084,      3.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1440171,    100.0%
+- CommitEvents                                                             ,                    40084,      2.8%
+- CommitIntentStatus                                                       ,                   100000,      6.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.5%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     29.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     14.9%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   600033,     44.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.9%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   400018,     27.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     13.9%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   600033,     41.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.46534008228,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2959502,     63.6%
-- Finalization Cost (XRD)                                                  ,               0.03625695,      7.8%
-- Storage Cost (XRD)                                                       ,            0.13313293228,     28.6%
+Total Cost (XRD)                                                           ,            0.47834008228,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3039502,     63.5%
+- Finalization Cost (XRD)                                                  ,               0.04125695,      8.6%
+- Storage Cost (XRD)                                                       ,            0.13313293228,     27.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5919004,    100.0%
+Execution Cost Breakdown                                                   ,                  6079004,    100.0%
 - AfterInvoke                                                              ,                      568,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3620,      0.1%
-- CheckReference                                                           ,                   240076,      4.1%
+- CheckIntentValidity                                                      ,                   160000,      2.6%
+- CheckReference                                                           ,                   240076,      3.9%
 - CloseSubstate                                                            ,                    49149,      0.8%
 - CreateNode                                                               ,                    19884,      0.3%
 - DropNode                                                                 ,                    34236,      0.6%
@@ -16,36 +17,36 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   611742,     10.3%
+- OpenSubstate::GlobalAccount                                              ,                   611742,     10.1%
 - OpenSubstate::GlobalAccountLocker                                        ,                    43189,      0.7%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   343077,      5.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81370,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  2583852,     43.7%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81370,      1.3%
+- OpenSubstate::GlobalPackage                                              ,                  2583852,     42.5%
 - OpenSubstate::InternalFungibleVault                                      ,                   185999,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    67567,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.0%
+- PrepareWasmCode                                                          ,                   353866,      5.8%
 - QueryActor                                                               ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   541449,      9.1%
+- ReadSubstate                                                             ,                   541449,      8.9%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.1%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
+- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.6%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
-- RunNativeCode::store_account_locker                                      ,                    62556,      1.1%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.5%
+- RunNativeCode::store_account_locker                                      ,                    62556,      1.0%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -53,11 +54,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    25440,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    13498,      0.2%
-Finalization Cost Breakdown                                                ,                   725139,    100.0%
-- CommitEvents                                                             ,                    25045,      3.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   825139,    100.0%
+- CommitEvents                                                             ,                    25045,      3.0%
+- CommitIntentStatus                                                       ,                   100000,     12.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     13.8%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     13.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     55.2%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,     12.1%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     12.1%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     12.1%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     48.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/018--account-locker-claim-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/018--account-locker-claim-fungibles-by-amount.txt
@@ -1,46 +1,47 @@
-Total Cost (XRD)                                                           ,            0.43441572401,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2687261,     61.9%
-- Finalization Cost (XRD)                                                  ,               0.03150765,      7.3%
-- Storage Cost (XRD)                                                       ,            0.13418197401,     30.9%
+Total Cost (XRD)                                                           ,            0.44741572401,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2767261,     61.8%
+- Finalization Cost (XRD)                                                  ,               0.03650765,      8.2%
+- Storage Cost (XRD)                                                       ,            0.13418197401,     30.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5374522,    100.0%
+Execution Cost Breakdown                                                   ,                  5534522,    100.0%
 - AfterInvoke                                                              ,                      676,      0.0%
 - AllocateNodeId                                                           ,                     1940,      0.0%
 - BeforeInvoke                                                             ,                     2138,      0.0%
-- CheckReference                                                           ,                   160050,      3.0%
-- CloseSubstate                                                            ,                    40764,      0.8%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                   160050,      2.9%
+- CloseSubstate                                                            ,                    40764,      0.7%
 - CreateNode                                                               ,                    17662,      0.3%
-- DropNode                                                                 ,                    29953,      0.6%
+- DropNode                                                                 ,                    29953,      0.5%
 - EmitEvent                                                                ,                     3546,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   369005,      6.9%
+- OpenSubstate::GlobalAccount                                              ,                   369005,      6.7%
 - OpenSubstate::GlobalAccountLocker                                        ,                    44270,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   254873,      4.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   254873,      4.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41352,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2534351,     47.2%
-- OpenSubstate::InternalFungibleVault                                      ,                   181670,      3.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41352,      0.7%
+- OpenSubstate::GlobalPackage                                              ,                  2534351,     45.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   181670,      3.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    60232,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      3.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.9%
 - PinNode                                                                  ,                      228,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.6%
+- PrepareWasmCode                                                          ,                   353866,      6.4%
 - QueryActor                                                               ,                     3500,      0.1%
-- ReadSubstate                                                             ,                   524240,      9.8%
+- ReadSubstate                                                             ,                   524240,      9.5%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::claim_account_locker                                      ,                    69736,      1.3%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
-- RunNativeCode::deposit_batch                                             ,                   110731,      2.1%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
+- RunNativeCode::deposit_batch                                             ,                   110731,      2.0%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_owner_role                                            ,                    20536,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
+- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -48,10 +49,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    20840,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    11116,      0.2%
-Finalization Cost Breakdown                                                ,                   630153,    100.0%
-- CommitEvents                                                             ,                    30068,      4.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   730153,    100.0%
+- CommitEvents                                                             ,                    30068,      4.1%
+- CommitIntentStatus                                                       ,                   100000,     13.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     15.9%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     15.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     63.5%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,     13.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     54.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/019--account-locker-claim-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/019--account-locker-claim-non-fungibles-by-amount.txt
@@ -1,36 +1,37 @@
-Total Cost (XRD)                                                           ,            0.39591267313,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.270149,     68.2%
-- Finalization Cost (XRD)                                                  ,               0.03125455,      7.9%
-- Storage Cost (XRD)                                                       ,            0.09450912313,     23.9%
+Total Cost (XRD)                                                           ,            0.40891267313,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.278149,     68.0%
+- Finalization Cost (XRD)                                                  ,               0.03625455,      8.9%
+- Storage Cost (XRD)                                                       ,            0.09450912313,     23.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5402980,    100.0%
+Execution Cost Breakdown                                                   ,                  5562980,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     2100,      0.0%
-- CheckReference                                                           ,                   160055,      3.0%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                   160055,      2.9%
 - CloseSubstate                                                            ,                    38184,      0.7%
 - CreateNode                                                               ,                    16014,      0.3%
-- DrainSubstates                                                           ,                    80545,      1.5%
+- DrainSubstates                                                           ,                    80545,      1.4%
 - DropNode                                                                 ,                    28380,      0.5%
 - EmitEvent                                                                ,                     2870,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   248209,      4.6%
+- OpenSubstate::GlobalAccount                                              ,                   248209,      4.5%
 - OpenSubstate::GlobalAccountLocker                                        ,                    44270,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.4%
-- OpenSubstate::GlobalPackage                                              ,                  2577705,     47.7%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.3%
+- OpenSubstate::GlobalPackage                                              ,                  2577705,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    59380,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      3.0%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      3.2%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.9%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      3.1%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.5%
+- PrepareWasmCode                                                          ,                   353866,      6.4%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   523280,      9.7%
+- ReadSubstate                                                             ,                   523280,      9.4%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
@@ -38,11 +39,11 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::claim_account_locker                                      ,                    69736,      1.3%
 - RunNativeCode::deposit_batch                                             ,                   110731,      2.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.4%
 - RunNativeCode::get_owner_role                                            ,                    20536,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -51,10 +52,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    20840,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    10334,      0.2%
-Finalization Cost Breakdown                                                ,                   625091,    100.0%
-- CommitEvents                                                             ,                    25044,      4.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   725091,    100.0%
+- CommitEvents                                                             ,                    25044,      3.5%
+- CommitIntentStatus                                                       ,                   100000,     13.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     16.0%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     64.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     13.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     55.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/020--account-locker-claim-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/020--account-locker-claim-non-fungibles-by-ids.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.39423939056,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26838035,     68.1%
-- Finalization Cost (XRD)                                                  ,               0.03125455,      7.9%
-- Storage Cost (XRD)                                                       ,            0.09460449056,     24.0%
+Total Cost (XRD)                                                           ,            0.40723939056,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27638035,     67.9%
+- Finalization Cost (XRD)                                                  ,               0.03625455,      8.9%
+- Storage Cost (XRD)                                                       ,            0.09460449056,     23.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5367607,    100.0%
+Execution Cost Breakdown                                                   ,                  5527607,    100.0%
 - AfterInvoke                                                              ,                      560,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     2104,      0.0%
-- CheckReference                                                           ,                   160055,      3.0%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                   160055,      2.9%
 - CloseSubstate                                                            ,                    38184,      0.7%
 - CreateNode                                                               ,                    16014,      0.3%
 - DropNode                                                                 ,                    28380,      0.5%
@@ -16,33 +17,33 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   248209,      4.6%
+- OpenSubstate::GlobalAccount                                              ,                   248209,      4.5%
 - OpenSubstate::GlobalAccountLocker                                        ,                    44270,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.4%
-- OpenSubstate::GlobalPackage                                              ,                  2577705,     48.0%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.3%
+- OpenSubstate::GlobalPackage                                              ,                  2577705,     46.6%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    59380,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      3.0%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      3.2%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.9%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      3.1%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.6%
+- PrepareWasmCode                                                          ,                   353866,      6.4%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   523280,      9.7%
-- RemoveSubstate                                                           ,                    40717,      0.8%
+- ReadSubstate                                                             ,                   523280,      9.5%
+- RemoveSubstate                                                           ,                    40717,      0.7%
 - RunNativeCode::AuthZone_assert_access_rule                               ,                    13204,      0.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::claim_non_fungibles_account_locker                        ,                    74322,      1.4%
-- RunNativeCode::deposit_batch                                             ,                   110731,      2.1%
+- RunNativeCode::claim_non_fungibles_account_locker                        ,                    74322,      1.3%
+- RunNativeCode::deposit_batch                                             ,                   110731,      2.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.4%
 - RunNativeCode::get_owner_role                                            ,                    20536,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -51,10 +52,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    20880,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    10334,      0.2%
-Finalization Cost Breakdown                                                ,                   625091,    100.0%
-- CommitEvents                                                             ,                    25044,      4.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   725091,    100.0%
+- CommitEvents                                                             ,                    25044,      3.5%
+- CommitIntentStatus                                                       ,                   100000,     13.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     16.0%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     64.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     13.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     55.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/021--account-locker-recover-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/021--account-locker-recover-fungibles-by-amount.txt
@@ -1,40 +1,41 @@
-Total Cost (XRD)                                                           ,            0.43364554717,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.291137,     67.1%
-- Finalization Cost (XRD)                                                  ,               0.02625565,      6.1%
-- Storage Cost (XRD)                                                       ,            0.11625289717,     26.8%
+Total Cost (XRD)                                                           ,            0.44664554717,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.299137,     67.0%
+- Finalization Cost (XRD)                                                  ,               0.03125565,      7.0%
+- Storage Cost (XRD)                                                       ,            0.11625289717,     26.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5822740,    100.0%
+Execution Cost Breakdown                                                   ,                  5982740,    100.0%
 - AfterInvoke                                                              ,                      616,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3426,      0.1%
-- CheckReference                                                           ,                   240076,      4.1%
-- CloseSubstate                                                            ,                    49665,      0.9%
+- CheckIntentValidity                                                      ,                   160000,      2.7%
+- CheckReference                                                           ,                   240076,      4.0%
+- CloseSubstate                                                            ,                    49665,      0.8%
 - CreateNode                                                               ,                    19566,      0.3%
 - DropNode                                                                 ,                    34680,      0.6%
-- EmitEvent                                                                ,                     2974,      0.1%
+- EmitEvent                                                                ,                     2974,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   491108,      8.4%
-- OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.5%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   291970,      5.0%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
+- OpenSubstate::GlobalAccount                                              ,                   491108,      8.2%
+- OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   291970,      4.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    41352,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2371668,     40.7%
-- OpenSubstate::InternalFungibleVault                                      ,                   349614,      6.0%
+- OpenSubstate::GlobalPackage                                              ,                  2371668,     39.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   349614,      5.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    75830,      1.3%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.8%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.7%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.1%
+- PrepareWasmCode                                                          ,                   353866,      5.9%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   532233,      9.1%
+- ReadSubstate                                                             ,                   532233,      8.9%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.1%
-- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.7%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
+- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::deposit_batch                                             ,                   110731,      1.9%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.6%
@@ -43,7 +44,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
-- RunNativeCode::recover_account_locker                                    ,                    56273,      1.0%
+- RunNativeCode::recover_account_locker                                    ,                    56273,      0.9%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
@@ -52,9 +53,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    29840,      0.5%
 - VerifyTxSignatures                                                       ,                    21000,      0.4%
 - WriteSubstate                                                            ,                    13760,      0.2%
-Finalization Cost Breakdown                                                ,                   525113,    100.0%
-- CommitEvents                                                             ,                    25059,      4.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   625113,    100.0%
+- CommitEvents                                                             ,                    25059,      4.0%
+- CommitIntentStatus                                                       ,                   100000,     16.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400036,     76.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400036,     64.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/022--account-locker-recover-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/022--account-locker-recover-non-fungibles-by-amount.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.45518907974,    100.0%
-- Execution Cost (XRD)                                                     ,               0.30277655,     66.5%
-- Finalization Cost (XRD)                                                  ,                 0.036255,      8.0%
-- Storage Cost (XRD)                                                       ,            0.11615752974,     25.5%
+Total Cost (XRD)                                                           ,            0.46818907974,    100.0%
+- Execution Cost (XRD)                                                     ,               0.31077655,     66.4%
+- Finalization Cost (XRD)                                                  ,                 0.041255,      8.8%
+- Storage Cost (XRD)                                                       ,            0.11615752974,     24.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6055531,    100.0%
+Execution Cost Breakdown                                                   ,                  6215531,    100.0%
 - AfterInvoke                                                              ,                      564,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.0%
 - BeforeInvoke                                                             ,                     3490,      0.1%
-- CheckReference                                                           ,                   240081,      4.0%
+- CheckIntentValidity                                                      ,                   160000,      2.6%
+- CheckReference                                                           ,                   240081,      3.9%
 - CloseSubstate                                                            ,                    49923,      0.8%
 - CreateNode                                                               ,                    19550,      0.3%
 - DrainSubstates                                                           ,                    40545,      0.7%
@@ -17,20 +18,20 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   491108,      8.1%
+- OpenSubstate::GlobalAccount                                              ,                   491108,      7.9%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.4%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   128557,      2.1%
-- OpenSubstate::GlobalPackage                                              ,                  2548777,     42.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      3.0%
-- OpenSubstate::InternalGenericComponent                                   ,                    75998,      1.3%
-- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.7%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      2.8%
+- OpenSubstate::GlobalPackage                                              ,                  2548777,     41.0%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    75998,      1.2%
+- OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.6%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   170520,      2.7%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.8%
+- PrepareWasmCode                                                          ,                   353866,      5.7%
 - QueryActor                                                               ,                     3000,      0.0%
-- ReadSubstate                                                             ,                   548887,      9.1%
+- ReadSubstate                                                             ,                   548887,      8.8%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
@@ -47,19 +48,19 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::recover_account_locker                                    ,                    56273,      0.9%
-- RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.1%
+- RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.0%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    29840,      0.5%
 - VerifyTxSignatures                                                       ,                    21000,      0.3%
 - WriteSubstate                                                            ,                    13760,      0.2%
-Finalization Cost Breakdown                                                ,                   725100,    100.0%
-- CommitEvents                                                             ,                    25044,      3.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   825100,    100.0%
+- CommitEvents                                                             ,                    25044,      3.0%
+- CommitIntentStatus                                                       ,                   100000,     12.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     27.6%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     55.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     12.1%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     24.2%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     48.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/023--account-locker-recover-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/costings/023--account-locker-recover-non-fungibles-by-ids.txt
@@ -1,51 +1,52 @@
-Total Cost (XRD)                                                           ,            0.52419183291,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3215679,     61.3%
-- Finalization Cost (XRD)                                                  ,               0.04650745,      8.9%
-- Storage Cost (XRD)                                                       ,            0.15611648291,     29.8%
+Total Cost (XRD)                                                           ,            0.53719183291,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3295679,     61.4%
+- Finalization Cost (XRD)                                                  ,               0.05150745,      9.6%
+- Storage Cost (XRD)                                                       ,            0.15611648291,     29.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6431358,    100.0%
+Execution Cost Breakdown                                                   ,                  6591358,    100.0%
 - AfterInvoke                                                              ,                      628,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
 - BeforeInvoke                                                             ,                     3596,      0.1%
-- CheckReference                                                           ,                   240081,      3.7%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
+- CheckReference                                                           ,                   240081,      3.6%
 - CloseSubstate                                                            ,                    52890,      0.8%
 - CreateNode                                                               ,                    21188,      0.3%
-- DropNode                                                                 ,                    36221,      0.6%
+- DropNode                                                                 ,                    36221,      0.5%
 - EmitEvent                                                                ,                     3442,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   611904,      9.5%
+- OpenSubstate::GlobalAccount                                              ,                   611904,      9.3%
 - OpenSubstate::GlobalAccountLocker                                        ,                    84694,      1.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.6%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164648,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   135082,      2.1%
-- OpenSubstate::GlobalPackage                                              ,                  2744374,     42.7%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.8%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   135082,      2.0%
+- OpenSubstate::GlobalPackage                                              ,                  2744374,     41.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      2.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    77018,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                   161799,      2.5%
 - OpenSubstate::InternalNonFungibleVault                                   ,                    92129,      1.4%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.5%
+- PrepareWasmCode                                                          ,                   353866,      5.4%
 - QueryActor                                                               ,                     3500,      0.1%
-- ReadSubstate                                                             ,                   587992,      9.1%
+- ReadSubstate                                                             ,                   587992,      8.9%
 - RemoveSubstate                                                           ,                    40717,      0.6%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.4%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.2%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.0%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
+- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.1%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      0.9%
 - RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.6%
 - RunNativeCode::deposit_batch                                             ,                   110731,      1.7%
-- RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
+- RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
 - RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.2%
-- RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.3%
+- RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.2%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.5%
 - RunNativeCode::recover_non_fungibles_account_locker                      ,                    64973,      1.0%
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.0%
@@ -57,11 +58,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    29880,      0.5%
 - VerifyTxSignatures                                                       ,                    21000,      0.3%
 - WriteSubstate                                                            ,                    14542,      0.2%
-Finalization Cost Breakdown                                                ,                   930149,    100.0%
-- CommitEvents                                                             ,                    30053,      3.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1030149,    100.0%
+- CommitEvents                                                             ,                    30053,      2.9%
+- CommitIntentStatus                                                       ,                   100000,      9.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     10.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     21.5%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   500049,     53.8%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,      9.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     19.4%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   500049,     48.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/001--account-locker-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/001--account-locker-create-accounts.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.67041488325 XRD
-├─ Network execution: 0.2228191 XRD, 4456382 execution cost units
-├─ Network finalization: 0.13526745 XRD, 2705349 finalization cost units
+TRANSACTION COST: 0.68341488325 XRD
+├─ Network execution: 0.2308191 XRD, 4616382 execution cost units
+├─ Network finalization: 0.14026745 XRD, 2805349 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31232833325 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.67041488325"),
+     amount: Decimal("0.68341488325"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.335207441625"),
+     amount: Decimal("0.341707441625"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.335207441625"),
+     amount: Decimal("0.341707441625"),
    }
 
 STATE UPDATES: 10 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.1676037208125"),
+             0u8 => Decimal("0.1708537208125"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.32958511675")),
+         LiquidFungibleResource(Decimal("99999999999999999.31658511675")),
        )
 ├─ account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh across 5 partitions
   ├─ Partition(2): 1 change
@@ -418,7 +418,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.335207441625")),
+         LiquidFungibleResource(Decimal("0.341707441625")),
        )
 
 OUTPUTS: 6
@@ -432,10 +432,10 @@ OUTPUTS: 6
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.67041488325
+   Change: -0.68341488325
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.335207441625
+   Change: 0.341707441625
 
 NEW ENTITIES: 5
 ├─ Component: account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/002--account-locker-create-account-locker.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/002--account-locker-create-account-locker.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.71719887689 XRD
-├─ Network execution: 0.26356165 XRD, 5271233 execution cost units
-├─ Network finalization: 0.146268 XRD, 2925360 finalization cost units
+TRANSACTION COST: 0.73019887689 XRD
+├─ Network execution: 0.27156165 XRD, 5431233 execution cost units
+├─ Network finalization: 0.151268 XRD, 3025360 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.30736922689 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.71719887689"),
+     amount: Decimal("0.73019887689"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.358599438445"),
+     amount: Decimal("0.365099438445"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.358599438445"),
+     amount: Decimal("0.365099438445"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.346903440035"),
+             0u8 => Decimal("0.353403440035"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.61238623986")),
+         LiquidFungibleResource(Decimal("99999999999999998.58638623986")),
        )
 ├─ locker_sim1dp8g5xtahznlr27t3jagtplg24d5sfqr2r799h3qfl3jpmdxu7wlr3 across 4 partitions
   ├─ Partition(2): 1 change
@@ -350,7 +350,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.69380688007")),
+         LiquidFungibleResource(Decimal("0.70680688007")),
        )
 
 OUTPUTS: 3
@@ -364,13 +364,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.71719887689
+   Change: -0.73019887689
 ├─ Vault: internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f
    ResAddr: resource_sim1tkgvw0yvyt0vpyzrlkw38rplh5pmgny372rcpxp3973df6yfwqttyw
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.358599438445
+   Change: 0.365099438445
 
 NEW ENTITIES: 2
 └─ Component: locker_sim1dp8g5xtahznlr27t3jagtplg24d5sfqr2r799h3qfl3jpmdxu7wlr3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/003--account-locker-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/003--account-locker-create-resources.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.70134025564 XRD
-├─ Network execution: 0.19178635 XRD, 3835727 execution cost units
-├─ Network finalization: 0.19026375 XRD, 3805275 finalization cost units
+TRANSACTION COST: 0.71434025564 XRD
+├─ Network execution: 0.19978635 XRD, 3995727 execution cost units
+├─ Network finalization: 0.19526375 XRD, 3905275 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31929015564 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.70134025564"),
+     amount: Decimal("0.71434025564"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.35067012782"),
+     amount: Decimal("0.35717012782"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.35067012782"),
+     amount: Decimal("0.35717012782"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.522238503945"),
+             0u8 => Decimal("0.531988503945"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.91104598422")),
+         LiquidFungibleResource(Decimal("99999999999999997.87204598422")),
        )
 ├─ resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk across 4 partitions
   ├─ Partition(5): 1 change
@@ -322,7 +322,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.04447700789")),
+         LiquidFungibleResource(Decimal("1.06397700789")),
        )
 
 OUTPUTS: 3
@@ -333,10 +333,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.70134025564
+   Change: -0.71434025564
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.35067012782
+   Change: 0.35717012782
 
 NEW ENTITIES: 2
 ├─ Resource: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/004--account-locker-setting-up-account-deposit-rules.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/004--account-locker-setting-up-account-deposit-rules.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.42393254385 XRD
-├─ Network execution: 0.2310304 XRD, 4620608 execution cost units
-├─ Network finalization: 0.03125435 XRD, 625087 finalization cost units
+TRANSACTION COST: 0.43693254385 XRD
+├─ Network execution: 0.2390304 XRD, 4780608 execution cost units
+├─ Network finalization: 0.03625435 XRD, 725087 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.16164779385 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.42393254385"),
+     amount: Decimal("0.43693254385"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.211966271925"),
+     amount: Decimal("0.218466271925"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.211966271925"),
+     amount: Decimal("0.218466271925"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6282216399075"),
+             0u8 => Decimal("0.6412216399075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -115,13 +115,13 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.48711344037")),
+         LiquidFungibleResource(Decimal("99999999999999997.43511344037")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.256443279815")),
+         LiquidFungibleResource(Decimal("1.282443279815")),
        )
 
 OUTPUTS: 5
@@ -134,9 +134,9 @@ OUTPUTS: 5
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.42393254385
+   Change: -0.43693254385
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.211966271925
+   Change: 0.218466271925
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/005--account-locker-send-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46534008228 XRD
-├─ Network execution: 0.2959502 XRD, 5919004 execution cost units
-├─ Network finalization: 0.03625695 XRD, 725139 finalization cost units
+TRANSACTION COST: 0.47834008228 XRD
+├─ Network execution: 0.3039502 XRD, 6079004 execution cost units
+├─ Network finalization: 0.04125695 XRD, 825139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13313293228 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46534008228"),
+     amount: Decimal("0.47834008228"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.23267004114"),
+     amount: Decimal("0.23917004114"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.23267004114"),
+     amount: Decimal("0.23917004114"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.7445566604775"),
+             0u8 => Decimal("0.7608066604775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.02177335809")),
+         LiquidFungibleResource(Decimal("99999999999999996.95677335809")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -137,7 +137,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.489113320955")),
+         LiquidFungibleResource(Decimal("1.521613320955")),
        )
 
 OUTPUTS: 5
@@ -150,12 +150,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46534008228
+   Change: -0.47834008228
 ├─ Vault: internal_vault_sim1tq9fel5e3slzv27grm0ym4qpe3c4934d7qttkahkayyngt75577yp4
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.23267004114
+   Change: 0.23917004114
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/006--account-locker-send-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.53596194639 XRD
-├─ Network execution: 0.3058286 XRD, 6116572 execution cost units
-├─ Network finalization: 0.05151015 XRD, 1030203 finalization cost units
+TRANSACTION COST: 0.54896194639 XRD
+├─ Network execution: 0.3138286 XRD, 6276572 execution cost units
+├─ Network finalization: 0.05651015 XRD, 1130203 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17862319639 XRD
 └─ Royalties: 0 XRD
@@ -41,15 +41,15 @@ EVENTS: 9
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.53596194639"),
+     amount: Decimal("0.54896194639"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.267980973195"),
+     amount: Decimal("0.274480973195"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.267980973195"),
+     amount: Decimal("0.274480973195"),
    }
 
 STATE UPDATES: 10 entities
@@ -59,7 +59,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.878547147075"),
+             0u8 => Decimal("0.898047147075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -104,7 +104,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.4858114117")),
+         LiquidFungibleResource(Decimal("99999999999999996.4078114117")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -190,7 +190,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.75709429415")),
+         LiquidFungibleResource(Decimal("1.79609429415")),
        )
 
 OUTPUTS: 5
@@ -203,12 +203,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.53596194639
+   Change: -0.54896194639
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.267980973195
+   Change: 0.274480973195
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/007--account-locker-send-fungibles-and-dont-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.50145889194 XRD
-├─ Network execution: 0.28254355 XRD, 5650871 execution cost units
-├─ Network finalization: 0.0512594 XRD, 1025188 finalization cost units
+TRANSACTION COST: 0.51445889194 XRD
+├─ Network execution: 0.29054355 XRD, 5810871 execution cost units
+├─ Network finalization: 0.0562594 XRD, 1125188 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.16765594194 XRD
 └─ Royalties: 0 XRD
@@ -36,15 +36,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.50145889194"),
+     amount: Decimal("0.51445889194"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.25072944597"),
+     amount: Decimal("0.25722944597"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.25072944597"),
+     amount: Decimal("0.25722944597"),
    }
 
 STATE UPDATES: 10 entities
@@ -54,7 +54,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.00391187006"),
+             0u8 => Decimal("1.02666187006"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -99,7 +99,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.98435251976")),
+         LiquidFungibleResource(Decimal("99999999999999995.89335251976")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -185,7 +185,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.00782374012")),
+         LiquidFungibleResource(Decimal("2.05332374012")),
        )
 
 OUTPUTS: 5
@@ -198,12 +198,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.50145889194
+   Change: -0.51445889194
 ├─ Vault: internal_vault_sim1tpgwdt3l9whdtw6e7m73xfnp8z34nj5atqh78rqtx7trdpvtl0k7z6
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.25072944597
+   Change: 0.25722944597
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/008--account-locker-airdrop-fungibles-and-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.61637545122 XRD
-├─ Network execution: 0.37297955 XRD, 7459591 execution cost units
-├─ Network finalization: 0.0475112 XRD, 950224 finalization cost units
+TRANSACTION COST: 0.62937545122 XRD
+├─ Network execution: 0.38097955 XRD, 7619591 execution cost units
+├─ Network finalization: 0.0525112 XRD, 1050224 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19588470122 XRD
 └─ Royalties: 0 XRD
@@ -59,15 +59,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.61637545122"),
+     amount: Decimal("0.62937545122"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.30818772561"),
+     amount: Decimal("0.31468772561"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.30818772561"),
+     amount: Decimal("0.31468772561"),
    }
 
 STATE UPDATES: 11 entities
@@ -77,7 +77,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.158005732865"),
+             0u8 => Decimal("1.184005732865"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -122,7 +122,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.36797706854")),
+         LiquidFungibleResource(Decimal("99999999999999995.26397706854")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -175,7 +175,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.31601146573")),
+         LiquidFungibleResource(Decimal("2.36801146573")),
        )
 
 OUTPUTS: 5
@@ -188,7 +188,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.61637545122
+   Change: -0.62937545122
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
@@ -200,6 +200,6 @@ BALANCE CHANGES: 5
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.30818772561
+   Change: 0.31468772561
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/009--account-locker-airdrop-fungibles-and-dont-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.61559094676 XRD
-├─ Network execution: 0.3309308 XRD, 6618616 execution cost units
-├─ Network finalization: 0.0622633 XRD, 1245266 finalization cost units
+TRANSACTION COST: 0.62859094676 XRD
+├─ Network execution: 0.3389308 XRD, 6778616 execution cost units
+├─ Network finalization: 0.0672633 XRD, 1345266 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.22239684676 XRD
 └─ Royalties: 0 XRD
@@ -60,15 +60,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.61559094676"),
+     amount: Decimal("0.62859094676"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.30779547338"),
+     amount: Decimal("0.31429547338"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.30779547338"),
+     amount: Decimal("0.31429547338"),
    }
 
 STATE UPDATES: 12 entities
@@ -78,7 +78,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.311903469555"),
+             0u8 => Decimal("1.341153469555"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -123,7 +123,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.75238612178")),
+         LiquidFungibleResource(Decimal("99999999999999994.63538612178")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -221,7 +221,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.62380693911")),
+         LiquidFungibleResource(Decimal("2.68230693911")),
        )
 
 OUTPUTS: 5
@@ -234,7 +234,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.61559094676
+   Change: -0.62859094676
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
@@ -246,6 +246,6 @@ BALANCE CHANGES: 5
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.30779547338
+   Change: 0.31429547338
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/010--account-locker-send-non-fungibles-and-try-direct-deposit-succeeds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.51129126523 XRD
-├─ Network execution: 0.32570285 XRD, 6514057 execution cost units
-├─ Network finalization: 0.0462566 XRD, 925132 finalization cost units
+TRANSACTION COST: 0.52429126523 XRD
+├─ Network execution: 0.33370285 XRD, 6674057 execution cost units
+├─ Network finalization: 0.0512566 XRD, 1025132 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13933181523 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.51129126523"),
+     amount: Decimal("0.52429126523"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.255645632615"),
+     amount: Decimal("0.262145632615"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.255645632615"),
+     amount: Decimal("0.262145632615"),
    }
 
 STATE UPDATES: 9 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.4397262858625"),
+             0u8 => Decimal("1.4722262858625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.24109485655")),
+         LiquidFungibleResource(Decimal("99999999999999994.11109485655")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -151,7 +151,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.879452571725")),
+         LiquidFungibleResource(Decimal("2.944452571725")),
        )
 
 OUTPUTS: 5
@@ -164,12 +164,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.51129126523
+   Change: -0.52429126523
 ├─ Vault: internal_vault_sim1nz49q5dgwxz5dg2spgwd2vqsfawzywahlw5ztxwpcyjl4p8le2crd6
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.255645632615
+   Change: 0.262145632615
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/011--account-locker-send-non-fungibles-and-try-direct-deposit-refunds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.51129126523 XRD
-├─ Network execution: 0.32570285 XRD, 6514057 execution cost units
-├─ Network finalization: 0.0462566 XRD, 925132 finalization cost units
+TRANSACTION COST: 0.52429126523 XRD
+├─ Network execution: 0.33370285 XRD, 6674057 execution cost units
+├─ Network finalization: 0.0512566 XRD, 1025132 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13933181523 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.51129126523"),
+     amount: Decimal("0.52429126523"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.255645632615"),
+     amount: Decimal("0.262145632615"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.255645632615"),
+     amount: Decimal("0.262145632615"),
    }
 
 STATE UPDATES: 9 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.56754910217"),
+             0u8 => Decimal("1.60329910217"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.72980359132")),
+         LiquidFungibleResource(Decimal("99999999999999993.58680359132")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -151,7 +151,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.13509820434")),
+         LiquidFungibleResource(Decimal("3.20659820434")),
        )
 
 OUTPUTS: 5
@@ -164,12 +164,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.51129126523
+   Change: -0.52429126523
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#2#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.255645632615
+   Change: 0.262145632615
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/012--account-locker-send-non-fungibles-and-dont-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.49647110327 XRD
-├─ Network execution: 0.308212 XRD, 6164240 execution cost units
-├─ Network finalization: 0.046257 XRD, 925140 finalization cost units
+TRANSACTION COST: 0.50947110327 XRD
+├─ Network execution: 0.316212 XRD, 6324240 execution cost units
+├─ Network finalization: 0.051257 XRD, 1025140 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14200210327 XRD
 └─ Royalties: 0 XRD
@@ -42,15 +42,15 @@ EVENTS: 8
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.49647110327"),
+     amount: Decimal("0.50947110327"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.248235551635"),
+     amount: Decimal("0.254735551635"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.248235551635"),
+     amount: Decimal("0.254735551635"),
    }
 
 STATE UPDATES: 9 entities
@@ -60,7 +60,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.6916668779875"),
+             0u8 => Decimal("1.7306668779875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -102,7 +102,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.23333248805")),
+         LiquidFungibleResource(Decimal("99999999999999993.07733248805")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -152,7 +152,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.383333755975")),
+         LiquidFungibleResource(Decimal("3.461333755975")),
        )
 
 OUTPUTS: 5
@@ -165,12 +165,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.49647110327
+   Change: -0.50947110327
 ├─ Vault: internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.248235551635
+   Change: 0.254735551635
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/013--account-locker-airdrop-non-fungibles-by-amount-and-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.71678811101 XRD
-├─ Network execution: 0.41926485 XRD, 8385297 execution cost units
-├─ Network finalization: 0.0775106 XRD, 1550212 finalization cost units
+TRANSACTION COST: 0.72978811101 XRD
+├─ Network execution: 0.42726485 XRD, 8545297 execution cost units
+├─ Network finalization: 0.0825106 XRD, 1650212 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.22001266101 XRD
 └─ Royalties: 0 XRD
@@ -77,15 +77,15 @@ EVENTS: 13
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.71678811101"),
+     amount: Decimal("0.72978811101"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.358394055505"),
+     amount: Decimal("0.364894055505"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.358394055505"),
+     amount: Decimal("0.364894055505"),
    }
 
 STATE UPDATES: 11 entities
@@ -95,7 +95,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.87086390574"),
+             0u8 => Decimal("1.91311390574"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -141,7 +141,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.51654437704")),
+         LiquidFungibleResource(Decimal("99999999999999992.34754437704")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -213,7 +213,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.74172781148")),
+         LiquidFungibleResource(Decimal("3.82622781148")),
        )
 
 OUTPUTS: 5
@@ -226,7 +226,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.71678811101
+   Change: -0.72978811101
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#4#}, -{}
@@ -238,6 +238,6 @@ BALANCE CHANGES: 5
    Change: +{#5#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.358394055505
+   Change: 0.364894055505
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/014--account-locker-airdrop-non-fungibles-by-amount-and-dont-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.66669586381 XRD
-├─ Network execution: 0.37323695 XRD, 7464739 execution cost units
-├─ Network finalization: 0.07726095 XRD, 1545219 finalization cost units
+TRANSACTION COST: 0.67969586381 XRD
+├─ Network execution: 0.38123695 XRD, 7624739 execution cost units
+├─ Network finalization: 0.08226095 XRD, 1645219 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.21619796381 XRD
 └─ Royalties: 0 XRD
@@ -76,15 +76,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.66669586381"),
+     amount: Decimal("0.67969586381"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.333347931905"),
+     amount: Decimal("0.339847931905"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.333347931905"),
+     amount: Decimal("0.339847931905"),
    }
 
 STATE UPDATES: 11 entities
@@ -94,7 +94,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.0375378716925"),
+             0u8 => Decimal("2.0830378716925"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -140,7 +140,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.84984851323")),
+         LiquidFungibleResource(Decimal("99999999999999991.66784851323")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -212,7 +212,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.075075743385")),
+         LiquidFungibleResource(Decimal("4.166075743385")),
        )
 
 OUTPUTS: 5
@@ -225,7 +225,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.66669586381
+   Change: -0.67969586381
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#7#}, -{}
@@ -237,6 +237,6 @@ BALANCE CHANGES: 5
    Change: +{#8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.333347931905
+   Change: 0.339847931905
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/015--account-locker-airdrop-non-fungibles-by-ids-and-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.65633599779 XRD
-├─ Network execution: 0.41236195 XRD, 8247239 execution cost units
-├─ Network finalization: 0.0672582 XRD, 1345164 finalization cost units
+TRANSACTION COST: 0.66933599779 XRD
+├─ Network execution: 0.42036195 XRD, 8407239 execution cost units
+├─ Network finalization: 0.0722582 XRD, 1445164 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17671584779 XRD
 └─ Royalties: 0 XRD
@@ -73,15 +73,15 @@ EVENTS: 12
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.65633599779"),
+     amount: Decimal("0.66933599779"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.328167998895"),
+     amount: Decimal("0.334667998895"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.328167998895"),
+     amount: Decimal("0.334667998895"),
    }
 
 STATE UPDATES: 10 entities
@@ -91,7 +91,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.20162187114"),
+             0u8 => Decimal("2.25037187114"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -137,7 +137,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.19351251544")),
+         LiquidFungibleResource(Decimal("99999999999999990.99851251544")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -182,7 +182,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.40324374228")),
+         LiquidFungibleResource(Decimal("4.50074374228")),
        )
 
 OUTPUTS: 5
@@ -195,7 +195,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.65633599779
+   Change: -0.66933599779
 ├─ Vault: internal_vault_sim1nzxzp4wznnrxj7xw0ujvpm36q8mvv8kjyjld486cqcsalfk030437p
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#10#}, -{}
@@ -207,6 +207,6 @@ BALANCE CHANGES: 5
    Change: +{#12#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.328167998895
+   Change: 0.334667998895
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/016--account-locker-airdrop-non-fungibles-by-ids-and-dont-try-direct-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.60624375059 XRD
-├─ Network execution: 0.36633405 XRD, 7326681 execution cost units
-├─ Network finalization: 0.06700855 XRD, 1340171 finalization cost units
+TRANSACTION COST: 0.61924375059 XRD
+├─ Network execution: 0.37433405 XRD, 7486681 execution cost units
+├─ Network finalization: 0.07200855 XRD, 1440171 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17290115059 XRD
 └─ Royalties: 0 XRD
@@ -72,15 +72,15 @@ EVENTS: 11
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.60624375059"),
+     amount: Decimal("0.61924375059"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.303121875295"),
+     amount: Decimal("0.309621875295"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.303121875295"),
+     amount: Decimal("0.309621875295"),
    }
 
 STATE UPDATES: 10 entities
@@ -90,7 +90,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.3531828087875"),
+             0u8 => Decimal("2.4051828087875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -136,7 +136,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999990.58726876485")),
+         LiquidFungibleResource(Decimal("99999999999999990.37926876485")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -181,7 +181,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.706365617575")),
+         LiquidFungibleResource(Decimal("4.810365617575")),
        )
 
 OUTPUTS: 5
@@ -194,7 +194,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.60624375059
+   Change: -0.61924375059
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{#13#}, -{}
@@ -206,6 +206,6 @@ BALANCE CHANGES: 5
    Change: +{#15#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.303121875295
+   Change: 0.309621875295
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/017--account-locker-global-caller-badge-is-an-authorized-depositor.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46534008228 XRD
-├─ Network execution: 0.2959502 XRD, 5919004 execution cost units
-├─ Network finalization: 0.03625695 XRD, 725139 finalization cost units
+TRANSACTION COST: 0.47834008228 XRD
+├─ Network execution: 0.3039502 XRD, 6079004 execution cost units
+├─ Network finalization: 0.04125695 XRD, 825139 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13313293228 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46534008228"),
+     amount: Decimal("0.47834008228"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.23267004114"),
+     amount: Decimal("0.23917004114"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.23267004114"),
+     amount: Decimal("0.23917004114"),
    }
 
 STATE UPDATES: 9 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.4695178293575"),
+             0u8 => Decimal("2.5247678293575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999990.12192868257")),
+         LiquidFungibleResource(Decimal("99999999999999989.90092868257")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -137,7 +137,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.939035658715")),
+         LiquidFungibleResource(Decimal("5.049535658715")),
        )
 
 OUTPUTS: 5
@@ -150,12 +150,12 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46534008228
+   Change: -0.47834008228
 ├─ Vault: internal_vault_sim1tpqxdp75lc02x9w24dud57q22t9nu3e4g3cav9zzhestx7fcs3u4gg
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.23267004114
+   Change: 0.23917004114
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/018--account-locker-claim-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/018--account-locker-claim-fungibles-by-amount.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43441572401 XRD
-├─ Network execution: 0.2687261 XRD, 5374522 execution cost units
-├─ Network finalization: 0.03150765 XRD, 630153 finalization cost units
+TRANSACTION COST: 0.44741572401 XRD
+├─ Network execution: 0.2767261 XRD, 5534522 execution cost units
+├─ Network finalization: 0.03650765 XRD, 730153 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13418197401 XRD
 └─ Royalties: 0 XRD
@@ -41,15 +41,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43441572401"),
+     amount: Decimal("0.44741572401"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.217207862005"),
+     amount: Decimal("0.223707862005"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.217207862005"),
+     amount: Decimal("0.223707862005"),
    }
 
 STATE UPDATES: 8 entities
@@ -59,7 +59,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.57812176036"),
+             0u8 => Decimal("2.63662176036"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -98,7 +98,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.68751295856")),
+         LiquidFungibleResource(Decimal("99999999999999989.45351295856")),
        )
 ├─ internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx across 1 partitions
   └─ Partition(64): 1 change
@@ -139,7 +139,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.15624352072")),
+         LiquidFungibleResource(Decimal("5.27324352072")),
        )
 
 OUTPUTS: 3
@@ -150,7 +150,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.43441572401
+   Change: -0.44741572401
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: -1
@@ -159,6 +159,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.217207862005
+   Change: 0.223707862005
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/019--account-locker-claim-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/019--account-locker-claim-non-fungibles-by-amount.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39591267313 XRD
-├─ Network execution: 0.270149 XRD, 5402980 execution cost units
-├─ Network finalization: 0.03125455 XRD, 625091 finalization cost units
+TRANSACTION COST: 0.40891267313 XRD
+├─ Network execution: 0.278149 XRD, 5562980 execution cost units
+├─ Network finalization: 0.03625455 XRD, 725091 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09450912313 XRD
 └─ Royalties: 0 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39591267313"),
+     amount: Decimal("0.40891267313"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.197956336565"),
+     amount: Decimal("0.204456336565"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.197956336565"),
+     amount: Decimal("0.204456336565"),
    }
 
 STATE UPDATES: 7 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.6770999286425"),
+             0u8 => Decimal("2.7388499286425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.29160028543")),
+         LiquidFungibleResource(Decimal("99999999999999989.04460028543")),
        )
 ├─ internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9 across 2 partitions
   ├─ Partition(64): 1 change
@@ -121,7 +121,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.354199857285")),
+         LiquidFungibleResource(Decimal("5.477699857285")),
        )
 
 OUTPUTS: 3
@@ -132,7 +132,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39591267313
+   Change: -0.40891267313
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#13#}
@@ -141,6 +141,6 @@ BALANCE CHANGES: 4
    Change: +{#13#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.197956336565
+   Change: 0.204456336565
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/020--account-locker-claim-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/020--account-locker-claim-non-fungibles-by-ids.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39423939056 XRD
-├─ Network execution: 0.26838035 XRD, 5367607 execution cost units
-├─ Network finalization: 0.03125455 XRD, 625091 finalization cost units
+TRANSACTION COST: 0.40723939056 XRD
+├─ Network execution: 0.27638035 XRD, 5527607 execution cost units
+├─ Network finalization: 0.03625455 XRD, 725091 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09460449056 XRD
 └─ Royalties: 0 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39423939056"),
+     amount: Decimal("0.40723939056"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.19711969528"),
+     amount: Decimal("0.20361969528"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.19711969528"),
+     amount: Decimal("0.20361969528"),
    }
 
 STATE UPDATES: 7 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.7756597762825"),
+             0u8 => Decimal("2.8406597762825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.89736089487")),
+         LiquidFungibleResource(Decimal("99999999999999988.63736089487")),
        )
 ├─ internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405 across 2 partitions
   ├─ Partition(64): 1 change
@@ -121,7 +121,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.551319552565")),
+         LiquidFungibleResource(Decimal("5.681319552565")),
        )
 
 OUTPUTS: 3
@@ -132,7 +132,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39423939056
+   Change: -0.40723939056
 ├─ Vault: internal_vault_sim1nrstdzgdlu2ka8r8jfzl0a7xj84nznpjr3h63ev255xtz82xuhz405
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#3#}
@@ -141,6 +141,6 @@ BALANCE CHANGES: 4
    Change: +{#3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.19711969528
+   Change: 0.20361969528
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/021--account-locker-recover-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/021--account-locker-recover-fungibles-by-amount.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43364554717 XRD
-├─ Network execution: 0.291137 XRD, 5822740 execution cost units
-├─ Network finalization: 0.02625565 XRD, 525113 finalization cost units
+TRANSACTION COST: 0.44664554717 XRD
+├─ Network execution: 0.299137 XRD, 5982740 execution cost units
+├─ Network finalization: 0.03125565 XRD, 625113 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11625289717 XRD
 └─ Royalties: 0 XRD
@@ -37,15 +37,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43364554717"),
+     amount: Decimal("0.44664554717"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.216822773585"),
+     amount: Decimal("0.223322773585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.216822773585"),
+     amount: Decimal("0.223322773585"),
    }
 
 STATE UPDATES: 8 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.884071163075"),
+             0u8 => Decimal("2.952321163075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.4637153477")),
+         LiquidFungibleResource(Decimal("99999999999999988.1907153477")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -112,7 +112,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.76814232615")),
+         LiquidFungibleResource(Decimal("5.90464232615")),
        )
 
 OUTPUTS: 4
@@ -124,7 +124,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.43364554717
+   Change: -0.44664554717
 ├─ Vault: internal_vault_sim1tqf9qqqfurkf2qf7exnh2tupdqnrcf49seskepj9jjye78truj7dsx
    ResAddr: resource_sim1t5820sqdx0jf9zgjd5ge6y0fvfxsnx6dlh5sgfkm4nemgz44q0v7xk
    Change: -1
@@ -133,6 +133,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.216822773585
+   Change: 0.223322773585
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/022--account-locker-recover-non-fungibles-by-amount.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/022--account-locker-recover-non-fungibles-by-amount.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.45518907974 XRD
-├─ Network execution: 0.30277655 XRD, 6055531 execution cost units
-├─ Network finalization: 0.036255 XRD, 725100 finalization cost units
+TRANSACTION COST: 0.46818907974 XRD
+├─ Network execution: 0.31077655 XRD, 6215531 execution cost units
+├─ Network finalization: 0.041255 XRD, 825100 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11615752974 XRD
 └─ Royalties: 0 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.45518907974"),
+     amount: Decimal("0.46818907974"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.22759453987"),
+     amount: Decimal("0.23409453987"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.22759453987"),
+     amount: Decimal("0.23409453987"),
    }
 
 STATE UPDATES: 8 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.99786843301"),
+             0u8 => Decimal("3.06936843301"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.00852626796")),
+         LiquidFungibleResource(Decimal("99999999999999987.72252626796")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -127,7 +127,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.99573686602")),
+         LiquidFungibleResource(Decimal("6.13873686602")),
        )
 
 OUTPUTS: 4
@@ -139,7 +139,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.45518907974
+   Change: -0.46818907974
 ├─ Vault: internal_vault_sim1np4v02tu69ju0s5ac7xpt9jk590fa4epxx398539ycc057wqqfjdq9
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#7#}
@@ -148,6 +148,6 @@ BALANCE CHANGES: 4
    Change: +{#7#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.22759453987
+   Change: 0.23409453987
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/023--account-locker-recover-non-fungibles-by-ids.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/receipts/023--account-locker-recover-non-fungibles-by-ids.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52419183291 XRD
-├─ Network execution: 0.3215679 XRD, 6431358 execution cost units
-├─ Network finalization: 0.04650745 XRD, 930149 finalization cost units
+TRANSACTION COST: 0.53719183291 XRD
+├─ Network execution: 0.3295679 XRD, 6591358 execution cost units
+├─ Network finalization: 0.05150745 XRD, 1030149 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.15611648291 XRD
 └─ Royalties: 0 XRD
@@ -49,15 +49,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52419183291"),
+     amount: Decimal("0.53719183291"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.262095916455"),
+     amount: Decimal("0.268595916455"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.262095916455"),
+     amount: Decimal("0.268595916455"),
    }
 
 STATE UPDATES: 9 entities
@@ -67,7 +67,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("3.1289163912375"),
+             0u8 => Decimal("3.2036663912375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -106,7 +106,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999987.48433443505")),
+         LiquidFungibleResource(Decimal("99999999999999987.18533443505")),
        )
 ├─ internal_vault_sim1tzjmjma6hatpvy7uzs07x06dlqzry6cwz55grlkwpkxxgd6medwp2f across 1 partitions
   └─ Partition(64): 1 change
@@ -160,7 +160,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("6.257832782475")),
+         LiquidFungibleResource(Decimal("6.407332782475")),
        )
 
 OUTPUTS: 4
@@ -172,7 +172,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.52419183291
+   Change: -0.53719183291
 ├─ Vault: internal_vault_sim1nrxkgnug32kd87wny27junyc3s9dey2a7ulpylsz9tz3gjql8cwcjf
    ResAddr: resource_sim1n2pnt93g8hmwdkyh4xjw0ldmad3p25hx93t2rw58ke974tpeqemklu
    Change: +{}, -{#15#}
@@ -181,6 +181,6 @@ BALANCE CHANGES: 4
    Change: +{#15#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.262095916455
+   Change: 0.268595916455
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/account_locker/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: account_locker
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 785bf373e6fcc24a (allowed to change if not deployed to any network)
-Events       : 2ef2b3e2e73a100b (allowed to change if not deployed to any network)
+State changes: faae4a2c40ed343b (allowed to change if not deployed to any network)
+Events       : 0c9bbb6e9d0b65c5 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - badge_holder_account: account_sim1cx4qy6q2aa9vgl3x87nny50nephemg6yntq95neulu85hndy5wwzkh

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/001--create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/001--create-accounts.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            1.01783689517,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.385988,     37.9%
-- Finalization Cost (XRD)                                                  ,               0.17227325,     16.9%
-- Storage Cost (XRD)                                                       ,            0.45957564517,     45.2%
+Total Cost (XRD)                                                           ,            1.03083689517,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.393988,     38.2%
+- Finalization Cost (XRD)                                                  ,               0.17727325,     17.2%
+- Storage Cost (XRD)                                                       ,            0.45957564517,     44.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7719760,    100.0%
+Execution Cost Breakdown                                                   ,                  7879760,    100.0%
 - AfterInvoke                                                              ,                     1416,      0.0%
 - AllocateNodeId                                                           ,                     5044,      0.1%
 - BeforeInvoke                                                             ,                     5708,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.0%
 - CheckReference                                                           ,                    40011,      0.5%
 - CloseSubstate                                                            ,                    70821,      0.9%
 - CreateNode                                                               ,                    44142,      0.6%
@@ -17,28 +18,28 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
 - MoveModule                                                               ,                     6160,      0.1%
-- OpenSubstate::GlobalAccount                                              ,                   654408,      8.5%
+- OpenSubstate::GlobalAccount                                              ,                   654408,      8.3%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   184460,      2.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   184460,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    86039,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  3204531,     41.5%
-- OpenSubstate::InternalFungibleVault                                      ,                   112914,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  3204531,     40.7%
+- OpenSubstate::InternalFungibleVault                                      ,                   112914,      1.4%
 - OpenSubstate::InternalGenericComponent                                   ,                   108605,      1.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.6%
 - PinNode                                                                  ,                      528,      0.0%
-- PrepareWasmCode                                                          ,                   707732,      9.2%
+- PrepareWasmCode                                                          ,                   707732,      9.0%
 - QueryActor                                                               ,                     3500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   947789,     12.3%
+- ReadSubstate                                                             ,                   947789,     12.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
-- RunNativeCode::Worktop_put                                               ,                    58066,      0.8%
+- RunNativeCode::Worktop_put                                               ,                    58066,      0.7%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
-- RunNativeCode::create                                                    ,                    73776,      1.0%
+- RunNativeCode::create                                                    ,                    73776,      0.9%
 - RunNativeCode::create_advanced                                           ,                   163614,      2.1%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      0.9%
-- RunNativeCode::create_with_data                                          ,                    82413,      1.1%
+- RunNativeCode::create_with_data                                          ,                    82413,      1.0%
 - RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      1.4%
 - RunNativeCode::deposit                                                   ,                    67707,      0.9%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      0.6%
@@ -47,7 +48,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.6%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.6%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.5%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.6%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.5%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.5%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -56,12 +57,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    47440,      0.6%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    20320,      0.3%
-Finalization Cost Breakdown                                                ,                  3445465,    100.0%
+Finalization Cost Breakdown                                                ,                  3545465,    100.0%
 - CommitEvents                                                             ,                    45083,      1.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                  1200148,     34.8%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500126,     43.5%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500085,     14.5%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.9%
+- CommitStateUpdates::GlobalAccount                                        ,                  1200148,     33.9%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500126,     42.3%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500085,     14.1%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/002--trivial_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/002--trivial_subintent.txt
@@ -1,39 +1,39 @@
-Total Cost (XRD)                                                           ,            0.15482124477,    100.0%
-- Execution Cost (XRD)                                                     ,                0.0931674,     60.2%
-- Finalization Cost (XRD)                                                  ,                0.0102508,      6.6%
-- Storage Cost (XRD)                                                       ,            0.05140304477,     33.2%
+Total Cost (XRD)                                                           ,            0.16782124477,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1011674,     60.3%
+- Finalization Cost (XRD)                                                  ,                0.0152508,      9.1%
+- Storage Cost (XRD)                                                       ,            0.05140304477,     30.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  1863348,    100.0%
+Execution Cost Breakdown                                                   ,                  2023348,    100.0%
 - AfterInvoke                                                              ,                       24,      0.0%
 - AllocateNodeId                                                           ,                      776,      0.0%
 - BeforeInvoke                                                             ,                      600,      0.0%
-- CheckIntentValidity                                                      ,                   160000,      8.6%
-- CheckReference                                                           ,                    40011,      2.1%
+- CheckIntentValidity                                                      ,                   320000,     15.8%
+- CheckReference                                                           ,                    40011,      2.0%
 - CloseSubstate                                                            ,                    10191,      0.5%
 - CreateNode                                                               ,                     6498,      0.3%
 - DropNode                                                                 ,                    11994,      0.6%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     2000,      0.1%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   244472,     13.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      6.6%
-- OpenSubstate::GlobalPackage                                              ,                   902340,     48.4%
-- OpenSubstate::InternalFungibleVault                                      ,                    85206,      4.6%
-- OpenSubstate::InternalGenericComponent                                   ,                    13089,      0.7%
+- OpenSubstate::GlobalAccount                                              ,                   244472,     12.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      6.1%
+- OpenSubstate::GlobalPackage                                              ,                   902340,     44.6%
+- OpenSubstate::InternalFungibleVault                                      ,                    85206,      4.2%
+- OpenSubstate::InternalGenericComponent                                   ,                    13089,      0.6%
 - PinNode                                                                  ,                       96,      0.0%
-- QueryActor                                                               ,                     1000,      0.1%
-- ReadSubstate                                                             ,                    68753,      3.7%
-- RunNativeCode::Worktop_drop                                              ,                    35836,      1.9%
-- RunNativeCode::lock_fee                                                  ,                   116047,      6.2%
+- QueryActor                                                               ,                     1000,      0.0%
+- ReadSubstate                                                             ,                    68753,      3.4%
+- RunNativeCode::Worktop_drop                                              ,                    35836,      1.8%
+- RunNativeCode::lock_fee                                                  ,                   116047,      5.7%
 - SendToStack                                                              ,                     1012,      0.1%
 - SetCallFrameData                                                         ,                     1212,      0.1%
 - SwitchStack                                                              ,                     2500,      0.1%
-- ValidateTxPayload                                                        ,                    18560,      1.0%
-- VerifyTxSignatures                                                       ,                    14000,      0.8%
+- ValidateTxPayload                                                        ,                    18560,      0.9%
+- VerifyTxSignatures                                                       ,                    14000,      0.7%
 - WriteSubstate                                                            ,                     3610,      0.2%
-Finalization Cost Breakdown                                                ,                   205016,    100.0%
-- CommitEvents                                                             ,                     5007,      2.4%
-- CommitIntentStatus                                                       ,                   100000,     48.8%
+Finalization Cost Breakdown                                                ,                   305016,    100.0%
+- CommitEvents                                                             ,                     5007,      1.6%
+- CommitIntentStatus                                                       ,                   200000,     65.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     48.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/003--with_timestamp_range.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/003--with_timestamp_range.txt
@@ -1,38 +1,39 @@
-Total Cost (XRD)                                                           ,            0.13359288065,    100.0%
-- Execution Cost (XRD)                                                     ,                0.0849499,     63.6%
-- Finalization Cost (XRD)                                                  ,                0.0052508,      3.9%
-- Storage Cost (XRD)                                                       ,            0.04339218065,     32.5%
+Total Cost (XRD)                                                           ,            0.14659288065,    100.0%
+- Execution Cost (XRD)                                                     ,                0.0929499,     63.4%
+- Finalization Cost (XRD)                                                  ,                0.0102508,      7.0%
+- Storage Cost (XRD)                                                       ,            0.04339218065,     29.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  1698998,    100.0%
+Execution Cost Breakdown                                                   ,                  1858998,    100.0%
 - AfterInvoke                                                              ,                       18,      0.0%
 - AllocateNodeId                                                           ,                      485,      0.0%
 - BeforeInvoke                                                             ,                      434,      0.0%
-- CheckReference                                                           ,                    40011,      2.4%
-- CheckTimestamp                                                           ,                    40000,      2.4%
+- CheckIntentValidity                                                      ,                   160000,      8.6%
+- CheckReference                                                           ,                    40011,      2.2%
+- CheckTimestamp                                                           ,                    40000,      2.2%
 - CloseSubstate                                                            ,                     8385,      0.5%
-- CreateNode                                                               ,                     4262,      0.3%
-- DropNode                                                                 ,                     7697,      0.5%
+- CreateNode                                                               ,                     4262,      0.2%
+- DropNode                                                                 ,                     7697,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.1%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   244472,     14.4%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      7.2%
-- OpenSubstate::GlobalPackage                                              ,                   900766,     53.0%
-- OpenSubstate::InternalFungibleVault                                      ,                    85206,      5.0%
+- OpenSubstate::GlobalAccount                                              ,                   244472,     13.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      6.6%
+- OpenSubstate::GlobalPackage                                              ,                   900766,     48.5%
+- OpenSubstate::InternalFungibleVault                                      ,                    85206,      4.6%
 - OpenSubstate::InternalGenericComponent                                   ,                     8557,      0.5%
 - PinNode                                                                  ,                       60,      0.0%
 - QueryActor                                                               ,                     1000,      0.1%
-- ReadSubstate                                                             ,                    65787,      3.9%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      1.1%
-- RunNativeCode::lock_fee                                                  ,                   116047,      6.8%
+- ReadSubstate                                                             ,                    65787,      3.5%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      1.0%
+- RunNativeCode::lock_fee                                                  ,                   116047,      6.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.1%
-- ValidateTxPayload                                                        ,                    15200,      0.9%
+- ValidateTxPayload                                                        ,                    15200,      0.8%
 - VerifyTxSignatures                                                       ,                    14000,      0.8%
-- WriteSubstate                                                            ,                     2566,      0.2%
-Finalization Cost Breakdown                                                ,                   105016,    100.0%
-- CommitEvents                                                             ,                     5007,      4.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     2566,      0.1%
+Finalization Cost Breakdown                                                ,                   205016,    100.0%
+- CommitEvents                                                             ,                     5007,      2.4%
+- CommitIntentStatus                                                       ,                   100000,     48.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     95.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     48.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/004--depth_four_transaction.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/004--depth_four_transaction.txt
@@ -1,39 +1,39 @@
-Total Cost (XRD)                                                           ,            0.20478320049,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1136744,     55.5%
-- Finalization Cost (XRD)                                                  ,                0.0202508,      9.9%
-- Storage Cost (XRD)                                                       ,            0.07085800049,     34.6%
+Total Cost (XRD)                                                           ,            0.21778320049,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1216744,     55.9%
+- Finalization Cost (XRD)                                                  ,                0.0252508,     11.6%
+- Storage Cost (XRD)                                                       ,            0.07085800049,     32.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2273488,    100.0%
+Execution Cost Breakdown                                                   ,                  2433488,    100.0%
 - AfterInvoke                                                              ,                       36,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.1%
 - BeforeInvoke                                                             ,                      932,      0.0%
-- CheckIntentValidity                                                      ,                   480000,     21.1%
-- CheckReference                                                           ,                    40011,      1.8%
+- CheckIntentValidity                                                      ,                   640000,     26.3%
+- CheckReference                                                           ,                    40011,      1.6%
 - CloseSubstate                                                            ,                    13803,      0.6%
 - CreateNode                                                               ,                    10970,      0.5%
-- DropNode                                                                 ,                    20588,      0.9%
+- DropNode                                                                 ,                    20588,      0.8%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     4000,      0.2%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   244472,     10.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      5.4%
-- OpenSubstate::GlobalPackage                                              ,                   905488,     39.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    85206,      3.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    22153,      1.0%
+- OpenSubstate::GlobalAccount                                              ,                   244472,     10.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   122465,      5.0%
+- OpenSubstate::GlobalPackage                                              ,                   905488,     37.2%
+- OpenSubstate::InternalFungibleVault                                      ,                    85206,      3.5%
+- OpenSubstate::InternalGenericComponent                                   ,                    22153,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                    74685,      3.3%
-- RunNativeCode::Worktop_drop                                              ,                    71672,      3.2%
-- RunNativeCode::lock_fee                                                  ,                   116047,      5.1%
+- ReadSubstate                                                             ,                    74685,      3.1%
+- RunNativeCode::Worktop_drop                                              ,                    71672,      2.9%
+- RunNativeCode::lock_fee                                                  ,                   116047,      4.8%
 - SendToStack                                                              ,                     3036,      0.1%
 - SetCallFrameData                                                         ,                     2424,      0.1%
 - SwitchStack                                                              ,                     5500,      0.2%
-- ValidateTxPayload                                                        ,                    26720,      1.2%
+- ValidateTxPayload                                                        ,                    26720,      1.1%
 - VerifyTxSignatures                                                       ,                    14000,      0.6%
-- WriteSubstate                                                            ,                     5698,      0.3%
-Finalization Cost Breakdown                                                ,                   405016,    100.0%
-- CommitEvents                                                             ,                     5007,      1.2%
-- CommitIntentStatus                                                       ,                   300000,     74.1%
+- WriteSubstate                                                            ,                     5698,      0.2%
+Finalization Cost Breakdown                                                ,                   505016,    100.0%
+- CommitEvents                                                             ,                     5007,      1.0%
+- CommitIntentStatus                                                       ,                   400000,     79.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     19.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/005--trading_with_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/005--trading_with_subintent.txt
@@ -1,49 +1,49 @@
-Total Cost (XRD)                                                           ,            0.52712354586,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2216793,     42.1%
-- Finalization Cost (XRD)                                                  ,               0.04776145,      9.1%
-- Storage Cost (XRD)                                                       ,            0.25768279586,     48.9%
+Total Cost (XRD)                                                           ,            0.54012354586,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2296793,     42.5%
+- Finalization Cost (XRD)                                                  ,               0.05276145,      9.8%
+- Storage Cost (XRD)                                                       ,            0.25768279586,     47.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4433586,    100.0%
+Execution Cost Breakdown                                                   ,                  4593586,    100.0%
 - AfterInvoke                                                              ,                     1180,      0.0%
 - AllocateNodeId                                                           ,                     3783,      0.1%
 - BeforeInvoke                                                             ,                     4006,      0.1%
-- CheckIntentValidity                                                      ,                   160000,      3.6%
-- CheckReference                                                           ,                   160054,      3.6%
-- CloseSubstate                                                            ,                    77658,      1.8%
-- CreateNode                                                               ,                    33352,      0.8%
-- DropNode                                                                 ,                    57247,      1.3%
+- CheckIntentValidity                                                      ,                   320000,      7.0%
+- CheckReference                                                           ,                   160054,      3.5%
+- CloseSubstate                                                            ,                    77658,      1.7%
+- CreateNode                                                               ,                    33352,      0.7%
+- DropNode                                                                 ,                    57247,      1.2%
 - EmitEvent                                                                ,                     6404,      0.1%
 - GetOwnedNodes                                                            ,                     2000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   826085,     18.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   311415,      7.0%
-- OpenSubstate::GlobalPackage                                              ,                  1247222,     28.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   188128,      4.2%
-- OpenSubstate::InternalGenericComponent                                   ,                   147665,      3.3%
+- OpenSubstate::GlobalAccount                                              ,                   826085,     18.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   311415,      6.8%
+- OpenSubstate::GlobalPackage                                              ,                  1247222,     27.2%
+- OpenSubstate::InternalFungibleVault                                      ,                   188128,      4.1%
+- OpenSubstate::InternalGenericComponent                                   ,                   147665,      3.2%
 - PinNode                                                                  ,                      444,      0.0%
 - QueryActor                                                               ,                     4000,      0.1%
-- ReadSubstate                                                             ,                   229158,      5.2%
+- ReadSubstate                                                             ,                   229158,      5.0%
 - RunNativeCode::Worktop_drop                                              ,                    35836,      0.8%
-- RunNativeCode::Worktop_put                                               ,                   116132,      2.6%
+- RunNativeCode::Worktop_put                                               ,                   116132,      2.5%
 - RunNativeCode::Worktop_take_all                                          ,                    58408,      1.3%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      1.6%
-- RunNativeCode::deposit                                                   ,                   135414,      3.1%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      1.5%
+- RunNativeCode::deposit                                                   ,                   135414,      2.9%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    99144,      2.2%
-- RunNativeCode::lock_fee                                                  ,                   116047,      2.6%
+- RunNativeCode::lock_fee                                                  ,                   116047,      2.5%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      1.1%
-- RunNativeCode::take_FungibleVault                                        ,                    84914,      1.9%
-- RunNativeCode::withdraw                                                  ,                   115702,      2.6%
+- RunNativeCode::take_FungibleVault                                        ,                    84914,      1.8%
+- RunNativeCode::withdraw                                                  ,                   115702,      2.5%
 - SendToStack                                                              ,                     2148,      0.0%
 - SetCallFrameData                                                         ,                     1212,      0.0%
 - SwitchStack                                                              ,                     3500,      0.1%
-- ValidateTxPayload                                                        ,                    42600,      1.0%
+- ValidateTxPayload                                                        ,                    42600,      0.9%
 - VerifyTxSignatures                                                       ,                    21000,      0.5%
 - WriteSubstate                                                            ,                    20870,      0.5%
-Finalization Cost Breakdown                                                ,                   955229,    100.0%
-- CommitEvents                                                             ,                    55113,      5.8%
-- CommitIntentStatus                                                       ,                   100000,     10.5%
+Finalization Cost Breakdown                                                ,                  1055229,    100.0%
+- CommitEvents                                                             ,                    55113,      5.2%
+- CommitIntentStatus                                                       ,                   200000,     19.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   200022,     20.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   600094,     62.8%
+- CommitStateUpdates::GlobalAccount                                        ,                   200022,     19.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   600094,     56.9%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/006--transaction_with_complex_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/006--transaction_with_complex_subintent.txt
@@ -1,50 +1,50 @@
-Total Cost (XRD)                                                           ,            0.43939346471,    100.0%
-- Execution Cost (XRD)                                                     ,               0.22722755,     51.7%
-- Finalization Cost (XRD)                                                  ,                0.0312539,      7.1%
-- Storage Cost (XRD)                                                       ,            0.18091201471,     41.2%
+Total Cost (XRD)                                                           ,            0.45239346471,    100.0%
+- Execution Cost (XRD)                                                     ,               0.23522755,     52.0%
+- Finalization Cost (XRD)                                                  ,                0.0362539,      8.0%
+- Storage Cost (XRD)                                                       ,            0.18091201471,     40.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4544551,    100.0%
+Execution Cost Breakdown                                                   ,                  4704551,    100.0%
 - AfterInvoke                                                              ,                     1228,      0.0%
 - AllocateNodeId                                                           ,                     4462,      0.1%
 - BeforeInvoke                                                             ,                     4746,      0.1%
-- CheckIntentValidity                                                      ,                   480000,     10.6%
-- CheckReference                                                           ,                   200070,      4.4%
+- CheckIntentValidity                                                      ,                   640000,     13.6%
+- CheckReference                                                           ,                   200070,      4.3%
 - CloseSubstate                                                            ,                    82947,      1.8%
 - CreateNode                                                               ,                    37650,      0.8%
 - DropNode                                                                 ,                    69252,      1.5%
 - EmitEvent                                                                ,                     2908,      0.1%
 - GetOwnedNodes                                                            ,                     4000,      0.1%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   534489,     11.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   255466,      5.6%
-- OpenSubstate::GlobalPackage                                              ,                  1243859,     27.4%
-- OpenSubstate::InternalFungibleVault                                      ,                   255083,      5.6%
-- OpenSubstate::InternalGenericComponent                                   ,                   191936,      4.2%
+- OpenSubstate::GlobalAccount                                              ,                   534489,     11.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   255466,      5.4%
+- OpenSubstate::GlobalPackage                                              ,                  1243859,     26.4%
+- OpenSubstate::InternalFungibleVault                                      ,                   255083,      5.4%
+- OpenSubstate::InternalGenericComponent                                   ,                   191936,      4.1%
 - PinNode                                                                  ,                      552,      0.0%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   218327,      4.8%
+- ReadSubstate                                                             ,                   218327,      4.6%
 - RunNativeCode::Worktop_assert_resources_include                          ,                    19117,      0.4%
 - RunNativeCode::Worktop_assert_resources_only                             ,                    38234,      0.8%
 - RunNativeCode::Worktop_drain                                             ,                    22448,      0.5%
-- RunNativeCode::Worktop_drop                                              ,                    71672,      1.6%
-- RunNativeCode::Worktop_put                                               ,                   145165,      3.2%
+- RunNativeCode::Worktop_drop                                              ,                    71672,      1.5%
+- RunNativeCode::Worktop_put                                               ,                   145165,      3.1%
 - RunNativeCode::Worktop_take                                              ,                    17966,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    29204,      0.6%
 - RunNativeCode::deposit_batch                                             ,                   110731,      2.4%
-- RunNativeCode::get_amount_FungibleBucket                                 ,                   143208,      3.2%
-- RunNativeCode::lock_fee                                                  ,                   116047,      2.6%
+- RunNativeCode::get_amount_FungibleBucket                                 ,                   143208,      3.0%
+- RunNativeCode::lock_fee                                                  ,                   116047,      2.5%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.3%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.2%
 - SendToStack                                                              ,                     4300,      0.1%
 - SetCallFrameData                                                         ,                     2424,      0.1%
 - SwitchStack                                                              ,                     8000,      0.2%
-- ValidateTxPayload                                                        ,                    58240,      1.3%
-- VerifyTxSignatures                                                       ,                    21000,      0.5%
+- ValidateTxPayload                                                        ,                    58240,      1.2%
+- VerifyTxSignatures                                                       ,                    21000,      0.4%
 - WriteSubstate                                                            ,                    22458,      0.5%
-Finalization Cost Breakdown                                                ,                   625078,    100.0%
-- CommitEvents                                                             ,                    25051,      4.0%
-- CommitIntentStatus                                                       ,                   300000,     48.0%
+Finalization Cost Breakdown                                                ,                   725078,    100.0%
+- CommitEvents                                                             ,                    25051,      3.5%
+- CommitIntentStatus                                                       ,                   400000,     55.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     48.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     41.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/007--first_transaction_with_subintent_which_fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/007--first_transaction_with_subintent_which_fails.txt
@@ -1,41 +1,41 @@
-Total Cost (XRD)                                                           ,             0.2204047197,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14506445,     65.8%
+Total Cost (XRD)                                                           ,             0.2284047197,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15306445,     67.0%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,             0.0753402697,     34.2%
+- Storage Cost (XRD)                                                       ,             0.0753402697,     33.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2901289,    100.0%
+Execution Cost Breakdown                                                   ,                  3061289,    100.0%
 - AfterInvoke                                                              ,                      378,      0.0%
 - AllocateNodeId                                                           ,                     1649,      0.1%
 - BeforeInvoke                                                             ,                     1708,      0.1%
-- CheckIntentValidity                                                      ,                   160000,      5.5%
-- CheckReference                                                           ,                   120038,      4.1%
+- CheckIntentValidity                                                      ,                   320000,     10.5%
+- CheckReference                                                           ,                   120038,      3.9%
 - CloseSubstate                                                            ,                    29928,      1.0%
 - CreateNode                                                               ,                    14162,      0.5%
 - DropNode                                                                 ,                    20061,      0.7%
 - EmitEvent                                                                ,                     1732,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   489485,     16.9%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   209409,      7.2%
-- OpenSubstate::GlobalPackage                                              ,                  1083302,     37.3%
-- OpenSubstate::InternalFungibleVault                                      ,                   170412,      5.9%
-- OpenSubstate::InternalGenericComponent                                   ,                    55935,      1.9%
+- OpenSubstate::GlobalAccount                                              ,                   489485,     16.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   209409,      6.8%
+- OpenSubstate::GlobalPackage                                              ,                  1083302,     35.4%
+- OpenSubstate::InternalFungibleVault                                      ,                   170412,      5.6%
+- OpenSubstate::InternalGenericComponent                                   ,                    55935,      1.8%
 - PinNode                                                                  ,                      204,      0.0%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   116436,      4.0%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   116436,      3.8%
 - RunNativeCode::Worktop_assert_contains_amount                            ,                    18549,      0.6%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
-- RunNativeCode::Worktop_put                                               ,                    58066,      2.0%
+- RunNativeCode::Worktop_put                                               ,                    58066,      1.9%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.5%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      1.1%
-- RunNativeCode::lock_fee                                                  ,                   116047,      4.0%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.5%
-- RunNativeCode::withdraw                                                  ,                    57851,      2.0%
+- RunNativeCode::lock_fee                                                  ,                   116047,      3.8%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.4%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.9%
 - SendToStack                                                              ,                     1074,      0.0%
 - SetCallFrameData                                                         ,                     1212,      0.0%
 - SwitchStack                                                              ,                     2500,      0.1%
-- ValidateTxPayload                                                        ,                    31600,      1.1%
+- ValidateTxPayload                                                        ,                    31600,      1.0%
 - VerifyTxSignatures                                                       ,                    21000,      0.7%
-- WriteSubstate                                                            ,                     7526,      0.3%
+- WriteSubstate                                                            ,                     7526,      0.2%
 Finalization Cost Breakdown                                                ,                        0,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/008--second_transaction_with_subintent_can_succeed.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/costings/008--second_transaction_with_subintent_can_succeed.txt
@@ -1,47 +1,47 @@
-Total Cost (XRD)                                                           ,            0.29855147796,    100.0%
-- Execution Cost (XRD)                                                     ,               0.16552695,     55.4%
-- Finalization Cost (XRD)                                                  ,                0.0212539,      7.1%
-- Storage Cost (XRD)                                                       ,            0.11177062796,     37.4%
+Total Cost (XRD)                                                           ,            0.31155147796,    100.0%
+- Execution Cost (XRD)                                                     ,               0.17352695,     55.7%
+- Finalization Cost (XRD)                                                  ,                0.0262539,      8.4%
+- Storage Cost (XRD)                                                       ,            0.11177062796,     35.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3310539,    100.0%
+Execution Cost Breakdown                                                   ,                  3470539,    100.0%
 - AfterInvoke                                                              ,                      516,      0.0%
 - AllocateNodeId                                                           ,                     2037,      0.1%
 - BeforeInvoke                                                             ,                     2106,      0.1%
-- CheckIntentValidity                                                      ,                   160000,      4.8%
-- CheckReference                                                           ,                   120038,      3.6%
+- CheckIntentValidity                                                      ,                   320000,      9.2%
+- CheckReference                                                           ,                   120038,      3.5%
 - CloseSubstate                                                            ,                    40248,      1.2%
 - CreateNode                                                               ,                    17958,      0.5%
-- DropNode                                                                 ,                    32385,      1.0%
+- DropNode                                                                 ,                    32385,      0.9%
 - EmitEvent                                                                ,                     2908,      0.1%
 - GetOwnedNodes                                                            ,                     2000,      0.1%
 - LockFee                                                                  ,                      500,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   534489,     16.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   251049,      7.6%
-- OpenSubstate::GlobalPackage                                              ,                  1090209,     32.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   255083,      7.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    76471,      2.3%
+- OpenSubstate::GlobalAccount                                              ,                   534489,     15.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   251049,      7.2%
+- OpenSubstate::GlobalPackage                                              ,                  1090209,     31.4%
+- OpenSubstate::InternalFungibleVault                                      ,                   255083,      7.3%
+- OpenSubstate::InternalGenericComponent                                   ,                    76471,      2.2%
 - PinNode                                                                  ,                      252,      0.0%
 - QueryActor                                                               ,                     2000,      0.1%
-- ReadSubstate                                                             ,                   138510,      4.2%
+- ReadSubstate                                                             ,                   138510,      4.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
-- RunNativeCode::Worktop_drop                                              ,                    35836,      1.1%
-- RunNativeCode::Worktop_put                                               ,                    58066,      1.8%
+- RunNativeCode::Worktop_drop                                              ,                    35836,      1.0%
+- RunNativeCode::Worktop_put                                               ,                    58066,      1.7%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.4%
-- RunNativeCode::deposit_batch                                             ,                   110731,      3.3%
+- RunNativeCode::deposit_batch                                             ,                   110731,      3.2%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      1.3%
-- RunNativeCode::lock_fee                                                  ,                   116047,      3.5%
+- RunNativeCode::lock_fee                                                  ,                   116047,      3.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.7%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.3%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.2%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.7%
 - SendToStack                                                              ,                     1074,      0.0%
 - SetCallFrameData                                                         ,                     1212,      0.0%
 - SwitchStack                                                              ,                     2500,      0.1%
-- ValidateTxPayload                                                        ,                    29240,      0.9%
+- ValidateTxPayload                                                        ,                    29240,      0.8%
 - VerifyTxSignatures                                                       ,                    21000,      0.6%
 - WriteSubstate                                                            ,                    11322,      0.3%
-Finalization Cost Breakdown                                                ,                   425078,    100.0%
-- CommitEvents                                                             ,                    25051,      5.9%
-- CommitIntentStatus                                                       ,                   100000,     23.5%
+Finalization Cost Breakdown                                                ,                   525078,    100.0%
+- CommitEvents                                                             ,                    25051,      4.8%
+- CommitIntentStatus                                                       ,                   200000,     38.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     70.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     57.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/001--create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/001--create-accounts.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.01783689517 XRD
-├─ Network execution: 0.385988 XRD, 7719760 execution cost units
-├─ Network finalization: 0.17227325 XRD, 3445465 finalization cost units
+TRANSACTION COST: 1.03083689517 XRD
+├─ Network execution: 0.393988 XRD, 7879760 execution cost units
+├─ Network finalization: 0.17727325 XRD, 3545465 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.45957564517 XRD
 └─ Royalties: 0 XRD
@@ -50,15 +50,15 @@ EVENTS: 12
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.01783689517"),
+     amount: Decimal("1.03083689517"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.508918447585"),
+     amount: Decimal("0.515418447585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.508918447585"),
+     amount: Decimal("0.515418447585"),
    }
 
 STATE UPDATES: 11 entities
@@ -68,7 +68,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2544592237925"),
+             0u8 => Decimal("0.2577092237925"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -101,7 +101,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.98216310483")),
+         LiquidFungibleResource(Decimal("99999999999989998.96916310483")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -432,7 +432,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.508918447585")),
+         LiquidFungibleResource(Decimal("0.515418447585")),
        )
 
 OUTPUTS: 10
@@ -453,7 +453,7 @@ OUTPUTS: 10
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.01783689517
+   Change: -10001.03083689517
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
@@ -462,7 +462,7 @@ BALANCE CHANGES: 4
    Change: 1000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.508918447585
+   Change: 0.515418447585
 
 NEW ENTITIES: 3
 ├─ Component: account_sim1cyq8zqa0cz6jufuskdum6w8uex3wt3n9dwegkq40y9gu65pyxcusds

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/002--trivial_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/002--trivial_subintent.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.15482124477 XRD
-├─ Network execution: 0.0931674 XRD, 1863348 execution cost units
-├─ Network finalization: 0.0102508 XRD, 205016 finalization cost units
+TRANSACTION COST: 0.16782124477 XRD
+├─ Network execution: 0.1011674 XRD, 2023348 execution cost units
+├─ Network finalization: 0.0152508 XRD, 305016 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.05140304477 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.15482124477"),
+     amount: Decimal("0.16782124477"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.077410622385"),
+     amount: Decimal("0.083910622385"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.077410622385"),
+     amount: Decimal("0.083910622385"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.293164534985"),
+             0u8 => Decimal("0.299664534985"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -64,13 +64,13 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9999.84517875523")),
+         LiquidFungibleResource(Decimal("9999.83217875523")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.58632906997")),
+         LiquidFungibleResource(Decimal("0.59932906997")),
        )
 
 OUTPUTS: 2
@@ -80,9 +80,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.15482124477
+   Change: -0.16782124477
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.077410622385
+   Change: 0.083910622385
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/003--with_timestamp_range.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/003--with_timestamp_range.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.13359288065 XRD
-├─ Network execution: 0.0849499 XRD, 1698998 execution cost units
-├─ Network finalization: 0.0052508 XRD, 105016 finalization cost units
+TRANSACTION COST: 0.14659288065 XRD
+├─ Network execution: 0.0929499 XRD, 1858998 execution cost units
+├─ Network finalization: 0.0102508 XRD, 205016 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04339218065 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.13359288065"),
+     amount: Decimal("0.14659288065"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.066796440325"),
+     amount: Decimal("0.073296440325"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.066796440325"),
+     amount: Decimal("0.073296440325"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.3265627551475"),
+             0u8 => Decimal("0.3363127551475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,13 +60,13 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9999.71158587458")),
+         LiquidFungibleResource(Decimal("9999.68558587458")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.653125510295")),
+         LiquidFungibleResource(Decimal("0.672625510295")),
        )
 
 OUTPUTS: 1
@@ -75,9 +75,9 @@ OUTPUTS: 1
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.13359288065
+   Change: -0.14659288065
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.066796440325
+   Change: 0.073296440325
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/004--depth_four_transaction.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/004--depth_four_transaction.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.20478320049 XRD
-├─ Network execution: 0.1136744 XRD, 2273488 execution cost units
-├─ Network finalization: 0.0202508 XRD, 405016 finalization cost units
+TRANSACTION COST: 0.21778320049 XRD
+├─ Network execution: 0.1216744 XRD, 2433488 execution cost units
+├─ Network finalization: 0.0252508 XRD, 505016 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07085800049 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20478320049"),
+     amount: Decimal("0.21778320049"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.102391600245"),
+     amount: Decimal("0.108891600245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.102391600245"),
+     amount: Decimal("0.108891600245"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.37775855527"),
+             0u8 => Decimal("0.39075855527"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -72,13 +72,13 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9999.50680267409")),
+         LiquidFungibleResource(Decimal("9999.46780267409")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.75551711054")),
+         LiquidFungibleResource(Decimal("0.78151711054")),
        )
 
 OUTPUTS: 2
@@ -88,9 +88,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20478320049
+   Change: -0.21778320049
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.102391600245
+   Change: 0.108891600245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/005--trading_with_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/005--trading_with_subintent.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52712354586 XRD
-├─ Network execution: 0.2216793 XRD, 4433586 execution cost units
-├─ Network finalization: 0.04776145 XRD, 955229 finalization cost units
+TRANSACTION COST: 0.54012354586 XRD
+├─ Network execution: 0.2296793 XRD, 4593586 execution cost units
+├─ Network finalization: 0.05276145 XRD, 1055229 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.25768279586 XRD
 └─ Royalties: 0 XRD
@@ -60,15 +60,15 @@ EVENTS: 14
    )
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52712354586"),
+     amount: Decimal("0.54012354586"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.26356177293"),
+     amount: Decimal("0.27006177293"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.26356177293"),
+     amount: Decimal("0.27006177293"),
    }
 
 STATE UPDATES: 9 entities
@@ -78,7 +78,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.509539441735"),
+             0u8 => Decimal("0.525789441735"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -120,7 +120,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9975.47967912823")),
+         LiquidFungibleResource(Decimal("9975.42767912823")),
        )
 ├─ internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0 across 1 partitions
   └─ Partition(64): 1 change
@@ -190,7 +190,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.01907888347")),
+         LiquidFungibleResource(Decimal("1.05157888347")),
        )
 
 OUTPUTS: 7
@@ -205,7 +205,7 @@ OUTPUTS: 7
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -24.02712354586
+   Change: -24.04012354586
 ├─ Vault: internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0
    ResAddr: resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8
    Change: -10
@@ -217,6 +217,6 @@ BALANCE CHANGES: 5
    Change: 23.5
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.26356177293
+   Change: 0.27006177293
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/006--transaction_with_complex_subintent.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/006--transaction_with_complex_subintent.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43939346471 XRD
-├─ Network execution: 0.22722755 XRD, 4544551 execution cost units
-├─ Network finalization: 0.0312539 XRD, 625078 finalization cost units
+TRANSACTION COST: 0.45239346471 XRD
+├─ Network execution: 0.23522755 XRD, 4704551 execution cost units
+├─ Network finalization: 0.0362539 XRD, 725078 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.18091201471 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43939346471"),
+     amount: Decimal("0.45239346471"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.219696732355"),
+     amount: Decimal("0.226196732355"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.219696732355"),
+     amount: Decimal("0.226196732355"),
    }
 
 STATE UPDATES: 6 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6193878079125"),
+             0u8 => Decimal("0.6388878079125"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9975.04028566352")),
+         LiquidFungibleResource(Decimal("9974.97528566352")),
        )
 ├─ internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0 across 1 partitions
   └─ Partition(64): 1 change
@@ -108,7 +108,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.238775615825")),
+         LiquidFungibleResource(Decimal("1.277775615825")),
        )
 
 OUTPUTS: 4
@@ -120,7 +120,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.43939346471
+   Change: -0.45239346471
 ├─ Vault: internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0
    ResAddr: resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8
    Change: -10
@@ -129,6 +129,6 @@ BALANCE CHANGES: 4
    Change: 10
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.219696732355
+   Change: 0.226196732355
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/007--first_transaction_with_subintent_which_fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/007--first_transaction_with_subintent_which_fails.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(WorktopError(AssertionFailed(ResourceConstraintFailed { resource_address: ResourceAddress(5da66318c6318c61f5a61b4c6318c6318cf794aa8d295f14e6318c6318c6), error: ExpectedAtLeastAmount { expected_at_least_amount: 1, actual_amount: 0 } })))
 
-TRANSACTION COST: 0.2204047197 XRD
-├─ Network execution: 0.14506445 XRD, 2901289 execution cost units
+TRANSACTION COST: 0.2284047197 XRD
+├─ Network execution: 0.15306445 XRD, 3061289 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0753402697 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2204047197"),
+     amount: Decimal("0.2284047197"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.11020235985"),
+     amount: Decimal("0.11420235985"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.11020235985"),
+     amount: Decimal("0.11420235985"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6744889878375"),
+             0u8 => Decimal("0.6959889878375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9974.81988094382")),
+         LiquidFungibleResource(Decimal("9974.74688094382")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.348977975675")),
+         LiquidFungibleResource(Decimal("1.391977975675")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2204047197
+   Change: -0.2284047197
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.11020235985
+   Change: 0.11420235985
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/008--second_transaction_with_subintent_can_succeed.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/receipts/008--second_transaction_with_subintent_can_succeed.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29855147796 XRD
-├─ Network execution: 0.16552695 XRD, 3310539 execution cost units
-├─ Network finalization: 0.0212539 XRD, 425078 finalization cost units
+TRANSACTION COST: 0.31155147796 XRD
+├─ Network execution: 0.17352695 XRD, 3470539 execution cost units
+├─ Network finalization: 0.0262539 XRD, 525078 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11177062796 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29855147796"),
+     amount: Decimal("0.31155147796"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.14927573898"),
+     amount: Decimal("0.15577573898"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.14927573898"),
+     amount: Decimal("0.15577573898"),
    }
 
 STATE UPDATES: 6 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.7491268573275"),
+             0u8 => Decimal("0.7738768573275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -82,7 +82,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("9974.52132946586")),
+         LiquidFungibleResource(Decimal("9974.43532946586")),
        )
 ├─ internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0 across 1 partitions
   └─ Partition(64): 1 change
@@ -100,7 +100,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.498253714655")),
+         LiquidFungibleResource(Decimal("1.547753714655")),
        )
 
 OUTPUTS: 3
@@ -111,7 +111,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tzla7q8crqdpm2mvj2v2c4gl9ffpce8krmjqjcex6sqepxxdpfsnkd
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29855147796
+   Change: -0.31155147796
 ├─ Vault: internal_vault_sim1tz7udp8myqsz4j2252zflxahmecw0qnc8cvxv6e0tnp86vu3tw53r0
    ResAddr: resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8
    Change: -50
@@ -120,6 +120,6 @@ BALANCE CHANGES: 4
    Change: 50
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.14927573898
+   Change: 0.15577573898
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/basic_subintents/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: basic_subintents
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: c3f257249d57d891 (allowed to change if not deployed to any network)
-Events       : aa47b9795c444de3 (allowed to change if not deployed to any network)
+State changes: 9599cfa2d7f45128 (allowed to change if not deployed to any network)
+Events       : 4b2d2679593a2455 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - parent_account: account_sim1cyq8zqa0cz6jufuskdum6w8uex3wt3n9dwegkq40y9gu65pyxcusds

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/001--fungible-max-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/001--fungible-max-div-create.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.68802500819,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2529725,     36.8%
-- Finalization Cost (XRD)                                                  ,               0.13626635,     19.8%
-- Storage Cost (XRD)                                                       ,            0.29878615819,     43.4%
+Total Cost (XRD)                                                           ,            0.70102500819,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2609725,     37.2%
+- Finalization Cost (XRD)                                                  ,               0.14126635,     20.2%
+- Storage Cost (XRD)                                                       ,            0.29878615819,     42.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5059450,    100.0%
+Execution Cost Breakdown                                                   ,                  5219450,    100.0%
 - AfterInvoke                                                              ,                      716,      0.0%
 - AllocateNodeId                                                           ,                     2813,      0.1%
 - BeforeInvoke                                                             ,                     3538,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      3.1%
 - CheckReference                                                           ,                    40011,      0.8%
-- CloseSubstate                                                            ,                    38055,      0.8%
+- CloseSubstate                                                            ,                    38055,      0.7%
 - CreateNode                                                               ,                    25120,      0.5%
 - DropNode                                                                 ,                    39703,      0.8%
 - EmitEvent                                                                ,                     2860,      0.1%
@@ -17,22 +18,22 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5320,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   134252,      2.7%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   134252,      2.6%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2492569,     49.3%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      9.6%
+- OpenSubstate::GlobalPackage                                              ,                  2492569,     47.8%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      9.3%
 - OpenSubstate::InternalFungibleVault                                      ,                    97340,      1.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    57240,      1.1%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - PinNode                                                                  ,                      300,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      7.0%
+- PrepareWasmCode                                                          ,                   353866,      6.8%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   512126,     10.1%
+- ReadSubstate                                                             ,                   512126,      9.8%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
-- RunNativeCode::create                                                    ,                    49184,      1.0%
+- RunNativeCode::create                                                    ,                    49184,      0.9%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
 - RunNativeCode::create_with_data                                          ,                    54942,      1.1%
 - RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      2.1%
@@ -41,19 +42,19 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.7%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      846,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    21480,      0.4%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    10206,      0.2%
-Finalization Cost Breakdown                                                ,                  2725327,    100.0%
+Finalization Cost Breakdown                                                ,                  2825327,    100.0%
 - CommitEvents                                                             ,                    25045,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500098,     55.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     25.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400051,     14.7%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500098,     53.1%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     24.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400051,     14.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/002--fungible-max-div-mint.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/002--fungible-max-div-mint.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.29196054273,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2081507,     71.3%
-- Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.06780624273,     23.2%
+Total Cost (XRD)                                                           ,            0.30496054273,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2161507,     70.9%
+- Finalization Cost (XRD)                                                  ,                0.0210036,      6.9%
+- Storage Cost (XRD)                                                       ,            0.06780624273,     22.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4163014,    100.0%
+Execution Cost Breakdown                                                   ,                  4323014,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1382,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.7%
 - CheckReference                                                           ,                    80028,      1.9%
 - CloseSubstate                                                            ,                    28896,      0.7%
 - CreateNode                                                               ,                    12092,      0.3%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      6.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      5.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.2%
+- OpenSubstate::GlobalPackage                                              ,                  1908517,     44.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    42563,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.5%
+- PrepareWasmCode                                                          ,                   353866,      8.2%
 - QueryActor                                                               ,                     2500,      0.1%
-- ReadSubstate                                                             ,                   482919,     11.6%
+- ReadSubstate                                                             ,                   482919,     11.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14640,      0.4%
+- ValidateTxPayload                                                        ,                    14640,      0.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                     7696,      0.2%
-Finalization Cost Breakdown                                                ,                   320072,    100.0%
-- CommitEvents                                                             ,                    20036,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   420072,    100.0%
+- CommitEvents                                                             ,                    20036,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     23.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     31.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     62.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/003--fungible-max-div-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/003--fungible-max-div-burn.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.29866122199,    100.0%
-- Execution Cost (XRD)                                                     ,               0.20703125,     69.3%
-- Finalization Cost (XRD)                                                  ,                0.0160036,      5.4%
-- Storage Cost (XRD)                                                       ,            0.07562637199,     25.3%
+Total Cost (XRD)                                                           ,            0.31166122199,    100.0%
+- Execution Cost (XRD)                                                     ,               0.21503125,     69.0%
+- Finalization Cost (XRD)                                                  ,                0.0210036,      6.7%
+- Storage Cost (XRD)                                                       ,            0.07562637199,     24.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4140625,    100.0%
+Execution Cost Breakdown                                                   ,                  4300625,    100.0%
 - AfterInvoke                                                              ,                      378,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1456,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.7%
 - CheckReference                                                           ,                    80028,      1.9%
 - CloseSubstate                                                            ,                    29025,      0.7%
 - CreateNode                                                               ,                    12220,      0.3%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   253849,      6.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1908517,     46.1%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285024,      6.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   216285,      5.2%
-- OpenSubstate::InternalGenericComponent                                   ,                    43504,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   253849,      5.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1908517,     44.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285024,      6.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   216285,      5.0%
+- OpenSubstate::InternalGenericComponent                                   ,                    43504,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.5%
+- PrepareWasmCode                                                          ,                   353866,      8.2%
 - QueryActor                                                               ,                     2500,      0.1%
-- ReadSubstate                                                             ,                   483874,     11.7%
+- ReadSubstate                                                             ,                   483874,     11.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
-- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.4%
+- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
 - RunNativeCode::burn_FungibleResourceManager                              ,                    45969,      1.1%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17840,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     7824,      0.2%
-Finalization Cost Breakdown                                                ,                   320072,    100.0%
-- CommitEvents                                                             ,                    20036,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   420072,    100.0%
+- CommitEvents                                                             ,                    20036,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     23.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     31.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     62.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/004--fungible-max-div-transfer-32-times.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/004--fungible-max-div-transfer-32-times.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            2.01463520695,    100.0%
-- Execution Cost (XRD)                                                     ,                0.8005528,     39.7%
-- Finalization Cost (XRD)                                                  ,               0.08254785,      4.1%
-- Storage Cost (XRD)                                                       ,            1.13153455695,     56.2%
+Total Cost (XRD)                                                           ,            2.02763520695,    100.0%
+- Execution Cost (XRD)                                                     ,                0.8085528,     39.9%
+- Finalization Cost (XRD)                                                  ,               0.08754785,      4.3%
+- Storage Cost (XRD)                                                       ,            1.13153455695,     55.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 16011056,    100.0%
+Execution Cost Breakdown                                                   ,                 16171056,    100.0%
 - AfterInvoke                                                              ,                     8446,      0.1%
-- AllocateNodeId                                                           ,                    24056,      0.2%
+- AllocateNodeId                                                           ,                    24056,      0.1%
 - BeforeInvoke                                                             ,                    28576,      0.2%
+- CheckIntentValidity                                                      ,                   160000,      1.0%
 - CheckReference                                                           ,                    80028,      0.5%
-- CloseSubstate                                                            ,                   537672,      3.4%
+- CloseSubstate                                                            ,                   537672,      3.3%
 - CreateNode                                                               ,                   215252,      1.3%
 - DropNode                                                                 ,                   382515,      2.4%
 - EmitEvent                                                                ,                    41112,      0.3%
@@ -17,18 +18,18 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   443634,      2.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   443634,      2.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.3%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2814940,     17.6%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1161848,      7.3%
+- OpenSubstate::GlobalPackage                                              ,                  2814940,     17.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1161848,      7.2%
 - OpenSubstate::InternalFungibleVault                                      ,                   400479,      2.5%
-- OpenSubstate::InternalGenericComponent                                   ,                  1070615,      6.7%
+- OpenSubstate::InternalGenericComponent                                   ,                  1070615,      6.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.3%
 - PinNode                                                                  ,                     2952,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      2.2%
 - QueryActor                                                               ,                    18500,      0.1%
-- ReadSubstate                                                             ,                  1596515,     10.0%
+- ReadSubstate                                                             ,                  1596515,      9.9%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.2%
@@ -40,11 +41,11 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.2%
-- RunNativeCode::put_FungibleVault                                         ,                   810282,      5.1%
-- RunNativeCode::take_FungibleBucket                                       ,                   635360,      4.0%
+- RunNativeCode::put_FungibleVault                                         ,                   810282,      5.0%
+- RunNativeCode::take_FungibleBucket                                       ,                   635360,      3.9%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.3%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
-- RunNativeCode::try_deposit_or_abort                                      ,                  3135616,     19.6%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.7%
+- RunNativeCode::try_deposit_or_abort                                      ,                  3135616,     19.4%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -53,10 +54,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                   178960,      1.1%
 - VerifyTxSignatures                                                       ,                    14000,      0.1%
 - WriteSubstate                                                            ,                   121522,      0.8%
-Finalization Cost Breakdown                                                ,                  1650957,    100.0%
-- CommitEvents                                                             ,                   350764,     21.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1750957,    100.0%
+- CommitEvents                                                             ,                   350764,     20.0%
+- CommitIntentStatus                                                       ,                   100000,      5.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.1%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     42.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500060,     30.3%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      5.7%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     40.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500060,     28.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/005--fungible-max-div-freeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/005--fungible-max-div-freeze-withdraw.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
+Total Cost (XRD)                                                           ,            0.20514541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14407625,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     19.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2721525,    100.0%
+Execution Cost Breakdown                                                   ,                  2881525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/006--fungible-max-div-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/006--fungible-max-div-freeze-deposit.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
+Total Cost (XRD)                                                           ,            0.20514541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14407625,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     19.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2721525,    100.0%
+Execution Cost Breakdown                                                   ,                  2881525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/007--fungible-max-div-freeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/007--fungible-max-div-freeze-burn.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
+Total Cost (XRD)                                                           ,            0.20514541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14407625,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     19.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2721525,    100.0%
+Execution Cost Breakdown                                                   ,                  2881525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/008--fungible-max-div-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/008--fungible-max-div-recall-frozen-vault.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.30026213853,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2057298,     68.5%
-- Finalization Cost (XRD)                                                  ,               0.02100405,      7.0%
-- Storage Cost (XRD)                                                       ,            0.07352828853,     24.5%
+Total Cost (XRD)                                                           ,            0.31326213853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2137298,     68.2%
+- Finalization Cost (XRD)                                                  ,               0.02600405,      8.3%
+- Storage Cost (XRD)                                                       ,            0.07352828853,     23.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4114596,    100.0%
+Execution Cost Breakdown                                                   ,                  4274596,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.7%
 - CheckReference                                                           ,                    80022,      1.9%
 - CloseSubstate                                                            ,                    29025,      0.7%
 - CreateNode                                                               ,                    12220,      0.3%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.0%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1776336,     43.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   260945,      6.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      6.8%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1776336,     41.6%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.7%
+- OpenSubstate::InternalFungibleVault                                      ,                   260945,      6.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.6%
+- PrepareWasmCode                                                          ,                   353866,      8.3%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   472347,     11.5%
+- ReadSubstate                                                             ,                   472347,     11.1%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     8116,      0.2%
-Finalization Cost Breakdown                                                ,                   420081,    100.0%
-- CommitEvents                                                             ,                    20036,      4.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   520081,    100.0%
+- CommitEvents                                                             ,                    20036,      3.9%
+- CommitIntentStatus                                                       ,                   100000,     19.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     71.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     57.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/009--fungible-max-div-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/009--fungible-max-div-unfreeze-withdraw.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
+Total Cost (XRD)                                                           ,             0.2052527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14399285,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2719857,    100.0%
+Execution Cost Breakdown                                                   ,                  2879857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/010--fungible-max-div-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/010--fungible-max-div-unfreeze-deposit.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
+Total Cost (XRD)                                                           ,             0.2052527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14399285,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2719857,    100.0%
+Execution Cost Breakdown                                                   ,                  2879857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/011--fungible-max-div-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/011--fungible-max-div-unfreeze-burn.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,             0.1922527449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13599285,     70.7%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     21.3%
+Total Cost (XRD)                                                           ,             0.2052527449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14399285,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     20.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2719857,    100.0%
+Execution Cost Breakdown                                                   ,                  2879857,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunNativeCode::unfreeze_FungibleVault                                    ,                    17338,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/012--fungible-max-div-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/012--fungible-max-div-recall-unfrozen-vault.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.29126098853,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2017291,     69.3%
-- Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.07352828853,     25.2%
+Total Cost (XRD)                                                           ,            0.30426098853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2097291,     68.9%
+- Finalization Cost (XRD)                                                  ,                0.0210036,      6.9%
+- Storage Cost (XRD)                                                       ,            0.07352828853,     24.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4034582,    100.0%
+Execution Cost Breakdown                                                   ,                  4194582,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
-- CheckReference                                                           ,                    80022,      2.0%
+- CheckIntentValidity                                                      ,                   160000,      3.8%
+- CheckReference                                                           ,                    80022,      1.9%
 - CloseSubstate                                                            ,                    29025,      0.7%
 - CreateNode                                                               ,                    12220,      0.3%
 - DropNode                                                                 ,                    21838,      0.5%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.0%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      7.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.5%
-- OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      6.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1776336,     42.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.3%
+- OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.8%
+- PrepareWasmCode                                                          ,                   353866,      8.4%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   472347,     11.7%
+- ReadSubstate                                                             ,                   472347,     11.3%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      3.0%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     8116,      0.2%
-Finalization Cost Breakdown                                                ,                   320072,    100.0%
-- CommitEvents                                                             ,                    20036,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   420072,    100.0%
+- CommitEvents                                                             ,                    20036,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     23.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     31.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     62.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/013--fungible-max-div-freeze-withdraw-again.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/013--fungible-max-div-freeze-withdraw-again.txt
@@ -1,44 +1,45 @@
-Total Cost (XRD)                                                           ,            0.19214541004,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13607625,     70.8%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.9%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     21.2%
+Total Cost (XRD)                                                           ,            0.20514541004,    100.0%
+- Execution Cost (XRD)                                                     ,               0.14407625,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.9%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     19.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2721525,    100.0%
+Execution Cost Breakdown                                                   ,                  2881525,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.9%
-- CloseSubstate                                                            ,                    12255,      0.5%
+- CheckIntentValidity                                                      ,                   160000,      5.6%
+- CheckReference                                                           ,                    80022,      2.8%
+- CloseSubstate                                                            ,                    12255,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
-- OpenSubstate::GlobalPackage                                              ,                  1253926,     46.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   203519,      7.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
+- OpenSubstate::GlobalPackage                                              ,                  1253926,     43.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   134289,      4.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.0%
+- PrepareWasmCode                                                          ,                   353866,     12.3%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408409,     15.0%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.7%
+- ReadSubstate                                                             ,                   408409,     14.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_FungibleVault                                      ,                    19090,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
-- WriteSubstate                                                            ,                     4288,      0.2%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     4288,      0.1%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200013,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/014--fungible-min-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/014--fungible-min-div-create.txt
@@ -1,33 +1,34 @@
-Total Cost (XRD)                                                           ,            0.58258175439,    100.0%
-- Execution Cost (XRD)                                                     ,               0.24047695,     41.3%
-- Finalization Cost (XRD)                                                  ,               0.10626115,     18.2%
-- Storage Cost (XRD)                                                       ,            0.23584365439,     40.5%
+Total Cost (XRD)                                                           ,            0.59558175439,    100.0%
+- Execution Cost (XRD)                                                     ,               0.24847695,     41.7%
+- Finalization Cost (XRD)                                                  ,               0.11126115,     18.7%
+- Storage Cost (XRD)                                                       ,            0.23584365439,     39.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4809539,    100.0%
+Execution Cost Breakdown                                                   ,                  4969539,    100.0%
 - AfterInvoke                                                              ,                      582,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     2518,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      3.2%
 - CheckReference                                                           ,                    40011,      0.8%
 - CloseSubstate                                                            ,                    34056,      0.7%
 - CreateNode                                                               ,                    19638,      0.4%
-- DropNode                                                                 ,                    31725,      0.7%
+- DropNode                                                                 ,                    31725,      0.6%
 - EmitEvent                                                                ,                     2860,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     3920,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   134252,      2.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   134252,      2.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  2488148,     51.7%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      8.5%
+- OpenSubstate::GlobalPackage                                              ,                  2488148,     50.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      8.2%
 - OpenSubstate::InternalFungibleVault                                      ,                    97340,      2.0%
-- OpenSubstate::InternalGenericComponent                                   ,                    50613,      1.1%
+- OpenSubstate::InternalGenericComponent                                   ,                    50613,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      7.4%
+- PrepareWasmCode                                                          ,                   353866,      7.1%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   504621,     10.5%
+- ReadSubstate                                                             ,                   504621,     10.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
@@ -35,11 +36,11 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.6%
 - RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      2.2%
-- RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
+- RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.5%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      475,      0.0%
@@ -47,11 +48,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    21480,      0.4%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     9530,      0.2%
-Finalization Cost Breakdown                                                ,                  2125223,    100.0%
-- CommitEvents                                                             ,                    25045,      1.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  2225223,    100.0%
+- CommitEvents                                                             ,                    25045,      1.1%
+- CommitIntentStatus                                                       ,                   100000,      4.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500098,     70.6%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.7%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      4.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400051,     18.8%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1500098,     67.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      4.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400051,     18.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/015--fungible-min-div-mint-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/015--fungible-min-div-mint-correct-granularity.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.29196054273,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2081507,     71.3%
-- Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.06780624273,     23.2%
+Total Cost (XRD)                                                           ,            0.30496054273,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2161507,     70.9%
+- Finalization Cost (XRD)                                                  ,                0.0210036,      6.9%
+- Storage Cost (XRD)                                                       ,            0.06780624273,     22.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4163014,    100.0%
+Execution Cost Breakdown                                                   ,                  4323014,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1382,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.7%
 - CheckReference                                                           ,                    80028,      1.9%
 - CloseSubstate                                                            ,                    28896,      0.7%
 - CreateNode                                                               ,                    12092,      0.3%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      6.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   253204,      5.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1908517,     45.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.2%
+- OpenSubstate::GlobalPackage                                              ,                  1908517,     44.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   215750,      5.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    42563,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.5%
+- PrepareWasmCode                                                          ,                   353866,      8.2%
 - QueryActor                                                               ,                     2500,      0.1%
-- ReadSubstate                                                             ,                   482919,     11.6%
+- ReadSubstate                                                             ,                   482919,     11.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14640,      0.4%
+- ValidateTxPayload                                                        ,                    14640,      0.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                     7696,      0.2%
-Finalization Cost Breakdown                                                ,                   320072,    100.0%
-- CommitEvents                                                             ,                    20036,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   420072,    100.0%
+- CommitEvents                                                             ,                    20036,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     23.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     31.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     62.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/016--fungible-min-div-mint-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/016--fungible-min-div-mint-wrong-granularity.txt
@@ -1,37 +1,38 @@
-Total Cost (XRD)                                                           ,            0.16594922938,    100.0%
-- Execution Cost (XRD)                                                     ,               0.13104475,     79.0%
+Total Cost (XRD)                                                           ,            0.17394922938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13904475,     79.9%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.03490447938,     21.0%
+- Storage Cost (XRD)                                                       ,            0.03490447938,     20.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2620895,    100.0%
+Execution Cost Breakdown                                                   ,                  2780895,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      478,      0.0%
-- CheckReference                                                           ,                    80028,      3.1%
-- CloseSubstate                                                            ,                     9675,      0.4%
+- CheckIntentValidity                                                      ,                   160000,      5.8%
+- CheckReference                                                           ,                    80028,      2.9%
+- CloseSubstate                                                            ,                     9675,      0.3%
 - CreateNode                                                               ,                     5114,      0.2%
 - DropNode                                                                 ,                     4939,      0.2%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   207059,      7.9%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.7%
-- OpenSubstate::GlobalPackage                                              ,                  1216522,     46.4%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   207059,      7.4%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
+- OpenSubstate::GlobalPackage                                              ,                  1216522,     43.7%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.2%
 - OpenSubstate::InternalGenericComponent                                   ,                     4538,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
 - PinNode                                                                  ,                       72,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     13.5%
+- PrepareWasmCode                                                          ,                   353866,     12.7%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   408569,     15.6%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.6%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
-- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.1%
+- ReadSubstate                                                             ,                   408569,     14.7%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
+- RunNativeCode::mint_FungibleResourceManager                              ,                    39230,      1.4%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14640,      0.6%
+- ValidateTxPayload                                                        ,                    14640,      0.5%
 - VerifyTxSignatures                                                       ,                     7000,      0.3%
 - WriteSubstate                                                            ,                     2340,      0.1%
 Finalization Cost Breakdown                                                ,                        0,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/017--fungible-min-div-transfer-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/017--fungible-min-div-transfer-correct-granularity.txt
@@ -1,39 +1,40 @@
-Total Cost (XRD)                                                           ,            0.40612452083,    100.0%
-- Execution Cost (XRD)                                                     ,               0.23791465,     58.6%
-- Finalization Cost (XRD)                                                  ,               0.03650745,      9.0%
-- Storage Cost (XRD)                                                       ,            0.13170242083,     32.4%
+Total Cost (XRD)                                                           ,            0.41912452083,    100.0%
+- Execution Cost (XRD)                                                     ,               0.24591465,     58.7%
+- Finalization Cost (XRD)                                                  ,               0.04150745,      9.9%
+- Storage Cost (XRD)                                                       ,            0.13170242083,     31.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4758293,    100.0%
+Execution Cost Breakdown                                                   ,                  4918293,    100.0%
 - AfterInvoke                                                              ,                      504,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     1764,      0.0%
-- CheckReference                                                           ,                    80028,      1.7%
+- CheckIntentValidity                                                      ,                   160000,      3.3%
+- CheckReference                                                           ,                    80028,      1.6%
 - CloseSubstate                                                            ,                    37539,      0.8%
 - CreateNode                                                               ,                    15850,      0.3%
-- DropNode                                                                 ,                    26729,      0.6%
+- DropNode                                                                 ,                    26729,      0.5%
 - EmitEvent                                                                ,                     3480,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   257074,      5.4%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   257074,      5.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  1913850,     40.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   691764,     14.5%
-- OpenSubstate::InternalFungibleVault                                      ,                   223423,      4.7%
+- OpenSubstate::GlobalPackage                                              ,                  1913850,     38.9%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   691764,     14.1%
+- OpenSubstate::InternalFungibleVault                                      ,                   223423,      4.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    54068,      1.1%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - PinNode                                                                  ,                      204,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      7.4%
+- PrepareWasmCode                                                          ,                   353866,      7.2%
 - QueryActor                                                               ,                     2500,      0.1%
-- ReadSubstate                                                             ,                   502994,     10.6%
+- ReadSubstate                                                             ,                   502994,     10.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.5%
@@ -44,10 +45,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    18960,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    10062,      0.2%
-Finalization Cost Breakdown                                                ,                   730149,    100.0%
-- CommitEvents                                                             ,                    30060,      4.1%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   830149,    100.0%
+- CommitEvents                                                             ,                    30060,      3.6%
+- CommitIntentStatus                                                       ,                   100000,     12.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.7%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,     13.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500060,     68.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     12.0%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,     12.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500060,     60.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/018--fungible-min-div-transfer-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/018--fungible-min-div-transfer-wrong-granularity.txt
@@ -1,39 +1,40 @@
-Total Cost (XRD)                                                           ,            0.21022956182,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1650254,     78.5%
+Total Cost (XRD)                                                           ,            0.21822956182,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1730254,     79.3%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.04520416182,     21.5%
+- Storage Cost (XRD)                                                       ,            0.04520416182,     20.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3300508,    100.0%
+Execution Cost Breakdown                                                   ,                  3460508,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      672,      0.0%
-- CheckReference                                                           ,                    80028,      2.4%
+- CheckIntentValidity                                                      ,                   160000,      4.6%
+- CheckReference                                                           ,                    80028,      2.3%
 - CloseSubstate                                                            ,                    12900,      0.4%
 - CreateNode                                                               ,                     6222,      0.2%
 - DropNode                                                                 ,                     4939,      0.1%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   205769,      6.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   205769,      5.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.3%
-- OpenSubstate::GlobalPackage                                              ,                  1431122,     43.4%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      8.6%
-- OpenSubstate::InternalFungibleVault                                      ,                   174835,      5.3%
+- OpenSubstate::GlobalPackage                                              ,                  1431122,     41.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      8.2%
+- OpenSubstate::InternalFungibleVault                                      ,                   174835,      5.1%
 - OpenSubstate::InternalGenericComponent                                   ,                     6237,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.2%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     10.7%
+- PrepareWasmCode                                                          ,                   353866,     10.2%
 - QueryActor                                                               ,                     1500,      0.0%
-- ReadSubstate                                                             ,                   427023,     12.9%
+- ReadSubstate                                                             ,                   427023,     12.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.3%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.8%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.3%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.2%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    18960,      0.6%
+- ValidateTxPayload                                                        ,                    18960,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.4%
 - WriteSubstate                                                            ,                     2340,      0.1%
 Finalization Cost Breakdown                                                ,                        0,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/019--fungible-min-div-create-proof-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/019--fungible-min-div-create-proof-correct-granularity.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.26101381042,    100.0%
-- Execution Cost (XRD)                                                     ,               0.19865015,     76.1%
-- Finalization Cost (XRD)                                                  ,               0.01525215,      5.8%
-- Storage Cost (XRD)                                                       ,            0.04711151042,     18.0%
+Total Cost (XRD)                                                           ,            0.27401381042,    100.0%
+- Execution Cost (XRD)                                                     ,               0.20665015,     75.4%
+- Finalization Cost (XRD)                                                  ,               0.02025215,      7.4%
+- Storage Cost (XRD)                                                       ,            0.04711151042,     17.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3973003,    100.0%
+Execution Cost Breakdown                                                   ,                  4133003,    100.0%
 - AfterInvoke                                                              ,                      246,      0.0%
 - AllocateNodeId                                                           ,                     1164,      0.0%
 - BeforeInvoke                                                             ,                     2256,      0.1%
-- CheckReference                                                           ,                    80028,      2.0%
+- CheckIntentValidity                                                      ,                   160000,      3.9%
+- CheckReference                                                           ,                    80028,      1.9%
 - CloseSubstate                                                            ,                    25155,      0.6%
 - CreateNode                                                               ,                    10500,      0.3%
 - DropNode                                                                 ,                    18744,      0.5%
@@ -16,37 +17,37 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164784,      4.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164784,      4.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    40685,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1898289,     47.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      7.2%
-- OpenSubstate::InternalFungibleVault                                      ,                   179737,      4.5%
+- OpenSubstate::GlobalPackage                                              ,                  1898289,     45.9%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      6.9%
+- OpenSubstate::InternalFungibleVault                                      ,                   179737,      4.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    29087,      0.7%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      144,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.9%
-- QueryActor                                                               ,                     2000,      0.1%
-- ReadSubstate                                                             ,                   461962,     11.6%
+- PrepareWasmCode                                                          ,                   353866,      8.6%
+- QueryActor                                                               ,                     2000,      0.0%
+- ReadSubstate                                                             ,                   461962,     11.2%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.6%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
-- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.6%
-- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      1.0%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
+- RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.5%
+- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      0.9%
 - RunNativeCode::drop_FungibleProof                                        ,                     9745,      0.2%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
-- RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.4%
+- RunNativeCode::on_drop_FungibleProof                                     ,                    14191,      0.3%
 - RunNativeCode::on_move_FungibleProof                                     ,                    16180,      0.4%
 - RunNativeCode::unlock_amount_FungibleVault                               ,                    23272,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    16760,      0.4%
-- VerifyTxSignatures                                                       ,                    14000,      0.4%
+- VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     7736,      0.2%
-Finalization Cost Breakdown                                                ,                   305043,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405043,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     65.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     49.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/020--fungible-min-div-create-proof-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/020--fungible-min-div-create-proof-wrong-granularity.txt
@@ -1,36 +1,37 @@
-Total Cost (XRD)                                                           ,            0.20058305317,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1606241,     80.1%
+Total Cost (XRD)                                                           ,            0.20858305317,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1686241,     80.8%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.03995895317,     19.9%
+- Storage Cost (XRD)                                                       ,            0.03995895317,     19.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3212482,    100.0%
+Execution Cost Breakdown                                                   ,                  3372482,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      736,      0.0%
-- CheckReference                                                           ,                    80028,      2.5%
+- CheckIntentValidity                                                      ,                   160000,      4.7%
+- CheckReference                                                           ,                    80028,      2.4%
 - CloseSubstate                                                            ,                    12126,      0.4%
 - CreateNode                                                               ,                     6222,      0.2%
-- DropNode                                                                 ,                     4939,      0.2%
+- DropNode                                                                 ,                     4939,      0.1%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   164139,      5.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  1431122,     44.5%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      8.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   133423,      4.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   164139,      4.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.3%
+- OpenSubstate::GlobalPackage                                              ,                  1431122,     42.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   284483,      8.4%
+- OpenSubstate::InternalFungibleVault                                      ,                   133423,      4.0%
 - OpenSubstate::InternalGenericComponent                                   ,                     6237,      0.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.2%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     11.0%
+- PrepareWasmCode                                                          ,                   353866,     10.5%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   425123,     13.2%
+- ReadSubstate                                                             ,                   425123,     12.6%
 - RunNativeCode::create_proof_of_amount                                    ,                    62543,      1.9%
-- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      1.2%
+- RunNativeCode::create_proof_of_amount_FungibleVault                      ,                    38091,      1.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.3%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    16760,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/021--fungible-min-div-recall-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/021--fungible-min-div-recall-correct-granularity.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.29126098853,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2017291,     69.3%
-- Finalization Cost (XRD)                                                  ,                0.0160036,      5.5%
-- Storage Cost (XRD)                                                       ,            0.07352828853,     25.2%
+Total Cost (XRD)                                                           ,            0.30426098853,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2097291,     68.9%
+- Finalization Cost (XRD)                                                  ,                0.0210036,      6.9%
+- Storage Cost (XRD)                                                       ,            0.07352828853,     24.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4034582,    100.0%
+Execution Cost Breakdown                                                   ,                  4194582,    100.0%
 - AfterInvoke                                                              ,                      324,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1386,      0.0%
-- CheckReference                                                           ,                    80022,      2.0%
+- CheckIntentValidity                                                      ,                   160000,      3.8%
+- CheckReference                                                           ,                    80022,      1.9%
 - CloseSubstate                                                            ,                    29025,      0.7%
 - CreateNode                                                               ,                    12220,      0.3%
 - DropNode                                                                 ,                    21838,      0.5%
@@ -16,35 +17,35 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      7.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1776336,     44.0%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      7.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.5%
-- OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   288706,      6.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  1776336,     42.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   180931,      4.3%
+- OpenSubstate::InternalGenericComponent                                   ,                    42947,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.8%
+- PrepareWasmCode                                                          ,                   353866,      8.4%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   472347,     11.7%
+- ReadSubstate                                                             ,                   472347,     11.3%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.5%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
 - RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.0%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      3.0%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.9%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     8116,      0.2%
-Finalization Cost Breakdown                                                ,                   320072,    100.0%
-- CommitEvents                                                             ,                    20036,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   420072,    100.0%
+- CommitEvents                                                             ,                    20036,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     23.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     31.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     62.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/022--fungible-min-div-recall-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/costings/022--fungible-min-div-recall-wrong-granularity.txt
@@ -1,37 +1,38 @@
-Total Cost (XRD)                                                           ,             0.1685290192,    100.0%
-- Execution Cost (XRD)                                                     ,               0.12656735,     75.1%
+Total Cost (XRD)                                                           ,             0.1765290192,    100.0%
+- Execution Cost (XRD)                                                     ,               0.13456735,     76.2%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,             0.0419616692,     24.9%
+- Storage Cost (XRD)                                                       ,             0.0419616692,     23.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2531347,    100.0%
+Execution Cost Breakdown                                                   ,                  2691347,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      482,      0.0%
-- CheckReference                                                           ,                    80022,      3.2%
+- CheckIntentValidity                                                      ,                   160000,      5.9%
+- CheckReference                                                           ,                    80022,      3.0%
 - CloseSubstate                                                            ,                     9804,      0.4%
 - CreateNode                                                               ,                     5242,      0.2%
 - DropNode                                                                 ,                     4939,      0.2%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   243851,      9.6%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.7%
-- OpenSubstate::GlobalPackage                                              ,                  1084341,     42.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    93947,      3.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   243851,      9.1%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.6%
+- OpenSubstate::GlobalPackage                                              ,                  1084341,     40.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    93947,      3.5%
 - OpenSubstate::InternalGenericComponent                                   ,                     4538,      0.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.6%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.5%
 - PinNode                                                                  ,                       72,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     14.0%
+- PrepareWasmCode                                                          ,                   353866,     13.1%
 - QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   397459,     15.7%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.6%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.8%
-- RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.1%
+- ReadSubstate                                                             ,                   397459,     14.8%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.7%
+- RunNativeCode::recall_FungibleVault                                      ,                    42221,      1.6%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17600,      0.7%
-- VerifyTxSignatures                                                       ,                    14000,      0.6%
+- VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     2340,      0.1%
 Finalization Cost Breakdown                                                ,                        0,    100.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/001--fungible-max-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/001--fungible-max-div-create.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.68802500819 XRD
-├─ Network execution: 0.2529725 XRD, 5059450 execution cost units
-├─ Network finalization: 0.13626635 XRD, 2725327 finalization cost units
+TRANSACTION COST: 0.70102500819 XRD
+├─ Network execution: 0.2609725 XRD, 5219450 execution cost units
+├─ Network finalization: 0.14126635 XRD, 2825327 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.29878615819 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.68802500819"),
+     amount: Decimal("0.70102500819"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.344012504095"),
+     amount: Decimal("0.350512504095"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.344012504095"),
+     amount: Decimal("0.350512504095"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.1720062520475"),
+             0u8 => Decimal("0.1752562520475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.31197499181")),
+         LiquidFungibleResource(Decimal("99999999999999999.29897499181")),
        )
 ├─ resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09 across 4 partitions
   ├─ Partition(5): 1 change
@@ -326,7 +326,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.344012504095")),
+         LiquidFungibleResource(Decimal("0.350512504095")),
        )
 
 OUTPUTS: 3
@@ -340,13 +340,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.68802500819
+   Change: -0.70102500819
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 100000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.344012504095
+   Change: 0.350512504095
 
 NEW ENTITIES: 2
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/002--fungible-max-div-mint.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/002--fungible-max-div-mint.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29196054273 XRD
-├─ Network execution: 0.2081507 XRD, 4163014 execution cost units
-├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
+TRANSACTION COST: 0.30496054273 XRD
+├─ Network execution: 0.2161507 XRD, 4323014 execution cost units
+├─ Network finalization: 0.0210036 XRD, 420072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06780624273 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29196054273"),
+     amount: Decimal("0.30496054273"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145980271365"),
+     amount: Decimal("0.152480271365"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145980271365"),
+     amount: Decimal("0.152480271365"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.24499638773"),
+             0u8 => Decimal("0.25149638773"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.02001444908")),
+         LiquidFungibleResource(Decimal("99999999999999998.99401444908")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.48999277546")),
+         LiquidFungibleResource(Decimal("0.50299277546")),
        )
 
 OUTPUTS: 3
@@ -103,12 +103,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29196054273
+   Change: -0.30496054273
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 100
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145980271365
+   Change: 0.152480271365
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/003--fungible-max-div-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/003--fungible-max-div-burn.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29866122199 XRD
-├─ Network execution: 0.20703125 XRD, 4140625 execution cost units
-├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
+TRANSACTION COST: 0.31166122199 XRD
+├─ Network execution: 0.21503125 XRD, 4300625 execution cost units
+├─ Network finalization: 0.0210036 XRD, 420072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07562637199 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29866122199"),
+     amount: Decimal("0.31166122199"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.149330610995"),
+     amount: Decimal("0.155830610995"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.149330610995"),
+     amount: Decimal("0.155830610995"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.3196616932275"),
+             0u8 => Decimal("0.3294116932275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.72135322709")),
+         LiquidFungibleResource(Decimal("99999999999999998.68235322709")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.639323386455")),
+         LiquidFungibleResource(Decimal("0.658823386455")),
        )
 
 OUTPUTS: 4
@@ -104,12 +104,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29866122199
+   Change: -0.31166122199
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: -10
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.149330610995
+   Change: 0.155830610995
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/004--fungible-max-div-transfer-32-times.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/004--fungible-max-div-transfer-32-times.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 2.01463520695 XRD
-├─ Network execution: 0.8005528 XRD, 16011056 execution cost units
-├─ Network finalization: 0.08254785 XRD, 1650957 finalization cost units
+TRANSACTION COST: 2.02763520695 XRD
+├─ Network execution: 0.8085528 XRD, 16171056 execution cost units
+├─ Network finalization: 0.08754785 XRD, 1750957 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.13153455695 XRD
 └─ Royalties: 0 XRD
@@ -326,15 +326,15 @@ EVENTS: 73
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("2.01463520695"),
+     amount: Decimal("2.02763520695"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.007317603475"),
+     amount: Decimal("1.013817603475"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.007317603475"),
+     amount: Decimal("1.013817603475"),
    }
 
 STATE UPDATES: 8 entities
@@ -344,7 +344,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.823320494965"),
+             0u8 => Decimal("0.836320494965"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -377,7 +377,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.70671802014")),
+         LiquidFungibleResource(Decimal("99999999999999996.65471802014")),
        )
 ├─ internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst across 1 partitions
   └─ Partition(64): 1 change
@@ -523,7 +523,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.64664098993")),
+         LiquidFungibleResource(Decimal("1.67264098993")),
        )
 
 OUTPUTS: 67
@@ -598,7 +598,7 @@ OUTPUTS: 67
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -2.01463520695
+   Change: -2.02763520695
 ├─ Vault: internal_vault_sim1tqqp6e7t3gyracm4g475nack22pmw0dq0wd3hgl8wcggz34rl8xvst
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: -0.032
@@ -607,7 +607,7 @@ BALANCE CHANGES: 4
    Change: 0.032
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.007317603475
+   Change: 1.013817603475
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/005--fungible-max-div-freeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/005--fungible-max-div-freeze-withdraw.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19214541004 XRD
-├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.20514541004 XRD
+├─ Network execution: 0.14407625 XRD, 2881525 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19214541004"),
+     amount: Decimal("0.20514541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.871356847475"),
+             0u8 => Decimal("0.887606847475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.5145726101")),
+         LiquidFungibleResource(Decimal("99999999999999996.4495726101")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.74271369495")),
+         LiquidFungibleResource(Decimal("1.77521369495")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19214541004
+   Change: -0.20514541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09607270502
+   Change: 0.10257270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/006--fungible-max-div-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/006--fungible-max-div-freeze-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19214541004 XRD
-├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.20514541004 XRD
+├─ Network execution: 0.14407625 XRD, 2881525 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19214541004"),
+     amount: Decimal("0.20514541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.919393199985"),
+             0u8 => Decimal("0.938893199985"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.32242720006")),
+         LiquidFungibleResource(Decimal("99999999999999996.24442720006")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.83878639997")),
+         LiquidFungibleResource(Decimal("1.87778639997")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19214541004
+   Change: -0.20514541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09607270502
+   Change: 0.10257270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/007--fungible-max-div-freeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/007--fungible-max-div-freeze-burn.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19214541004 XRD
-├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.20514541004 XRD
+├─ Network execution: 0.14407625 XRD, 2881525 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19214541004"),
+     amount: Decimal("0.20514541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.967429552495"),
+             0u8 => Decimal("0.990179552495"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.13028179002")),
+         LiquidFungibleResource(Decimal("99999999999999996.03928179002")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.93485910499")),
+         LiquidFungibleResource(Decimal("1.98035910499")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19214541004
+   Change: -0.20514541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09607270502
+   Change: 0.10257270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/008--fungible-max-div-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/008--fungible-max-div-recall-frozen-vault.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30026213853 XRD
-├─ Network execution: 0.2057298 XRD, 4114596 execution cost units
-├─ Network finalization: 0.02100405 XRD, 420081 finalization cost units
+TRANSACTION COST: 0.31326213853 XRD
+├─ Network execution: 0.2137298 XRD, 4274596 execution cost units
+├─ Network finalization: 0.02600405 XRD, 520081 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30026213853"),
+     amount: Decimal("0.31326213853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.150131069265"),
+     amount: Decimal("0.156631069265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.150131069265"),
+     amount: Decimal("0.156631069265"),
    }
 
 STATE UPDATES: 7 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.0424950871275"),
+             0u8 => Decimal("1.0684950871275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,7 +86,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.83001965149")),
+         LiquidFungibleResource(Decimal("99999999999999995.72601965149")),
        )
 ├─ internal_vault_sim1trl737k2t8f0y32gd9p4pdm4rkszwtgmd9rknragf3rgegns5pts2p across 1 partitions
   └─ Partition(64): 1 change
@@ -98,7 +98,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.084990174255")),
+         LiquidFungibleResource(Decimal("2.136990174255")),
        )
 
 OUTPUTS: 3
@@ -112,12 +112,12 @@ BALANCE CHANGES: 4
    Change: -1
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30026213853
+   Change: -0.31326213853
 ├─ Vault: internal_vault_sim1trl737k2t8f0y32gd9p4pdm4rkszwtgmd9rknragf3rgegns5pts2p
    ResAddr: resource_sim1t5cryrd2t8xhdk3cra2flmvqydf7l5l3kschqerv7w0prljc2uhh09
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.150131069265
+   Change: 0.156631069265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/009--fungible-max-div-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/009--fungible-max-div-unfreeze-withdraw.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1922527449 XRD
-├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2052527449 XRD
+├─ Network execution: 0.14399285 XRD, 2879857 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1922527449"),
+     amount: Decimal("0.2052527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.0905582733525"),
+             0u8 => Decimal("1.1198082733525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.63776690659")),
+         LiquidFungibleResource(Decimal("99999999999999995.52076690659")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.181116546705")),
+         LiquidFungibleResource(Decimal("2.239616546705")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1922527449
+   Change: -0.2052527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09612637245
+   Change: 0.10262637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/010--fungible-max-div-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/010--fungible-max-div-unfreeze-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1922527449 XRD
-├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2052527449 XRD
+├─ Network execution: 0.14399285 XRD, 2879857 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1922527449"),
+     amount: Decimal("0.2052527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.1386214595775"),
+             0u8 => Decimal("1.1711214595775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.44551416169")),
+         LiquidFungibleResource(Decimal("99999999999999995.31551416169")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.277242919155")),
+         LiquidFungibleResource(Decimal("2.342242919155")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1922527449
+   Change: -0.2052527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09612637245
+   Change: 0.10262637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/011--fungible-max-div-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/011--fungible-max-div-unfreeze-burn.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.1922527449 XRD
-├─ Network execution: 0.13599285 XRD, 2719857 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2052527449 XRD
+├─ Network execution: 0.14399285 XRD, 2879857 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1922527449"),
+     amount: Decimal("0.2052527449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09612637245"),
+     amount: Decimal("0.10262637245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.1866846458025"),
+             0u8 => Decimal("1.2224346458025"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999995.25326141679")),
+         LiquidFungibleResource(Decimal("99999999999999995.11026141679")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.373369291605")),
+         LiquidFungibleResource(Decimal("2.444869291605")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1922527449
+   Change: -0.2052527449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09612637245
+   Change: 0.10262637245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/012--fungible-max-div-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/012--fungible-max-div-recall-unfrozen-vault.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29126098853 XRD
-├─ Network execution: 0.2017291 XRD, 4034582 execution cost units
-├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
+TRANSACTION COST: 0.30426098853 XRD
+├─ Network execution: 0.2097291 XRD, 4194582 execution cost units
+├─ Network finalization: 0.0210036 XRD, 420072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29126098853"),
+     amount: Decimal("0.30426098853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145630494265"),
+     amount: Decimal("0.152130494265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145630494265"),
+     amount: Decimal("0.152130494265"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.259499892935"),
+             0u8 => Decimal("1.298499892935"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,13 +86,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.96200042826")),
+         LiquidFungibleResource(Decimal("99999999999999994.80600042826")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.51899978587")),
+         LiquidFungibleResource(Decimal("2.59699978587")),
        )
 
 OUTPUTS: 3
@@ -103,9 +103,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29126098853
+   Change: -0.30426098853
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145630494265
+   Change: 0.152130494265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/013--fungible-max-div-freeze-withdraw-again.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/013--fungible-max-div-freeze-withdraw-again.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.19214541004 XRD
-├─ Network execution: 0.13607625 XRD, 2721525 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.20514541004 XRD
+├─ Network execution: 0.14407625 XRD, 2881525 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.19214541004"),
+     amount: Decimal("0.20514541004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.09607270502"),
+     amount: Decimal("0.10257270502"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.307536245445"),
+             0u8 => Decimal("1.349786245445"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.76985501822")),
+         LiquidFungibleResource(Decimal("99999999999999994.60085501822")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.61507249089")),
+         LiquidFungibleResource(Decimal("2.69957249089")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.19214541004
+   Change: -0.20514541004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.09607270502
+   Change: 0.10257270502
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/014--fungible-min-div-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/014--fungible-min-div-create.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.58258175439 XRD
-├─ Network execution: 0.24047695 XRD, 4809539 execution cost units
-├─ Network finalization: 0.10626115 XRD, 2125223 finalization cost units
+TRANSACTION COST: 0.59558175439 XRD
+├─ Network execution: 0.24847695 XRD, 4969539 execution cost units
+├─ Network finalization: 0.11126115 XRD, 2225223 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.23584365439 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.58258175439"),
+     amount: Decimal("0.59558175439"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.291290877195"),
+     amount: Decimal("0.297790877195"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.291290877195"),
+     amount: Decimal("0.297790877195"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.4531816840425"),
+             0u8 => Decimal("1.4986816840425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.18727326383")),
+         LiquidFungibleResource(Decimal("99999999999999994.00527326383")),
        )
 ├─ resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96 across 4 partitions
   ├─ Partition(5): 1 change
@@ -233,7 +233,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.906363368085")),
+         LiquidFungibleResource(Decimal("2.997363368085")),
        )
 
 OUTPUTS: 3
@@ -247,13 +247,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.58258175439
+   Change: -0.59558175439
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: 100000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.291290877195
+   Change: 0.297790877195
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/015--fungible-min-div-mint-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/015--fungible-min-div-mint-correct-granularity.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29196054273 XRD
-├─ Network execution: 0.2081507 XRD, 4163014 execution cost units
-├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
+TRANSACTION COST: 0.30496054273 XRD
+├─ Network execution: 0.2161507 XRD, 4323014 execution cost units
+├─ Network finalization: 0.0210036 XRD, 420072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06780624273 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29196054273"),
+     amount: Decimal("0.30496054273"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145980271365"),
+     amount: Decimal("0.152480271365"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145980271365"),
+     amount: Decimal("0.152480271365"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.526171819725"),
+             0u8 => Decimal("1.574921819725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -80,7 +80,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.8953127211")),
+         LiquidFungibleResource(Decimal("99999999999999993.7003127211")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -92,7 +92,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.05234363945")),
+         LiquidFungibleResource(Decimal("3.14984363945")),
        )
 
 OUTPUTS: 3
@@ -103,12 +103,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29196054273
+   Change: -0.30496054273
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: 166
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145980271365
+   Change: 0.152480271365
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/016--fungible-min-div-mint-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/016--fungible-min-div-mint-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(FungibleResourceManagerError(InvalidAmount(1.1, 0)))
 
-TRANSACTION COST: 0.16594922938 XRD
-├─ Network execution: 0.13104475 XRD, 2620895 execution cost units
+TRANSACTION COST: 0.17394922938 XRD
+├─ Network execution: 0.13904475 XRD, 2780895 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.16594922938"),
+     amount: Decimal("0.17394922938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08297461469"),
+     amount: Decimal("0.08697461469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08297461469"),
+     amount: Decimal("0.08697461469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.56765912707"),
+             0u8 => Decimal("1.61840912707"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.72936349172")),
+         LiquidFungibleResource(Decimal("99999999999999993.52636349172")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.13531825414")),
+         LiquidFungibleResource(Decimal("3.23681825414")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.16594922938
+   Change: -0.17394922938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08297461469
+   Change: 0.08697461469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/017--fungible-min-div-transfer-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/017--fungible-min-div-transfer-correct-granularity.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.40612452083 XRD
-├─ Network execution: 0.23791465 XRD, 4758293 execution cost units
-├─ Network finalization: 0.03650745 XRD, 730149 finalization cost units
+TRANSACTION COST: 0.41912452083 XRD
+├─ Network execution: 0.24591465 XRD, 4918293 execution cost units
+├─ Network finalization: 0.04150745 XRD, 830149 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13170242083 XRD
 └─ Royalties: 0 XRD
@@ -38,15 +38,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.40612452083"),
+     amount: Decimal("0.41912452083"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.203062260415"),
+     amount: Decimal("0.209562260415"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.203062260415"),
+     amount: Decimal("0.209562260415"),
    }
 
 STATE UPDATES: 8 entities
@@ -56,7 +56,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.6691902572775"),
+             0u8 => Decimal("1.7231902572775"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -89,7 +89,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.32323897089")),
+         LiquidFungibleResource(Decimal("99999999999999993.10723897089")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -142,7 +142,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.338380514555")),
+         LiquidFungibleResource(Decimal("3.446380514555")),
        )
 
 OUTPUTS: 3
@@ -153,7 +153,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.40612452083
+   Change: -0.41912452083
 ├─ Vault: internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex
    ResAddr: resource_sim1tk8mv5cp2uuhjgw34qqh9v7jf6atjsnyrym9f3653k7pyd4gamsx96
    Change: -234
@@ -162,6 +162,6 @@ BALANCE CHANGES: 4
    Change: 234
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.203062260415
+   Change: 0.209562260415
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/018--fungible-min-div-transfer-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/018--fungible-min-div-transfer-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(0.0001)))
 
-TRANSACTION COST: 0.21022956182 XRD
-├─ Network execution: 0.1650254 XRD, 3300508 execution cost units
+TRANSACTION COST: 0.21822956182 XRD
+├─ Network execution: 0.1730254 XRD, 3460508 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04520416182 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.21022956182"),
+     amount: Decimal("0.21822956182"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10511478091"),
+     amount: Decimal("0.10911478091"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10511478091"),
+     amount: Decimal("0.10911478091"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.7217476477325"),
+             0u8 => Decimal("1.7777476477325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.11300940907")),
+         LiquidFungibleResource(Decimal("99999999999999992.88900940907")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.443495295465")),
+         LiquidFungibleResource(Decimal("3.555495295465")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.21022956182
+   Change: -0.21822956182
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10511478091
+   Change: 0.10911478091
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/019--fungible-min-div-create-proof-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/019--fungible-min-div-create-proof-correct-granularity.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.26101381042 XRD
-├─ Network execution: 0.19865015 XRD, 3973003 execution cost units
-├─ Network finalization: 0.01525215 XRD, 305043 finalization cost units
+TRANSACTION COST: 0.27401381042 XRD
+├─ Network execution: 0.20665015 XRD, 4133003 execution cost units
+├─ Network finalization: 0.02025215 XRD, 405043 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04711151042 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.26101381042"),
+     amount: Decimal("0.27401381042"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.13050690521"),
+     amount: Decimal("0.13700690521"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.13050690521"),
+     amount: Decimal("0.13700690521"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.7870011003375"),
+             0u8 => Decimal("1.8462511003375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.85199559865")),
+         LiquidFungibleResource(Decimal("99999999999999992.61499559865")),
        )
 ├─ internal_vault_sim1tpcy68e3056prrst2k9qvk04727s0q9yqwvj63hun7azu7lujcn9ex across 1 partitions
   └─ Partition(64): 1 change
@@ -79,7 +79,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.574002200675")),
+         LiquidFungibleResource(Decimal("3.692502200675")),
        )
 
 OUTPUTS: 2
@@ -89,9 +89,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.26101381042
+   Change: -0.27401381042
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.13050690521
+   Change: 0.13700690521
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/020--fungible-min-div-create-proof-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/020--fungible-min-div-create-proof-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(0.0001)))
 
-TRANSACTION COST: 0.20058305317 XRD
-├─ Network execution: 0.1606241 XRD, 3212482 execution cost units
+TRANSACTION COST: 0.20858305317 XRD
+├─ Network execution: 0.1686241 XRD, 3372482 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03995895317 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20058305317"),
+     amount: Decimal("0.20858305317"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.100291526585"),
+     amount: Decimal("0.104291526585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.100291526585"),
+     amount: Decimal("0.104291526585"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.83714686363"),
+             0u8 => Decimal("1.89839686363"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.65141254548")),
+         LiquidFungibleResource(Decimal("99999999999999992.40641254548")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.67429372726")),
+         LiquidFungibleResource(Decimal("3.79679372726")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20058305317
+   Change: -0.20858305317
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.100291526585
+   Change: 0.104291526585
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/021--fungible-min-div-recall-correct-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/021--fungible-min-div-recall-correct-granularity.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.29126098853 XRD
-├─ Network execution: 0.2017291 XRD, 4034582 execution cost units
-├─ Network finalization: 0.0160036 XRD, 320072 finalization cost units
+TRANSACTION COST: 0.30426098853 XRD
+├─ Network execution: 0.2097291 XRD, 4194582 execution cost units
+├─ Network finalization: 0.0210036 XRD, 420072 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07352828853 XRD
 └─ Royalties: 0 XRD
@@ -29,15 +29,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.29126098853"),
+     amount: Decimal("0.30426098853"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.145630494265"),
+     amount: Decimal("0.152130494265"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.145630494265"),
+     amount: Decimal("0.152130494265"),
    }
 
 STATE UPDATES: 6 entities
@@ -47,7 +47,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9099621107625"),
+             0u8 => Decimal("1.9744621107625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -86,13 +86,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.36015155695")),
+         LiquidFungibleResource(Decimal("99999999999999992.10215155695")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.819924221525")),
+         LiquidFungibleResource(Decimal("3.948924221525")),
        )
 
 OUTPUTS: 3
@@ -103,9 +103,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.29126098853
+   Change: -0.30426098853
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.145630494265
+   Change: 0.152130494265
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/022--fungible-min-div-recall-wrong-granularity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/receipts/022--fungible-min-div-recall-wrong-granularity.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: ApplicationError(VaultError(InvalidAmount(123.12321)))
 
-TRANSACTION COST: 0.1685290192 XRD
-├─ Network execution: 0.12656735 XRD, 2531347 execution cost units
+TRANSACTION COST: 0.1765290192 XRD
+├─ Network execution: 0.13456735 XRD, 2691347 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0419616692 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.1685290192"),
+     amount: Decimal("0.1765290192"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.0842645096"),
+     amount: Decimal("0.0882645096"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.0842645096"),
+     amount: Decimal("0.0882645096"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9520943655625"),
+             0u8 => Decimal("2.0185943655625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.19162253775")),
+         LiquidFungibleResource(Decimal("99999999999999991.92562253775")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.904188731125")),
+         LiquidFungibleResource(Decimal("4.037188731125")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.1685290192
+   Change: -0.1765290192
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.0842645096
+   Change: 0.0882645096
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/fungible_resource/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: fungible_resource
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 59159dd195d775a3 (allowed to change if not deployed to any network)
-Events       : cdfdf4f81788e605 (allowed to change if not deployed to any network)
+State changes: a16e17b08b450f25 (allowed to change if not deployed to any network)
+Events       : 325e5d6a1567e5fb (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - user_account_1: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/costings/001--global_n_owned_emitting_events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/costings/001--global_n_owned_emitting_events.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,           31.11940278773,    100.0%
-- Execution Cost (XRD)                                                     ,               0.73894425,      2.4%
-- Finalization Cost (XRD)                                                  ,                0.1288607,      0.4%
+Total Cost (XRD)                                                           ,           31.13240278773,    100.0%
+- Execution Cost (XRD)                                                     ,               0.74694425,      2.4%
+- Finalization Cost (XRD)                                                  ,                0.1338607,      0.4%
 - Storage Cost (XRD)                                                       ,           30.25159783773,     97.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14778885,    100.0%
+Execution Cost Breakdown                                                   ,                 14938885,    100.0%
 - AfterInvoke                                                              ,                      530,      0.0%
 - AllocateNodeId                                                           ,                     2619,      0.0%
 - BeforeInvoke                                                             ,                   174964,      1.2%
+- CheckIntentValidity                                                      ,                   160000,      1.1%
 - CheckReference                                                           ,                    40011,      0.3%
 - CloseSubstate                                                            ,                    26832,      0.2%
 - CreateNode                                                               ,                   477934,      3.2%
@@ -17,23 +18,23 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5880,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    48822,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  3135265,     21.2%
+- OpenSubstate::GlobalPackage                                              ,                  3135265,     21.0%
 - OpenSubstate::InternalFungibleVault                                      ,                    91807,      0.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    33637,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.3%
 - PinNode                                                                  ,                      252,      0.0%
-- PrepareWasmCode                                                          ,                  1197496,      8.1%
+- PrepareWasmCode                                                          ,                  1197496,      8.0%
 - QueryActor                                                               ,                     1500,      0.0%
-- ReadSubstate                                                             ,                  1332511,      9.0%
+- ReadSubstate                                                             ,                  1332511,      8.9%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::create                                                    ,                    49184,      0.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.2%
 - RunNativeCode::create_with_data                                          ,                    54942,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunNativeCode::publish_wasm_advanced                                     ,                  4176881,     28.3%
+- RunNativeCode::publish_wasm_advanced                                     ,                  4176881,     28.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - RunWasmCode::GlobalBp_emit_event                                         ,                    15145,      0.1%
 - RunWasmCode::GlobalBp_new                                                ,                    55165,      0.4%
@@ -41,14 +42,14 @@ Execution Cost Breakdown                                                   ,    
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      776,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  3483320,     23.6%
+- ValidateTxPayload                                                        ,                  3483320,     23.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     7952,      0.1%
-Finalization Cost Breakdown                                                ,                  2577214,    100.0%
-- CommitEvents                                                             ,                    20016,      0.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  2677214,    100.0%
+- CommitEvents                                                             ,                    20016,      0.7%
+- CommitIntentStatus                                                       ,                   100000,      3.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   400063,     15.5%
-- CommitStateUpdates::GlobalPackage                                        ,                  1657067,     64.3%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     11.6%
-- CommitStateUpdates::InternalGenericComponent                             ,                   200021,      7.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   400063,     14.9%
+- CommitStateUpdates::GlobalPackage                                        ,                  1657067,     61.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     11.2%
+- CommitStateUpdates::InternalGenericComponent                             ,                   200021,      7.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/receipts/001--global_n_owned_emitting_events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/receipts/001--global_n_owned_emitting_events.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 31.11940278773 XRD
-├─ Network execution: 0.73894425 XRD, 14778885 execution cost units
-├─ Network finalization: 0.1288607 XRD, 2577214 finalization cost units
+TRANSACTION COST: 31.13240278773 XRD
+├─ Network execution: 0.74694425 XRD, 14938885 execution cost units
+├─ Network finalization: 0.1338607 XRD, 2677214 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 30.25159783773 XRD
 └─ Royalties: 0 XRD
@@ -24,15 +24,15 @@ EVENTS: 7
    Event: GlobalBpEvent
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("31.11940278773"),
+     amount: Decimal("31.13240278773"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("15.559701393865"),
+     amount: Decimal("15.566201393865"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("15.559701393865"),
+     amount: Decimal("15.566201393865"),
    }
 
 STATE UPDATES: 9 entities
@@ -42,7 +42,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("7.7798506969325"),
+             0u8 => Decimal("7.7831006969325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,7 +75,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999968.88059721227")),
+         LiquidFungibleResource(Decimal("99999999999999968.86759721227")),
        )
 ├─ package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96 across 11 partitions
   ├─ Partition(1): 2 changes
@@ -687,7 +687,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("15.559701393865")),
+         LiquidFungibleResource(Decimal("15.566201393865")),
        )
 
 OUTPUTS: 4
@@ -699,10 +699,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -31.11940278773
+   Change: -31.13240278773
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 15.559701393865
+   Change: 15.566201393865
 
 NEW ENTITIES: 2
 └─ Package: package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/global_n_owned/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: global_n_owned
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 7411e81fdf13949b (allowed to change if not deployed to any network)
-Events       : 13e773bed3504059 (allowed to change if not deployed to any network)
+State changes: be272723df79de93 (allowed to change if not deployed to any network)
+Events       : d2cdde9ba10ae4e0 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - global_n_owned_package_address: package_sim1pkaulm4hum34fy2k0tnflzmyh2qvv9vq9kwlpxwrh68k9t36zkng96

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/costings/001--kv-store-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/costings/001--kv-store-with-remote-type.txt
@@ -1,52 +1,53 @@
-Total Cost (XRD)                                                           ,            37.0793026514,    100.0%
-- Execution Cost (XRD)                                                     ,                0.7376455,      2.0%
-- Finalization Cost (XRD)                                                  ,                0.1039411,      0.3%
+Total Cost (XRD)                                                           ,            37.0923026514,    100.0%
+- Execution Cost (XRD)                                                     ,                0.7456455,      2.0%
+- Finalization Cost (XRD)                                                  ,                0.1089411,      0.3%
 - Storage Cost (XRD)                                                       ,            36.2377160514,     97.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14752910,    100.0%
+Execution Cost Breakdown                                                   ,                 14912910,    100.0%
 - AfterInvoke                                                              ,                      460,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                   208346,      1.4%
+- CheckIntentValidity                                                      ,                   160000,      1.1%
 - CheckReference                                                           ,                    40011,      0.3%
 - CloseSubstate                                                            ,                    22575,      0.2%
-- CreateNode                                                               ,                   568884,      3.9%
+- CreateNode                                                               ,                   568884,      3.8%
 - DropNode                                                                 ,                    30637,      0.2%
 - EmitEvent                                                                ,                     1128,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     4480,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    44089,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2627095,     17.8%
+- OpenSubstate::GlobalPackage                                              ,                  2627095,     17.6%
 - OpenSubstate::InternalFungibleVault                                      ,                    91807,      0.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    26883,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    41406,      0.3%
 - PinNode                                                                  ,                      228,      0.0%
 - PrepareWasmCode                                                          ,                   695384,      4.7%
 - QueryActor                                                               ,                     1500,      0.0%
-- ReadSubstate                                                             ,                   820097,      5.6%
+- ReadSubstate                                                             ,                   820097,      5.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::create                                                    ,                    49184,      0.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.2%
 - RunNativeCode::create_with_data                                          ,                    54942,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunNativeCode::publish_wasm_advanced                                     ,                  4918202,     33.3%
+- RunNativeCode::publish_wasm_advanced                                     ,                  4918202,     33.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - RunWasmCode::KVStore_create_key_value_store_with_remote_type             ,                    63969,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  4153400,     28.2%
+- ValidateTxPayload                                                        ,                  4153400,     27.9%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     7150,      0.0%
-Finalization Cost Breakdown                                                ,                  2078822,    100.0%
+Finalization Cost Breakdown                                                ,                  2178822,    100.0%
 - CommitEvents                                                             ,                    10016,      0.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      4.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   400062,     19.2%
-- CommitStateUpdates::GlobalPackage                                        ,                  1168663,     56.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     14.4%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   200034,      9.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   400062,     18.4%
+- CommitStateUpdates::GlobalPackage                                        ,                  1168663,     53.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     13.8%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   200034,      9.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/receipts/001--kv-store-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/receipts/001--kv-store-with-remote-type.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 37.0793026514 XRD
-├─ Network execution: 0.7376455 XRD, 14752910 execution cost units
-├─ Network finalization: 0.1039411 XRD, 2078822 finalization cost units
+TRANSACTION COST: 37.0923026514 XRD
+├─ Network execution: 0.7456455 XRD, 14912910 execution cost units
+├─ Network finalization: 0.1089411 XRD, 2178822 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 36.2377160514 XRD
 └─ Royalties: 0 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("37.0793026514"),
+     amount: Decimal("37.0923026514"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("18.5396513257"),
+     amount: Decimal("18.5461513257"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("18.5396513257"),
+     amount: Decimal("18.5461513257"),
    }
 
 STATE UPDATES: 9 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("9.26982566285"),
+             0u8 => Decimal("9.27307566285"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999962.9206973486")),
+         LiquidFungibleResource(Decimal("99999999999999962.9076973486")),
        )
 ├─ package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt across 11 partitions
   ├─ Partition(1): 1 change
@@ -427,7 +427,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("18.5396513257")),
+         LiquidFungibleResource(Decimal("18.5461513257")),
        )
 
 OUTPUTS: 4
@@ -439,10 +439,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -37.0793026514
+   Change: -37.0923026514
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 18.5396513257
+   Change: 18.5461513257
 
 NEW ENTITIES: 2
 └─ Package: package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/kv_store_with_remote_type/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: kv_store_with_remote_type
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 0530e08a0fbeee57 (allowed to change if not deployed to any network)
-Events       : 3e12393f8656767b (allowed to change if not deployed to any network)
+State changes: 731f251d2acb6164 (allowed to change if not deployed to any network)
+Events       : 77a94038288f2798 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - kv_store_with_remote_type_package_address: package_sim1phrx0wcqf0t56shsrygqjvrmll7m39n5jayzkuk2f0w76f698cfwwt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/001--max_transaction-publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/001--max_transaction-publish-package.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            43.9747960389,    100.0%
-- Execution Cost (XRD)                                                     ,               0.83756775,      1.9%
-- Finalization Cost (XRD)                                                  ,               0.10458285,      0.2%
-- Storage Cost (XRD)                                                       ,            43.0326454389,     97.9%
+Total Cost (XRD)                                                           ,            43.9877960389,    100.0%
+- Execution Cost (XRD)                                                     ,               0.84556775,      1.9%
+- Finalization Cost (XRD)                                                  ,               0.10958285,      0.2%
+- Storage Cost (XRD)                                                       ,            43.0326454389,     97.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 16751355,    100.0%
+Execution Cost Breakdown                                                   ,                 16911355,    100.0%
 - AfterInvoke                                                              ,                      460,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                   248008,      1.5%
+- CheckIntentValidity                                                      ,                   160000,      0.9%
 - CheckReference                                                           ,                    40011,      0.2%
 - CloseSubstate                                                            ,                    22317,      0.1%
 - CreateNode                                                               ,                   671640,      4.0%
@@ -17,36 +18,36 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     4480,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    44103,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2689664,     16.1%
+- OpenSubstate::GlobalPackage                                              ,                  2689664,     15.9%
 - OpenSubstate::InternalFungibleVault                                      ,                    91807,      0.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    26953,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    41039,      0.2%
 - PinNode                                                                  ,                      228,      0.0%
 - PrepareWasmCode                                                          ,                   757840,      4.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   882900,      5.3%
+- ReadSubstate                                                             ,                   882900,      5.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::create                                                    ,                    49184,      0.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.2%
 - RunNativeCode::create_with_data                                          ,                    54942,      0.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
-- RunNativeCode::publish_wasm_advanced                                     ,                  5802440,     34.6%
+- RunNativeCode::publish_wasm_advanced                                     ,                  5802440,     34.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - RunWasmCode::MaxTransaction_new                                          ,                    53903,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      788,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  4947640,     29.5%
+- ValidateTxPayload                                                        ,                  4947640,     29.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     6922,      0.0%
-Finalization Cost Breakdown                                                ,                  2091657,    100.0%
+Finalization Cost Breakdown                                                ,                  2191657,    100.0%
 - CommitEvents                                                             ,                    10016,      0.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      4.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   400064,     19.1%
-- CommitStateUpdates::GlobalPackage                                        ,                  1181499,     56.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     14.3%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   200031,      9.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   400064,     18.3%
+- CommitStateUpdates::GlobalPackage                                        ,                  1181499,     53.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     13.7%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   200031,      9.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/002--max_transaction-with-large-events.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/002--max_transaction-with-large-events.txt
@@ -1,31 +1,32 @@
-Total Cost (XRD)                                                           ,          799.32746029787,    100.0%
-- Execution Cost (XRD)                                                     ,               1.04674085,      0.1%
-- Finalization Cost (XRD)                                                  ,                0.1784497,      0.0%
+Total Cost (XRD)                                                           ,          799.34046029787,    100.0%
+- Execution Cost (XRD)                                                     ,               1.05474085,      0.1%
+- Finalization Cost (XRD)                                                  ,                0.1834497,      0.0%
 - Storage Cost (XRD)                                                       ,          798.10226974787,     99.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20934817,    100.0%
+Execution Cost Breakdown                                                   ,                 21094817,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      644,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      0.8%
 - CheckReference                                                           ,                    80024,      0.4%
 - CloseSubstate                                                            ,                    11352,      0.1%
 - CreateNode                                                               ,                     6032,      0.0%
 - DropNode                                                                 ,                    10841,      0.1%
-- EmitEvent                                                                ,                 16839736,     80.4%
+- EmitEvent                                                                ,                 16839736,     79.8%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      0.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.2%
-- OpenSubstate::GlobalPackage                                              ,                  1961579,      9.4%
+- OpenSubstate::GlobalPackage                                              ,                  1961579,      9.3%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.4%
 - OpenSubstate::InternalGenericComponent                                   ,                    10138,      0.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.2%
 - PinNode                                                                  ,                       84,      0.0%
 - PrepareWasmCode                                                          ,                   757840,      3.6%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   811091,      3.9%
+- ReadSubstate                                                             ,                   811091,      3.8%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
@@ -36,9 +37,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    11960,      0.1%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     3904,      0.0%
-Finalization Cost Breakdown                                                ,                  3568994,    100.0%
-- CommitEvents                                                             ,                  3368967,     94.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  3668994,    100.0%
+- CommitEvents                                                             ,                  3368967,     91.8%
+- CommitIntentStatus                                                       ,                   100000,      2.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/003--max_transaction-with-large-state-updates.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/costings/003--max_transaction-with-large-state-updates.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,         4205.56802035162,    100.0%
-- Execution Cost (XRD)                                                     ,                4.7884284,      0.1%
-- Finalization Cost (XRD)                                                  ,                0.6707546,      0.0%
+Total Cost (XRD)                                                           ,         4205.58102035162,    100.0%
+- Execution Cost (XRD)                                                     ,                4.7964284,      0.1%
+- Finalization Cost (XRD)                                                  ,                0.6757546,      0.0%
 - Storage Cost (XRD)                                                       ,         4200.10883735162,     99.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 95768568,    100.0%
+Execution Cost Breakdown                                                   ,                 95928568,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      630,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      0.2%
 - CheckReference                                                           ,                    80023,      0.1%
 - CloseSubstate                                                            ,                    17931,      0.0%
 - CreateNode                                                               ,                     6032,      0.0%
@@ -21,7 +22,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalPackage                                              ,                  2001592,      2.1%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.1%
 - OpenSubstate::InternalGenericComponent                                   ,                    10138,      0.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                  3498836,      3.7%
+- OpenSubstate::InternalKeyValueStore                                      ,                  3498836,      3.6%
 - PinNode                                                                  ,                       84,      0.0%
 - PrepareWasmCode                                                          ,                   757840,      0.8%
 - QueryActor                                                               ,                     1000,      0.0%
@@ -35,11 +36,11 @@ Execution Cost Breakdown                                                   ,    
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    11600,      0.0%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
-- WriteSubstate                                                            ,                 88089168,     92.0%
-Finalization Cost Breakdown                                                ,                 13415092,    100.0%
+- WriteSubstate                                                            ,                 88089168,     91.8%
+Finalization Cost Breakdown                                                ,                 13515092,    100.0%
 - CommitEvents                                                             ,                     5007,      0.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      0.7%
 - CommitLogs                                                               ,                        0,      0.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   200028,      1.5%
 - CommitStateUpdates::InternalFungibleVault                                ,                   100009,      0.7%
-- CommitStateUpdates::InternalKeyValueStore                                ,                 13110048,     97.7%
+- CommitStateUpdates::InternalKeyValueStore                                ,                 13110048,     97.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/001--max_transaction-publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/001--max_transaction-publish-package.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 43.9747960389 XRD
-├─ Network execution: 0.83756775 XRD, 16751355 execution cost units
-├─ Network finalization: 0.10458285 XRD, 2091657 finalization cost units
+TRANSACTION COST: 43.9877960389 XRD
+├─ Network execution: 0.84556775 XRD, 16911355 execution cost units
+├─ Network finalization: 0.10958285 XRD, 2191657 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 43.0326454389 XRD
 └─ Royalties: 0 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("43.9747960389"),
+     amount: Decimal("43.9877960389"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("21.98739801945"),
+     amount: Decimal("21.99389801945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("21.98739801945"),
+     amount: Decimal("21.99389801945"),
    }
 
 STATE UPDATES: 9 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("10.993699009725"),
+             0u8 => Decimal("10.996949009725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999956.0252039611")),
+         LiquidFungibleResource(Decimal("99999999999999956.0122039611")),
        )
 ├─ package_sim1ph5xhxsxn2ekenmudd0p5rmsjggmzkxcd8eu3pjjame6f2mxc0jwmn across 11 partitions
   ├─ Partition(1): 1 change
@@ -521,7 +521,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("21.98739801945")),
+         LiquidFungibleResource(Decimal("21.99389801945")),
        )
 
 OUTPUTS: 4
@@ -533,10 +533,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -43.9747960389
+   Change: -43.9877960389
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 21.98739801945
+   Change: 21.99389801945
 
 NEW ENTITIES: 2
 └─ Package: package_sim1ph5xhxsxn2ekenmudd0p5rmsjggmzkxcd8eu3pjjame6f2mxc0jwmn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/003--max_transaction-with-large-state-updates.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/receipts/003--max_transaction-with-large-state-updates.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 4205.56802035162 XRD
-├─ Network execution: 4.7884284 XRD, 95768568 execution cost units
-├─ Network finalization: 0.6707546 XRD, 13415092 finalization cost units
+TRANSACTION COST: 4205.58102035162 XRD
+├─ Network execution: 4.7964284 XRD, 95928568 execution cost units
+├─ Network finalization: 0.6757546 XRD, 13515092 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 4200.10883735162 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("4205.56802035162"),
+     amount: Decimal("4205.58102035162"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("2102.78401017581"),
+     amount: Decimal("2102.79051017581"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("2102.78401017581"),
+     amount: Decimal("2102.79051017581"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1262.2175691720975"),
+             0u8 => Decimal("1262.2273191720975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -73,7 +73,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999994951.12972331161")),
+         LiquidFungibleResource(Decimal("99999999999994951.09072331161")),
        )
 ├─ internal_keyvaluestore_sim1krwy3nu9853y0gqa3kpcrrvjx9je56r3pm53wcwmy6m5ahsx3l8rev across 1 partitions
   └─ Partition(64): 21 changes
@@ -123,7 +123,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2524.435138344195")),
+         LiquidFungibleResource(Decimal("2524.454638344195")),
        )
 
 OUTPUTS: 2
@@ -133,9 +133,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -4205.56802035162
+   Change: -4205.58102035162
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 2102.78401017581
+   Change: 2102.79051017581
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/max_transaction/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: max_transaction
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 70a6763aea82c40d (allowed to change if not deployed to any network)
-Events       : 492eacef54b910dc (allowed to change if not deployed to any network)
+State changes: 5ef9a946963fdf5b (allowed to change if not deployed to any network)
+Events       : 5402ca786a998d3c (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - component_with_large_state: component_sim1crawpnl7k2d2vlv9q730c3g2yrj59hpc0hzhy24v48qrw6lhxecxcg

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/001--maya-router-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/001--maya-router-create-accounts.txt
@@ -1,16 +1,17 @@
-Total Cost (XRD)                                                           ,            0.39897357299,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.196332,     49.2%
-- Finalization Cost (XRD)                                                  ,                 0.060258,     15.1%
-- Storage Cost (XRD)                                                       ,            0.14238357299,     35.7%
+Total Cost (XRD)                                                           ,            0.41197357299,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.204332,     49.6%
+- Finalization Cost (XRD)                                                  ,                 0.065258,     15.8%
+- Storage Cost (XRD)                                                       ,            0.14238357299,     34.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3926640,    100.0%
+Execution Cost Breakdown                                                   ,                  4086640,    100.0%
 - AfterInvoke                                                              ,                      454,      0.0%
 - AllocateNodeId                                                           ,                     2134,      0.1%
-- BeforeInvoke                                                             ,                     2020,      0.1%
+- BeforeInvoke                                                             ,                     2020,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.9%
 - CheckReference                                                           ,                    40011,      1.0%
 - CloseSubstate                                                            ,                    19995,      0.5%
-- CreateNode                                                               ,                    17866,      0.5%
+- CreateNode                                                               ,                    17866,      0.4%
 - DropNode                                                                 ,                    29026,      0.7%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
@@ -18,23 +19,23 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - MoveModule                                                               ,                     2240,      0.1%
 - OpenSubstate::GlobalAccount                                              ,                     1880,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    84038,      2.1%
-- OpenSubstate::GlobalPackage                                              ,                  2182523,     55.6%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.3%
+- OpenSubstate::GlobalPackage                                              ,                  2182523,     53.4%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.2%
 - OpenSubstate::InternalGenericComponent                                   ,                    24514,      0.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      9.0%
+- PrepareWasmCode                                                          ,                   353866,      8.7%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   456626,     11.6%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
-- RunNativeCode::create                                                    ,                    49184,      1.3%
-- RunNativeCode::create_advanced                                           ,                   163614,      4.2%
-- RunNativeCode::create_with_data                                          ,                    54942,      1.4%
+- ReadSubstate                                                             ,                   456626,     11.2%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
+- RunNativeCode::create                                                    ,                    49184,      1.2%
+- RunNativeCode::create_advanced                                           ,                   163614,      4.0%
+- RunNativeCode::create_with_data                                          ,                    54942,      1.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      742,      0.0%
@@ -42,10 +43,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    20880,      0.5%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                     6400,      0.2%
-Finalization Cost Breakdown                                                ,                  1205160,    100.0%
+Finalization Cost Breakdown                                                ,                  1305160,    100.0%
 - CommitEvents                                                             ,                     5007,      0.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      7.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                  1000126,     83.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.3%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      8.3%
+- CommitStateUpdates::GlobalAccount                                        ,                  1000126,     76.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      7.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/002--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/002--faucet-top-up.txt
@@ -1,37 +1,38 @@
-Total Cost (XRD)                                                           ,            0.43739680544,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29093665,     66.5%
-- Finalization Cost (XRD)                                                  ,                0.0312563,      7.1%
-- Storage Cost (XRD)                                                       ,            0.11520385544,     26.3%
+Total Cost (XRD)                                                           ,            0.45039680544,    100.0%
+- Execution Cost (XRD)                                                     ,               0.29893665,     66.4%
+- Finalization Cost (XRD)                                                  ,                0.0362563,      8.0%
+- Storage Cost (XRD)                                                       ,            0.11520385544,     25.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5818733,    100.0%
+Execution Cost Breakdown                                                   ,                  5978733,    100.0%
 - AfterInvoke                                                              ,                      520,      0.0%
 - AllocateNodeId                                                           ,                     1843,      0.0%
 - BeforeInvoke                                                             ,                     1796,      0.0%
-- CheckReference                                                           ,                    80022,      1.4%
-- CloseSubstate                                                            ,                    38829,      0.7%
+- CheckIntentValidity                                                      ,                   160000,      2.7%
+- CheckReference                                                           ,                    80022,      1.3%
+- CloseSubstate                                                            ,                    38829,      0.6%
 - CreateNode                                                               ,                    16554,      0.3%
 - DropNode                                                                 ,                    28158,      0.5%
 - EmitEvent                                                                ,                     2860,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalAccount                                              ,                   366729,      6.3%
-- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.8%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      3.0%
+- OpenSubstate::GlobalAccount                                              ,                   366729,      6.1%
+- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      2.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2602605,     44.7%
+- OpenSubstate::GlobalPackage                                              ,                  2602605,     43.5%
 - OpenSubstate::InternalFungibleVault                                      ,                   106652,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    49147,      0.8%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.5%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.4%
 - PinNode                                                                  ,                      216,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     12.2%
+- PrepareWasmCode                                                          ,                   707732,     11.8%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   869143,     14.9%
+- ReadSubstate                                                             ,                   869143,     14.5%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
+- RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    22032,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.5%
@@ -39,19 +40,19 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.7%
-- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.7%
+- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.6%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14880,      0.3%
+- ValidateTxPayload                                                        ,                    14880,      0.2%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    11030,      0.2%
-Finalization Cost Breakdown                                                ,                   625126,    100.0%
-- CommitEvents                                                             ,                    25045,      4.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   725126,    100.0%
+- CommitEvents                                                             ,                    25045,      3.5%
+- CommitIntentStatus                                                       ,                   100000,     13.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   100011,     16.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     48.0%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     16.0%
+- CommitStateUpdates::GlobalAccount                                        ,                   100011,     13.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     41.4%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,     13.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/003--maya-router-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/003--maya-router-create-resources.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            1.06964287912,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27983645,     26.2%
-- Finalization Cost (XRD)                                                  ,                0.2572747,     24.1%
-- Storage Cost (XRD)                                                       ,            0.53253172912,     49.8%
+Total Cost (XRD)                                                           ,            1.08264287912,    100.0%
+- Execution Cost (XRD)                                                     ,               0.28783645,     26.6%
+- Finalization Cost (XRD)                                                  ,                0.2622747,     24.2%
+- Storage Cost (XRD)                                                       ,            0.53253172912,     49.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5596729,    100.0%
+Execution Cost Breakdown                                                   ,                  5756729,    100.0%
 - AfterInvoke                                                              ,                     1080,      0.0%
 - AllocateNodeId                                                           ,                     3686,      0.1%
 - BeforeInvoke                                                             ,                     5462,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.8%
 - CheckReference                                                           ,                    80022,      1.4%
 - CloseSubstate                                                            ,                    52245,      0.9%
 - CreateNode                                                               ,                    33110,      0.6%
@@ -17,29 +18,29 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - MoveModule                                                               ,                    11480,      0.2%
-- OpenSubstate::GlobalAccount                                              ,                   690752,     12.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   144463,      2.6%
+- OpenSubstate::GlobalAccount                                              ,                   690752,     12.0%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   144463,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2500740,     44.7%
+- OpenSubstate::GlobalPackage                                              ,                  2500740,     43.4%
 - OpenSubstate::InternalFungibleVault                                      ,                   102726,      1.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    86542,      1.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      384,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.3%
+- PrepareWasmCode                                                          ,                   353866,      6.1%
 - QueryActor                                                               ,                     3000,      0.1%
-- ReadSubstate                                                             ,                   542531,      9.7%
+- ReadSubstate                                                             ,                   542531,      9.4%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    58066,      1.0%
 - RunNativeCode::create                                                    ,                    49184,      0.9%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      1.3%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      1.2%
 - RunNativeCode::create_with_data                                          ,                    54942,      1.0%
-- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   214132,      3.8%
+- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   214132,      3.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      0.8%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.9%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.1%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      864,      0.0%
@@ -47,11 +48,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    39880,      0.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    14628,      0.3%
-Finalization Cost Breakdown                                                ,                  5145494,    100.0%
+Finalization Cost Breakdown                                                ,                  5245494,    100.0%
 - CommitEvents                                                             ,                    45083,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccount                                        ,                   200022,      3.9%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  4300286,     83.6%
+- CommitStateUpdates::GlobalAccount                                        ,                   200022,      3.8%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  4300286,     82.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500085,      9.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500085,      9.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/004--maya-router-publish-and-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/costings/004--maya-router-publish-and-instantiate.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            68.2986730791,    100.0%
-- Execution Cost (XRD)                                                     ,               1.25912295,      1.8%
-- Finalization Cost (XRD)                                                  ,               0.15169575,      0.2%
+Total Cost (XRD)                                                           ,            68.3116730791,    100.0%
+- Execution Cost (XRD)                                                     ,               1.26712295,      1.9%
+- Finalization Cost (XRD)                                                  ,               0.15669575,      0.2%
 - Storage Cost (XRD)                                                       ,            66.8878543791,     97.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 25182459,    100.0%
+Execution Cost Breakdown                                                   ,                 25342459,    100.0%
 - AfterInvoke                                                              ,                      710,      0.0%
 - AllocateNodeId                                                           ,                     3201,      0.0%
 - BeforeInvoke                                                             ,                   410742,      1.6%
+- CheckIntentValidity                                                      ,                   160000,      0.6%
 - CheckReference                                                           ,                    40011,      0.2%
 - CloseSubstate                                                            ,                    27735,      0.1%
 - CreateNode                                                               ,                  1015562,      4.0%
@@ -36,21 +37,21 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::instantiate_account_locker                                ,                    49102,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
-- RunNativeCode::publish_wasm_advanced                                     ,                  9388601,     37.3%
+- RunNativeCode::publish_wasm_advanced                                     ,                  9388601,     37.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - RunWasmCode::MayaRouter_instantiate                                      ,                    95772,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1163,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  8177800,     32.5%
+- ValidateTxPayload                                                        ,                  8177800,     32.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                     8418,      0.0%
-Finalization Cost Breakdown                                                ,                  3033915,    100.0%
+Finalization Cost Breakdown                                                ,                  3133915,    100.0%
 - CommitEvents                                                             ,                    10016,      0.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalAccountLocker                                  ,                   700074,     23.1%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   400071,     13.2%
-- CommitStateUpdates::GlobalPackage                                        ,                  1523665,     50.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      9.9%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100042,      3.3%
+- CommitStateUpdates::GlobalAccountLocker                                  ,                   700074,     22.3%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   400071,     12.8%
+- CommitStateUpdates::GlobalPackage                                        ,                  1523665,     48.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,      9.6%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100042,      3.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/001--maya-router-create-accounts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/001--maya-router-create-accounts.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.39897357299 XRD
-├─ Network execution: 0.196332 XRD, 3926640 execution cost units
-├─ Network finalization: 0.060258 XRD, 1205160 finalization cost units
+TRANSACTION COST: 0.41197357299 XRD
+├─ Network execution: 0.204332 XRD, 4086640 execution cost units
+├─ Network finalization: 0.065258 XRD, 1305160 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14238357299 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.39897357299"),
+     amount: Decimal("0.41197357299"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.199486786495"),
+     amount: Decimal("0.205986786495"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.199486786495"),
+     amount: Decimal("0.205986786495"),
    }
 
 STATE UPDATES: 7 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.0997433932475"),
+             0u8 => Decimal("0.1029933932475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -67,7 +67,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.60102642701")),
+         LiquidFungibleResource(Decimal("99999999999999999.58802642701")),
        )
 ├─ account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy across 5 partitions
   ├─ Partition(2): 1 change
@@ -211,7 +211,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.199486786495")),
+         LiquidFungibleResource(Decimal("0.205986786495")),
        )
 
 OUTPUTS: 3
@@ -222,10 +222,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.39897357299
+   Change: -0.41197357299
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.199486786495
+   Change: 0.205986786495
 
 NEW ENTITIES: 2
 ├─ Component: account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/002--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/002--faucet-top-up.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.43739680544 XRD
-├─ Network execution: 0.29093665 XRD, 5818733 execution cost units
-├─ Network finalization: 0.0312563 XRD, 625126 finalization cost units
+TRANSACTION COST: 0.45039680544 XRD
+├─ Network execution: 0.29893665 XRD, 5978733 execution cost units
+├─ Network finalization: 0.0362563 XRD, 725126 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11520385544 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.43739680544"),
+     amount: Decimal("0.45039680544"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.21869840272"),
+     amount: Decimal("0.22519840272"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.21869840272"),
+     amount: Decimal("0.22519840272"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2090925946075"),
+             0u8 => Decimal("0.2155925946075"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.16362962157")),
+         LiquidFungibleResource(Decimal("99999999999989999.13762962157")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -129,7 +129,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.418185189215")),
+         LiquidFungibleResource(Decimal("0.431185189215")),
        )
 
 OUTPUTS: 4
@@ -141,12 +141,12 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.43739680544
+   Change: -10000.45039680544
 ├─ Vault: internal_vault_sim1tzd883cmyxpkvj3s540tqfq5dhh887ymjlapc59pdhmf9qh66kqxr3
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.21869840272
+   Change: 0.22519840272
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/003--maya-router-create-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/003--maya-router-create-resources.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.06964287912 XRD
-├─ Network execution: 0.27983645 XRD, 5596729 execution cost units
-├─ Network finalization: 0.2572747 XRD, 5145494 finalization cost units
+TRANSACTION COST: 1.08264287912 XRD
+├─ Network execution: 0.28783645 XRD, 5756729 execution cost units
+├─ Network finalization: 0.2622747 XRD, 5245494 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.53253172912 XRD
 └─ Royalties: 0 XRD
@@ -50,15 +50,15 @@ EVENTS: 12
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.06964287912"),
+     amount: Decimal("1.08264287912"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.53482143956"),
+     amount: Decimal("0.54132143956"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.53482143956"),
+     amount: Decimal("0.54132143956"),
    }
 
 STATE UPDATES: 10 entities
@@ -68,7 +68,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4765033143875"),
+             0u8 => Decimal("0.4862533143875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -111,7 +111,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.09398674245")),
+         LiquidFungibleResource(Decimal("99999999999989998.05498674245")),
        )
 ├─ resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf across 5 partitions
   ├─ Partition(2): 6 changes
@@ -456,7 +456,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.953006628775")),
+         LiquidFungibleResource(Decimal("0.972506628775")),
        )
 
 OUTPUTS: 4
@@ -474,7 +474,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.06964287912
+   Change: -1.08264287912
 ├─ Vault: internal_vault_sim1tryac3w8efhstsnsygpr8y7dkgjh23eqw8samk73rr69qumddqxnnv
    ResAddr: resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf
    Change: 100000000000
@@ -483,7 +483,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.53482143956
+   Change: 0.54132143956
 
 NEW ENTITIES: 2
 ├─ Resource: resource_sim1tkl8f4ev0djxy2jjy4fpnaexhw0t0t39seqs26u0mfqjzn3e4m80zf

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/004--maya-router-publish-and-instantiate.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/receipts/004--maya-router-publish-and-instantiate.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 68.2986730791 XRD
-├─ Network execution: 1.25912295 XRD, 25182459 execution cost units
-├─ Network finalization: 0.15169575 XRD, 3033915 finalization cost units
+TRANSACTION COST: 68.3116730791 XRD
+├─ Network execution: 1.26712295 XRD, 25342459 execution cost units
+├─ Network finalization: 0.15669575 XRD, 3133915 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 66.8878543791 XRD
 └─ Royalties: 0 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("68.2986730791"),
+     amount: Decimal("68.3116730791"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("34.14933653955"),
+     amount: Decimal("34.15583653955"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("34.14933653955"),
+     amount: Decimal("34.15583653955"),
    }
 
 STATE UPDATES: 10 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("17.5511715841625"),
+             0u8 => Decimal("17.5641715841625"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989929.79531366335")),
+         LiquidFungibleResource(Decimal("99999999999989929.74331366335")),
        )
 ├─ package_sim1pha7h60q9p4hx40chf8uxntzs3tqgnd72kfu2akz2lx67hq5e32ex3 across 12 partitions
   ├─ Partition(1): 1 change
@@ -375,7 +375,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("35.102343168325")),
+         LiquidFungibleResource(Decimal("35.128343168325")),
        )
 
 OUTPUTS: 4
@@ -387,10 +387,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -68.2986730791
+   Change: -68.3116730791
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 34.14933653955
+   Change: 34.15583653955
 
 NEW ENTITIES: 3
 └─ Package: package_sim1pha7h60q9p4hx40chf8uxntzs3tqgnd72kfu2akz2lx67hq5e32ex3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/maya_router/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: maya_router
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 96ed194a25f3ef39 (allowed to change if not deployed to any network)
-Events       : d8156132163d1eb7 (allowed to change if not deployed to any network)
+State changes: c39ba25673fed2d8 (allowed to change if not deployed to any network)
+Events       : f8003975b06eb5dc (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - owner_account: account_sim1cy2m8fzpwz7uyvkdlrleay34k94yz63skerrshcrl0d3fpm2cnmlqy

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/001--metadata-create-package-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/001--metadata-create-package-with-metadata.txt
@@ -1,16 +1,17 @@
-Total Cost (XRD)                                                           ,           50.38687245485,    100.0%
-- Execution Cost (XRD)                                                     ,                1.0392595,      2.1%
-- Finalization Cost (XRD)                                                  ,                0.2910838,      0.6%
-- Storage Cost (XRD)                                                       ,           49.05652915485,     97.4%
+Total Cost (XRD)                                                           ,           50.39987245485,    100.0%
+- Execution Cost (XRD)                                                     ,                1.0472595,      2.1%
+- Finalization Cost (XRD)                                                  ,                0.2960838,      0.6%
+- Storage Cost (XRD)                                                       ,           49.05652915485,     97.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20785190,    100.0%
+Execution Cost Breakdown                                                   ,                 20945190,    100.0%
 - AfterInvoke                                                              ,                      914,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.0%
 - BeforeInvoke                                                             ,                   295208,      1.4%
+- CheckIntentValidity                                                      ,                   160000,      0.8%
 - CheckReference                                                           ,                    40011,      0.2%
-- CloseSubstate                                                            ,                    52245,      0.3%
-- CreateNode                                                               ,                   760872,      3.7%
+- CloseSubstate                                                            ,                    52245,      0.2%
+- CreateNode                                                               ,                   760872,      3.6%
 - DropNode                                                                 ,                    47642,      0.2%
 - EmitEvent                                                                ,                     3432,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
@@ -21,7 +22,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   181265,      0.9%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.2%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    88707,      0.4%
-- OpenSubstate::GlobalPackage                                              ,                  3500089,     16.8%
+- OpenSubstate::GlobalPackage                                              ,                  3500089,     16.7%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      2.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   108257,      0.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    65865,      0.3%
@@ -42,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.2%
-- RunNativeCode::publish_wasm_advanced                                     ,                  6739617,     32.4%
+- RunNativeCode::publish_wasm_advanced                                     ,                  6739617,     32.2%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.2%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.6%
@@ -51,15 +52,15 @@ Execution Cost Breakdown                                                   ,    
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  5795120,     27.9%
+- ValidateTxPayload                                                        ,                  5795120,     27.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                    13708,      0.1%
-Finalization Cost Breakdown                                                ,                  5821676,    100.0%
+Finalization Cost Breakdown                                                ,                  5921676,    100.0%
 - CommitEvents                                                             ,                    30054,      0.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.7%
 - CommitLogs                                                               ,                        0,      0.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.7%
-- CommitStateUpdates::GlobalPackage                                        ,                  4391399,     75.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     12.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500085,      8.6%
+- CommitStateUpdates::GlobalPackage                                        ,                  4391399,     74.2%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     11.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500085,      8.4%
 - CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      1.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/002--metadata-create-component-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/002--metadata-create-component-with-metadata.txt
@@ -1,16 +1,17 @@
-Total Cost (XRD)                                                           ,            1.82359473628,    100.0%
-- Execution Cost (XRD)                                                     ,                0.7175547,     39.3%
-- Finalization Cost (XRD)                                                  ,               0.22904115,     12.6%
-- Storage Cost (XRD)                                                       ,            0.87699888628,     48.1%
+Total Cost (XRD)                                                           ,            1.83659473628,    100.0%
+- Execution Cost (XRD)                                                     ,                0.7255547,     39.5%
+- Finalization Cost (XRD)                                                  ,               0.23404115,     12.7%
+- Storage Cost (XRD)                                                       ,            0.87699888628,     47.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 14351094,    100.0%
+Execution Cost Breakdown                                                   ,                 14511094,    100.0%
 - AfterInvoke                                                              ,                      844,      0.0%
 - AllocateNodeId                                                           ,                     5529,      0.0%
 - BeforeInvoke                                                             ,                     7296,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      1.1%
 - CheckReference                                                           ,                    80024,      0.6%
 - CloseSubstate                                                            ,                    84108,      0.6%
-- CreateNode                                                               ,                    50662,      0.4%
+- CreateNode                                                               ,                    50662,      0.3%
 - DropNode                                                                 ,                    87886,      0.6%
 - EmitEvent                                                                ,                    21136,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
@@ -19,18 +20,18 @@ Execution Cost Breakdown                                                   ,    
 - MoveModule                                                               ,                     1960,      0.0%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.3%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   171184,      1.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                  5242541,     36.5%
+- OpenSubstate::GlobalGenericComponent                                     ,                  5242541,     36.1%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    44020,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  3830264,     26.7%
+- OpenSubstate::GlobalPackage                                              ,                  3830264,     26.4%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      2.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   185061,      1.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    90723,      0.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      1.4%
 - PinNode                                                                  ,                      660,      0.0%
-- PrepareWasmCode                                                          ,                  1147558,      8.0%
+- PrepareWasmCode                                                          ,                  1147558,      7.9%
 - QueryActor                                                               ,                     2000,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                  1395914,      9.7%
+- ReadSubstate                                                             ,                  1395914,      9.6%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.2%
@@ -41,7 +42,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.2%
-- RunNativeCode::set                                                       ,                   667872,      4.7%
+- RunNativeCode::set                                                       ,                   667872,      4.6%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.3%
@@ -53,10 +54,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    90960,      0.6%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                    38200,      0.3%
-Finalization Cost Breakdown                                                ,                  4580823,    100.0%
+Finalization Cost Breakdown                                                ,                  4680823,    100.0%
 - CommitEvents                                                             ,                   180386,      3.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                  4100414,     89.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,      4.4%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                  4100414,     87.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,      4.3%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      2.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/003--metadata-create-resource-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/003--metadata-create-resource-with-metadata.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            1.30613901636,    100.0%
-- Execution Cost (XRD)                                                     ,               0.36157815,     27.7%
-- Finalization Cost (XRD)                                                  ,               0.27202975,     20.8%
-- Storage Cost (XRD)                                                       ,            0.67253111636,     51.5%
+Total Cost (XRD)                                                           ,            1.31913901636,    100.0%
+- Execution Cost (XRD)                                                     ,               0.36957815,     28.0%
+- Finalization Cost (XRD)                                                  ,               0.27702975,     21.0%
+- Storage Cost (XRD)                                                       ,            0.67253111636,     51.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7231563,    100.0%
+Execution Cost Breakdown                                                   ,                  7391563,    100.0%
 - AfterInvoke                                                              ,                      958,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     9258,      0.1%
-- CheckReference                                                           ,                    40011,      0.6%
+- CheckIntentValidity                                                      ,                   160000,      2.2%
+- CheckReference                                                           ,                    40011,      0.5%
 - CloseSubstate                                                            ,                    57018,      0.8%
 - CreateNode                                                               ,                    30448,      0.4%
 - DropNode                                                                 ,                    45948,      0.6%
@@ -19,32 +20,32 @@ Execution Cost Breakdown                                                   ,    
 - MoveModule                                                               ,                    12880,      0.2%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   182628,      2.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
+- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    44020,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3188532,     44.1%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   609967,      8.4%
+- OpenSubstate::GlobalPackage                                              ,                  3188532,     43.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   609967,      8.3%
 - OpenSubstate::InternalFungibleVault                                      ,                   191323,      2.6%
-- OpenSubstate::InternalGenericComponent                                   ,                    84158,      1.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    84158,      1.1%
+- OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.7%
 - PinNode                                                                  ,                      348,      0.0%
-- PrepareWasmCode                                                          ,                   707732,      9.8%
+- PrepareWasmCode                                                          ,                   707732,      9.6%
 - QueryActor                                                               ,                     3000,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   920669,     12.7%
+- ReadSubstate                                                             ,                   920669,     12.5%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    58066,      0.8%
 - RunNativeCode::create                                                    ,                    24592,      0.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.5%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.4%
-- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      1.5%
+- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   107066,      1.4%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.4%
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.6%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.7%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.6%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.5%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -53,12 +54,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    80600,      1.1%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    15346,      0.2%
-Finalization Cost Breakdown                                                ,                  5440595,    100.0%
+Finalization Cost Breakdown                                                ,                  5540595,    100.0%
 - CommitEvents                                                             ,                    40074,      0.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  4700431,     86.4%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  4700431,     84.8%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.8%
 - CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      1.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,      7.4%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,      7.2%
 - CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      1.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/004--metadata-create-resource-with-metadata-partially-locked.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/004--metadata-create-resource-with-metadata-partially-locked.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.77345736926,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3575207,     46.2%
-- Finalization Cost (XRD)                                                  ,               0.12201425,     15.8%
-- Storage Cost (XRD)                                                       ,            0.29392241926,     38.0%
+Total Cost (XRD)                                                           ,            0.78645736926,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3655207,     46.5%
+- Finalization Cost (XRD)                                                  ,               0.12701425,     16.2%
+- Storage Cost (XRD)                                                       ,            0.29392241926,     37.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7150414,    100.0%
+Execution Cost Breakdown                                                   ,                  7310414,    100.0%
 - AfterInvoke                                                              ,                      958,      0.0%
 - AllocateNodeId                                                           ,                     3104,      0.0%
 - BeforeInvoke                                                             ,                     3844,      0.1%
-- CheckReference                                                           ,                    40011,      0.6%
+- CheckIntentValidity                                                      ,                   160000,      2.2%
+- CheckReference                                                           ,                    40011,      0.5%
 - CloseSubstate                                                            ,                    55857,      0.8%
 - CreateNode                                                               ,                    27882,      0.4%
 - DropNode                                                                 ,                    45948,      0.6%
@@ -18,21 +19,21 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - MoveModule                                                               ,                     4480,      0.1%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   179070,      2.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   179070,      2.4%
+- OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42019,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3188532,     44.6%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   609967,      8.5%
-- OpenSubstate::InternalFungibleVault                                      ,                   191323,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  3188532,     43.6%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   609967,      8.3%
+- OpenSubstate::InternalFungibleVault                                      ,                   191323,      2.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    84158,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      2.8%
 - PinNode                                                                  ,                      348,      0.0%
-- PrepareWasmCode                                                          ,                   707732,      9.9%
+- PrepareWasmCode                                                          ,                   707732,      9.7%
 - QueryActor                                                               ,                     3000,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   916820,     12.8%
+- ReadSubstate                                                             ,                   916820,     12.5%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    58066,      0.8%
 - RunNativeCode::create                                                    ,                    24592,      0.3%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.5%
@@ -45,7 +46,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.7%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
-- RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.5%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      423,      0.0%
@@ -53,12 +54,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    26400,      0.4%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    15346,      0.2%
-Finalization Cost Breakdown                                                ,                  2440285,    100.0%
+Finalization Cost Breakdown                                                ,                  2540285,    100.0%
 - CommitEvents                                                             ,                    40074,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1700121,     69.7%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.1%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      4.1%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     16.4%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      4.1%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1700121,     66.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.9%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     15.7%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      3.9%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/005--metadata-update-initially-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/005--metadata-update-initially-locked-metadata-fails.txt
@@ -1,34 +1,35 @@
-Total Cost (XRD)                                                           ,            0.17882392938,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14391945,     80.5%
+Total Cost (XRD)                                                           ,            0.18682392938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15191945,     81.3%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.03490447938,     19.5%
+- Storage Cost (XRD)                                                       ,            0.03490447938,     18.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2878389,    100.0%
+Execution Cost Breakdown                                                   ,                  3038389,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      472,      0.0%
-- CheckReference                                                           ,                    80025,      2.8%
+- CheckIntentValidity                                                      ,                   160000,      5.3%
+- CheckReference                                                           ,                    80025,      2.6%
 - CloseSubstate                                                            ,                     9546,      0.3%
 - CreateNode                                                               ,                     5242,      0.2%
 - DropNode                                                                 ,                     4939,      0.2%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   364833,     12.7%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalPackage                                              ,                  1332267,     46.3%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   364833,     12.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalPackage                                              ,                  1332267,     43.8%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.0%
 - OpenSubstate::InternalGenericComponent                                   ,                     5632,      0.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
 - PinNode                                                                  ,                       72,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.3%
+- PrepareWasmCode                                                          ,                   353866,     11.6%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   403319,     14.0%
+- ReadSubstate                                                             ,                   403319,     13.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::set                                                       ,                    20871,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/006--metadata-update-updatable-metadata-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/006--metadata-update-updatable-metadata-succeeds.txt
@@ -1,45 +1,46 @@
-Total Cost (XRD)                                                           ,             0.2189164893,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1547769,     70.7%
-- Finalization Cost (XRD)                                                  ,                0.0155022,      7.1%
-- Storage Cost (XRD)                                                       ,             0.0486373893,     22.2%
+Total Cost (XRD)                                                           ,             0.2319164893,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1627769,     70.2%
+- Finalization Cost (XRD)                                                  ,                0.0205022,      8.8%
+- Storage Cost (XRD)                                                       ,             0.0486373893,     21.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3095538,    100.0%
+Execution Cost Breakdown                                                   ,                  3255538,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      630,      0.0%
-- CheckReference                                                           ,                    80025,      2.6%
+- CheckIntentValidity                                                      ,                   160000,      4.9%
+- CheckReference                                                           ,                    80025,      2.5%
 - CloseSubstate                                                            ,                    12126,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
-- DropNode                                                                 ,                    10969,      0.4%
+- DropNode                                                                 ,                    10969,      0.3%
 - EmitEvent                                                                ,                     1100,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   364827,     11.8%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  1501852,     48.5%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
-- OpenSubstate::InternalGenericComponent                                   ,                    11360,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   364827,     11.2%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.3%
+- OpenSubstate::GlobalPackage                                              ,                  1501852,     46.1%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    11360,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.2%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     11.4%
+- PrepareWasmCode                                                          ,                   353866,     10.9%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   414102,     13.4%
+- ReadSubstate                                                             ,                   414102,     12.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunNativeCode::set                                                       ,                    20871,      0.7%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
+- RunNativeCode::set                                                       ,                    20871,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14480,      0.5%
-- VerifyTxSignatures                                                       ,                    14000,      0.5%
+- ValidateTxPayload                                                        ,                    14480,      0.4%
+- VerifyTxSignatures                                                       ,                    14000,      0.4%
 - WriteSubstate                                                            ,                     4290,      0.1%
-Finalization Cost Breakdown                                                ,                   310044,    100.0%
-- CommitEvents                                                             ,                    10012,      3.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   410044,    100.0%
+- CommitEvents                                                             ,                    10012,      2.4%
+- CommitIntentStatus                                                       ,                   100000,     24.4%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100005,     32.3%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.3%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.3%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100005,     24.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.4%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/007--metadata-lock-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/007--metadata-lock-metadata.txt
@@ -1,45 +1,46 @@
-Total Cost (XRD)                                                           ,            0.21151329719,    100.0%
-- Execution Cost (XRD)                                                     ,               0.15496725,     73.3%
-- Finalization Cost (XRD)                                                  ,               0.01525195,      7.2%
-- Storage Cost (XRD)                                                       ,            0.04129409719,     19.5%
+Total Cost (XRD)                                                           ,            0.22451329719,    100.0%
+- Execution Cost (XRD)                                                     ,               0.16296725,     72.6%
+- Finalization Cost (XRD)                                                  ,               0.02025195,      9.0%
+- Storage Cost (XRD)                                                       ,            0.04129409719,     18.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3099345,    100.0%
+Execution Cost Breakdown                                                   ,                  3259345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      622,      0.0%
-- CheckReference                                                           ,                    80025,      2.6%
+- CheckIntentValidity                                                      ,                   160000,      4.9%
+- CheckReference                                                           ,                    80025,      2.5%
 - CloseSubstate                                                            ,                    12126,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
-- DropNode                                                                 ,                    10969,      0.4%
+- DropNode                                                                 ,                    10969,      0.3%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   364823,     11.8%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
-- OpenSubstate::GlobalPackage                                              ,                  1501852,     48.5%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
-- OpenSubstate::InternalGenericComponent                                   ,                    11360,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   364823,     11.2%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.3%
+- OpenSubstate::GlobalPackage                                              ,                  1501852,     46.1%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    11360,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.2%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     11.4%
+- PrepareWasmCode                                                          ,                   353866,     10.9%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   414251,     13.4%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
+- ReadSubstate                                                             ,                   414251,     12.7%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock                                                      ,                    25245,      0.8%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    14320,      0.5%
-- VerifyTxSignatures                                                       ,                    14000,      0.5%
+- ValidateTxPayload                                                        ,                    14320,      0.4%
+- VerifyTxSignatures                                                       ,                    14000,      0.4%
 - WriteSubstate                                                            ,                     4290,      0.1%
-Finalization Cost Breakdown                                                ,                   305039,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405039,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100005,     32.8%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100005,     24.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,               0.46889646,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2221501,     47.4%
-- Finalization Cost (XRD)                                                  ,                0.0560115,     11.9%
-- Storage Cost (XRD)                                                       ,               0.19073486,     40.7%
+Total Cost (XRD)                                                           ,               0.48189646,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2301501,     47.8%
+- Finalization Cost (XRD)                                                  ,                0.0610115,     12.7%
+- Storage Cost (XRD)                                                       ,               0.19073486,     39.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4443002,    100.0%
+Execution Cost Breakdown                                                   ,                  4603002,    100.0%
 - AfterInvoke                                                              ,                      222,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     2114,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.5%
 - CheckReference                                                           ,                    40011,      0.9%
-- CloseSubstate                                                            ,                    20124,      0.5%
+- CloseSubstate                                                            ,                    20124,      0.4%
 - CreateNode                                                               ,                    13478,      0.3%
 - DropNode                                                                 ,                    22157,      0.5%
 - EmitEvent                                                                ,                     2432,      0.1%
@@ -17,24 +18,24 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.7%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  2057370,     46.3%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   808703,     18.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.6%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.9%
+- OpenSubstate::GlobalPackage                                              ,                  2057370,     44.7%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   808703,     17.6%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    22311,      0.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.0%
+- PrepareWasmCode                                                          ,                   353866,      7.7%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   454081,     10.2%
+- ReadSubstate                                                             ,                   454081,      9.9%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::create                                                    ,                    24592,      0.6%
+- RunNativeCode::create                                                    ,                    24592,      0.5%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunNativeCode::on_virtualize                                             ,                    34520,      0.8%
+- RunNativeCode::on_virtualize                                             ,                    34520,      0.7%
 - RunNativeCode::set                                                       ,                    62613,      1.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -42,11 +43,11 @@ Execution Cost Breakdown                                                   ,    
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    24160,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
-- WriteSubstate                                                            ,                     6784,      0.2%
-Finalization Cost Breakdown                                                ,                  1120230,    100.0%
-- CommitEvents                                                             ,                    20053,      1.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- WriteSubstate                                                            ,                     6784,      0.1%
+Finalization Cost Breakdown                                                ,                  1220230,    100.0%
+- CommitEvents                                                             ,                    20053,      1.6%
+- CommitIntentStatus                                                       ,                   100000,      8.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.9%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   900150,     80.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      8.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.2%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   900150,     73.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      8.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,             0.4067899193,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2120265,     52.1%
-- Finalization Cost (XRD)                                                  ,                0.0507586,     12.5%
-- Storage Cost (XRD)                                                       ,             0.1440048193,     35.4%
+Total Cost (XRD)                                                           ,             0.4197899193,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2200265,     52.4%
+- Finalization Cost (XRD)                                                  ,                0.0557586,     13.3%
+- Storage Cost (XRD)                                                       ,             0.1440048193,     34.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4240530,    100.0%
+Execution Cost Breakdown                                                   ,                  4400530,    100.0%
 - AfterInvoke                                                              ,                      216,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1810,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.6%
 - CheckReference                                                           ,                    40011,      0.9%
 - CloseSubstate                                                            ,                    18447,      0.4%
 - CreateNode                                                               ,                    12560,      0.3%
@@ -17,36 +18,36 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  2056337,     48.5%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   645935,     15.2%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.1%
+- OpenSubstate::GlobalPackage                                              ,                  2056337,     46.7%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   645935,     14.7%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    20149,      0.5%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      156,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.3%
+- PrepareWasmCode                                                          ,                   353866,      8.0%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   451054,     10.6%
+- ReadSubstate                                                             ,                   451054,     10.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::create                                                    ,                    24592,      0.6%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.8%
-- RunNativeCode::set                                                       ,                    41742,      1.0%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
+- RunNativeCode::set                                                       ,                    41742,      0.9%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17880,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     5810,      0.1%
-Finalization Cost Breakdown                                                ,                  1015172,    100.0%
-- CommitEvents                                                             ,                    15024,      1.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1115172,    100.0%
+- CommitEvents                                                             ,                    15024,      1.3%
+- CommitIntentStatus                                                       ,                   100000,      9.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.9%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   800121,     78.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      9.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.0%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   800121,     71.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      9.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/010--metadata-update-recently-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/costings/010--metadata-update-recently-locked-metadata-fails.txt
@@ -1,34 +1,35 @@
-Total Cost (XRD)                                                           ,            0.17882392938,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14391945,     80.5%
+Total Cost (XRD)                                                           ,            0.18682392938,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15191945,     81.3%
 - Finalization Cost (XRD)                                                  ,                        0,      0.0%
-- Storage Cost (XRD)                                                       ,            0.03490447938,     19.5%
+- Storage Cost (XRD)                                                       ,            0.03490447938,     18.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2878389,    100.0%
+Execution Cost Breakdown                                                   ,                  3038389,    100.0%
 - AfterInvoke                                                              ,                       64,      0.0%
 - AllocateNodeId                                                           ,                      582,      0.0%
 - BeforeInvoke                                                             ,                      472,      0.0%
-- CheckReference                                                           ,                    80025,      2.8%
+- CheckIntentValidity                                                      ,                   160000,      5.3%
+- CheckReference                                                           ,                    80025,      2.6%
 - CloseSubstate                                                            ,                     9546,      0.3%
 - CreateNode                                                               ,                     5242,      0.2%
 - DropNode                                                                 ,                     4939,      0.2%
 - EmitEvent                                                                ,                      556,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   364833,     12.7%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalPackage                                              ,                  1332267,     46.3%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   364833,     12.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalPackage                                              ,                  1332267,     43.8%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.0%
 - OpenSubstate::InternalGenericComponent                                   ,                     5632,      0.2%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
 - PinNode                                                                  ,                       72,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.3%
+- PrepareWasmCode                                                          ,                   353866,     11.6%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   403319,     14.0%
+- ReadSubstate                                                             ,                   403319,     13.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.6%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
 - RunNativeCode::set                                                       ,                    20871,      0.7%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14640,      0.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/001--metadata-create-package-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/001--metadata-create-package-with-metadata.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 50.38687245485 XRD
-├─ Network execution: 1.0392595 XRD, 20785190 execution cost units
-├─ Network finalization: 0.2910838 XRD, 5821676 finalization cost units
+TRANSACTION COST: 50.39987245485 XRD
+├─ Network execution: 1.0472595 XRD, 20945190 execution cost units
+├─ Network finalization: 0.2960838 XRD, 5921676 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 49.05652915485 XRD
 └─ Royalties: 0 XRD
@@ -37,15 +37,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("50.38687245485"),
+     amount: Decimal("50.39987245485"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("25.193436227425"),
+     amount: Decimal("25.199936227425"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("25.193436227425"),
+     amount: Decimal("25.199936227425"),
    }
 
 STATE UPDATES: 10 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("12.5967181137125"),
+             0u8 => Decimal("12.5999681137125"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989949.61312754515")),
+         LiquidFungibleResource(Decimal("99999999999989949.60012754515")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -853,7 +853,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("25.193436227425")),
+         LiquidFungibleResource(Decimal("25.199936227425")),
        )
 
 OUTPUTS: 5
@@ -866,13 +866,13 @@ OUTPUTS: 5
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10050.38687245485
+   Change: -10050.39987245485
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 25.193436227425
+   Change: 25.199936227425
 
 NEW ENTITIES: 2
 └─ Package: package_sim1p5pjdx5g7h0ygzc3ev2r5vj3zprctn6vr7p7t3mqvzjp2r6frahcq3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/002--metadata-create-component-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/002--metadata-create-component-with-metadata.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.82359473628 XRD
-├─ Network execution: 0.7175547 XRD, 14351094 execution cost units
-├─ Network finalization: 0.22904115 XRD, 4580823 finalization cost units
+TRANSACTION COST: 1.83659473628 XRD
+├─ Network execution: 0.7255547 XRD, 14511094 execution cost units
+├─ Network finalization: 0.23404115 XRD, 4680823 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.87699888628 XRD
 └─ Royalties: 0 XRD
@@ -313,15 +313,15 @@ EVENTS: 39
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.82359473628"),
+     amount: Decimal("1.83659473628"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.91179736814"),
+     amount: Decimal("0.91829736814"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.91179736814"),
+     amount: Decimal("0.91829736814"),
    }
 
 STATE UPDATES: 8 entities
@@ -331,7 +331,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.0526167977825"),
+             0u8 => Decimal("13.0591167977825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -364,7 +364,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979947.78953280887")),
+         LiquidFungibleResource(Decimal("99999999999979947.76353280887")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -699,7 +699,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("26.105233595565")),
+         LiquidFungibleResource(Decimal("26.118233595565")),
        )
 
 OUTPUTS: 37
@@ -744,13 +744,13 @@ OUTPUTS: 37
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.82359473628
+   Change: -10001.83659473628
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.91179736814
+   Change: 0.91829736814
 
 NEW ENTITIES: 1
 └─ Component: component_sim1cz4djw7ufpm4rjkwnphzxrn2q7kx8k4a0k2l4wqfz0dwfv4fd9znvr

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/003--metadata-create-resource-with-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/003--metadata-create-resource-with-metadata.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.30613901636 XRD
-├─ Network execution: 0.36157815 XRD, 7231563 execution cost units
-├─ Network finalization: 0.27202975 XRD, 5440595 finalization cost units
+TRANSACTION COST: 1.31913901636 XRD
+├─ Network execution: 0.36957815 XRD, 7391563 execution cost units
+├─ Network finalization: 0.27702975 XRD, 5540595 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.67253111636 XRD
 └─ Royalties: 0 XRD
@@ -46,15 +46,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.30613901636"),
+     amount: Decimal("1.31913901636"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.65306950818"),
+     amount: Decimal("0.65956950818"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.65306950818"),
+     amount: Decimal("0.65956950818"),
    }
 
 STATE UPDATES: 10 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.3791515518725"),
+             0u8 => Decimal("13.3889015518725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969946.48339379251")),
+         LiquidFungibleResource(Decimal("99999999999969946.44439379251")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -501,7 +501,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("26.758303103745")),
+         LiquidFungibleResource(Decimal("26.777803103745")),
        )
 
 OUTPUTS: 4
@@ -516,7 +516,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.30613901636
+   Change: -10001.31913901636
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
@@ -525,7 +525,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.65306950818
+   Change: 0.65956950818
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1t5z9e7s76mryajk97lrmpe3cyxy2zaj456y2px85ksu2ts4n6qwa39

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/004--metadata-create-resource-with-metadata-partially-locked.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/004--metadata-create-resource-with-metadata-partially-locked.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.77345736926 XRD
-├─ Network execution: 0.3575207 XRD, 7150414 execution cost units
-├─ Network finalization: 0.12201425 XRD, 2440285 finalization cost units
+TRANSACTION COST: 0.78645736926 XRD
+├─ Network execution: 0.3655207 XRD, 7310414 execution cost units
+├─ Network finalization: 0.12701425 XRD, 2540285 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.29392241926 XRD
 └─ Royalties: 0 XRD
@@ -46,15 +46,15 @@ EVENTS: 11
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.77345736926"),
+     amount: Decimal("0.78645736926"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.38672868463"),
+     amount: Decimal("0.39322868463"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.38672868463"),
+     amount: Decimal("0.39322868463"),
    }
 
 STATE UPDATES: 10 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.5725158941875"),
+             0u8 => Decimal("13.5855158941875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.70993642325")),
+         LiquidFungibleResource(Decimal("99999999999959945.65793642325")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -272,7 +272,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.145031788375")),
+         LiquidFungibleResource(Decimal("27.171031788375")),
        )
 
 OUTPUTS: 4
@@ -287,7 +287,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.77345736926
+   Change: -10000.78645736926
 ├─ Vault: internal_vault_sim1tqtzph4pdwpxaf7s9qhr6fke8fj6082r3p9ux3w8zuj586dzlj2eh4
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
@@ -296,7 +296,7 @@ BALANCE CHANGES: 4
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.38672868463
+   Change: 0.39322868463
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1t4xqgmnnrx396mwjwy46844xmq83nrnwtw6uth6pa3uvxs65ltyavt

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/005--metadata-update-initially-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/005--metadata-update-initially-locked-metadata-fails.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(KeyValueEntryLocked)
 
-TRANSACTION COST: 0.17882392938 XRD
-├─ Network execution: 0.14391945 XRD, 2878389 execution cost units
+TRANSACTION COST: 0.18682392938 XRD
+├─ Network execution: 0.15191945 XRD, 3038389 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.17882392938"),
+     amount: Decimal("0.18682392938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08941196469"),
+     amount: Decimal("0.09341196469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08941196469"),
+     amount: Decimal("0.09341196469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.6172218765325"),
+             0u8 => Decimal("13.6322218765325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.53111249387")),
+         LiquidFungibleResource(Decimal("99999999999959945.47111249387")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.234443753065")),
+         LiquidFungibleResource(Decimal("27.264443753065")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.17882392938
+   Change: -0.18682392938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08941196469
+   Change: 0.09341196469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/006--metadata-update-updatable-metadata-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/006--metadata-update-updatable-metadata-succeeds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2189164893 XRD
-├─ Network execution: 0.1547769 XRD, 3095538 execution cost units
-├─ Network finalization: 0.0155022 XRD, 310044 finalization cost units
+TRANSACTION COST: 0.2319164893 XRD
+├─ Network execution: 0.1627769 XRD, 3255538 execution cost units
+├─ Network finalization: 0.0205022 XRD, 410044 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0486373893 XRD
 └─ Royalties: 0 XRD
@@ -23,15 +23,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2189164893"),
+     amount: Decimal("0.2319164893"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10945824465"),
+     amount: Decimal("0.11595824465"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10945824465"),
+     amount: Decimal("0.11595824465"),
    }
 
 STATE UPDATES: 6 entities
@@ -41,7 +41,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.6719509988575"),
+             0u8 => Decimal("13.6902009988575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -82,13 +82,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.31219600457")),
+         LiquidFungibleResource(Decimal("99999999999959945.23919600457")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.343901997715")),
+         LiquidFungibleResource(Decimal("27.380401997715")),
        )
 
 OUTPUTS: 2
@@ -98,9 +98,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2189164893
+   Change: -0.2319164893
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10945824465
+   Change: 0.11595824465
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/007--metadata-lock-metadata.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/007--metadata-lock-metadata.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.21151329719 XRD
-├─ Network execution: 0.15496725 XRD, 3099345 execution cost units
-├─ Network finalization: 0.01525195 XRD, 305039 finalization cost units
+TRANSACTION COST: 0.22451329719 XRD
+├─ Network execution: 0.16296725 XRD, 3259345 execution cost units
+├─ Network finalization: 0.02025195 XRD, 405039 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04129409719 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.21151329719"),
+     amount: Decimal("0.22451329719"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.105756648595"),
+     amount: Decimal("0.112256648595"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.105756648595"),
+     amount: Decimal("0.112256648595"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.724829323155"),
+             0u8 => Decimal("13.746329323155"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959945.10068270738")),
+         LiquidFungibleResource(Decimal("99999999999959945.01468270738")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.44965864631")),
+         LiquidFungibleResource(Decimal("27.49265864631")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.21151329719
+   Change: -0.22451329719
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.105756648595
+   Change: 0.112256648595
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/008--metadata-set-metadata-on-dashboard-account-succeeds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.46889646 XRD
-├─ Network execution: 0.2221501 XRD, 4443002 execution cost units
-├─ Network finalization: 0.0560115 XRD, 1120230 finalization cost units
+TRANSACTION COST: 0.48189646 XRD
+├─ Network execution: 0.2301501 XRD, 4603002 execution cost units
+├─ Network finalization: 0.0610115 XRD, 1220230 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19073486 XRD
 └─ Royalties: 0 XRD
@@ -37,15 +37,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.46889646"),
+     amount: Decimal("0.48189646"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.23444823"),
+     amount: Decimal("0.24094823"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.23444823"),
+     amount: Decimal("0.24094823"),
    }
 
 STATE UPDATES: 6 entities
@@ -55,7 +55,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.842053438155"),
+             0u8 => Decimal("13.866803438155"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -88,7 +88,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.63178624738")),
+         LiquidFungibleResource(Decimal("99999999999959944.53278624738")),
        )
 ├─ account_sim16xygyhqp3x3awxlz3c5dzrm7jqghgpgs776v4af0yfr7xljqv060nu across 5 partitions
   ├─ Partition(2): 5 changes
@@ -206,7 +206,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.68410687631")),
+         LiquidFungibleResource(Decimal("27.73360687631")),
        )
 
 OUTPUTS: 4
@@ -218,10 +218,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.46889646
+   Change: -0.48189646
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.23444823
+   Change: 0.24094823
 
 NEW ENTITIES: 1
 └─ Component: account_sim16xygyhqp3x3awxlz3c5dzrm7jqghgpgs776v4af0yfr7xljqv060nu

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/009--metadata-set-metadata-on-sandbox-account-succeeds.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.4067899193 XRD
-├─ Network execution: 0.2120265 XRD, 4240530 execution cost units
-├─ Network finalization: 0.0507586 XRD, 1015172 finalization cost units
+TRANSACTION COST: 0.4197899193 XRD
+├─ Network execution: 0.2200265 XRD, 4400530 execution cost units
+├─ Network finalization: 0.0557586 XRD, 1115172 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.1440048193 XRD
 └─ Royalties: 0 XRD
@@ -30,15 +30,15 @@ EVENTS: 6
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.4067899193"),
+     amount: Decimal("0.4197899193"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.20339495965"),
+     amount: Decimal("0.20989495965"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.20339495965"),
+     amount: Decimal("0.20989495965"),
    }
 
 STATE UPDATES: 6 entities
@@ -48,7 +48,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.94375091798"),
+             0u8 => Decimal("13.97175091798"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -81,7 +81,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.22499632808")),
+         LiquidFungibleResource(Decimal("99999999999959944.11299632808")),
        )
 ├─ account_sim168ydk240yx69yl7zdz2mzkdjc3r5p6n4gwypqsype2d6d942vg95h3 across 5 partitions
   ├─ Partition(2): 4 changes
@@ -193,7 +193,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.88750183596")),
+         LiquidFungibleResource(Decimal("27.94350183596")),
        )
 
 OUTPUTS: 3
@@ -204,10 +204,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.4067899193
+   Change: -0.4197899193
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.20339495965
+   Change: 0.20989495965
 
 NEW ENTITIES: 1
 └─ Component: account_sim168ydk240yx69yl7zdz2mzkdjc3r5p6n4gwypqsype2d6d942vg95h3

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/010--metadata-update-recently-locked-metadata-fails.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/receipts/010--metadata-update-recently-locked-metadata-fails.txt
@@ -1,7 +1,7 @@
 TRANSACTION STATUS: COMMITTED FAILURE: SystemError(KeyValueEntryLocked)
 
-TRANSACTION COST: 0.17882392938 XRD
-├─ Network execution: 0.14391945 XRD, 2878389 execution cost units
+TRANSACTION COST: 0.18682392938 XRD
+├─ Network execution: 0.15191945 XRD, 3038389 execution cost units
 ├─ Network finalization: 0 XRD, 0 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.03490447938 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.17882392938"),
+     amount: Decimal("0.18682392938"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.08941196469"),
+     amount: Decimal("0.09341196469"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.08941196469"),
+     amount: Decimal("0.09341196469"),
    }
 
 STATE UPDATES: 4 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 4 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("13.988456900325"),
+             0u8 => Decimal("14.018456900325"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -60,21 +60,21 @@ STATE UPDATES: 4 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999959944.0461723987")),
+         LiquidFungibleResource(Decimal("99999999999959943.9261723987")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("27.97691380065")),
+         LiquidFungibleResource(Decimal("28.03691380065")),
        )
 
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.17882392938
+   Change: -0.18682392938
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.08941196469
+   Change: 0.09341196469
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/metadata/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: metadata
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 666ba779bc556f93 (allowed to change if not deployed to any network)
-Events       : 870f7c8cd086e0d7 (allowed to change if not deployed to any network)
+State changes: 02e42fe35b295e81 (allowed to change if not deployed to any network)
+Events       : 0fe37bb5c5091f1d (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - user_account_1: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/001--non-fungible-resource-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/001--non-fungible-resource-create.txt
@@ -1,49 +1,50 @@
-Total Cost (XRD)                                                           ,            0.86139216999,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2761705,     32.1%
-- Finalization Cost (XRD)                                                  ,               0.16627255,     19.3%
-- Storage Cost (XRD)                                                       ,            0.41894911999,     48.6%
+Total Cost (XRD)                                                           ,            0.87439216999,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2841705,     32.5%
+- Finalization Cost (XRD)                                                  ,               0.17127255,     19.6%
+- Storage Cost (XRD)                                                       ,            0.41894911999,     47.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5523410,    100.0%
+Execution Cost Breakdown                                                   ,                  5683410,    100.0%
 - AfterInvoke                                                              ,                      690,      0.0%
-- AllocateNodeId                                                           ,                     2813,      0.1%
+- AllocateNodeId                                                           ,                     2813,      0.0%
 - BeforeInvoke                                                             ,                     4554,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.8%
 - CheckReference                                                           ,                    40011,      0.7%
 - CloseSubstate                                                            ,                    38700,      0.7%
 - CreateNode                                                               ,                    26214,      0.5%
 - DropNode                                                                 ,                    39807,      0.7%
-- EmitEvent                                                                ,                     2782,      0.1%
+- EmitEvent                                                                ,                     2782,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     6720,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    57016,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  2731520,     49.5%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      8.8%
+- OpenSubstate::GlobalPackage                                              ,                  2731520,     48.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      8.6%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    57712,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     7751,      0.1%
 - PinNode                                                                  ,                      300,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.4%
+- PrepareWasmCode                                                          ,                   353866,      6.2%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   551367,     10.0%
+- ReadSubstate                                                             ,                   551367,      9.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    49184,      0.9%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.3%
 - RunNativeCode::create_with_data                                          ,                    54942,      1.0%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      3.9%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      3.8%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.6%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.1%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1105,      0.0%
@@ -51,12 +52,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    38360,      0.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    10218,      0.2%
-Finalization Cost Breakdown                                                ,                  3325451,    100.0%
-- CommitEvents                                                             ,                    25033,      0.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  3425451,    100.0%
+- CommitEvents                                                             ,                    25033,      0.7%
+- CommitIntentStatus                                                       ,                   100000,      2.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.0%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000232,     60.1%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     21.1%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.0%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     12.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.9%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000232,     58.4%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     20.4%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.9%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     11.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/002--non-fungible-resource-create-string.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/002--non-fungible-resource-create-string.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.75151466441,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26362785,     35.1%
-- Finalization Cost (XRD)                                                  ,                0.1362671,     18.1%
-- Storage Cost (XRD)                                                       ,            0.35161971441,     46.8%
+Total Cost (XRD)                                                           ,            0.76451466441,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27162785,     35.5%
+- Finalization Cost (XRD)                                                  ,                0.1412671,     18.5%
+- Storage Cost (XRD)                                                       ,            0.35161971441,     46.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5272557,    100.0%
+Execution Cost Breakdown                                                   ,                  5432557,    100.0%
 - AfterInvoke                                                              ,                      554,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3492,      0.1%
-- CheckReference                                                           ,                    40011,      0.8%
-- CloseSubstate                                                            ,                    34701,      0.7%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                    40011,      0.7%
+- CloseSubstate                                                            ,                    34701,      0.6%
 - CreateNode                                                               ,                    20690,      0.4%
 - DropNode                                                                 ,                    31827,      0.6%
 - EmitEvent                                                                ,                     2776,      0.1%
@@ -17,32 +18,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5320,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14330,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.7%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    51081,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    51081,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     7751,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   543858,     10.3%
+- ReadSubstate                                                             ,                   543858,     10.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    24592,      0.5%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.1%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
@@ -50,12 +51,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    37520,      0.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     9542,      0.2%
-Finalization Cost Breakdown                                                ,                  2725342,    100.0%
+Finalization Cost Breakdown                                                ,                  2825342,    100.0%
 - CommitEvents                                                             ,                    25033,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     73.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.5%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     70.8%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/003--non-fungible-resource-create-bytes.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/003--non-fungible-resource-create-bytes.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.75726816021,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26365885,     34.8%
-- Finalization Cost (XRD)                                                  ,               0.13626755,     18.0%
-- Storage Cost (XRD)                                                       ,            0.35734176021,     47.2%
+Total Cost (XRD)                                                           ,            0.77026816021,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27165885,     35.3%
+- Finalization Cost (XRD)                                                  ,               0.14126755,     18.3%
+- Storage Cost (XRD)                                                       ,            0.35734176021,     46.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5273177,    100.0%
+Execution Cost Breakdown                                                   ,                  5433177,    100.0%
 - AfterInvoke                                                              ,                      574,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3512,      0.1%
-- CheckReference                                                           ,                    40011,      0.8%
-- CloseSubstate                                                            ,                    34701,      0.7%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                    40011,      0.7%
+- CloseSubstate                                                            ,                    34701,      0.6%
 - CreateNode                                                               ,                    20710,      0.4%
 - DropNode                                                                 ,                    31847,      0.6%
 - EmitEvent                                                                ,                     2836,      0.1%
@@ -17,32 +18,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5320,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14330,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.7%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    51121,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    51121,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     7751,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   543898,     10.3%
+- ReadSubstate                                                             ,                   543898,     10.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    24592,      0.5%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.1%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
@@ -50,12 +51,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    37920,      0.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     9542,      0.2%
-Finalization Cost Breakdown                                                ,                  2725351,    100.0%
+Finalization Cost Breakdown                                                ,                  2825351,    100.0%
 - CommitEvents                                                             ,                    25042,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     73.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.5%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     70.8%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/004--non-fungible-resource-create-ruid.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/004--non-fungible-resource-create-ruid.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.76337514774,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2629943,     34.5%
-- Finalization Cost (XRD)                                                  ,                 0.136268,     17.9%
-- Storage Cost (XRD)                                                       ,            0.36411284774,     47.7%
+Total Cost (XRD)                                                           ,            0.77637514774,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2709943,     34.9%
+- Finalization Cost (XRD)                                                  ,                 0.141268,     18.2%
+- Storage Cost (XRD)                                                       ,            0.36411284774,     46.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5259886,    100.0%
+Execution Cost Breakdown                                                   ,                  5419886,    100.0%
 - AfterInvoke                                                              ,                      604,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3504,      0.1%
-- CheckReference                                                           ,                    40011,      0.8%
-- CloseSubstate                                                            ,                    34701,      0.7%
+- CheckIntentValidity                                                      ,                   160000,      3.0%
+- CheckReference                                                           ,                    40011,      0.7%
+- CloseSubstate                                                            ,                    34701,      0.6%
 - CreateNode                                                               ,                    20740,      0.4%
 - DropNode                                                                 ,                    31877,      0.6%
 - EmitEvent                                                                ,                     2926,      0.1%
@@ -18,32 +19,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5320,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14330,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    51181,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::InternalGenericComponent                                   ,                    51181,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     7751,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   543958,     10.3%
+- ReadSubstate                                                             ,                   543958,     10.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    24592,      0.5%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
-- RunNativeCode::create_ruid_non_fungible_with_initial_supply              ,                   201857,      3.8%
+- RunNativeCode::create_ruid_non_fungible_with_initial_supply              ,                   201857,      3.7%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      734,      0.0%
@@ -51,12 +52,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    37760,      0.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     9542,      0.2%
-Finalization Cost Breakdown                                                ,                  2725360,    100.0%
+Finalization Cost Breakdown                                                ,                  2825360,    100.0%
 - CommitEvents                                                             ,                    25051,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     73.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.5%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000227,     70.8%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/005--non-fungible-resource-mint-32-nfts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/005--non-fungible-resource-mint-32-nfts.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            2.04157524637,    100.0%
-- Execution Cost (XRD)                                                     ,               0.49825105,     24.4%
-- Finalization Cost (XRD)                                                  ,                0.3360679,     16.5%
-- Storage Cost (XRD)                                                       ,            1.20725629637,     59.1%
+Total Cost (XRD)                                                           ,            2.05457524637,    100.0%
+- Execution Cost (XRD)                                                     ,               0.50625105,     24.6%
+- Finalization Cost (XRD)                                                  ,                0.3410679,     16.6%
+- Storage Cost (XRD)                                                       ,            1.20725629637,     58.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  9965021,    100.0%
+Execution Cost Breakdown                                                   ,                 10125021,    100.0%
 - AfterInvoke                                                              ,                      856,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     9500,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      1.6%
 - CheckReference                                                           ,                    80033,      0.8%
 - CloseSubstate                                                            ,                    41925,      0.4%
 - CreateNode                                                               ,                    12634,      0.1%
@@ -18,15 +19,15 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      1.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.4%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                  5328481,     53.5%
-- OpenSubstate::GlobalPackage                                              ,                  2147468,     21.6%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      2.9%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                  5328481,     52.6%
+- OpenSubstate::GlobalPackage                                              ,                  2147468,     21.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      2.8%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.9%
 - OpenSubstate::InternalGenericComponent                                   ,                    43815,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.4%
 - OpenSubstate::InternalNonFungibleVault                                   ,                   142914,      1.4%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      3.6%
+- PrepareWasmCode                                                          ,                   353866,      3.5%
 - QueryActor                                                               ,                     3000,      0.0%
 - ReadSubstate                                                             ,                   552242,      5.5%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
@@ -35,22 +36,22 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.1%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.1%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.5%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.4%
 - RunNativeCode::mint_NonFungibleResourceManager                           ,                    96256,      1.0%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.4%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.3%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     4832,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                   176360,      1.8%
+- ValidateTxPayload                                                        ,                   176360,      1.7%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    22928,      0.2%
-Finalization Cost Breakdown                                                ,                  6721358,    100.0%
+Finalization Cost Breakdown                                                ,                  6821358,    100.0%
 - CommitEvents                                                             ,                    20234,      0.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.5%
 - CommitLogs                                                               ,                        0,      0.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.5%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  3201024,     47.6%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  3201024,     46.9%
 - CommitStateUpdates::InternalFungibleVault                                ,                   100009,      1.5%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                  3300073,     49.1%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                  3300073,     48.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/006--non-fungible-resource-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/006--non-fungible-resource-burn.txt
@@ -1,17 +1,18 @@
-Total Cost (XRD)                                                           ,            0.42116546511,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26216325,     62.2%
-- Finalization Cost (XRD)                                                  ,               0.04675475,     11.1%
-- Storage Cost (XRD)                                                       ,            0.11224746511,     26.7%
+Total Cost (XRD)                                                           ,            0.43416546511,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27016325,     62.2%
+- Finalization Cost (XRD)                                                  ,               0.05175475,     11.9%
+- Storage Cost (XRD)                                                       ,            0.11224746511,     25.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5243265,    100.0%
+Execution Cost Breakdown                                                   ,                  5403265,    100.0%
 - AfterInvoke                                                              ,                      678,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
-- BeforeInvoke                                                             ,                     2622,      0.1%
+- BeforeInvoke                                                             ,                     2622,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.0%
 - CheckReference                                                           ,                    80033,      1.5%
 - CloseSubstate                                                            ,                    49794,      0.9%
 - CreateNode                                                               ,                    19982,      0.4%
-- DrainSubstates                                                           ,                   120818,      2.3%
+- DrainSubstates                                                           ,                   120818,      2.2%
 - DropNode                                                                 ,                    35783,      0.7%
 - EmitEvent                                                                ,                     3918,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
@@ -19,42 +20,42 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   229432,      4.4%
-- OpenSubstate::GlobalPackage                                              ,                  2160671,     41.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   290024,      5.5%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   229432,      4.2%
+- OpenSubstate::GlobalPackage                                              ,                  2160671,     40.0%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   290024,      5.4%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    84022,      1.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   132271,      2.5%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   132271,      2.4%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     4000,      0.1%
-- ReadSubstate                                                             ,                   571028,     10.9%
+- ReadSubstate                                                             ,                   571028,     10.6%
 - RemoveSubstate                                                           ,                    40717,      0.8%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    58066,      1.1%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.3%
 - RunNativeCode::Worktop_take_non_fungibles                                ,                    22523,      0.4%
-- RunNativeCode::burn_NonFungibleResourceManager                           ,                   177162,      3.4%
+- RunNativeCode::burn_NonFungibleResourceManager                           ,                   177162,      3.3%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    27162,      0.5%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    35829,      0.7%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.2%
 - RunNativeCode::take_non_fungibles                                        ,                    64562,      1.2%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.1%
-- RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.6%
+- RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.5%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    24120,      0.5%
+- ValidateTxPayload                                                        ,                    24120,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    13988,      0.3%
-Finalization Cost Breakdown                                                ,                   935095,    100.0%
-- CommitEvents                                                             ,                    35050,      3.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1035095,    100.0%
+- CommitEvents                                                             ,                    35050,      3.4%
+- CommitIntentStatus                                                       ,                   100000,      9.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     10.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   300009,     32.1%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     10.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400009,     42.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.7%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   300009,     29.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      9.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400009,     38.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/007--non-fungible-resource-transfer.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/007--non-fungible-resource-transfer.txt
@@ -1,16 +1,17 @@
-Total Cost (XRD)                                                           ,            0.57103255949,    100.0%
-- Execution Cost (XRD)                                                     ,               0.29968495,     52.5%
-- Finalization Cost (XRD)                                                  ,               0.07651195,     13.4%
-- Storage Cost (XRD)                                                       ,            0.19483565949,     34.1%
+Total Cost (XRD)                                                           ,            0.58403255949,    100.0%
+- Execution Cost (XRD)                                                     ,               0.30768495,     52.7%
+- Finalization Cost (XRD)                                                  ,               0.08151195,     14.0%
+- Storage Cost (XRD)                                                       ,            0.19483565949,     33.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5993699,    100.0%
+Execution Cost Breakdown                                                   ,                  6153699,    100.0%
 - AfterInvoke                                                              ,                      586,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
 - BeforeInvoke                                                             ,                     2848,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      2.6%
 - CheckReference                                                           ,                    80033,      1.3%
 - CloseSubstate                                                            ,                    42699,      0.7%
-- CreateNode                                                               ,                    21322,      0.4%
+- CreateNode                                                               ,                    21322,      0.3%
 - DrainSubstates                                                           ,                    80545,      1.3%
 - DropNode                                                                 ,                    34691,      0.6%
 - EmitEvent                                                                ,                     3376,      0.1%
@@ -21,31 +22,31 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.0%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                   139179,      2.3%
-- OpenSubstate::GlobalPackage                                              ,                  2732131,     45.6%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   772151,     12.9%
+- OpenSubstate::GlobalPackage                                              ,                  2732131,     44.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   772151,     12.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.5%
 - OpenSubstate::InternalGenericComponent                                   ,                    60863,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                   133894,      2.2%
 - PinNode                                                                  ,                      264,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.9%
+- PrepareWasmCode                                                          ,                   353866,      5.8%
 - QueryActor                                                               ,                     2500,      0.0%
-- ReadSubstate                                                             ,                   562338,      9.4%
+- ReadSubstate                                                             ,                   562338,      9.1%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    24592,      0.4%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.2%
-- RunNativeCode::create_with_data                                          ,                    27471,      0.5%
+- RunNativeCode::create_with_data                                          ,                    27471,      0.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.6%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::take_NonFungibleVault                                     ,                    64737,      1.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.0%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.0%
+- RunNativeCode::withdraw                                                  ,                    57851,      0.9%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      522,      0.0%
@@ -53,11 +54,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    18960,      0.3%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    10738,      0.2%
-Finalization Cost Breakdown                                                ,                  1530239,    100.0%
-- CommitEvents                                                             ,                    30044,      2.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1630239,    100.0%
+- CommitEvents                                                             ,                    30044,      1.8%
+- CommitIntentStatus                                                       ,                   100000,      6.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.5%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     45.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      6.5%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   600053,     39.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.1%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     42.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      6.1%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   600053,     36.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/008--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/008--non-fungible-resource-freeze-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.20246316004,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.146394,     72.3%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     20.2%
+Total Cost (XRD)                                                           ,            0.21546316004,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.154394,     71.7%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.4%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     18.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2927880,    100.0%
+Execution Cost Breakdown                                                   ,                  3087880,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.7%
+- CheckIntentValidity                                                      ,                   160000,      5.2%
+- CheckReference                                                           ,                    80022,      2.6%
 - CloseSubstate                                                            ,                    12642,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
-- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.1%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   422076,     14.4%
+- PrepareWasmCode                                                          ,                   353866,     11.5%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   422076,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_NonFungibleVault                                   ,                    36496,      1.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     4288,      0.1%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     32.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/009--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/009--non-fungible-resource-freeze-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.20246316004,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.146394,     72.3%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,            0.04081726004,     20.2%
+Total Cost (XRD)                                                           ,            0.21546316004,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.154394,     71.7%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.4%
+- Storage Cost (XRD)                                                       ,            0.04081726004,     18.9%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2927880,    100.0%
+Execution Cost Breakdown                                                   ,                  3087880,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      612,      0.0%
-- CheckReference                                                           ,                    80022,      2.7%
+- CheckIntentValidity                                                      ,                   160000,      5.2%
+- CheckReference                                                           ,                    80022,      2.6%
 - CloseSubstate                                                            ,                    12642,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
-- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.9%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.1%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   422076,     14.4%
+- PrepareWasmCode                                                          ,                   353866,     11.5%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   422076,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::freeze_NonFungibleVault                                   ,                    36496,      1.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14120,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     4288,      0.1%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     32.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/010--non-fungible-resource-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/010--non-fungible-resource-recall-frozen-vault.txt
@@ -1,45 +1,46 @@
-Total Cost (XRD)                                                           ,            0.32274986512,    100.0%
-- Execution Cost (XRD)                                                     ,               0.21697825,     67.2%
-- Finalization Cost (XRD)                                                  ,               0.03100355,      9.6%
-- Storage Cost (XRD)                                                       ,            0.07476806512,     23.2%
+Total Cost (XRD)                                                           ,            0.33574986512,    100.0%
+- Execution Cost (XRD)                                                     ,               0.22497825,     67.0%
+- Finalization Cost (XRD)                                                  ,               0.03600355,     10.7%
+- Storage Cost (XRD)                                                       ,            0.07476806512,     22.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4339565,    100.0%
+Execution Cost Breakdown                                                   ,                  4499565,    100.0%
 - AfterInvoke                                                              ,                      298,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1420,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.6%
 - CheckReference                                                           ,                    80022,      1.8%
 - CloseSubstate                                                            ,                    29283,      0.7%
 - CreateNode                                                               ,                    12204,      0.3%
 - DropNode                                                                 ,                    21822,      0.5%
-- EmitEvent                                                                ,                     2210,      0.1%
+- EmitEvent                                                                ,                     2210,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   126726,      2.9%
-- OpenSubstate::GlobalPackage                                              ,                  1953445,     45.0%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.6%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.1%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   126726,      2.8%
+- OpenSubstate::GlobalPackage                                              ,                  1953445,     43.4%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.4%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    43083,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
-- OpenSubstate::InternalNonFungibleVault                                   ,                   171392,      3.9%
+- OpenSubstate::InternalNonFungibleVault                                   ,                   171392,      3.8%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.2%
+- PrepareWasmCode                                                          ,                   353866,      7.9%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   488979,     11.3%
+- ReadSubstate                                                             ,                   488979,     10.9%
 - RemoveSubstate                                                           ,                    40717,      0.9%
-- RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
+- RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.8%
 - RunNativeCode::recall_non_fungibles                                      ,                    57416,      1.3%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
@@ -47,10 +48,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    17640,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     8116,      0.2%
-Finalization Cost Breakdown                                                ,                   620071,    100.0%
-- CommitEvents                                                             ,                    20024,      3.2%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   720071,    100.0%
+- CommitEvents                                                             ,                    20024,      2.8%
+- CommitIntentStatus                                                       ,                   100000,     13.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     16.1%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     16.1%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     64.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     13.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     13.9%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400020,     55.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/011--non-fungible-resource-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/011--non-fungible-resource-unfreeze-withdraw.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
+Total Cost (XRD)                                                           ,             0.2155271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15426725,     71.6%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.4%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     19.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2925345,    100.0%
+Execution Cost Breakdown                                                   ,                  3085345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.7%
+- CheckIntentValidity                                                      ,                   160000,      5.2%
+- CheckReference                                                           ,                    80022,      2.6%
 - CloseSubstate                                                            ,                    12642,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
-- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.1%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   422076,     14.4%
+- PrepareWasmCode                                                          ,                   353866,     11.5%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   422076,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     4288,      0.1%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     32.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/012--non-fungible-resource-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/012--non-fungible-resource-unfreeze-deposit.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
+Total Cost (XRD)                                                           ,             0.2155271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15426725,     71.6%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.4%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     19.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2925345,    100.0%
+Execution Cost Breakdown                                                   ,                  3085345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.7%
+- CheckIntentValidity                                                      ,                   160000,      5.2%
+- CheckReference                                                           ,                    80022,      2.6%
 - CloseSubstate                                                            ,                    12642,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
-- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.1%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   422076,     14.4%
+- PrepareWasmCode                                                          ,                   353866,     11.5%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   422076,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     4288,      0.1%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     32.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/013--non-fungible-resource-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/013--non-fungible-resource-unfreeze-burn.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,             0.2025271449,    100.0%
-- Execution Cost (XRD)                                                     ,               0.14626725,     72.2%
-- Finalization Cost (XRD)                                                  ,                0.0152519,      7.5%
-- Storage Cost (XRD)                                                       ,             0.0410079949,     20.2%
+Total Cost (XRD)                                                           ,             0.2155271449,    100.0%
+- Execution Cost (XRD)                                                     ,               0.15426725,     71.6%
+- Finalization Cost (XRD)                                                  ,                0.0202519,      9.4%
+- Storage Cost (XRD)                                                       ,             0.0410079949,     19.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  2925345,    100.0%
+Execution Cost Breakdown                                                   ,                  3085345,    100.0%
 - AfterInvoke                                                              ,                       76,      0.0%
 - AllocateNodeId                                                           ,                      679,      0.0%
 - BeforeInvoke                                                             ,                      616,      0.0%
-- CheckReference                                                           ,                    80022,      2.7%
+- CheckIntentValidity                                                      ,                   160000,      5.2%
+- CheckReference                                                           ,                    80022,      2.6%
 - CloseSubstate                                                            ,                    12642,      0.4%
 - CreateNode                                                               ,                     6160,      0.2%
 - DropNode                                                                 ,                    10969,      0.4%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.2%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.5%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.8%
-- OpenSubstate::GlobalPackage                                              ,                  1428558,     48.8%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      3.1%
-- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.4%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.4%
-- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      4.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.4%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                    81868,      2.7%
+- OpenSubstate::GlobalPackage                                              ,                  1428558,     46.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.9%
+- OpenSubstate::InternalGenericComponent                                   ,                    10266,      0.3%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.3%
+- OpenSubstate::InternalNonFungibleVault                                   ,                    44129,      1.4%
 - PinNode                                                                  ,                       84,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     12.1%
-- QueryActor                                                               ,                     1500,      0.1%
-- ReadSubstate                                                             ,                   422076,     14.4%
+- PrepareWasmCode                                                          ,                   353866,     11.5%
+- QueryActor                                                               ,                     1500,      0.0%
+- ReadSubstate                                                             ,                   422076,     13.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.6%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.5%
-- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      1.0%
+- RunNativeCode::unfreeze_NonFungibleVault                                 ,                    33877,      1.1%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.9%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    14200,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.5%
 - WriteSubstate                                                            ,                     4288,      0.1%
-Finalization Cost Breakdown                                                ,                   305038,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   405038,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     32.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.7%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.7%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   100004,     24.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/014--non-fungible-resource-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/014--non-fungible-resource-recall-unfrozen-vault.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.30388497619,    100.0%
-- Execution Cost (XRD)                                                     ,               0.21297755,     70.1%
-- Finalization Cost (XRD)                                                  ,                0.0210031,      6.9%
-- Storage Cost (XRD)                                                       ,            0.06990432619,     23.0%
+Total Cost (XRD)                                                           ,            0.31688497619,    100.0%
+- Execution Cost (XRD)                                                     ,               0.22097755,     69.7%
+- Finalization Cost (XRD)                                                  ,                0.0260031,      8.2%
+- Storage Cost (XRD)                                                       ,            0.06990432619,     22.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4259551,    100.0%
+Execution Cost Breakdown                                                   ,                  4419551,    100.0%
 - AfterInvoke                                                              ,                      298,      0.0%
 - AllocateNodeId                                                           ,                     1358,      0.0%
 - BeforeInvoke                                                             ,                     1420,      0.0%
-- CheckReference                                                           ,                    80022,      1.9%
+- CheckIntentValidity                                                      ,                   160000,      3.6%
+- CheckReference                                                           ,                    80022,      1.8%
 - CloseSubstate                                                            ,                    29283,      0.7%
 - CreateNode                                                               ,                    12204,      0.3%
 - DropNode                                                                 ,                    21822,      0.5%
@@ -16,41 +17,41 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   126726,      3.0%
-- OpenSubstate::GlobalPackage                                              ,                  1953445,     45.9%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.7%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.1%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   126726,      2.9%
+- OpenSubstate::GlobalPackage                                              ,                  1953445,     44.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   285944,      6.5%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.0%
 - OpenSubstate::InternalGenericComponent                                   ,                    43083,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - OpenSubstate::InternalNonFungibleVault                                   ,                    91378,      2.1%
 - PinNode                                                                  ,                      168,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.3%
+- PrepareWasmCode                                                          ,                   353866,      8.0%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   488979,     11.5%
-- RemoveSubstate                                                           ,                    40717,      1.0%
+- ReadSubstate                                                             ,                   488979,     11.1%
+- RemoveSubstate                                                           ,                    40717,      0.9%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.3%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.8%
 - RunNativeCode::recall_non_fungibles                                      ,                    57416,      1.3%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.7%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      151,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    17640,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     8116,      0.2%
-Finalization Cost Breakdown                                                ,                   420062,    100.0%
-- CommitEvents                                                             ,                    20024,      4.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   520062,    100.0%
+- CommitEvents                                                             ,                    20024,      3.9%
+- CommitIntentStatus                                                       ,                   100000,     19.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     23.8%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   200011,     47.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     19.2%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   200011,     38.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/015--non-fungible-create-resource-with-supply-with-empty-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/015--non-fungible-create-resource-with-supply-with-empty-data.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.72592202002,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2631475,     36.3%
-- Finalization Cost (XRD)                                                  ,                0.1562636,     21.5%
-- Storage Cost (XRD)                                                       ,            0.30651092002,     42.2%
+Total Cost (XRD)                                                           ,            0.73892202002,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2711475,     36.7%
+- Finalization Cost (XRD)                                                  ,                0.1612636,     21.8%
+- Storage Cost (XRD)                                                       ,            0.30651092002,     41.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5262950,    100.0%
+Execution Cost Breakdown                                                   ,                  5422950,    100.0%
 - AfterInvoke                                                              ,                      592,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     2616,      0.0%
-- CheckReference                                                           ,                    40011,      0.8%
-- CloseSubstate                                                            ,                    34572,      0.7%
+- CheckIntentValidity                                                      ,                   160000,      3.0%
+- CheckReference                                                           ,                    40011,      0.7%
+- CloseSubstate                                                            ,                    34572,      0.6%
 - CreateNode                                                               ,                    20152,      0.4%
 - DropNode                                                                 ,                    31945,      0.6%
 - EmitEvent                                                                ,                     2890,      0.1%
@@ -17,32 +18,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     6160,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    12761,      0.2%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     51.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.7%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    51397,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
-- OpenSubstate::InternalNonFungibleVault                                   ,                     7951,      0.2%
+- OpenSubstate::InternalGenericComponent                                   ,                    51397,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
+- OpenSubstate::InternalNonFungibleVault                                   ,                     7951,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.7%
+- PrepareWasmCode                                                          ,                   353866,      6.5%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   542995,     10.3%
+- ReadSubstate                                                             ,                   542995,     10.0%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create                                                    ,                    24592,      0.5%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.1%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      988,      0.0%
@@ -50,12 +51,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    22880,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9670,      0.2%
-Finalization Cost Breakdown                                                ,                  3125272,    100.0%
+Finalization Cost Breakdown                                                ,                  3225272,    100.0%
 - CommitEvents                                                             ,                    25048,      0.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.2%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2300142,     73.6%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.2%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.2%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   500044,     16.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.1%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2300142,     71.3%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.1%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.1%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   500044,     15.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,             1.5462817945,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2716239,     17.6%
-- Finalization Cost (XRD)                                                  ,               0.21131105,     13.7%
-- Storage Cost (XRD)                                                       ,             1.0633468445,     68.8%
+Total Cost (XRD)                                                           ,             1.5592817945,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2796239,     17.9%
+- Finalization Cost (XRD)                                                  ,               0.21631105,     13.9%
+- Storage Cost (XRD)                                                       ,             1.0633468445,     68.2%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5432478,    100.0%
+Execution Cost Breakdown                                                   ,                  5592478,    100.0%
 - AfterInvoke                                                              ,                      646,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                    10678,      0.2%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
 - CheckReference                                                           ,                    40011,      0.7%
 - CloseSubstate                                                            ,                    34959,      0.6%
 - CreateNode                                                               ,                    27588,      0.5%
@@ -20,42 +21,42 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    12999,      0.2%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.5%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     48.8%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    51547,      0.9%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     9574,      0.2%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.5%
+- PrepareWasmCode                                                          ,                   353866,      6.3%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   544436,     10.0%
+- ReadSubstate                                                             ,                   544436,      9.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::create                                                    ,                    24592,      0.5%
-- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
+- RunNativeCode::create                                                    ,                    24592,      0.4%
+- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.3%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      3.9%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1455,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                   170080,      3.1%
+- ValidateTxPayload                                                        ,                   170080,      3.0%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9670,      0.2%
-Finalization Cost Breakdown                                                ,                  4226221,    100.0%
+Finalization Cost Breakdown                                                ,                  4326221,    100.0%
 - CommitEvents                                                             ,                    25069,      0.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.3%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.4%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  3101064,     73.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      2.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.4%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   800050,     18.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.3%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  3101064,     71.7%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      2.3%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.3%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   800050,     18.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/017--non-fungible-transfer-metadata-standard-nfs.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/017--non-fungible-transfer-metadata-standard-nfs.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.44452780747,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2567405,     57.8%
-- Finalization Cost (XRD)                                                  ,               0.05150725,     11.6%
-- Storage Cost (XRD)                                                       ,            0.13628005747,     30.7%
+Total Cost (XRD)                                                           ,            0.45752780747,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2647405,     57.9%
+- Finalization Cost (XRD)                                                  ,               0.05650725,     12.4%
+- Storage Cost (XRD)                                                       ,            0.13628005747,     29.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5134810,    100.0%
+Execution Cost Breakdown                                                   ,                  5294810,    100.0%
 - AfterInvoke                                                              ,                      488,      0.0%
 - AllocateNodeId                                                           ,                     1746,      0.0%
 - BeforeInvoke                                                             ,                     1868,      0.0%
-- CheckReference                                                           ,                    80031,      1.6%
+- CheckIntentValidity                                                      ,                   160000,      3.0%
+- CheckReference                                                           ,                    80031,      1.5%
 - CloseSubstate                                                            ,                    37410,      0.7%
 - CreateNode                                                               ,                    15820,      0.3%
 - DropNode                                                                 ,                    26731,      0.5%
@@ -16,32 +17,32 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.4%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    94341,      1.8%
-- OpenSubstate::GlobalPackage                                              ,                  2152801,     41.9%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   691764,     13.5%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.8%
-- OpenSubstate::InternalGenericComponent                                   ,                    54290,      1.1%
+- OpenSubstate::GlobalPackage                                              ,                  2152801,     40.7%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   691764,     13.1%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
+- OpenSubstate::InternalGenericComponent                                   ,                    54290,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
 - OpenSubstate::InternalNonFungibleVault                                   ,                    93211,      1.8%
 - PinNode                                                                  ,                      204,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.9%
+- PrepareWasmCode                                                          ,                   353866,      6.7%
 - QueryActor                                                               ,                     2500,      0.0%
-- ReadSubstate                                                             ,                   539693,     10.5%
-- RemoveSubstate                                                           ,                    81434,      1.6%
+- ReadSubstate                                                             ,                   539693,     10.2%
+- RemoveSubstate                                                           ,                    81434,      1.5%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    23886,      0.5%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.9%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::take_non_fungibles                                        ,                    64562,      1.3%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.4%
-- RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.6%
+- RunNativeCode::take_non_fungibles                                        ,                    64562,      1.2%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::withdraw_non_fungibles                                    ,                    81584,      1.5%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      302,      0.0%
@@ -49,11 +50,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    19360,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                    10062,      0.2%
-Finalization Cost Breakdown                                                ,                  1030145,    100.0%
-- CommitEvents                                                             ,                    30056,      2.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1130145,    100.0%
+- CommitEvents                                                             ,                    30056,      2.7%
+- CommitIntentStatus                                                       ,                   100000,      8.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      9.7%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      9.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      9.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   700051,     68.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.9%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      8.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      8.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   700051,     61.9%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/018--non-fungible-create-resource-with-supply-with-complex-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/018--non-fungible-create-resource-with-supply-with-complex-data.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.81711709289,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2690345,     32.9%
-- Finalization Cost (XRD)                                                  ,               0.12627245,     15.5%
-- Storage Cost (XRD)                                                       ,            0.42181014289,     51.6%
+Total Cost (XRD)                                                           ,            0.83011709289,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2770345,     33.4%
+- Finalization Cost (XRD)                                                  ,               0.13127245,     15.8%
+- Storage Cost (XRD)                                                       ,            0.42181014289,     50.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5380690,    100.0%
+Execution Cost Breakdown                                                   ,                  5540690,    100.0%
 - AfterInvoke                                                              ,                      556,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     4370,      0.1%
-- CheckReference                                                           ,                    80031,      1.5%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                    80031,      1.4%
 - CloseSubstate                                                            ,                    34830,      0.6%
 - CreateNode                                                               ,                    21664,      0.4%
 - DropNode                                                                 ,                    31923,      0.6%
@@ -17,32 +18,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5040,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    55737,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  2727099,     50.7%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.6%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    51367,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::GlobalPackage                                              ,                  2727099,     49.2%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   406740,      7.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
+- OpenSubstate::InternalGenericComponent                                   ,                    51367,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     6869,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.6%
+- PrepareWasmCode                                                          ,                   353866,      6.4%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   544461,     10.1%
+- ReadSubstate                                                             ,                   544461,      9.8%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::create                                                    ,                    24592,      0.5%
-- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
+- RunNativeCode::create                                                    ,                    24592,      0.4%
+- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.3%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      3.9%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.3%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      700,      0.0%
@@ -50,12 +51,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    55320,      1.0%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9670,      0.2%
-Finalization Cost Breakdown                                                ,                  2525449,    100.0%
+Finalization Cost Breakdown                                                ,                  2625449,    100.0%
 - CommitEvents                                                             ,                    25033,      1.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.0%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  1900338,     75.2%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      4.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      4.0%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     11.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.8%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  1900338,     72.4%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.8%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,     11.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/019--non-fungible-mutate-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/costings/019--non-fungible-mutate-data.txt
@@ -1,46 +1,47 @@
-Total Cost (XRD)                                                           ,            1.01281478973,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1763029,     17.4%
-- Finalization Cost (XRD)                                                  ,               0.01530295,      1.5%
-- Storage Cost (XRD)                                                       ,            0.82120893973,     81.1%
+Total Cost (XRD)                                                           ,            1.02581478973,    100.0%
+- Execution Cost (XRD)                                                     ,                0.1843029,     18.0%
+- Finalization Cost (XRD)                                                  ,               0.02030295,      2.0%
+- Storage Cost (XRD)                                                       ,            0.82120893973,     80.1%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3526058,    100.0%
+Execution Cost Breakdown                                                   ,                  3686058,    100.0%
 - AfterInvoke                                                              ,                       82,      0.0%
 - AllocateNodeId                                                           ,                      776,      0.0%
-- BeforeInvoke                                                             ,                     9054,      0.3%
-- CheckReference                                                           ,                    80031,      2.3%
+- BeforeInvoke                                                             ,                     9054,      0.2%
+- CheckIntentValidity                                                      ,                   160000,      4.3%
+- CheckReference                                                           ,                    80031,      2.2%
 - CloseSubstate                                                            ,                    15738,      0.4%
 - CreateNode                                                               ,                     7078,      0.2%
-- DropNode                                                                 ,                    12574,      0.4%
+- DropNode                                                                 ,                    12574,      0.3%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.2%
-- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   384884,     10.9%
-- OpenSubstate::GlobalPackage                                              ,                  1449523,     41.1%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.6%
+- OpenSubstate::GlobalNonFungibleResourceManager                           ,                   384884,     10.4%
+- OpenSubstate::GlobalPackage                                              ,                  1449523,     39.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.4%
 - OpenSubstate::InternalGenericComponent                                   ,                    13522,      0.4%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.1%
 - PinNode                                                                  ,                       96,      0.0%
-- PrepareWasmCode                                                          ,                   353866,     10.0%
+- PrepareWasmCode                                                          ,                   353866,      9.6%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                   467613,     13.3%
+- ReadSubstate                                                             ,                   467613,     12.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
-- RunNativeCode::lock_fee                                                  ,                    45243,      1.3%
-- RunNativeCode::update_non_fungible_data                                  ,                   106206,      3.0%
+- RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
+- RunNativeCode::update_non_fungible_data                                  ,                   106206,      2.9%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                   183160,      5.2%
+- ValidateTxPayload                                                        ,                   183160,      5.0%
 - VerifyTxSignatures                                                       ,                    14000,      0.4%
 - WriteSubstate                                                            ,                    21386,      0.6%
-Finalization Cost Breakdown                                                ,                   306059,    100.0%
-- CommitEvents                                                             ,                     5007,      1.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   406059,    100.0%
+- CommitEvents                                                             ,                     5007,      1.2%
+- CommitIntentStatus                                                       ,                   100000,     24.6%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   101025,     33.0%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     24.6%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                   101025,     24.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     24.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/001--non-fungible-resource-create.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/001--non-fungible-resource-create.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.86139216999 XRD
-├─ Network execution: 0.2761705 XRD, 5523410 execution cost units
-├─ Network finalization: 0.16627255 XRD, 3325451 finalization cost units
+TRANSACTION COST: 0.87439216999 XRD
+├─ Network execution: 0.2841705 XRD, 5683410 execution cost units
+├─ Network finalization: 0.17127255 XRD, 3425451 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.41894911999 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.86139216999"),
+     amount: Decimal("0.87439216999"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.430696084995"),
+     amount: Decimal("0.437196084995"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.430696084995"),
+     amount: Decimal("0.437196084995"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.2153480424975"),
+             0u8 => Decimal("0.2185980424975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999999.13860783001")),
+         LiquidFungibleResource(Decimal("99999999999999999.12560783001")),
        )
 ├─ resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l across 6 partitions
   ├─ Partition(1): 1 change
@@ -514,7 +514,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.430696084995")),
+         LiquidFungibleResource(Decimal("0.437196084995")),
        )
 
 OUTPUTS: 3
@@ -528,13 +528,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.86139216999
+   Change: -0.87439216999
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.430696084995
+   Change: 0.437196084995
 
 NEW ENTITIES: 2
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/002--non-fungible-resource-create-string.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/002--non-fungible-resource-create-string.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.75151466441 XRD
-├─ Network execution: 0.26362785 XRD, 5272557 execution cost units
-├─ Network finalization: 0.1362671 XRD, 2725342 finalization cost units
+TRANSACTION COST: 0.76451466441 XRD
+├─ Network execution: 0.27162785 XRD, 5432557 execution cost units
+├─ Network finalization: 0.1412671 XRD, 2825342 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.35161971441 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.75151466441"),
+     amount: Decimal("0.76451466441"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.375757332205"),
+     amount: Decimal("0.382257332205"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.375757332205"),
+     amount: Decimal("0.382257332205"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4032267086"),
+             0u8 => Decimal("0.4097267086"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.3870931656")),
+         LiquidFungibleResource(Decimal("99999999999999998.3610931656")),
        )
 ├─ resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2 across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.8064534172")),
+         LiquidFungibleResource(Decimal("0.8194534172")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.75151466441
+   Change: -0.76451466441
 ├─ Vault: internal_vault_sim1nzzvtpj0tjkaydq997fla88kg90hpn9km9cnev38ltuaalkm6qy48j
    ResAddr: resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2
    Change: +{<my_nft>}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.375757332205
+   Change: 0.382257332205
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngmh9yztljz0kg9pk0d8ul3wlxej866h0mhnvv5zkrmfsy25tdlxv2

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/003--non-fungible-resource-create-bytes.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/003--non-fungible-resource-create-bytes.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.75726816021 XRD
-├─ Network execution: 0.26365885 XRD, 5273177 execution cost units
-├─ Network finalization: 0.13626755 XRD, 2725351 finalization cost units
+TRANSACTION COST: 0.77026816021 XRD
+├─ Network execution: 0.27165885 XRD, 5433177 execution cost units
+├─ Network finalization: 0.14126755 XRD, 2825351 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.35734176021 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.75726816021"),
+     amount: Decimal("0.77026816021"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.378634080105"),
+     amount: Decimal("0.385134080105"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.378634080105"),
+     amount: Decimal("0.385134080105"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.5925437486525"),
+             0u8 => Decimal("0.6022937486525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.62982500539")),
+         LiquidFungibleResource(Decimal("99999999999999997.59082500539")),
        )
 ├─ resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.185087497305")),
+         LiquidFungibleResource(Decimal("1.204587497305")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.75726816021
+   Change: -0.77026816021
 ├─ Vault: internal_vault_sim1npk4ndjw8jn7kav0t2fc69geagkxdpdu7wvvnh4v2p4exwfn6dl0th
    ResAddr: resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs
    Change: +{[00000000000000000000000000000000]}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.378634080105
+   Change: 0.385134080105
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1nf89a30xn7gc79cytvgjca028gehd3ha3ydt0z0pp3rzlcuqv8d9fs

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/004--non-fungible-resource-create-ruid.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/004--non-fungible-resource-create-ruid.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.76337514774 XRD
-├─ Network execution: 0.2629943 XRD, 5259886 execution cost units
-├─ Network finalization: 0.136268 XRD, 2725360 finalization cost units
+TRANSACTION COST: 0.77637514774 XRD
+├─ Network execution: 0.2709943 XRD, 5419886 execution cost units
+├─ Network finalization: 0.141268 XRD, 2825360 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.36411284774 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.76337514774"),
+     amount: Decimal("0.77637514774"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.38168757387"),
+     amount: Decimal("0.38818757387"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.38168757387"),
+     amount: Decimal("0.38818757387"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.7833875355875"),
+             0u8 => Decimal("0.7963875355875"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999996.86644985765")),
+         LiquidFungibleResource(Decimal("99999999999999996.81444985765")),
        )
 ├─ resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7 across 6 partitions
   ├─ Partition(1): 1 change
@@ -411,7 +411,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.566775071175")),
+         LiquidFungibleResource(Decimal("1.592775071175")),
        )
 
 OUTPUTS: 3
@@ -425,13 +425,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.76337514774
+   Change: -0.77637514774
 ├─ Vault: internal_vault_sim1nz6ksuj04dn2dq5waa9jyzfm52erqd74ls0xx2r3rafv8xjs29efp5
    ResAddr: resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7
    Change: +{{01dae3e6299cc23a-5a8ecfea5b6bdb5b-52be14aa0a43c7bc-8498ea430b50b164}}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.38168757387
+   Change: 0.38818757387
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngvvctr9hl04wrlyfudzyx3t3aam07ffk3f04z9lxd5ec2p87gftk7

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/005--non-fungible-resource-mint-32-nfts.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/005--non-fungible-resource-mint-32-nfts.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 2.04157524637 XRD
-├─ Network execution: 0.49825105 XRD, 9965021 execution cost units
-├─ Network finalization: 0.3360679 XRD, 6721358 finalization cost units
+TRANSACTION COST: 2.05457524637 XRD
+├─ Network execution: 0.50625105 XRD, 10125021 execution cost units
+├─ Network finalization: 0.3410679 XRD, 6821358 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.20725629637 XRD
 └─ Royalties: 0 XRD
@@ -128,15 +128,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("2.04157524637"),
+     amount: Decimal("2.05457524637"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.020787623185"),
+     amount: Decimal("1.027287623185"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.020787623185"),
+     amount: Decimal("1.027287623185"),
    }
 
 STATE UPDATES: 7 entities
@@ -146,7 +146,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.29378134718"),
+             0u8 => Decimal("1.31003134718"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -501,7 +501,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.82487461128")),
+         LiquidFungibleResource(Decimal("99999999999999994.75987461128")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -642,7 +642,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.58756269436")),
+         LiquidFungibleResource(Decimal("2.62006269436")),
        )
 
 OUTPUTS: 3
@@ -653,12 +653,12 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -2.04157524637
+   Change: -2.05457524637
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#100#, #101#, #102#, #103#, #104#, #105#, #106#, #107#, #108#, #109#, #110#, #111#, #112#, #113#, #114#, #115#, #116#, #117#, #118#, #119#, #120#, #121#, #122#, #123#, #124#, #125#, #126#, #127#, #128#, #129#, #130#, #131#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.020787623185
+   Change: 1.027287623185
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/006--non-fungible-resource-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/006--non-fungible-resource-burn.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.42116546511 XRD
-├─ Network execution: 0.26216325 XRD, 5243265 execution cost units
-├─ Network finalization: 0.04675475 XRD, 935095 finalization cost units
+TRANSACTION COST: 0.43416546511 XRD
+├─ Network execution: 0.27016325 XRD, 5403265 execution cost units
+├─ Network finalization: 0.05175475 XRD, 1035095 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.11224746511 XRD
 └─ Royalties: 0 XRD
@@ -57,15 +57,15 @@ EVENTS: 10
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.42116546511"),
+     amount: Decimal("0.43416546511"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.210582732555"),
+     amount: Decimal("0.217082732555"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.210582732555"),
+     amount: Decimal("0.217082732555"),
    }
 
 STATE UPDATES: 7 entities
@@ -75,7 +75,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.3990727134575"),
+             0u8 => Decimal("1.4185727134575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -116,7 +116,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999994.40370914617")),
+         LiquidFungibleResource(Decimal("99999999999999994.32570914617")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -132,7 +132,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("2.798145426915")),
+         LiquidFungibleResource(Decimal("2.837145426915")),
        )
 
 OUTPUTS: 7
@@ -147,12 +147,12 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.42116546511
+   Change: -0.43416546511
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{}, -{#110#, #126#, #127#}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.210582732555
+   Change: 0.217082732555
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/007--non-fungible-resource-transfer.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/007--non-fungible-resource-transfer.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.57103255949 XRD
-├─ Network execution: 0.29968495 XRD, 5993699 execution cost units
-├─ Network finalization: 0.07651195 XRD, 1530239 finalization cost units
+TRANSACTION COST: 0.58403255949 XRD
+├─ Network execution: 0.30768495 XRD, 6153699 execution cost units
+├─ Network finalization: 0.08151195 XRD, 1630239 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19483565949 XRD
 └─ Royalties: 0 XRD
@@ -46,15 +46,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.57103255949"),
+     amount: Decimal("0.58403255949"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.285516279745"),
+     amount: Decimal("0.292016279745"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.285516279745"),
+     amount: Decimal("0.292016279745"),
    }
 
 STATE UPDATES: 8 entities
@@ -64,7 +64,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.54183085333"),
+             0u8 => Decimal("1.56458085333"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,7 +97,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.83267658668")),
+         LiquidFungibleResource(Decimal("99999999999999993.74167658668")),
        )
 ├─ internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q across 2 partitions
   ├─ Partition(64): 1 change
@@ -250,7 +250,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.08366170666")),
+         LiquidFungibleResource(Decimal("3.12916170666")),
        )
 
 OUTPUTS: 3
@@ -261,7 +261,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.57103255949
+   Change: -0.58403255949
 ├─ Vault: internal_vault_sim1nzupesg6es369wqjguu7umf92886ph6w3qj98uxq7tkavev439ut2q
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{}, -{#111#}
@@ -270,7 +270,7 @@ BALANCE CHANGES: 4
    Change: +{#111#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.285516279745
+   Change: 0.292016279745
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/008--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/008--non-fungible-resource-freeze-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.20246316004 XRD
-├─ Network execution: 0.146394 XRD, 2927880 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.21546316004 XRD
+├─ Network execution: 0.154394 XRD, 3087880 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20246316004"),
+     amount: Decimal("0.21546316004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10123158002"),
+     amount: Decimal("0.10773158002"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10123158002"),
+     amount: Decimal("0.10773158002"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.59244664334"),
+             0u8 => Decimal("1.61844664334"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.63021342664")),
+         LiquidFungibleResource(Decimal("99999999999999993.52621342664")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.18489328668")),
+         LiquidFungibleResource(Decimal("3.23689328668")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20246316004
+   Change: -0.21546316004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10123158002
+   Change: 0.10773158002
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/009--non-fungible-resource-freeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/009--non-fungible-resource-freeze-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.20246316004 XRD
-├─ Network execution: 0.146394 XRD, 2927880 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.21546316004 XRD
+├─ Network execution: 0.154394 XRD, 3087880 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.04081726004 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.20246316004"),
+     amount: Decimal("0.21546316004"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10123158002"),
+     amount: Decimal("0.10773158002"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10123158002"),
+     amount: Decimal("0.10773158002"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.64306243335"),
+             0u8 => Decimal("1.67231243335"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.4277502666")),
+         LiquidFungibleResource(Decimal("99999999999999993.3107502666")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.2861248667")),
+         LiquidFungibleResource(Decimal("3.3446248667")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.20246316004
+   Change: -0.21546316004
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10123158002
+   Change: 0.10773158002
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/010--non-fungible-resource-recall-frozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/010--non-fungible-resource-recall-frozen-vault.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32274986512 XRD
-├─ Network execution: 0.21697825 XRD, 4339565 execution cost units
-├─ Network finalization: 0.03100355 XRD, 620071 finalization cost units
+TRANSACTION COST: 0.33574986512 XRD
+├─ Network execution: 0.22497825 XRD, 4499565 execution cost units
+├─ Network finalization: 0.03600355 XRD, 720071 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.07476806512 XRD
 └─ Royalties: 0 XRD
@@ -35,15 +35,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32274986512"),
+     amount: Decimal("0.33574986512"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16137493256"),
+     amount: Decimal("0.16787493256"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16137493256"),
+     amount: Decimal("0.16787493256"),
    }
 
 STATE UPDATES: 7 entities
@@ -53,7 +53,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.72374989963"),
+             0u8 => Decimal("1.75624989963"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -94,7 +94,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999993.10500040148")),
+         LiquidFungibleResource(Decimal("99999999999999992.97500040148")),
        )
 ├─ internal_vault_sim1nq4qqp48us7mydmk7sfmjasfku00yzampszkkte00xx434qwtdfu3z across 2 partitions
   ├─ Partition(64): 1 change
@@ -111,7 +111,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.44749979926")),
+         LiquidFungibleResource(Decimal("3.51249979926")),
        )
 
 OUTPUTS: 3
@@ -125,12 +125,12 @@ BALANCE CHANGES: 4
    Change: +{}, -{#120#}
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32274986512
+   Change: -0.33574986512
 ├─ Vault: internal_vault_sim1nq4qqp48us7mydmk7sfmjasfku00yzampszkkte00xx434qwtdfu3z
    ResAddr: resource_sim1ntpe4zxy537sl7dduxwpxd3h548wf4dq6z2s6uks94pwzeeapq579l
    Change: +{#120#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16137493256
+   Change: 0.16787493256
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/011--non-fungible-resource-unfreeze-withdraw.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/011--non-fungible-resource-unfreeze-withdraw.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2025271449 XRD
-├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2155271449 XRD
+├─ Network execution: 0.15426725 XRD, 3085345 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2025271449"),
+     amount: Decimal("0.2155271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.774381685855"),
+             0u8 => Decimal("1.810131685855"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.90247325658")),
+         LiquidFungibleResource(Decimal("99999999999999992.75947325658")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.54876337171")),
+         LiquidFungibleResource(Decimal("3.62026337171")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2025271449
+   Change: -0.2155271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10126357245
+   Change: 0.10776357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/012--non-fungible-resource-unfreeze-deposit.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/012--non-fungible-resource-unfreeze-deposit.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2025271449 XRD
-├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2155271449 XRD
+├─ Network execution: 0.15426725 XRD, 3085345 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2025271449"),
+     amount: Decimal("0.2155271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.82501347208"),
+             0u8 => Decimal("1.86401347208"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.69994611168")),
+         LiquidFungibleResource(Decimal("99999999999999992.54394611168")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.65002694416")),
+         LiquidFungibleResource(Decimal("3.72802694416")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2025271449
+   Change: -0.2155271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10126357245
+   Change: 0.10776357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/013--non-fungible-resource-unfreeze-burn.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/013--non-fungible-resource-unfreeze-burn.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.2025271449 XRD
-├─ Network execution: 0.14626725 XRD, 2925345 execution cost units
-├─ Network finalization: 0.0152519 XRD, 305038 finalization cost units
+TRANSACTION COST: 0.2155271449 XRD
+├─ Network execution: 0.15426725 XRD, 3085345 execution cost units
+├─ Network finalization: 0.0202519 XRD, 405038 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.0410079949 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.2025271449"),
+     amount: Decimal("0.2155271449"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.10126357245"),
+     amount: Decimal("0.10776357245"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.875645258305"),
+             0u8 => Decimal("1.917895258305"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -75,13 +75,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.49741896678")),
+         LiquidFungibleResource(Decimal("99999999999999992.32841896678")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.75129051661")),
+         LiquidFungibleResource(Decimal("3.83579051661")),
        )
 
 OUTPUTS: 2
@@ -91,9 +91,9 @@ OUTPUTS: 2
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.2025271449
+   Change: -0.2155271449
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.10126357245
+   Change: 0.10776357245
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/014--non-fungible-resource-recall-unfrozen-vault.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/014--non-fungible-resource-recall-unfrozen-vault.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30388497619 XRD
-├─ Network execution: 0.21297755 XRD, 4259551 execution cost units
-├─ Network finalization: 0.0210031 XRD, 420062 finalization cost units
+TRANSACTION COST: 0.31688497619 XRD
+├─ Network execution: 0.22097755 XRD, 4419551 execution cost units
+├─ Network finalization: 0.0260031 XRD, 520062 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.06990432619 XRD
 └─ Royalties: 0 XRD
@@ -35,15 +35,15 @@ EVENTS: 7
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30388497619"),
+     amount: Decimal("0.31688497619"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.151942488095"),
+     amount: Decimal("0.158442488095"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.151942488095"),
+     amount: Decimal("0.158442488095"),
    }
 
 STATE UPDATES: 6 entities
@@ -53,7 +53,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("1.9516165023525"),
+             0u8 => Decimal("1.9971165023525"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -97,13 +97,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999992.19353399059")),
+         LiquidFungibleResource(Decimal("99999999999999992.01153399059")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("3.903233004705")),
+         LiquidFungibleResource(Decimal("3.994233004705")),
        )
 
 OUTPUTS: 3
@@ -114,9 +114,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30388497619
+   Change: -0.31688497619
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.151942488095
+   Change: 0.158442488095
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/015--non-fungible-create-resource-with-supply-with-empty-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/015--non-fungible-create-resource-with-supply-with-empty-data.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.72592202002 XRD
-├─ Network execution: 0.2631475 XRD, 5262950 execution cost units
-├─ Network finalization: 0.1562636 XRD, 3125272 finalization cost units
+TRANSACTION COST: 0.73892202002 XRD
+├─ Network execution: 0.2711475 XRD, 5422950 execution cost units
+├─ Network finalization: 0.1612636 XRD, 3225272 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.30651092002 XRD
 └─ Royalties: 0 XRD
@@ -45,15 +45,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.72592202002"),
+     amount: Decimal("0.73892202002"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.36296101001"),
+     amount: Decimal("0.36946101001"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.36296101001"),
+     amount: Decimal("0.36946101001"),
    }
 
 STATE UPDATES: 8 entities
@@ -63,7 +63,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.1330970073575"),
+             0u8 => Decimal("2.1818470073575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -96,7 +96,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999991.46761197057")),
+         LiquidFungibleResource(Decimal("99999999999999991.27261197057")),
        )
 ├─ resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx across 6 partitions
   ├─ Partition(1): 1 change
@@ -299,7 +299,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("4.266194014715")),
+         LiquidFungibleResource(Decimal("4.363694014715")),
        )
 
 OUTPUTS: 3
@@ -313,13 +313,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.72592202002
+   Change: -0.73892202002
 ├─ Vault: internal_vault_sim1nptkpwateyft954ecyn22njkpul50pta3sefh62mwuas6uzlh30042
    ResAddr: resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx
    Change: +{#1#, #2#, #3#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.36296101001
+   Change: 0.36946101001
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1nfacl5anpn7rthz3czyh282v0p9qr22trqwql96vh38cz6mafqfvnx

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/016--non-fungible-create-resource-with-supply-with-metadata-standard-data.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.5462817945 XRD
-├─ Network execution: 0.2716239 XRD, 5432478 execution cost units
-├─ Network finalization: 0.21131105 XRD, 4226221 finalization cost units
+TRANSACTION COST: 1.5592817945 XRD
+├─ Network execution: 0.2796239 XRD, 5592478 execution cost units
+├─ Network finalization: 0.21631105 XRD, 4326221 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.0633468445 XRD
 └─ Royalties: 0 XRD
@@ -54,15 +54,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.5462817945"),
+     amount: Decimal("1.5592817945"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.77314089725"),
+     amount: Decimal("0.77964089725"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.77314089725"),
+     amount: Decimal("0.77964089725"),
    }
 
 STATE UPDATES: 8 entities
@@ -72,7 +72,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.5196674559825"),
+             0u8 => Decimal("2.5716674559825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -105,7 +105,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.92133017607")),
+         LiquidFungibleResource(Decimal("99999999999999989.71333017607")),
        )
 ├─ resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn across 7 partitions
   ├─ Partition(1): 1 change
@@ -437,7 +437,7 @@ DEXes allow users to trade assets without the need for a trusted third party. Th
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.039334911965")),
+         LiquidFungibleResource(Decimal("5.143334911965")),
        )
 
 OUTPUTS: 3
@@ -451,13 +451,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.5462817945
+   Change: -1.5592817945
 ├─ Vault: internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n
    ResAddr: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn
    Change: +{#1#, #2#, #3#, #4#, #5#, #8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.77314089725
+   Change: 0.77964089725
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/017--non-fungible-transfer-metadata-standard-nfs.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/017--non-fungible-transfer-metadata-standard-nfs.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.44452780747 XRD
-├─ Network execution: 0.2567405 XRD, 5134810 execution cost units
-├─ Network finalization: 0.05150725 XRD, 1030145 finalization cost units
+TRANSACTION COST: 0.45752780747 XRD
+├─ Network execution: 0.2647405 XRD, 5294810 execution cost units
+├─ Network finalization: 0.05650725 XRD, 1130145 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.13628005747 XRD
 └─ Royalties: 0 XRD
@@ -50,15 +50,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.44452780747"),
+     amount: Decimal("0.45752780747"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.222263903735"),
+     amount: Decimal("0.228763903735"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.222263903735"),
+     amount: Decimal("0.228763903735"),
    }
 
 STATE UPDATES: 8 entities
@@ -68,7 +68,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.63079940785"),
+             0u8 => Decimal("2.68604940785"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -101,7 +101,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999989.4768023686")),
+         LiquidFungibleResource(Decimal("99999999999999989.2558023686")),
        )
 ├─ internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n across 2 partitions
   ├─ Partition(64): 1 change
@@ -160,7 +160,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.2615988157")),
+         LiquidFungibleResource(Decimal("5.3720988157")),
        )
 
 OUTPUTS: 3
@@ -171,7 +171,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.44452780747
+   Change: -0.45752780747
 ├─ Vault: internal_vault_sim1nrukmp5vx6sq3va905gnc6shf85ql9m83cachgjrjf80y54302yl8n
    ResAddr: resource_sim1ngy84t92hr3fthvrelg0kmcr2hwqxv00qed9wu2zkffa9yyv8h8zsn
    Change: +{}, -{#4#, #8#}
@@ -180,6 +180,6 @@ BALANCE CHANGES: 4
    Change: +{#4#, #8#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.222263903735
+   Change: 0.228763903735
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/018--non-fungible-create-resource-with-supply-with-complex-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/018--non-fungible-create-resource-with-supply-with-complex-data.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.81711709289 XRD
-├─ Network execution: 0.2690345 XRD, 5380690 execution cost units
-├─ Network finalization: 0.12627245 XRD, 2525449 finalization cost units
+TRANSACTION COST: 0.83011709289 XRD
+├─ Network execution: 0.2770345 XRD, 5540690 execution cost units
+├─ Network finalization: 0.13127245 XRD, 2625449 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.42181014289 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.81711709289"),
+     amount: Decimal("0.83011709289"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.408558546445"),
+     amount: Decimal("0.415058546445"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.408558546445"),
+     amount: Decimal("0.415058546445"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("2.8350786810725"),
+             0u8 => Decimal("2.8935786810725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999988.65968527571")),
+         LiquidFungibleResource(Decimal("99999999999999988.42568527571")),
        )
 ├─ resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm across 6 partitions
   ├─ Partition(1): 1 change
@@ -445,7 +445,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("5.670157362145")),
+         LiquidFungibleResource(Decimal("5.787157362145")),
        )
 
 OUTPUTS: 3
@@ -459,13 +459,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.81711709289
+   Change: -0.83011709289
 ├─ Vault: internal_vault_sim1nqvpupxfdwtvgqxp8jqddjtrrsd8u984qd6u93uz2mhezkdwsvx9u7
    ResAddr: resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.408558546445
+   Change: 0.415058546445
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngcvdpjg2dg5gjx4sqp9zh88hhvuafu7vw92dfyfrga9u3lnd5vatm

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/019--non-fungible-mutate-data.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/receipts/019--non-fungible-mutate-data.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.01281478973 XRD
-├─ Network execution: 0.1763029 XRD, 3526058 execution cost units
-├─ Network finalization: 0.01530295 XRD, 306059 finalization cost units
+TRANSACTION COST: 1.02581478973 XRD
+├─ Network execution: 0.1843029 XRD, 3686058 execution cost units
+├─ Network finalization: 0.02030295 XRD, 406059 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.82120893973 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.01281478973"),
+     amount: Decimal("1.02581478973"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.506407394865"),
+     amount: Decimal("0.512907394865"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.506407394865"),
+     amount: Decimal("0.512907394865"),
    }
 
 STATE UPDATES: 6 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("3.088282378505"),
+             0u8 => Decimal("3.150032378505"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,13 +71,13 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999987.64687048598")),
+         LiquidFungibleResource(Decimal("99999999999999987.39987048598")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("6.17656475701")),
+         LiquidFungibleResource(Decimal("6.30006475701")),
        )
 
 OUTPUTS: 3
@@ -88,9 +88,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.01281478973
+   Change: -1.02581478973
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.506407394865
+   Change: 0.512907394865
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: non_fungible_resource
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: ac7246d0f66c7fd2 (allowed to change if not deployed to any network)
-Events       : 063ccf94870488e7 (allowed to change if not deployed to any network)
+State changes: c12585644f8720ef (allowed to change if not deployed to any network)
+Events       : 5ff77bb83f0b7512 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - main_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/001--non-fungible-resource-with-remote-type-registration.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/001--non-fungible-resource-with-remote-type-registration.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,           57.47047115011,    100.0%
-- Execution Cost (XRD)                                                     ,                1.0233539,      1.8%
-- Finalization Cost (XRD)                                                  ,                0.1157698,      0.2%
+Total Cost (XRD)                                                           ,           57.48347115011,    100.0%
+- Execution Cost (XRD)                                                     ,                1.0313539,      1.8%
+- Finalization Cost (XRD)                                                  ,                0.1207698,      0.2%
 - Storage Cost (XRD)                                                       ,           56.33134745011,     98.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 20467078,    100.0%
+Execution Cost Breakdown                                                   ,                 20627078,    100.0%
 - AfterInvoke                                                              ,                      474,      0.0%
 - AllocateNodeId                                                           ,                     2328,      0.0%
-- BeforeInvoke                                                             ,                   337732,      1.7%
+- BeforeInvoke                                                             ,                   337732,      1.6%
+- CheckIntentValidity                                                      ,                   160000,      0.8%
 - CheckReference                                                           ,                    40011,      0.2%
 - CloseSubstate                                                            ,                    26187,      0.1%
 - CreateNode                                                               ,                   861686,      4.2%
@@ -20,7 +21,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      0.6%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.2%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.2%
-- OpenSubstate::GlobalPackage                                              ,                  2671531,     13.1%
+- OpenSubstate::GlobalPackage                                              ,                  2671531,     13.0%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   323922,      1.6%
 - OpenSubstate::InternalFungibleVault                                      ,                    91807,      0.4%
 - OpenSubstate::InternalGenericComponent                                   ,                    31988,      0.2%
@@ -38,19 +39,19 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.2%
-- RunNativeCode::publish_wasm_advanced                                     ,                  7772235,     38.0%
+- RunNativeCode::publish_wasm_advanced                                     ,                  7772235,     37.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      774,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  6724880,     32.9%
+- ValidateTxPayload                                                        ,                  6724880,     32.6%
 - VerifyTxSignatures                                                       ,                    14000,      0.1%
 - WriteSubstate                                                            ,                     7358,      0.0%
-Finalization Cost Breakdown                                                ,                  2315396,    100.0%
+Finalization Cost Breakdown                                                ,                  2415396,    100.0%
 - CommitEvents                                                             ,                    10016,      0.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      4.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.3%
-- CommitStateUpdates::GlobalPackage                                        ,                  1305211,     56.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   600104,     25.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     13.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      4.1%
+- CommitStateUpdates::GlobalPackage                                        ,                  1305211,     54.0%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   600104,     24.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     12.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/002--non-fungible-resource-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/costings/002--non-fungible-resource-with-remote-type.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.72609121022,    100.0%
-- Execution Cost (XRD)                                                     ,               0.26996405,     37.2%
-- Finalization Cost (XRD)                                                  ,                0.1362648,     18.8%
-- Storage Cost (XRD)                                                       ,            0.31986236022,     44.1%
+Total Cost (XRD)                                                           ,            0.73909121022,    100.0%
+- Execution Cost (XRD)                                                     ,               0.27796405,     37.6%
+- Finalization Cost (XRD)                                                  ,                0.1412648,     19.1%
+- Storage Cost (XRD)                                                       ,            0.31986236022,     43.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5399281,    100.0%
+Execution Cost Breakdown                                                   ,                  5559281,    100.0%
 - AfterInvoke                                                              ,                      556,      0.0%
 - AllocateNodeId                                                           ,                     2231,      0.0%
 - BeforeInvoke                                                             ,                     3108,      0.1%
-- CheckReference                                                           ,                    80024,      1.5%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
+- CheckReference                                                           ,                    80024,      1.4%
 - CloseSubstate                                                            ,                    35088,      0.6%
 - CreateNode                                                               ,                    20448,      0.4%
 - DropNode                                                                 ,                    32027,      0.6%
@@ -17,32 +18,32 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     5320,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   123058,      2.3%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   123058,      2.2%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    14767,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2813048,     52.1%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   405820,      7.5%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.7%
-- OpenSubstate::InternalGenericComponent                                   ,                    52230,      1.0%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.8%
+- OpenSubstate::GlobalPackage                                              ,                  2813048,     50.6%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   405820,      7.3%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.6%
+- OpenSubstate::InternalGenericComponent                                   ,                    52230,      0.9%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     7751,      0.1%
 - PinNode                                                                  ,                      240,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.6%
+- PrepareWasmCode                                                          ,                   353866,      6.4%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   550807,     10.2%
+- ReadSubstate                                                             ,                   550807,      9.9%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
-- RunNativeCode::create                                                    ,                    24592,      0.5%
-- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.4%
+- RunNativeCode::create                                                    ,                    24592,      0.4%
+- RunNativeCode::create_empty_vault_NonFungibleResourceManager             ,                    73991,      1.3%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
-- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      4.0%
-- RunNativeCode::deposit_batch                                             ,                   110731,      2.1%
+- RunNativeCode::create_with_initial_supply_NonFungibleResourceManager     ,                   215780,      3.9%
+- RunNativeCode::deposit_batch                                             ,                   110731,      2.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
-- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.3%
+- RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
-- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.7%
+- RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      804,      0.0%
@@ -50,12 +51,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    32840,      0.6%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9670,      0.2%
-Finalization Cost Breakdown                                                ,                  2725296,    100.0%
+Finalization Cost Breakdown                                                ,                  2825296,    100.0%
 - CommitEvents                                                             ,                    25033,      0.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      3.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.7%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000181,     73.4%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      3.5%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2000181,     70.8%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   100011,      3.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      3.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   400044,     14.2%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/001--non-fungible-resource-with-remote-type-registration.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/001--non-fungible-resource-with-remote-type-registration.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 57.47047115011 XRD
-├─ Network execution: 1.0233539 XRD, 20467078 execution cost units
-├─ Network finalization: 0.1157698 XRD, 2315396 finalization cost units
+TRANSACTION COST: 57.48347115011 XRD
+├─ Network execution: 1.0313539 XRD, 20627078 execution cost units
+├─ Network finalization: 0.1207698 XRD, 2415396 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 56.33134745011 XRD
 └─ Royalties: 0 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("57.47047115011"),
+     amount: Decimal("57.48347115011"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("28.735235575055"),
+     amount: Decimal("28.741735575055"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("28.735235575055"),
+     amount: Decimal("28.741735575055"),
    }
 
 STATE UPDATES: 8 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("14.3676177875275"),
+             0u8 => Decimal("14.3708677875275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999942.52952884989")),
+         LiquidFungibleResource(Decimal("99999999999999942.51652884989")),
        )
 ├─ package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t across 12 partitions
   ├─ Partition(1): 1 change
@@ -294,7 +294,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("28.735235575055")),
+         LiquidFungibleResource(Decimal("28.741735575055")),
        )
 
 OUTPUTS: 3
@@ -305,10 +305,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -57.47047115011
+   Change: -57.48347115011
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 28.735235575055
+   Change: 28.741735575055
 
 NEW ENTITIES: 2
 └─ Package: package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/002--non-fungible-resource-with-remote-type.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/receipts/002--non-fungible-resource-with-remote-type.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.72609121022 XRD
-├─ Network execution: 0.26996405 XRD, 5399281 execution cost units
-├─ Network finalization: 0.1362648 XRD, 2725296 finalization cost units
+TRANSACTION COST: 0.73909121022 XRD
+├─ Network execution: 0.27796405 XRD, 5559281 execution cost units
+├─ Network finalization: 0.1412648 XRD, 2825296 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.31986236022 XRD
 └─ Royalties: 0 XRD
@@ -39,15 +39,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.72609121022"),
+     amount: Decimal("0.73909121022"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.36304560511"),
+     amount: Decimal("0.36954560511"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.36304560511"),
+     amount: Decimal("0.36954560511"),
    }
 
 STATE UPDATES: 8 entities
@@ -57,7 +57,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("14.5491405900825"),
+             0u8 => Decimal("14.5556405900825"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -90,7 +90,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999941.80343763967")),
+         LiquidFungibleResource(Decimal("99999999999999941.77743763967")),
        )
 ├─ resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6 across 5 partitions
   ├─ Partition(5): 1 change
@@ -286,7 +286,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("29.098281180165")),
+         LiquidFungibleResource(Decimal("29.111281180165")),
        )
 
 OUTPUTS: 3
@@ -300,13 +300,13 @@ OUTPUTS: 3
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.72609121022
+   Change: -0.73909121022
 ├─ Vault: internal_vault_sim1nz2n08mf56scr8xqfyw8cvwq9228edqm6as0sws7puc4j8tcwn2mpt
    ResAddr: resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.36304560511
+   Change: 0.36954560511
 
 NEW ENTITIES: 1
 └─ Resource: resource_sim1ngunzdy2nc7jvync9wq32k6q80w59fg0c354vyy048skx79g8kl9x6

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/non_fungible_resource_with_remote_type/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: non_fungible_resource_with_remote_type
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: 8beb46bfca7ae878 (allowed to change if not deployed to any network)
-Events       : a451bc9883b7eaa1 (allowed to change if not deployed to any network)
+State changes: 703039aaf310e827 (allowed to change if not deployed to any network)
+Events       : b9fbbc51d906fc29 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - package_with_registered_types: package_sim1p4lm0y29mmmv8vplavve8he4swd06mvvtux6z6t9phyj63hgejdt2t

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/001--radiswap-create-new-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/001--radiswap-create-new-resources.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            1.62649013577,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3320966,     20.4%
-- Finalization Cost (XRD)                                                  ,               0.41329385,     25.4%
-- Storage Cost (XRD)                                                       ,            0.88109968577,     54.2%
+Total Cost (XRD)                                                           ,            1.63949013577,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3400966,     20.7%
+- Finalization Cost (XRD)                                                  ,               0.41829385,     25.5%
+- Storage Cost (XRD)                                                       ,            0.88109968577,     53.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6641932,    100.0%
+Execution Cost Breakdown                                                   ,                  6801932,    100.0%
 - AfterInvoke                                                              ,                     1712,      0.0%
 - AllocateNodeId                                                           ,                     5723,      0.1%
 - BeforeInvoke                                                             ,                     9534,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.4%
 - CheckReference                                                           ,                    40011,      0.6%
 - CloseSubstate                                                            ,                    74949,      1.1%
 - CreateNode                                                               ,                    52134,      0.8%
@@ -17,25 +18,25 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
 - MoveModule                                                               ,                    18760,      0.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   156994,      2.4%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   156994,      2.3%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  2517753,     37.9%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1135173,     17.1%
+- OpenSubstate::GlobalPackage                                              ,                  2517753,     37.0%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1135173,     16.7%
 - OpenSubstate::InternalFungibleVault                                      ,                   108988,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                   129404,      1.9%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - PinNode                                                                  ,                      588,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.3%
+- PrepareWasmCode                                                          ,                   353866,      5.2%
 - QueryActor                                                               ,                     4000,      0.1%
-- ReadSubstate                                                             ,                   590808,      8.9%
+- ReadSubstate                                                             ,                   590808,      8.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    87099,      1.3%
-- RunNativeCode::create                                                    ,                    98368,      1.5%
+- RunNativeCode::create                                                    ,                    98368,      1.4%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   106710,      1.6%
-- RunNativeCode::create_with_data                                          ,                   109884,      1.7%
-- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   321198,      4.8%
+- RunNativeCode::create_with_data                                          ,                   109884,      1.6%
+- RunNativeCode::create_with_initial_supply_and_address_FungibleResourceManager,                   321198,      4.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    66096,      1.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
@@ -49,11 +50,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    60760,      0.9%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    20522,      0.3%
-Finalization Cost Breakdown                                                ,                  8265877,    100.0%
+Finalization Cost Breakdown                                                ,                  8365877,    100.0%
 - CommitEvents                                                             ,                    65121,      0.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  6500478,     78.6%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  6500478,     77.7%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.2%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   900137,     10.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   700123,      8.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   900137,     10.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   700123,      8.4%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
@@ -1,35 +1,36 @@
-Total Cost (XRD)                                                           ,            1.12216695354,    100.0%
-- Execution Cost (XRD)                                                     ,               0.34382005,     30.6%
-- Finalization Cost (XRD)                                                  ,               0.21777715,     19.4%
-- Storage Cost (XRD)                                                       ,            0.56056975354,     50.0%
+Total Cost (XRD)                                                           ,            1.13516695354,    100.0%
+- Execution Cost (XRD)                                                     ,               0.35182005,     31.0%
+- Finalization Cost (XRD)                                                  ,               0.22277715,     19.6%
+- Storage Cost (XRD)                                                       ,            0.56056975354,     49.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6876401,    100.0%
+Execution Cost Breakdown                                                   ,                  7036401,    100.0%
 - AfterInvoke                                                              ,                      726,      0.0%
 - AllocateNodeId                                                           ,                     3395,      0.0%
 - BeforeInvoke                                                             ,                     5456,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.3%
 - CheckReference                                                           ,                    40011,      0.6%
 - CloseSubstate                                                            ,                    48375,      0.7%
-- CreateNode                                                               ,                    31516,      0.5%
+- CreateNode                                                               ,                    31516,      0.4%
 - DropNode                                                                 ,                    49517,      0.7%
 - EmitEvent                                                                ,                     6342,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     8120,      0.1%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      1.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      1.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.6%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    55447,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2737718,     39.8%
-- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                  1623735,     23.6%
+- OpenSubstate::GlobalPackage                                              ,                  2737718,     38.9%
+- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                  1623735,     23.1%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      1.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    70924,      1.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - OpenSubstate::InternalNonFungibleVault                                   ,                     6869,      0.1%
 - PinNode                                                                  ,                      372,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.1%
+- PrepareWasmCode                                                          ,                   353866,      5.0%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   567888,      8.3%
+- ReadSubstate                                                             ,                   567888,      8.1%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
@@ -40,24 +41,24 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::get_amount_NonFungibleBucket                              ,                    13581,      0.2%
 - RunNativeCode::get_non_fungible_local_ids_NonFungibleBucket              ,                    11943,      0.2%
-- RunNativeCode::lock_fee                                                  ,                    45243,      0.7%
+- RunNativeCode::lock_fee                                                  ,                    45243,      0.6%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.5%
 - RunNativeCode::put_NonFungibleVault                                      ,                    35354,      0.5%
 - RunNativeCode::set                                                       ,                   125226,      1.8%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.8%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1057,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    52720,      0.8%
+- ValidateTxPayload                                                        ,                    52720,      0.7%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    15344,      0.2%
-Finalization Cost Breakdown                                                ,                  4355543,    100.0%
-- CommitEvents                                                             ,                    55101,      1.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  4455543,    100.0%
+- CommitEvents                                                             ,                    55101,      1.2%
+- CommitIntentStatus                                                       ,                   100000,      2.2%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.3%
-- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2500192,     57.4%
-- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                  1300183,     29.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.3%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,      6.9%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      2.2%
+- CommitStateUpdates::GlobalNonFungibleResourceManager                     ,                  2500192,     56.1%
+- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                  1300183,     29.2%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.2%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   300040,      6.7%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/003--radiswap-publish-and-create-pools.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/003--radiswap-publish-and-create-pools.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,           59.02917113717,    100.0%
-- Execution Cost (XRD)                                                     ,                1.4243679,      2.4%
-- Finalization Cost (XRD)                                                  ,                0.4588272,      0.8%
+Total Cost (XRD)                                                           ,           59.04217113717,    100.0%
+- Execution Cost (XRD)                                                     ,                1.4323679,      2.4%
+- Finalization Cost (XRD)                                                  ,                0.4638272,      0.8%
 - Storage Cost (XRD)                                                       ,           57.14597603717,     96.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 28487358,    100.0%
+Execution Cost Breakdown                                                   ,                 28647358,    100.0%
 - AfterInvoke                                                              ,                     2492,      0.0%
 - AllocateNodeId                                                           ,                     9409,      0.0%
 - BeforeInvoke                                                             ,                   347642,      1.2%
+- CheckIntentValidity                                                      ,                   160000,      0.6%
 - CheckReference                                                           ,                   200075,      0.7%
 - CloseSubstate                                                            ,                   104103,      0.4%
 - CreateNode                                                               ,                   924410,      3.2%
@@ -21,7 +22,7 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   362792,      1.3%
 - OpenSubstate::GlobalGenericComponent                                     ,                    50347,      0.2%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    68239,      0.2%
-- OpenSubstate::GlobalPackage                                              ,                  5174275,     18.2%
+- OpenSubstate::GlobalPackage                                              ,                  5174275,     18.1%
 - OpenSubstate::GlobalPreallocatedEd25519Account                           ,                   406740,      1.4%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                     5692,      0.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   117887,      0.4%
@@ -47,7 +48,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_resource_type_FungibleResourceManager                 ,                    82048,      0.3%
 - RunNativeCode::instantiate_two_resource_pool                             ,                   225278,      0.8%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
-- RunNativeCode::publish_wasm_advanced                                     ,                  7777254,     27.3%
+- RunNativeCode::publish_wasm_advanced                                     ,                  7777254,     27.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.1%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.1%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.4%
@@ -57,17 +58,17 @@ Execution Cost Breakdown                                                   ,    
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     2917,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  6741400,     23.7%
+- ValidateTxPayload                                                        ,                  6741400,     23.5%
 - VerifyTxSignatures                                                       ,                     7000,      0.0%
 - WriteSubstate                                                            ,                    28336,      0.1%
-Finalization Cost Breakdown                                                ,                  9176544,    100.0%
+Finalization Cost Breakdown                                                ,                  9276544,    100.0%
 - CommitEvents                                                             ,                    70184,      0.8%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  3400338,     37.1%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   700134,      7.6%
-- CommitStateUpdates::GlobalPackage                                        ,                  1505221,     16.4%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  3400338,     36.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   700134,      7.5%
+- CommitStateUpdates::GlobalPackage                                        ,                  1505221,     16.2%
 - CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                   100011,      1.1%
-- CommitStateUpdates::GlobalTwoResourcePool                                ,                  1600338,     17.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                  1700313,     18.5%
+- CommitStateUpdates::GlobalTwoResourcePool                                ,                  1600338,     17.3%
+- CommitStateUpdates::InternalFungibleVault                                ,                  1700313,     18.3%
 - CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      1.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/004--radiswap-add-liquidity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/004--radiswap-add-liquidity.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            1.29336321567,    100.0%
-- Execution Cost (XRD)                                                     ,               0.78974915,     61.1%
-- Finalization Cost (XRD)                                                  ,               0.10602725,      8.2%
-- Storage Cost (XRD)                                                       ,            0.39758681567,     30.7%
+Total Cost (XRD)                                                           ,            1.30636321567,    100.0%
+- Execution Cost (XRD)                                                     ,               0.79774915,     61.1%
+- Finalization Cost (XRD)                                                  ,               0.11102725,      8.5%
+- Storage Cost (XRD)                                                       ,            0.39758681567,     30.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 15794983,    100.0%
+Execution Cost Breakdown                                                   ,                 15954983,    100.0%
 - AfterInvoke                                                              ,                     3932,      0.0%
 - AllocateNodeId                                                           ,                     9603,      0.1%
 - BeforeInvoke                                                             ,                    10406,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      1.0%
 - CheckReference                                                           ,                   240079,      1.5%
 - CloseSubstate                                                            ,                   210012,      1.3%
 - CreateNode                                                               ,                    87916,      0.6%
@@ -17,25 +18,25 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      440,      0.0%
 - OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.3%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                  1028596,      6.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                  1028596,      6.4%
 - OpenSubstate::GlobalGenericComponent                                     ,                   135757,      0.9%
-- OpenSubstate::GlobalPackage                                              ,                  4405038,     27.9%
+- OpenSubstate::GlobalPackage                                              ,                  4405038,     27.6%
 - OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  1065784,      6.7%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                   653312,      4.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   725060,      4.6%
+- OpenSubstate::InternalFungibleVault                                      ,                   725060,      4.5%
 - OpenSubstate::InternalGenericComponent                                   ,                   400119,      2.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      1.3%
 - PinNode                                                                  ,                     1164,      0.0%
-- PrepareWasmCode                                                          ,                  1716448,     10.9%
+- PrepareWasmCode                                                          ,                  1716448,     10.8%
 - QueryActor                                                               ,                    12000,      0.1%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                  2270355,     14.4%
+- ReadSubstate                                                             ,                  2270355,     14.2%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::Worktop_put                                               ,                   174198,      1.1%
 - RunNativeCode::Worktop_take_all                                          ,                    58408,      0.4%
 - RunNativeCode::contribute_two_resource_pool                              ,                   393834,      2.5%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      0.5%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    71140,      0.4%
 - RunNativeCode::drop_empty_bucket_FungibleResourceManager                 ,                    81876,      0.5%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                   297432,      1.9%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    86706,      0.5%
@@ -49,7 +50,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::take_advanced_FungibleBucket                              ,                    93100,      0.6%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      0.8%
 - RunNativeCode::withdraw                                                  ,                   173553,      1.1%
-- RunWasmCode::Faucet_free                                                 ,                    39767,      0.3%
+- RunWasmCode::Faucet_free                                                 ,                    39767,      0.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - RunWasmCode::Radiswap_add_liquidity                                      ,                   117474,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -57,12 +58,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    39200,      0.2%
 - VerifyTxSignatures                                                       ,                    14000,      0.1%
 - WriteSubstate                                                            ,                    56528,      0.4%
-Finalization Cost Breakdown                                                ,                  2120545,    100.0%
-- CommitEvents                                                             ,                   120314,      5.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  2220545,    100.0%
+- CommitEvents                                                             ,                   120314,      5.4%
+- CommitIntentStatus                                                       ,                   100000,      4.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   200018,      9.4%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   300038,     14.1%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   200022,      9.4%
-- CommitStateUpdates::InternalFungibleVault                                ,                  1200148,     56.6%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      4.7%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   200018,      9.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   300038,     13.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   200022,      9.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                  1200148,     54.0%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      4.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/005--radiswap-distribute-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/005--radiswap-distribute-tokens.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            3.42780178564,    100.0%
-- Execution Cost (XRD)                                                     ,                1.1437668,     33.4%
-- Finalization Cost (XRD)                                                  ,               0.43886595,     12.8%
-- Storage Cost (XRD)                                                       ,            1.84516903564,     53.8%
+Total Cost (XRD)                                                           ,            3.44080178564,    100.0%
+- Execution Cost (XRD)                                                     ,                1.1517668,     33.5%
+- Finalization Cost (XRD)                                                  ,               0.44386595,     12.9%
+- Storage Cost (XRD)                                                       ,            1.84516903564,     53.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 22875336,    100.0%
+Execution Cost Breakdown                                                   ,                 23035336,    100.0%
 - AfterInvoke                                                              ,                     8528,      0.0%
 - AllocateNodeId                                                           ,                    21631,      0.1%
 - BeforeInvoke                                                             ,                    23866,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      0.7%
 - CheckReference                                                           ,                   240087,      1.0%
-- CloseSubstate                                                            ,                   469044,      2.1%
+- CloseSubstate                                                            ,                   469044,      2.0%
 - CreateNode                                                               ,                   197648,      0.9%
 - DropNode                                                                 ,                   318440,      1.4%
 - EmitEvent                                                                ,                    55492,      0.2%
@@ -21,9 +22,9 @@ Execution Cost Breakdown                                                   ,    
 - OpenSubstate::GlobalFungibleResourceManager                              ,                  1039039,      4.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.2%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    88040,      0.4%
-- OpenSubstate::GlobalPackage                                              ,                  3439708,     15.0%
-- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                  4214484,     18.4%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  3004011,     13.1%
+- OpenSubstate::GlobalPackage                                              ,                  3439708,     14.9%
+- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                  4214484,     18.3%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                  3004011,     13.0%
 - OpenSubstate::InternalFungibleVault                                      ,                   712894,      3.1%
 - OpenSubstate::InternalGenericComponent                                   ,                   798412,      3.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      0.9%
@@ -31,22 +32,22 @@ Execution Cost Breakdown                                                   ,    
 - PrepareWasmCode                                                          ,                   707732,      3.1%
 - QueryActor                                                               ,                    29500,      0.1%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                  1846861,      8.1%
+- ReadSubstate                                                             ,                  1846861,      8.0%
 - RunNativeCode::Worktop_drain                                             ,                    44896,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::Worktop_put                                               ,                   551627,      2.4%
 - RunNativeCode::create                                                    ,                    73776,      0.3%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   675830,      3.0%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   675830,      2.9%
 - RunNativeCode::create_with_data                                          ,                    82413,      0.4%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                   616896,      2.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    28902,      0.1%
 - RunNativeCode::get_current_epoch                                         ,                    13363,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.2%
-- RunNativeCode::on_virtualize                                             ,                   103560,      0.5%
+- RunNativeCode::on_virtualize                                             ,                   103560,      0.4%
 - RunNativeCode::put_FungibleVault                                         ,                   466526,      2.0%
 - RunNativeCode::take_FungibleVault                                        ,                   806683,      3.5%
 - RunNativeCode::try_deposit_batch_or_abort                                ,                   485028,      2.1%
-- RunNativeCode::withdraw                                                  ,                  1041318,      4.6%
+- RunNativeCode::withdraw                                                  ,                  1041318,      4.5%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.2%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.1%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -55,12 +56,12 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    98960,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.1%
 - WriteSubstate                                                            ,                   118966,      0.5%
-Finalization Cost Breakdown                                                ,                  8777319,    100.0%
+Finalization Cost Breakdown                                                ,                  8877319,    100.0%
 - CommitEvents                                                             ,                   475999,      5.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      1.1%
 - CommitLogs                                                               ,                        0,      0.0%
 - CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      1.1%
-- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                  2400340,     27.3%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                  1300181,     14.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                  4400776,     50.1%
+- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                  2400340,     27.0%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                  1300181,     14.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                  4400776,     49.6%
 - CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      1.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/006--radiswap-swap-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/006--radiswap-swap-tokens.txt
@@ -1,14 +1,15 @@
-Total Cost (XRD)                                                           ,            0.60103684589,    100.0%
-- Execution Cost (XRD)                                                     ,                0.4182825,     69.6%
-- Finalization Cost (XRD)                                                  ,               0.03750975,      6.2%
-- Storage Cost (XRD)                                                       ,            0.14524459589,     24.2%
+Total Cost (XRD)                                                           ,            0.61403684589,    100.0%
+- Execution Cost (XRD)                                                     ,                0.4262825,     69.4%
+- Finalization Cost (XRD)                                                  ,               0.04250975,      6.9%
+- Storage Cost (XRD)                                                       ,            0.14524459589,     23.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8365650,    100.0%
+Execution Cost Breakdown                                                   ,                  8525650,    100.0%
 - AfterInvoke                                                              ,                     1432,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.0%
 - BeforeInvoke                                                             ,                     3698,      0.0%
-- CheckReference                                                           ,                    80023,      1.0%
+- CheckIntentValidity                                                      ,                   160000,      1.9%
+- CheckReference                                                           ,                    80023,      0.9%
 - CloseSubstate                                                            ,                    74433,      0.9%
 - CreateNode                                                               ,                    30402,      0.4%
 - DropNode                                                                 ,                    53760,      0.6%
@@ -16,23 +17,23 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   339206,      4.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                    87882,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  2992927,     35.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   530957,      6.3%
-- OpenSubstate::GlobalTwoResourcePool                                      ,                   657608,      7.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   438878,      5.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   339206,      4.0%
+- OpenSubstate::GlobalGenericComponent                                     ,                    87882,      1.0%
+- OpenSubstate::GlobalPackage                                              ,                  2992927,     35.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   530957,      6.2%
+- OpenSubstate::GlobalTwoResourcePool                                      ,                   657608,      7.7%
+- OpenSubstate::InternalFungibleVault                                      ,                   438878,      5.1%
 - OpenSubstate::InternalGenericComponent                                   ,                   125725,      1.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.5%
 - PinNode                                                                  ,                      408,      0.0%
-- PrepareWasmCode                                                          ,                   858224,     10.3%
+- PrepareWasmCode                                                          ,                   858224,     10.1%
 - QueryActor                                                               ,                     4000,      0.0%
-- ReadSubstate                                                             ,                  1086462,     13.0%
+- ReadSubstate                                                             ,                  1086462,     12.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    58066,      0.7%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
-- RunNativeCode::get_amount_FungibleBucket                                 ,                    88128,      1.1%
+- RunNativeCode::get_amount_FungibleBucket                                 ,                    88128,      1.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    43353,      0.5%
 - RunNativeCode::get_resource_address_FungibleBucket                       ,                    17768,      0.2%
 - RunNativeCode::get_vault_amounts_two_resource_pool                       ,                    47047,      0.6%
@@ -51,9 +52,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    22200,      0.3%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    19450,      0.2%
-Finalization Cost Breakdown                                                ,                   750195,    100.0%
-- CommitEvents                                                             ,                    50122,      6.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   850195,    100.0%
+- CommitEvents                                                             ,                    50122,      5.9%
+- CommitIntentStatus                                                       ,                   100000,     11.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   200028,     26.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500045,     66.7%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   200028,     23.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500045,     58.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/007--radiswap-remove-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/007--radiswap-remove-tokens.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,             0.6671455226,    100.0%
-- Execution Cost (XRD)                                                     ,                 0.445564,     66.8%
-- Finalization Cost (XRD)                                                  ,                0.0480128,      7.2%
-- Storage Cost (XRD)                                                       ,             0.1735687226,     26.0%
+Total Cost (XRD)                                                           ,             0.6801455226,    100.0%
+- Execution Cost (XRD)                                                     ,                 0.453564,     66.7%
+- Finalization Cost (XRD)                                                  ,                0.0530128,      7.8%
+- Storage Cost (XRD)                                                       ,             0.1735687226,     25.5%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  8911280,    100.0%
+Execution Cost Breakdown                                                   ,                  9071280,    100.0%
 - AfterInvoke                                                              ,                     1654,      0.0%
 - AllocateNodeId                                                           ,                     3977,      0.0%
 - BeforeInvoke                                                             ,                     4284,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      1.8%
 - CheckReference                                                           ,                   120039,      1.3%
 - CloseSubstate                                                            ,                    90300,      1.0%
 - CreateNode                                                               ,                    36534,      0.4%
@@ -16,18 +17,18 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   523492,      5.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   523492,      5.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    87882,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  3133810,     35.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   734184,      8.2%
+- OpenSubstate::GlobalPackage                                              ,                  3133810,     34.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   734184,      8.1%
 - OpenSubstate::GlobalTwoResourcePool                                      ,                   286154,      3.2%
-- OpenSubstate::InternalFungibleVault                                      ,                   524084,      5.9%
-- OpenSubstate::InternalGenericComponent                                   ,                   157186,      1.8%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   524084,      5.8%
+- OpenSubstate::InternalGenericComponent                                   ,                   157186,      1.7%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.4%
 - PinNode                                                                  ,                      492,      0.0%
-- PrepareWasmCode                                                          ,                   858224,      9.6%
+- PrepareWasmCode                                                          ,                   858224,      9.5%
 - QueryActor                                                               ,                     6000,      0.1%
-- ReadSubstate                                                             ,                  1134045,     12.7%
+- ReadSubstate                                                             ,                  1134045,     12.5%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::Worktop_put                                               ,                    87099,      1.0%
@@ -39,10 +40,10 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::get_resource_type_FungibleResourceManager                 ,                    41024,      0.5%
 - RunNativeCode::get_total_supply_FungibleResourceManager                  ,                    18028,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.5%
-- RunNativeCode::put_FungibleVault                                         ,                    49108,      0.6%
+- RunNativeCode::put_FungibleVault                                         ,                    49108,      0.5%
 - RunNativeCode::redeem_two_resource_pool                                  ,                   135373,      1.5%
 - RunNativeCode::take_FungibleVault                                        ,                   127371,      1.4%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.4%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      1.3%
 - RunNativeCode::withdraw                                                  ,                    57851,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.3%
 - RunWasmCode::Radiswap_remove_liquidity                                   ,                    61763,      0.7%
@@ -51,10 +52,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    22680,      0.3%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    23478,      0.3%
-Finalization Cost Breakdown                                                ,                   960256,    100.0%
-- CommitEvents                                                             ,                    60165,      6.3%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1060256,    100.0%
+- CommitEvents                                                             ,                    60165,      5.7%
+- CommitIntentStatus                                                       ,                   100000,      9.4%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,     10.4%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   200028,     20.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   600054,     62.5%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                   100009,      9.4%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   200028,     18.9%
+- CommitStateUpdates::InternalFungibleVault                                ,                   600054,     56.6%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/008--radiswap-set-two-way-linking.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/costings/008--radiswap-set-two-way-linking.txt
@@ -1,35 +1,36 @@
-Total Cost (XRD)                                                           ,            1.82124119961,    100.0%
-- Execution Cost (XRD)                                                     ,               0.65333295,     35.9%
-- Finalization Cost (XRD)                                                  ,                0.1830488,     10.1%
-- Storage Cost (XRD)                                                       ,            0.98485944961,     54.1%
+Total Cost (XRD)                                                           ,            1.83424119961,    100.0%
+- Execution Cost (XRD)                                                     ,               0.66133295,     36.1%
+- Finalization Cost (XRD)                                                  ,                0.1880488,     10.3%
+- Storage Cost (XRD)                                                       ,            0.98485944961,     53.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 13066659,    100.0%
+Execution Cost Breakdown                                                   ,                 13226659,    100.0%
 - AfterInvoke                                                              ,                     1212,      0.0%
 - AllocateNodeId                                                           ,                     7081,      0.1%
 - BeforeInvoke                                                             ,                    11868,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      1.2%
 - CheckReference                                                           ,                   320115,      2.4%
 - CloseSubstate                                                            ,                   140481,      1.1%
 - CreateNode                                                               ,                    62852,      0.5%
 - DropNode                                                                 ,                   113003,      0.9%
-- EmitEvent                                                                ,                    19836,      0.2%
+- EmitEvent                                                                ,                    19836,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                  2155612,     16.5%
-- OpenSubstate::GlobalGenericComponent                                     ,                  2074262,     15.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                  2155612,     16.3%
+- OpenSubstate::GlobalGenericComponent                                     ,                  2074262,     15.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42800,      0.3%
-- OpenSubstate::GlobalPackage                                              ,                  2401383,     18.4%
+- OpenSubstate::GlobalPackage                                              ,                  2401383,     18.2%
 - OpenSubstate::GlobalPreallocatedEd25519Account                           ,                   616989,      4.7%
-- OpenSubstate::GlobalTwoResourcePool                                      ,                  2032372,     15.6%
+- OpenSubstate::GlobalTwoResourcePool                                      ,                  2032372,     15.4%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.7%
-- OpenSubstate::InternalGenericComponent                                   ,                   269877,      2.1%
+- OpenSubstate::InternalGenericComponent                                   ,                   269877,      2.0%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.3%
 - OpenSubstate::InternalNonFungibleVault                                   ,                    90136,      0.7%
 - PinNode                                                                  ,                      876,      0.0%
 - PrepareWasmCode                                                          ,                   353866,      2.7%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   713520,      5.5%
+- ReadSubstate                                                             ,                   713520,      5.4%
 - RemoveSubstate                                                           ,                    40717,      0.3%
 - RunNativeCode::AuthZone_push                                             ,                    23850,      0.2%
 - RunNativeCode::NonFungibleProof_get_local_ids                            ,                   279240,      2.1%
@@ -40,7 +41,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.3%
 - RunNativeCode::on_drop_NonFungibleProof                                  ,                    14622,      0.1%
 - RunNativeCode::on_move_NonFungibleProof                                  ,                    17108,      0.1%
-- RunNativeCode::set                                                       ,                   647001,      5.0%
+- RunNativeCode::set                                                       ,                   647001,      4.9%
 - RunNativeCode::unlock_non_fungibles_NonFungibleVault                     ,                    34403,      0.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -49,13 +50,13 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                   141080,      1.1%
 - VerifyTxSignatures                                                       ,                    14000,      0.1%
 - WriteSubstate                                                            ,                    46444,      0.4%
-Finalization Cost Breakdown                                                ,                  3660976,    100.0%
-- CommitEvents                                                             ,                   160467,      4.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  3760976,    100.0%
+- CommitEvents                                                             ,                   160467,      4.3%
+- CommitIntentStatus                                                       ,                   100000,      2.7%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1000152,     27.3%
-- CommitStateUpdates::GlobalGenericComponent                               ,                  1100153,     30.1%
+- CommitStateUpdates::GlobalFungibleResourceManager                        ,                  1000152,     26.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                  1100153,     29.3%
 - CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                   100050,      2.7%
-- CommitStateUpdates::GlobalTwoResourcePool                                ,                  1000134,     27.3%
+- CommitStateUpdates::GlobalTwoResourcePool                                ,                  1000134,     26.6%
 - CommitStateUpdates::InternalFungibleVault                                ,                   100009,      2.7%
-- CommitStateUpdates::InternalNonFungibleVault                             ,                   200011,      5.5%
+- CommitStateUpdates::InternalNonFungibleVault                             ,                   200011,      5.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/001--radiswap-create-new-resources.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/001--radiswap-create-new-resources.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.62649013577 XRD
-├─ Network execution: 0.3320966 XRD, 6641932 execution cost units
-├─ Network finalization: 0.41329385 XRD, 8265877 finalization cost units
+TRANSACTION COST: 1.63949013577 XRD
+├─ Network execution: 0.3400966 XRD, 6801932 execution cost units
+├─ Network finalization: 0.41829385 XRD, 8365877 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.88109968577 XRD
 └─ Royalties: 0 XRD
@@ -67,15 +67,15 @@ EVENTS: 16
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.62649013577"),
+     amount: Decimal("1.63949013577"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.813245067885"),
+     amount: Decimal("0.819745067885"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.813245067885"),
+     amount: Decimal("0.819745067885"),
    }
 
 STATE UPDATES: 12 entities
@@ -85,7 +85,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4066225339425"),
+             0u8 => Decimal("0.4098725339425"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -118,7 +118,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999998.37350986423")),
+         LiquidFungibleResource(Decimal("99999999999999998.36050986423")),
        )
 ├─ resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p across 5 partitions
   ├─ Partition(2): 6 changes
@@ -747,7 +747,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.813245067885")),
+         LiquidFungibleResource(Decimal("0.819745067885")),
        )
 
 OUTPUTS: 5
@@ -769,7 +769,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.62649013577
+   Change: -1.63949013577
 ├─ Vault: internal_vault_sim1trjn2fuhqfhkgev8037gydh5gqgwqsfqr4usr0scxm6ledxt343tc4
    ResAddr: resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p
    Change: 100000000000
@@ -781,7 +781,7 @@ BALANCE CHANGES: 5
    Change: 100000000000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.813245067885
+   Change: 0.819745067885
 
 NEW ENTITIES: 4
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/002--radiswap-create-owner-badge-and-dapp-definition-account.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.12216695354 XRD
-├─ Network execution: 0.34382005 XRD, 6876401 execution cost units
-├─ Network finalization: 0.21777715 XRD, 4355543 finalization cost units
+TRANSACTION COST: 1.13516695354 XRD
+├─ Network execution: 0.35182005 XRD, 7036401 execution cost units
+├─ Network finalization: 0.22277715 XRD, 4455543 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.56056975354 XRD
 └─ Royalties: 0 XRD
@@ -87,15 +87,15 @@ EVENTS: 14
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.12216695354"),
+     amount: Decimal("1.13516695354"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.56108347677"),
+     amount: Decimal("0.56758347677"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.56108347677"),
+     amount: Decimal("0.56758347677"),
    }
 
 STATE UPDATES: 8 entities
@@ -105,7 +105,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.6871642723275"),
+             0u8 => Decimal("0.6936642723275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -138,7 +138,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999997.25134291069")),
+         LiquidFungibleResource(Decimal("99999999999999997.22534291069")),
        )
 ├─ resource_sim1ngtf8aw0v8l0wsy0clun8j7wggkmdy5gc7zhyrdy0m4sw98zny9y7n across 7 partitions
   ├─ Partition(1): 1 change
@@ -494,7 +494,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.374328544655")),
+         LiquidFungibleResource(Decimal("1.387328544655")),
        )
 
 OUTPUTS: 9
@@ -514,13 +514,13 @@ OUTPUTS: 9
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.12216695354
+   Change: -1.13516695354
 ├─ Vault: internal_vault_sim1nq62dyu2curupg4unfaytkchtc9q70lg7ckfje4nxthrzpan8fsqtu
    ResAddr: resource_sim1ngtf8aw0v8l0wsy0clun8j7wggkmdy5gc7zhyrdy0m4sw98zny9y7n
    Change: +{#1#}, -{}
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.56108347677
+   Change: 0.56758347677
 
 NEW ENTITIES: 2
 └─ Component: account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/003--radiswap-publish-and-create-pools.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/003--radiswap-publish-and-create-pools.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 59.02917113717 XRD
-├─ Network execution: 1.4243679 XRD, 28487358 execution cost units
-├─ Network finalization: 0.4588272 XRD, 9176544 finalization cost units
+TRANSACTION COST: 59.04217113717 XRD
+├─ Network execution: 1.4323679 XRD, 28647358 execution cost units
+├─ Network finalization: 0.4638272 XRD, 9276544 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 57.14597603717 XRD
 └─ Royalties: 0 XRD
@@ -101,15 +101,15 @@ EVENTS: 17
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("59.02917113717"),
+     amount: Decimal("59.04217113717"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("29.514585568585"),
+     amount: Decimal("29.521085568585"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("29.514585568585"),
+     amount: Decimal("29.521085568585"),
    }
 
 STATE UPDATES: 22 entities
@@ -119,7 +119,7 @@ STATE UPDATES: 22 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("15.44445705662"),
+             0u8 => Decimal("15.45420705662"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -152,7 +152,7 @@ STATE UPDATES: 22 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989938.22217177352")),
+         LiquidFungibleResource(Decimal("99999999999989938.18317177352")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -1175,7 +1175,7 @@ STATE UPDATES: 22 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("30.88891411324")),
+         LiquidFungibleResource(Decimal("30.90841411324")),
        )
 
 OUTPUTS: 7
@@ -1190,13 +1190,13 @@ OUTPUTS: 7
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10059.02917113717
+   Change: -10059.04217113717
 ├─ Vault: internal_vault_sim1tr4r3rur7229t56xpcz0s2cakhxydhjv44pmhu7gf5xkyws0jdzwya
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 29.514585568585
+   Change: 29.521085568585
 
 NEW ENTITIES: 7
 └─ Package: package_sim1p5wscdljf6s7yc0v5u9kjfaqmxk4ccqugvqfd58aazyrlk89u0dgsn

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/004--radiswap-add-liquidity.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/004--radiswap-add-liquidity.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.29336321567 XRD
-├─ Network execution: 0.78974915 XRD, 15794983 execution cost units
-├─ Network finalization: 0.10602725 XRD, 2120545 finalization cost units
+TRANSACTION COST: 1.30636321567 XRD
+├─ Network execution: 0.79774915 XRD, 15954983 execution cost units
+├─ Network finalization: 0.11102725 XRD, 2220545 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.39758681567 XRD
 └─ Royalties: 0 XRD
@@ -139,15 +139,15 @@ EVENTS: 27
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.29336321567"),
+     amount: Decimal("1.30636321567"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.646681607835"),
+     amount: Decimal("0.653181607835"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.646681607835"),
+     amount: Decimal("0.653181607835"),
    }
 
 STATE UPDATES: 20 entities
@@ -157,7 +157,7 @@ STATE UPDATES: 20 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("15.7677978605375"),
+             0u8 => Decimal("15.7807978605375"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -202,7 +202,7 @@ STATE UPDATES: 20 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999979936.92880855785")),
+         LiquidFungibleResource(Decimal("99999999999979936.87680855785")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -334,7 +334,7 @@ STATE UPDATES: 20 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("31.535595721075")),
+         LiquidFungibleResource(Decimal("31.561595721075")),
        )
 
 OUTPUTS: 12
@@ -360,7 +360,7 @@ OUTPUTS: 12
 BALANCE CHANGES: 11
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10001.29336321567
+   Change: -10001.30636321567
 ├─ Vault: internal_vault_sim1trjn2fuhqfhkgev8037gydh5gqgwqsfqr4usr0scxm6ledxt343tc4
    ResAddr: resource_sim1t5jlu5a523le5q26rclvu9agrr6yjw9783u58fz883gd4s3f47dg6p
    Change: -7000
@@ -390,6 +390,6 @@ BALANCE CHANGES: 11
    Change: 6324.555320336758663998
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.646681607835
+   Change: 0.653181607835
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/005--radiswap-distribute-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/005--radiswap-distribute-tokens.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 3.42780178564 XRD
-├─ Network execution: 1.1437668 XRD, 22875336 execution cost units
-├─ Network finalization: 0.43886595 XRD, 8777319 finalization cost units
+TRANSACTION COST: 3.44080178564 XRD
+├─ Network execution: 1.1517668 XRD, 23035336 execution cost units
+├─ Network finalization: 0.44386595 XRD, 8877319 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 1.84516903564 XRD
 └─ Royalties: 0 XRD
@@ -429,15 +429,15 @@ EVENTS: 98
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("3.42780178564"),
+     amount: Decimal("3.44080178564"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("1.71390089282"),
+     amount: Decimal("1.72040089282"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("1.71390089282"),
+     amount: Decimal("1.72040089282"),
    }
 
 STATE UPDATES: 34 entities
@@ -447,7 +447,7 @@ STATE UPDATES: 34 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.6247483069475"),
+             0u8 => Decimal("16.6409983069475"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -480,7 +480,7 @@ STATE UPDATES: 34 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969933.50100677221")),
+         LiquidFungibleResource(Decimal("99999999999969933.43600677221")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -1434,7 +1434,7 @@ STATE UPDATES: 34 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.249496613895")),
+         LiquidFungibleResource(Decimal("33.281996613895")),
        )
 
 OUTPUTS: 24
@@ -1466,7 +1466,7 @@ OUTPUTS: 24
 BALANCE CHANGES: 26
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10003.42780178564
+   Change: -10003.44080178564
 ├─ Vault: internal_vault_sim1tzqt799quvgq2ddm4253zqupswy9ekqn7fmm6szn7z47rsxfv685g6
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 9001
@@ -1541,7 +1541,7 @@ BALANCE CHANGES: 26
    Change: 333
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 1.71390089282
+   Change: 1.72040089282
 
 NEW ENTITIES: 3
 ├─ Component: account_sim168j3paqgngj74yzaljq4n422rtsmupaec3wnqq5425fd85cnd8xmdz

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/006--radiswap-swap-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/006--radiswap-swap-tokens.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.60103684589 XRD
-├─ Network execution: 0.4182825 XRD, 8365650 execution cost units
-├─ Network finalization: 0.03750975 XRD, 750195 finalization cost units
+TRANSACTION COST: 0.61403684589 XRD
+├─ Network execution: 0.4262825 XRD, 8525650 execution cost units
+├─ Network finalization: 0.04250975 XRD, 850195 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.14524459589 XRD
 └─ Royalties: 0 XRD
@@ -63,15 +63,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.60103684589"),
+     amount: Decimal("0.61403684589"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.300518422945"),
+     amount: Decimal("0.307018422945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.300518422945"),
+     amount: Decimal("0.307018422945"),
    }
 
 STATE UPDATES: 10 entities
@@ -81,7 +81,7 @@ STATE UPDATES: 10 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.77500751842"),
+             0u8 => Decimal("16.79450751842"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -120,7 +120,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969932.89996992632")),
+         LiquidFungibleResource(Decimal("99999999999969932.82196992632")),
        )
 ├─ internal_vault_sim1tq3ux37tj8mw4yx26j2uv0r0qxkdlcy0uhs0n6e2tjle20uk8pm2np across 1 partitions
   └─ Partition(64): 1 change
@@ -150,7 +150,7 @@ STATE UPDATES: 10 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.55001503684")),
+         LiquidFungibleResource(Decimal("33.58901503684")),
        )
 
 OUTPUTS: 5
@@ -163,7 +163,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 6
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.60103684589
+   Change: -0.61403684589
 ├─ Vault: internal_vault_sim1tq3ux37tj8mw4yx26j2uv0r0qxkdlcy0uhs0n6e2tjle20uk8pm2np
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -100
@@ -178,6 +178,6 @@ BALANCE CHANGES: 6
    Change: 69.30693069306930693
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.300518422945
+   Change: 0.307018422945
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/007--radiswap-remove-tokens.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/007--radiswap-remove-tokens.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.6671455226 XRD
-├─ Network execution: 0.445564 XRD, 8911280 execution cost units
-├─ Network finalization: 0.0480128 XRD, 960256 finalization cost units
+TRANSACTION COST: 0.6801455226 XRD
+├─ Network execution: 0.453564 XRD, 9071280 execution cost units
+├─ Network finalization: 0.0530128 XRD, 1060256 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.1735687226 XRD
 └─ Royalties: 0 XRD
@@ -77,15 +77,15 @@ EVENTS: 15
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.6671455226"),
+     amount: Decimal("0.6801455226"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.3335727613"),
+     amount: Decimal("0.3400727613"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.3335727613"),
+     amount: Decimal("0.3400727613"),
    }
 
 STATE UPDATES: 12 entities
@@ -95,7 +95,7 @@ STATE UPDATES: 12 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("16.94179389907"),
+             0u8 => Decimal("16.96454389907"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -140,7 +140,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969932.23282440372")),
+         LiquidFungibleResource(Decimal("99999999999969932.14182440372")),
        )
 ├─ internal_vault_sim1tp7shj4lnak2yuvqn5nr634kf354ddz0un56qsxl68j32aku5crjeu across 1 partitions
   └─ Partition(64): 1 change
@@ -176,7 +176,7 @@ STATE UPDATES: 12 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("33.88358779814")),
+         LiquidFungibleResource(Decimal("33.92908779814")),
        )
 
 OUTPUTS: 5
@@ -192,7 +192,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 7
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.6671455226
+   Change: -0.6801455226
 ├─ Vault: internal_vault_sim1tp7shj4lnak2yuvqn5nr634kf354ddz0un56qsxl68j32aku5crjeu
    ResAddr: resource_sim1t5d6cc8v4sdv4wlwzf2qngh74028lumvd2ftes7tq7vnass85ap5m5
    Change: -100
@@ -210,6 +210,6 @@ BALANCE CHANGES: 7
    Change: 82.837626389512430492
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.3335727613
+   Change: 0.3400727613
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/008--radiswap-set-two-way-linking.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/receipts/008--radiswap-set-two-way-linking.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.82124119961 XRD
-├─ Network execution: 0.65333295 XRD, 13066659 execution cost units
-├─ Network finalization: 0.1830488 XRD, 3660976 finalization cost units
+TRANSACTION COST: 1.83424119961 XRD
+├─ Network execution: 0.66133295 XRD, 13226659 execution cost units
+├─ Network finalization: 0.1880488 XRD, 3760976 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.98485944961 XRD
 └─ Royalties: 0 XRD
@@ -274,15 +274,15 @@ EVENTS: 35
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.82124119961"),
+     amount: Decimal("1.83424119961"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.910620599805"),
+     amount: Decimal("0.917120599805"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.910620599805"),
+     amount: Decimal("0.917120599805"),
    }
 
 STATE UPDATES: 13 entities
@@ -292,7 +292,7 @@ STATE UPDATES: 13 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("17.3971041989725"),
+             0u8 => Decimal("17.4231041989725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -551,7 +551,7 @@ STATE UPDATES: 13 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999969930.41158320411")),
+         LiquidFungibleResource(Decimal("99999999999969930.30758320411")),
        )
 ├─ account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd across 1 partitions
   └─ Partition(2): 1 change
@@ -583,7 +583,7 @@ STATE UPDATES: 13 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("34.794208397945")),
+         LiquidFungibleResource(Decimal("34.846208397945")),
        )
 
 OUTPUTS: 33
@@ -624,9 +624,9 @@ OUTPUTS: 33
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.82124119961
+   Change: -1.83424119961
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.910620599805
+   Change: 0.917120599805
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/radiswap/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: radiswap
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: dc0465eaf0114ef3 (allowed to change if not deployed to any network)
-Events       : cb94cc3eab1e4990 (allowed to change if not deployed to any network)
+State changes: 1fecec1159559daa (allowed to change if not deployed to any network)
+Events       : 1b1b68836de5e575 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - radiswap_dapp_definition_account: account_sim129uea6ms5wjstpze559am5ddw293cr2nxeqrha4ae4536dlw5x8whd

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/001--royalties--publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/001--royalties--publish-package.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,           31.47019666469,    100.0%
-- Execution Cost (XRD)                                                     ,               0.61836085,      2.0%
-- Finalization Cost (XRD)                                                  ,                0.0783874,      0.2%
-- Storage Cost (XRD)                                                       ,           30.77344841469,     97.8%
+Total Cost (XRD)                                                           ,           31.48319666469,    100.0%
+- Execution Cost (XRD)                                                     ,               0.62636085,      2.0%
+- Finalization Cost (XRD)                                                  ,                0.0833874,      0.3%
+- Storage Cost (XRD)                                                       ,           30.77344841469,     97.7%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                 12367217,    100.0%
+Execution Cost Breakdown                                                   ,                 12527217,    100.0%
 - AfterInvoke                                                              ,                      326,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                   182304,      1.5%
+- CheckIntentValidity                                                      ,                   160000,      1.3%
 - CheckReference                                                           ,                    40011,      0.3%
 - CloseSubstate                                                            ,                    17931,      0.1%
 - CreateNode                                                               ,                   474000,      3.8%
@@ -18,35 +19,35 @@ Execution Cost Breakdown                                                   ,    
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     3360,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   126616,      1.0%
-- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.4%
-- OpenSubstate::GlobalPackage                                              ,                  2277596,     18.4%
+- OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.3%
+- OpenSubstate::GlobalPackage                                              ,                  2277596,     18.2%
 - OpenSubstate::InternalFungibleVault                                      ,                    91807,      0.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    19161,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.3%
 - PinNode                                                                  ,                      156,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      2.9%
+- PrepareWasmCode                                                          ,                   353866,      2.8%
 - QueryActor                                                               ,                     1500,      0.0%
 - QueryCostingModule                                                       ,                      500,      0.0%
 - QueryFeeReserve                                                          ,                      500,      0.0%
-- ReadSubstate                                                             ,                   469400,      3.8%
+- ReadSubstate                                                             ,                   469400,      3.7%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.1%
 - RunNativeCode::create                                                    ,                    24592,      0.2%
 - RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.3%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.4%
-- RunNativeCode::publish_wasm_advanced                                     ,                  4351685,     35.2%
+- RunNativeCode::publish_wasm_advanced                                     ,                  4351685,     34.7%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.2%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      403,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                  3639760,     29.4%
+- ValidateTxPayload                                                        ,                  3639760,     29.1%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     5386,      0.0%
-Finalization Cost Breakdown                                                ,                  1567748,    100.0%
+Finalization Cost Breakdown                                                ,                  1667748,    100.0%
 - CommitEvents                                                             ,                    10016,      0.6%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      6.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.4%
-- CommitStateUpdates::GlobalPackage                                        ,                  1157667,     73.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     19.1%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.0%
+- CommitStateUpdates::GlobalPackage                                        ,                  1157667,     69.4%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     18.0%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/002--royalties--instantiate-components.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/002--royalties--instantiate-components.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,             1.0473229481,    100.0%
-- Execution Cost (XRD)                                                     ,               0.36593315,     34.9%
-- Finalization Cost (XRD)                                                  ,                0.2360239,     22.5%
-- Storage Cost (XRD)                                                       ,             0.4453658981,     42.5%
+Total Cost (XRD)                                                           ,             1.0603229481,    100.0%
+- Execution Cost (XRD)                                                     ,               0.37393315,     35.3%
+- Finalization Cost (XRD)                                                  ,                0.2410239,     22.7%
+- Storage Cost (XRD)                                                       ,             0.4453658981,     42.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  7318663,    100.0%
+Execution Cost Breakdown                                                   ,                  7478663,    100.0%
 - AfterInvoke                                                              ,                     1030,      0.0%
 - AllocateNodeId                                                           ,                     4074,      0.1%
 - BeforeInvoke                                                             ,                     4174,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.1%
 - CheckReference                                                           ,                    80024,      1.1%
 - CloseSubstate                                                            ,                    33927,      0.5%
 - CreateNode                                                               ,                    34832,      0.5%
@@ -17,35 +18,35 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      220,      0.0%
 - MoveModule                                                               ,                    11760,      0.2%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   136104,      1.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   136104,      1.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    46666,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3403443,     46.5%
+- OpenSubstate::GlobalPackage                                              ,                  3403443,     45.5%
 - OpenSubstate::InternalFungibleVault                                      ,                    95017,      1.3%
 - OpenSubstate::InternalGenericComponent                                   ,                    42997,      0.6%
-- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
+- OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.5%
 - PinNode                                                                  ,                      396,      0.0%
-- PrepareWasmCode                                                          ,                  1188958,     16.2%
+- PrepareWasmCode                                                          ,                  1188958,     15.9%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryCostingModule                                                       ,                     1500,      0.0%
 - QueryFeeReserve                                                          ,                     1500,      0.0%
-- ReadSubstate                                                             ,                  1315744,     18.0%
+- ReadSubstate                                                             ,                  1315744,     17.6%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::create                                                    ,                   154473,      2.1%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   106710,      1.5%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                   106710,      1.4%
 - RunNativeCode::create_with_data                                          ,                    82413,      1.1%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
-- RunWasmCode::RoyaltiesBp_new                                             ,                   331410,      4.5%
+- RunWasmCode::RoyaltiesBp_new                                             ,                   331410,      4.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                     1245,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    15680,      0.2%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
-- WriteSubstate                                                            ,                    10998,      0.2%
-Finalization Cost Breakdown                                                ,                  4720478,    100.0%
+- WriteSubstate                                                            ,                    10998,      0.1%
+Finalization Cost Breakdown                                                ,                  4820478,    100.0%
 - CommitEvents                                                             ,                    20034,      0.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+- CommitIntentStatus                                                       ,                   100000,      2.1%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                  4000321,     84.7%
-- CommitStateUpdates::InternalFungibleVault                                ,                   700123,     14.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                  4000321,     83.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   700123,     14.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/003--royalties--set-components-royalty.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/003--royalties--set-components-royalty.txt
@@ -1,46 +1,47 @@
-Total Cost (XRD)                                                           ,            0.35953568381,    100.0%
-- Execution Cost (XRD)                                                     ,               0.18344985,     51.0%
-- Finalization Cost (XRD)                                                  ,                0.0552553,     15.4%
-- Storage Cost (XRD)                                                       ,            0.12083053381,     33.6%
+Total Cost (XRD)                                                           ,            0.37253568381,    100.0%
+- Execution Cost (XRD)                                                     ,               0.19144985,     51.4%
+- Finalization Cost (XRD)                                                  ,                0.0602553,     16.2%
+- Storage Cost (XRD)                                                       ,            0.12083053381,     32.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3668997,    100.0%
+Execution Cost Breakdown                                                   ,                  3828997,    100.0%
 - AfterInvoke                                                              ,                      124,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     2254,      0.1%
-- CheckReference                                                           ,                   160053,      4.4%
+- CheckIntentValidity                                                      ,                   160000,      4.2%
+- CheckReference                                                           ,                   160053,      4.2%
 - CloseSubstate                                                            ,                    22059,      0.6%
-- CreateNode                                                               ,                    13376,      0.4%
+- CreateNode                                                               ,                    13376,      0.3%
 - DropNode                                                                 ,                    23681,      0.6%
 - EmitEvent                                                                ,                      556,      0.0%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.3%
-- OpenSubstate::GlobalGenericComponent                                     ,                   545917,     14.9%
-- OpenSubstate::GlobalPackage                                              ,                  1507335,     41.1%
-- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.5%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      3.2%
+- OpenSubstate::GlobalGenericComponent                                     ,                   545917,     14.3%
+- OpenSubstate::GlobalPackage                                              ,                  1507335,     39.4%
+- OpenSubstate::InternalFungibleVault                                      ,                    90202,      2.4%
 - OpenSubstate::InternalGenericComponent                                   ,                    18682,      0.5%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.1%
 - PinNode                                                                  ,                      180,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      9.6%
+- PrepareWasmCode                                                          ,                   353866,      9.2%
 - QueryActor                                                               ,                     1000,      0.0%
 - QueryCostingModule                                                       ,                     4500,      0.1%
 - QueryFeeReserve                                                          ,                     4500,      0.1%
-- ReadSubstate                                                             ,                   431150,     11.8%
+- ReadSubstate                                                             ,                   431150,     11.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.2%
-- RunNativeCode::set_royalty                                               ,                   153756,      4.2%
-- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.8%
+- RunNativeCode::set_royalty                                               ,                   153756,      4.0%
+- RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    45680,      1.2%
 - VerifyTxSignatures                                                       ,                     7000,      0.2%
 - WriteSubstate                                                            ,                    10650,      0.3%
-Finalization Cost Breakdown                                                ,                  1105106,    100.0%
-- CommitEvents                                                             ,                     5007,      0.5%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1205106,    100.0%
+- CommitEvents                                                             ,                     5007,      0.4%
+- CommitIntentStatus                                                       ,                   100000,      8.3%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                  1000090,     90.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      9.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                  1000090,     83.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,      8.3%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/004--royalties--call_all_components_all_methods.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/costings/004--royalties--call_all_components_all_methods.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,   347.667986987889999992,    100.0%
-- Execution Cost (XRD)                                                     ,               0.56971115,      0.2%
-- Finalization Cost (XRD)                                                  ,                0.0102517,      0.0%
+Total Cost (XRD)                                                           ,   347.680986987889999992,    100.0%
+- Execution Cost (XRD)                                                     ,               0.57771115,      0.2%
+- Finalization Cost (XRD)                                                  ,                0.0152517,      0.0%
 - Storage Cost (XRD)                                                       ,            0.08802413789,      0.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,   346.999999999999999992,     99.8%
-Execution Cost Breakdown                                                   ,                 11394223,    100.0%
+Execution Cost Breakdown                                                   ,                 11554223,    100.0%
 - AfterInvoke                                                              ,                      124,      0.0%
 - AllocateNodeId                                                           ,                     1455,      0.0%
 - BeforeInvoke                                                             ,                     1666,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      1.4%
 - CheckReference                                                           ,                   160053,      1.4%
 - CloseSubstate                                                            ,                    29799,      0.3%
 - CreateNode                                                               ,                    13376,      0.1%
@@ -17,15 +18,15 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
 - OpenSubstate::GlobalFungibleResourceManager                              ,                   121872,      1.1%
-- OpenSubstate::GlobalGenericComponent                                     ,                   685135,      6.0%
-- OpenSubstate::GlobalPackage                                              ,                  4158217,     36.5%
+- OpenSubstate::GlobalGenericComponent                                     ,                   685135,      5.9%
+- OpenSubstate::GlobalPackage                                              ,                  4158217,     36.0%
 - OpenSubstate::InternalFungibleVault                                      ,                    90202,      0.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    18682,      0.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.4%
 - PinNode                                                                  ,                      180,      0.0%
-- PrepareWasmCode                                                          ,                  2859142,     25.1%
+- PrepareWasmCode                                                          ,                  2859142,     24.7%
 - QueryActor                                                               ,                     1000,      0.0%
-- ReadSubstate                                                             ,                  2955944,     25.9%
+- ReadSubstate                                                             ,                  2955944,     25.6%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.2%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.1%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.4%
@@ -38,9 +39,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    33920,      0.3%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                     8064,      0.1%
-Finalization Cost Breakdown                                                ,                   205034,    100.0%
-- CommitEvents                                                             ,                     5007,      2.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   305034,    100.0%
+- CommitEvents                                                             ,                     5007,      1.6%
+- CommitIntentStatus                                                       ,                   100000,     32.8%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     48.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     48.8%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     32.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   100009,     32.8%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/001--royalties--publish-package.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/001--royalties--publish-package.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 31.47019666469 XRD
-├─ Network execution: 0.61836085 XRD, 12367217 execution cost units
-├─ Network finalization: 0.0783874 XRD, 1567748 finalization cost units
+TRANSACTION COST: 31.48319666469 XRD
+├─ Network execution: 0.62636085 XRD, 12527217 execution cost units
+├─ Network finalization: 0.0833874 XRD, 1667748 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 30.77344841469 XRD
 └─ Royalties: 0 XRD
@@ -20,15 +20,15 @@ EVENTS: 5
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("31.47019666469"),
+     amount: Decimal("31.48319666469"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("15.735098332345"),
+     amount: Decimal("15.741598332345"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("15.735098332345"),
+     amount: Decimal("15.741598332345"),
    }
 
 STATE UPDATES: 7 entities
@@ -38,7 +38,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("7.8675491661725"),
+             0u8 => Decimal("7.8707991661725"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -71,7 +71,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999968.52980333531")),
+         LiquidFungibleResource(Decimal("99999999999999968.51680333531")),
        )
 ├─ package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z across 11 partitions
   ├─ Partition(1): 1 change
@@ -307,7 +307,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("15.735098332345")),
+         LiquidFungibleResource(Decimal("15.741598332345")),
        )
 
 OUTPUTS: 3
@@ -318,10 +318,10 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -31.47019666469
+   Change: -31.48319666469
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 15.735098332345
+   Change: 15.741598332345
 
 NEW ENTITIES: 1
 └─ Package: package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/002--royalties--instantiate-components.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/002--royalties--instantiate-components.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 1.0473229481 XRD
-├─ Network execution: 0.36593315 XRD, 7318663 execution cost units
-├─ Network finalization: 0.2360239 XRD, 4720478 finalization cost units
+TRANSACTION COST: 1.0603229481 XRD
+├─ Network execution: 0.37393315 XRD, 7478663 execution cost units
+├─ Network finalization: 0.2410239 XRD, 4820478 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.4453658981 XRD
 └─ Royalties: 0 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("1.0473229481"),
+     amount: Decimal("1.0603229481"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.52366147405"),
+     amount: Decimal("0.53016147405"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.52366147405"),
+     amount: Decimal("0.53016147405"),
    }
 
 STATE UPDATES: 11 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 11 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.1293799031975"),
+             0u8 => Decimal("8.1358799031975"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999967.48248038721")),
+         LiquidFungibleResource(Decimal("99999999999999967.45648038721")),
        )
 ├─ component_sim1cr7guww2kc22r6vnk8ffep9sv2aphp0mg6hdngg8x2shzf2xn90zmw across 6 partitions
   ├─ Partition(3): 1 change
@@ -475,7 +475,7 @@ STATE UPDATES: 11 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.258759806395")),
+         LiquidFungibleResource(Decimal("16.271759806395")),
        )
 
 OUTPUTS: 4
@@ -487,10 +487,10 @@ OUTPUTS: 4
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -1.0473229481
+   Change: -1.0603229481
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.52366147405
+   Change: 0.53016147405
 
 NEW ENTITIES: 3
 ├─ Component: component_sim1cr7guww2kc22r6vnk8ffep9sv2aphp0mg6hdngg8x2shzf2xn90zmw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/003--royalties--set-components-royalty.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/003--royalties--set-components-royalty.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.35953568381 XRD
-├─ Network execution: 0.18344985 XRD, 3668997 execution cost units
-├─ Network finalization: 0.0552553 XRD, 1105106 finalization cost units
+TRANSACTION COST: 0.37253568381 XRD
+├─ Network execution: 0.19144985 XRD, 3828997 execution cost units
+├─ Network finalization: 0.0602553 XRD, 1205106 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.12083053381 XRD
 └─ Royalties: 0 XRD
@@ -16,15 +16,15 @@ EVENTS: 4
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.35953568381"),
+     amount: Decimal("0.37253568381"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.179767841905"),
+     amount: Decimal("0.186267841905"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.179767841905"),
+     amount: Decimal("0.186267841905"),
    }
 
 STATE UPDATES: 8 entities
@@ -34,7 +34,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.21926382415"),
+             0u8 => Decimal("8.22901382415"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -121,13 +121,13 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999967.1229447034")),
+         LiquidFungibleResource(Decimal("99999999999999967.0839447034")),
        )
 └─ internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel across 1 partitions
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.4385276483")),
+         LiquidFungibleResource(Decimal("16.4580276483")),
        )
 
 OUTPUTS: 10
@@ -145,9 +145,9 @@ OUTPUTS: 10
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.35953568381
+   Change: -0.37253568381
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.179767841905
+   Change: 0.186267841905
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/004--royalties--call_all_components_all_methods.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/receipts/004--royalties--call_all_components_all_methods.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 347.667986987889999992 XRD
-├─ Network execution: 0.56971115 XRD, 11394223 execution cost units
-├─ Network finalization: 0.0102517 XRD, 205034 finalization cost units
+TRANSACTION COST: 347.680986987889999992 XRD
+├─ Network execution: 0.57771115 XRD, 11554223 execution cost units
+├─ Network finalization: 0.0152517 XRD, 305034 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08802413789 XRD
 └─ Royalties: 346.999999999999999992 XRD
@@ -28,15 +28,15 @@ EVENTS: 7
    }
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("347.667986987889999992"),
+     amount: Decimal("347.680986987889999992"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.333993493945"),
+     amount: Decimal("0.340493493945"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.333993493945"),
+     amount: Decimal("0.340493493945"),
    }
 
 STATE UPDATES: 8 entities
@@ -46,7 +46,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("8.3862605711225"),
+             0u8 => Decimal("8.3992605711225"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -79,7 +79,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999999619.454957715510000008")),
+         LiquidFungibleResource(Decimal("99999999999999619.402957715510000008")),
        )
 ├─ internal_vault_sim1tqce6jxy9gwd6trwftkdhksyt4gfq348rypqeq00s40k7jk3z5r2ke across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("16.772521142245")),
+         LiquidFungibleResource(Decimal("16.798521142245")),
        )
 
 OUTPUTS: 10
@@ -121,7 +121,7 @@ OUTPUTS: 10
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -347.667986987889999992
+   Change: -347.680986987889999992
 ├─ Vault: internal_vault_sim1tqce6jxy9gwd6trwftkdhksyt4gfq348rypqeq00s40k7jk3z5r2ke
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 142.999999999999999998
@@ -133,6 +133,6 @@ BALANCE CHANGES: 5
    Change: 149.999999999999999994
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.333993493945
+   Change: 0.340493493945
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/royalties/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: royalties
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: d34978a2783e9354 (allowed to change if not deployed to any network)
-Events       : 8fb9a668425950d7 (allowed to change if not deployed to any network)
+State changes: d1b2f84bc3f4163b (allowed to change if not deployed to any network)
+Events       : 00146ba5bd308e60 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - royalty_package_address: package_sim1p4qz8edl2w0t5mzwt6zcq0nfnc0ax9rkfawnmsg0s974hxcsggr29z

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/001--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/001--faucet-top-up.txt
@@ -1,15 +1,16 @@
-Total Cost (XRD)                                                           ,            0.57228020924,    100.0%
-- Execution Cost (XRD)                                                     ,               0.33287235,     58.2%
-- Finalization Cost (XRD)                                                  ,                0.0612615,     10.7%
-- Storage Cost (XRD)                                                       ,            0.17814635924,     31.1%
+Total Cost (XRD)                                                           ,            0.58528020924,    100.0%
+- Execution Cost (XRD)                                                     ,               0.34087235,     58.2%
+- Finalization Cost (XRD)                                                  ,                0.0662615,     11.3%
+- Storage Cost (XRD)                                                       ,            0.17814635924,     30.4%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6657447,    100.0%
+Execution Cost Breakdown                                                   ,                  6817447,    100.0%
 - AfterInvoke                                                              ,                      654,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     2816,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      2.3%
 - CheckReference                                                           ,                    40011,      0.6%
-- CloseSubstate                                                            ,                    43602,      0.7%
+- CloseSubstate                                                            ,                    43602,      0.6%
 - CreateNode                                                               ,                    22036,      0.3%
 - DropNode                                                                 ,                    36136,      0.5%
 - EmitEvent                                                                ,                     2860,      0.0%
@@ -17,20 +18,20 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      165,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.7%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      2.6%
+- OpenSubstate::GlobalConsensusManager                                     ,                    43783,      0.6%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   173556,      2.5%
 - OpenSubstate::GlobalGenericComponent                                     ,                    47373,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.6%
-- OpenSubstate::GlobalPackage                                              ,                  3181935,     47.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      7.3%
+- OpenSubstate::GlobalPackage                                              ,                  3181935,     46.7%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   487127,      7.1%
 - OpenSubstate::InternalFungibleVault                                      ,                   106652,      1.6%
 - OpenSubstate::InternalGenericComponent                                   ,                    55774,      0.8%
 - OpenSubstate::InternalKeyValueStore                                      ,                   202765,      3.0%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   707732,     10.6%
+- PrepareWasmCode                                                          ,                   707732,     10.4%
 - QueryActor                                                               ,                     2500,      0.0%
 - QueryTransactionHash                                                     ,                      500,      0.0%
-- ReadSubstate                                                             ,                   889768,     13.4%
+- ReadSubstate                                                             ,                   889768,     13.1%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.4%
 - RunNativeCode::Worktop_take_all                                          ,                    14602,      0.2%
@@ -44,7 +45,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.5%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.6%
-- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.5%
+- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.4%
 - RunWasmCode::Faucet_free                                                 ,                    39767,      0.6%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -53,11 +54,11 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    14880,      0.2%
 - VerifyTxSignatures                                                       ,                     7000,      0.1%
 - WriteSubstate                                                            ,                    11706,      0.2%
-Finalization Cost Breakdown                                                ,                  1225230,    100.0%
-- CommitEvents                                                             ,                    25045,      2.0%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1325230,    100.0%
+- CommitEvents                                                             ,                    25045,      1.9%
+- CommitIntentStatus                                                       ,                   100000,      7.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.2%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     57.1%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     24.5%
-- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      8.2%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     52.8%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300047,     22.6%
+- CommitStateUpdates::InternalKeyValueStore                                ,                   100005,      7.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/002--transfer--try_deposit_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/002--transfer--try_deposit_or_abort.txt
@@ -1,59 +1,60 @@
-Total Cost (XRD)                                                           ,            0.52880486178,    100.0%
-- Execution Cost (XRD)                                                     ,               0.27217065,     51.5%
-- Finalization Cost (XRD)                                                  ,               0.06151245,     11.6%
-- Storage Cost (XRD)                                                       ,            0.19512176178,     36.9%
+Total Cost (XRD)                                                           ,            0.54180486178,    100.0%
+- Execution Cost (XRD)                                                     ,               0.28017065,     51.7%
+- Finalization Cost (XRD)                                                  ,               0.06651245,     12.3%
+- Storage Cost (XRD)                                                       ,            0.19512176178,     36.0%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  5443413,    100.0%
+Execution Cost Breakdown                                                   ,                  5603413,    100.0%
 - AfterInvoke                                                              ,                      686,      0.0%
 - AllocateNodeId                                                           ,                     2425,      0.0%
 - BeforeInvoke                                                             ,                     2964,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.9%
 - CheckReference                                                           ,                    40011,      0.7%
 - CloseSubstate                                                            ,                    43731,      0.8%
 - CreateNode                                                               ,                    22092,      0.4%
-- DropNode                                                                 ,                    36192,      0.7%
+- DropNode                                                                 ,                    36192,      0.6%
 - EmitEvent                                                                ,                     3480,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   175335,      3.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   175335,      3.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.8%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.8%
-- OpenSubstate::GlobalPackage                                              ,                  2494754,     45.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   772151,     14.2%
-- OpenSubstate::InternalFungibleVault                                      ,                   181670,      3.3%
+- OpenSubstate::GlobalPackage                                              ,                  2494754,     44.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   772151,     13.8%
+- OpenSubstate::InternalFungibleVault                                      ,                   181670,      3.2%
 - OpenSubstate::InternalGenericComponent                                   ,                    66591,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.7%
 - PinNode                                                                  ,                      276,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      6.5%
+- PrepareWasmCode                                                          ,                   353866,      6.3%
 - QueryActor                                                               ,                     2500,      0.0%
-- ReadSubstate                                                             ,                   524934,      9.6%
+- ReadSubstate                                                             ,                   524934,      9.4%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.5%
 - RunNativeCode::Worktop_take                                              ,                    17966,      0.3%
-- RunNativeCode::create                                                    ,                    24592,      0.5%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.7%
+- RunNativeCode::create                                                    ,                    24592,      0.4%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.5%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      0.8%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      0.8%
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.6%
-- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
+- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.4%
 - RunNativeCode::take_FungibleVault                                        ,                    42457,      0.8%
-- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.8%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.1%
+- RunNativeCode::try_deposit_or_abort                                      ,                    97988,      1.7%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.0%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.5%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SetSubstate                                                              ,                      371,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
 - ValidateTxPayload                                                        ,                    21200,      0.4%
-- VerifyTxSignatures                                                       ,                    14000,      0.3%
+- VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    11138,      0.2%
-Finalization Cost Breakdown                                                ,                  1230249,    100.0%
-- CommitEvents                                                             ,                    30060,      2.4%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1330249,    100.0%
+- CommitEvents                                                             ,                    30060,      2.3%
+- CommitIntentStatus                                                       ,                   100000,      7.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      8.1%
-- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     56.9%
-- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     32.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.5%
+- CommitStateUpdates::GlobalPreallocatedSecp256k1Account                   ,                   700115,     52.6%
+- CommitStateUpdates::InternalFungibleVault                                ,                   400056,     30.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/003--transfer--try_deposit_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/003--transfer--try_deposit_or_refund.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.33551309196,    100.0%
-- Execution Cost (XRD)                                                     ,               0.22156115,     66.0%
-- Finalization Cost (XRD)                                                  ,                0.0212548,      6.3%
-- Storage Cost (XRD)                                                       ,            0.09269714196,     27.6%
+Total Cost (XRD)                                                           ,            0.34851309196,    100.0%
+- Execution Cost (XRD)                                                     ,               0.22956115,     65.9%
+- Finalization Cost (XRD)                                                  ,                0.0262548,      7.5%
+- Storage Cost (XRD)                                                       ,            0.09269714196,     26.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4431223,    100.0%
+Execution Cost Breakdown                                                   ,                  4591223,    100.0%
 - AfterInvoke                                                              ,                      490,      0.0%
 - AllocateNodeId                                                           ,                     1649,      0.0%
 - BeforeInvoke                                                             ,                     1844,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.5%
 - CheckReference                                                           ,                    40011,      0.9%
 - CloseSubstate                                                            ,                    36120,      0.8%
 - CreateNode                                                               ,                    14978,      0.3%
@@ -16,26 +17,26 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   169998,      3.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   169998,      3.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1861672,     42.0%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     12.9%
-- OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.9%
+- OpenSubstate::GlobalPackage                                              ,                  1861672,     40.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     12.4%
+- OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    58944,      1.3%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      204,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.0%
+- PrepareWasmCode                                                          ,                   353866,      7.7%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   487037,     11.0%
+- ReadSubstate                                                             ,                   487037,     10.6%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
 - RunNativeCode::Worktop_take                                              ,                    17966,      0.4%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    44064,      1.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
-- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      2.0%
+- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
+- RunNativeCode::try_deposit_or_refund                                     ,                    88114,      1.9%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -43,9 +44,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    21240,      0.5%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9680,      0.2%
-Finalization Cost Breakdown                                                ,                   425096,    100.0%
-- CommitEvents                                                             ,                    25051,      5.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   525096,    100.0%
+- CommitEvents                                                             ,                    25051,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     19.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     70.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     57.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/004--transfer--try_deposit_batch_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/004--transfer--try_deposit_batch_or_abort.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.32585539845,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2173394,     66.7%
-- Finalization Cost (XRD)                                                  ,                0.0212548,      6.5%
-- Storage Cost (XRD)                                                       ,            0.08726119845,     26.8%
+Total Cost (XRD)                                                           ,            0.33885539845,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2253394,     66.5%
+- Finalization Cost (XRD)                                                  ,                0.0262548,      7.7%
+- Storage Cost (XRD)                                                       ,            0.08726119845,     25.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4346788,    100.0%
+Execution Cost Breakdown                                                   ,                  4506788,    100.0%
 - AfterInvoke                                                              ,                      440,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1662,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.6%
 - CheckReference                                                           ,                    40011,      0.9%
 - CloseSubstate                                                            ,                    33927,      0.8%
 - CreateNode                                                               ,                    14180,      0.3%
@@ -16,26 +17,26 @@ Execution Cost Breakdown                                                   ,    
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1780095,     41.0%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     13.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   260079,      6.0%
+- OpenSubstate::GlobalPackage                                              ,                  1780095,     39.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     12.7%
+- OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.8%
 - OpenSubstate::InternalGenericComponent                                   ,                    53048,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      192,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.1%
+- PrepareWasmCode                                                          ,                   353866,      7.9%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   482780,     11.1%
-- RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
+- ReadSubstate                                                             ,                   482780,     10.7%
+- RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
-- RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.8%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.8%
+- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   121257,      2.7%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -43,9 +44,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    18960,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9280,      0.2%
-Finalization Cost Breakdown                                                ,                   425096,    100.0%
-- CommitEvents                                                             ,                    25051,      5.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   525096,    100.0%
+- CommitEvents                                                             ,                    25051,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     19.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     70.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     57.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/005--transfer--try_deposit_batch_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/005--transfer--try_deposit_batch_or_refund.txt
@@ -1,41 +1,42 @@
-Total Cost (XRD)                                                           ,            0.32876686588,    100.0%
-- Execution Cost (XRD)                                                     ,                0.2201555,     67.0%
-- Finalization Cost (XRD)                                                  ,                0.0212548,      6.5%
-- Storage Cost (XRD)                                                       ,            0.08735656588,     26.6%
+Total Cost (XRD)                                                           ,            0.34176686588,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2281555,     66.8%
+- Finalization Cost (XRD)                                                  ,                0.0262548,      7.7%
+- Storage Cost (XRD)                                                       ,            0.08735656588,     25.6%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  4403110,    100.0%
+Execution Cost Breakdown                                                   ,                  4563110,    100.0%
 - AfterInvoke                                                              ,                      442,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1664,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.5%
 - CheckReference                                                           ,                    40011,      0.9%
-- CloseSubstate                                                            ,                    33927,      0.8%
+- CloseSubstate                                                            ,                    33927,      0.7%
 - CreateNode                                                               ,                    14180,      0.3%
 - DropNode                                                                 ,                    25172,      0.6%
 - EmitEvent                                                                ,                     2908,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.8%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   169405,      3.7%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.0%
-- OpenSubstate::GlobalPackage                                              ,                  1860098,     42.2%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     13.0%
-- OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.9%
+- OpenSubstate::GlobalPackage                                              ,                  1860098,     40.8%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   570968,     12.5%
+- OpenSubstate::InternalFungibleVault                                      ,                   260079,      5.7%
 - OpenSubstate::InternalGenericComponent                                   ,                    53048,      1.2%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.9%
 - PinNode                                                                  ,                      192,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.0%
+- PrepareWasmCode                                                          ,                   353866,      7.8%
 - QueryActor                                                               ,                     2000,      0.0%
-- ReadSubstate                                                             ,                   482780,     11.0%
-- RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
+- ReadSubstate                                                             ,                   482780,     10.6%
+- RunNativeCode::Worktop_drain                                             ,                    11224,      0.2%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
-- RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
-- RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.8%
+- RunNativeCode::Worktop_put                                               ,                    29033,      0.6%
+- RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.7%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.0%
-- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
-- RunNativeCode::try_deposit_batch_or_refund                               ,                    97532,      2.2%
+- RunNativeCode::put_FungibleVault                                         ,                    24554,      0.5%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      0.9%
+- RunNativeCode::try_deposit_batch_or_refund                               ,                    97532,      2.1%
 - RunNativeCode::withdraw                                                  ,                    57851,      1.3%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.6%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -43,9 +44,9 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    19000,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9280,      0.2%
-Finalization Cost Breakdown                                                ,                   425096,    100.0%
-- CommitEvents                                                             ,                    25051,      5.9%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   525096,    100.0%
+- CommitEvents                                                             ,                    25051,      4.8%
+- CommitIntentStatus                                                       ,                   100000,     19.0%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.5%
-- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     70.6%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     19.0%
+- CommitStateUpdates::InternalFungibleVault                                ,                   300027,     57.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/006--self-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/006--self-transfer--deposit_batch.txt
@@ -1,51 +1,52 @@
-Total Cost (XRD)                                                           ,            0.30067496957,    100.0%
-- Execution Cost (XRD)                                                     ,                0.1986853,     66.1%
-- Finalization Cost (XRD)                                                  ,               0.01625435,      5.4%
-- Storage Cost (XRD)                                                       ,            0.08573531957,     28.5%
+Total Cost (XRD)                                                           ,            0.31367496957,    100.0%
+- Execution Cost (XRD)                                                     ,                0.2066853,     65.9%
+- Finalization Cost (XRD)                                                  ,               0.02125435,      6.8%
+- Storage Cost (XRD)                                                       ,            0.08573531957,     27.3%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  3973706,    100.0%
+Execution Cost Breakdown                                                   ,                  4133706,    100.0%
 - AfterInvoke                                                              ,                      440,      0.0%
 - AllocateNodeId                                                           ,                     1552,      0.0%
 - BeforeInvoke                                                             ,                     1630,      0.0%
+- CheckIntentValidity                                                      ,                   160000,      3.9%
 - CheckReference                                                           ,                    40011,      1.0%
 - CloseSubstate                                                            ,                    33669,      0.8%
-- CreateNode                                                               ,                    14180,      0.4%
+- CreateNode                                                               ,                    14180,      0.3%
 - DropNode                                                                 ,                    25172,      0.6%
 - EmitEvent                                                                ,                     2908,      0.1%
 - GetOwnedNodes                                                            ,                     1000,      0.0%
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                       55,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   168812,      4.2%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   168812,      4.1%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      1.1%
-- OpenSubstate::GlobalPackage                                              ,                  1780095,     44.8%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   290024,      7.3%
-- OpenSubstate::InternalFungibleVault                                      ,                   180065,      4.5%
+- OpenSubstate::GlobalPackage                                              ,                  1780095,     43.1%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   290024,      7.0%
+- OpenSubstate::InternalFungibleVault                                      ,                   180065,      4.4%
 - OpenSubstate::InternalGenericComponent                                   ,                    53605,      1.3%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      1.0%
 - PinNode                                                                  ,                      192,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      8.9%
-- QueryActor                                                               ,                     2000,      0.1%
-- ReadSubstate                                                             ,                   482148,     12.1%
+- PrepareWasmCode                                                          ,                   353866,      8.6%
+- QueryActor                                                               ,                     2000,      0.0%
+- ReadSubstate                                                             ,                   482148,     11.7%
 - RunNativeCode::Worktop_drain                                             ,                    11224,      0.3%
-- RunNativeCode::Worktop_drop                                              ,                    17918,      0.5%
+- RunNativeCode::Worktop_drop                                              ,                    17918,      0.4%
 - RunNativeCode::Worktop_put                                               ,                    29033,      0.7%
-- RunNativeCode::deposit_batch                                             ,                   110731,      2.8%
+- RunNativeCode::deposit_batch                                             ,                   110731,      2.7%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    33048,      0.8%
-- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.4%
+- RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.3%
 - RunNativeCode::lock_fee                                                  ,                    45243,      1.1%
 - RunNativeCode::put_FungibleVault                                         ,                    24554,      0.6%
-- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.1%
-- RunNativeCode::withdraw                                                  ,                    57851,      1.5%
+- RunNativeCode::take_FungibleVault                                        ,                    42457,      1.0%
+- RunNativeCode::withdraw                                                  ,                    57851,      1.4%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.7%
 - SetCallFrameData                                                         ,                      606,      0.0%
 - SwitchStack                                                              ,                     1000,      0.0%
-- ValidateTxPayload                                                        ,                    18320,      0.5%
-- VerifyTxSignatures                                                       ,                    14000,      0.4%
+- ValidateTxPayload                                                        ,                    18320,      0.4%
+- VerifyTxSignatures                                                       ,                    14000,      0.3%
 - WriteSubstate                                                            ,                     9280,      0.2%
-Finalization Cost Breakdown                                                ,                   325087,    100.0%
-- CommitEvents                                                             ,                    25051,      7.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                   425087,    100.0%
+- CommitEvents                                                             ,                    25051,      5.9%
+- CommitIntentStatus                                                       ,                   100000,     23.5%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     30.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     61.5%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,     23.5%
+- CommitStateUpdates::InternalFungibleVault                                ,                   200018,     47.1%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/007--multi-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/costings/007--multi-transfer--deposit_batch.txt
@@ -1,13 +1,14 @@
-Total Cost (XRD)                                                           ,            0.62422446304,    100.0%
-- Execution Cost (XRD)                                                     ,                0.3156205,     50.6%
-- Finalization Cost (XRD)                                                  ,                0.0675151,     10.8%
-- Storage Cost (XRD)                                                       ,            0.24108886304,     38.6%
+Total Cost (XRD)                                                           ,            0.63722446304,    100.0%
+- Execution Cost (XRD)                                                     ,                0.3236205,     50.8%
+- Finalization Cost (XRD)                                                  ,                0.0725151,     11.4%
+- Storage Cost (XRD)                                                       ,            0.24108886304,     37.8%
 - Tipping Cost (XRD)                                                       ,                        0,      0.0%
 - Royalty Cost (XRD)                                                       ,                        0,      0.0%
-Execution Cost Breakdown                                                   ,                  6312410,    100.0%
+Execution Cost Breakdown                                                   ,                  6472410,    100.0%
 - AfterInvoke                                                              ,                     1008,      0.0%
 - AllocateNodeId                                                           ,                     3298,      0.1%
 - BeforeInvoke                                                             ,                     3926,      0.1%
+- CheckIntentValidity                                                      ,                   160000,      2.5%
 - CheckReference                                                           ,                    40011,      0.6%
 - CloseSubstate                                                            ,                    64629,      1.0%
 - CreateNode                                                               ,                    30232,      0.5%
@@ -17,24 +18,24 @@ Execution Cost Breakdown                                                   ,    
 - LockFee                                                                  ,                      500,      0.0%
 - MarkSubstateAsTransient                                                  ,                      110,      0.0%
 - MoveModule                                                               ,                     1400,      0.0%
-- OpenSubstate::GlobalFungibleResourceManager                              ,                   182274,      2.9%
+- OpenSubstate::GlobalFungibleResourceManager                              ,                   182274,      2.8%
 - OpenSubstate::GlobalGenericComponent                                     ,                    43690,      0.7%
 - OpenSubstate::GlobalNonFungibleResourceManager                           ,                    42686,      0.7%
-- OpenSubstate::GlobalPackage                                              ,                  2508568,     39.7%
-- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                   487127,      7.7%
-- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   575968,      9.1%
-- OpenSubstate::InternalFungibleVault                                      ,                   271533,      4.3%
-- OpenSubstate::InternalGenericComponent                                   ,                   104545,      1.7%
+- OpenSubstate::GlobalPackage                                              ,                  2508568,     38.8%
+- OpenSubstate::GlobalPreallocatedEd25519Account                           ,                   487127,      7.5%
+- OpenSubstate::GlobalPreallocatedSecp256k1Account                         ,                   575968,      8.9%
+- OpenSubstate::InternalFungibleVault                                      ,                   271533,      4.2%
+- OpenSubstate::InternalGenericComponent                                   ,                   104545,      1.6%
 - OpenSubstate::InternalKeyValueStore                                      ,                    40536,      0.6%
 - PinNode                                                                  ,                      384,      0.0%
-- PrepareWasmCode                                                          ,                   353866,      5.6%
+- PrepareWasmCode                                                          ,                   353866,      5.5%
 - QueryActor                                                               ,                     3500,      0.1%
-- ReadSubstate                                                             ,                   570496,      9.0%
-- RunNativeCode::Worktop_drain                                             ,                    22448,      0.4%
+- ReadSubstate                                                             ,                   570496,      8.8%
+- RunNativeCode::Worktop_drain                                             ,                    22448,      0.3%
 - RunNativeCode::Worktop_drop                                              ,                    17918,      0.3%
 - RunNativeCode::Worktop_put                                               ,                    58066,      0.9%
 - RunNativeCode::create                                                    ,                    24592,      0.4%
-- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.6%
+- RunNativeCode::create_empty_vault_FungibleResourceManager                ,                    35570,      0.5%
 - RunNativeCode::create_with_data                                          ,                    27471,      0.4%
 - RunNativeCode::get_amount_FungibleBucket                                 ,                    66096,      1.0%
 - RunNativeCode::get_amount_FungibleVault                                  ,                    14451,      0.2%
@@ -42,7 +43,7 @@ Execution Cost Breakdown                                                   ,    
 - RunNativeCode::on_virtualize                                             ,                    34520,      0.5%
 - RunNativeCode::put_FungibleVault                                         ,                    49108,      0.8%
 - RunNativeCode::take_FungibleVault                                        ,                    84914,      1.3%
-- RunNativeCode::try_deposit_batch_or_abort                                ,                   242514,      3.8%
+- RunNativeCode::try_deposit_batch_or_abort                                ,                   242514,      3.7%
 - RunNativeCode::withdraw                                                  ,                   115702,      1.8%
 - RunWasmCode::Faucet_lock_fee                                             ,                    27840,      0.4%
 - SetCallFrameData                                                         ,                      606,      0.0%
@@ -51,10 +52,10 @@ Execution Cost Breakdown                                                   ,    
 - ValidateTxPayload                                                        ,                    25840,      0.4%
 - VerifyTxSignatures                                                       ,                    14000,      0.2%
 - WriteSubstate                                                            ,                    16506,      0.3%
-Finalization Cost Breakdown                                                ,                  1350302,    100.0%
-- CommitEvents                                                             ,                    50104,      3.7%
-- CommitIntentStatus                                                       ,                        0,      0.0%
+Finalization Cost Breakdown                                                ,                  1450302,    100.0%
+- CommitEvents                                                             ,                    50104,      3.5%
+- CommitIntentStatus                                                       ,                   100000,      6.9%
 - CommitLogs                                                               ,                        0,      0.0%
-- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      7.4%
-- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                   700115,     51.8%
-- CommitStateUpdates::InternalFungibleVault                                ,                   500065,     37.0%
+- CommitStateUpdates::GlobalGenericComponent                               ,                   100018,      6.9%
+- CommitStateUpdates::GlobalPreallocatedEd25519Account                     ,                   700115,     48.3%
+- CommitStateUpdates::InternalFungibleVault                                ,                   500065,     34.5%

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/001--faucet-top-up.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/001--faucet-top-up.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.57228020924 XRD
-├─ Network execution: 0.33287235 XRD, 6657447 execution cost units
-├─ Network finalization: 0.0612615 XRD, 1225230 finalization cost units
+TRANSACTION COST: 0.58528020924 XRD
+├─ Network execution: 0.34087235 XRD, 6817447 execution cost units
+├─ Network finalization: 0.0662615 XRD, 1325230 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.17814635924 XRD
 └─ Royalties: 0 XRD
@@ -33,15 +33,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.57228020924"),
+     amount: Decimal("0.58528020924"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.28614010462"),
+     amount: Decimal("0.29264010462"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.28614010462"),
+     amount: Decimal("0.29264010462"),
    }
 
 STATE UPDATES: 8 entities
@@ -51,7 +51,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.14307005231"),
+             0u8 => Decimal("0.14632005231"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -84,7 +84,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989999.42771979076")),
+         LiquidFungibleResource(Decimal("99999999999989999.41471979076")),
        )
 ├─ internal_keyvaluestore_sim1krn7clzr3qmq2zhwr77mdenksxswf00yeh8tn3vyzesg4kr3p54gv8 across 1 partitions
   └─ Partition(64): 1 change
@@ -222,7 +222,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.28614010462")),
+         LiquidFungibleResource(Decimal("0.29264010462")),
        )
 
 OUTPUTS: 4
@@ -234,13 +234,13 @@ OUTPUTS: 4
 BALANCE CHANGES: 3
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -10000.57228020924
+   Change: -10000.58528020924
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: 10000
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.28614010462
+   Change: 0.29264010462
 
 NEW ENTITIES: 1
 └─ Component: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/002--transfer--try_deposit_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/002--transfer--try_deposit_or_abort.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.52880486178 XRD
-├─ Network execution: 0.27217065 XRD, 5443413 execution cost units
-├─ Network finalization: 0.06151245 XRD, 1230249 finalization cost units
+TRANSACTION COST: 0.54180486178 XRD
+├─ Network execution: 0.28017065 XRD, 5603413 execution cost units
+├─ Network finalization: 0.06651245 XRD, 1330249 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.19512176178 XRD
 └─ Royalties: 0 XRD
@@ -38,15 +38,15 @@ EVENTS: 9
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.52880486178"),
+     amount: Decimal("0.54180486178"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.26440243089"),
+     amount: Decimal("0.27090243089"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.26440243089"),
+     amount: Decimal("0.27090243089"),
    }
 
 STATE UPDATES: 8 entities
@@ -56,7 +56,7 @@ STATE UPDATES: 8 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.275271267755"),
+             0u8 => Decimal("0.281771267755"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -89,7 +89,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.89891492898")),
+         LiquidFungibleResource(Decimal("99999999999989998.87291492898")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -229,7 +229,7 @@ STATE UPDATES: 8 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.55054253551")),
+         LiquidFungibleResource(Decimal("0.56354253551")),
        )
 
 OUTPUTS: 4
@@ -241,7 +241,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.52880486178
+   Change: -0.54180486178
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -250,7 +250,7 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.26440243089
+   Change: 0.27090243089
 
 NEW ENTITIES: 1
 └─ Component: account_sim168qgdkgfqxpnswu38wy6fy5v0q0um52zd0umuely5t9xrf88t3unc0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/003--transfer--try_deposit_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/003--transfer--try_deposit_or_refund.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.33551309196 XRD
-├─ Network execution: 0.22156115 XRD, 4431223 execution cost units
-├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
+TRANSACTION COST: 0.34851309196 XRD
+├─ Network execution: 0.22956115 XRD, 4591223 execution cost units
+├─ Network finalization: 0.0262548 XRD, 525096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.09269714196 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.33551309196"),
+     amount: Decimal("0.34851309196"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16775654598"),
+     amount: Decimal("0.17425654598"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16775654598"),
+     amount: Decimal("0.17425654598"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.359149540745"),
+             0u8 => Decimal("0.368899540745"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.56340183702")),
+         LiquidFungibleResource(Decimal("99999999999989998.52440183702")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.71829908149")),
+         LiquidFungibleResource(Decimal("0.73779908149")),
        )
 
 OUTPUTS: 4
@@ -115,7 +115,7 @@ OUTPUTS: 4
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.33551309196
+   Change: -0.34851309196
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -124,6 +124,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16775654598
+   Change: 0.17425654598
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/004--transfer--try_deposit_batch_or_abort.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/004--transfer--try_deposit_batch_or_abort.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32585539845 XRD
-├─ Network execution: 0.2173394 XRD, 4346788 execution cost units
-├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
+TRANSACTION COST: 0.33885539845 XRD
+├─ Network execution: 0.2253394 XRD, 4506788 execution cost units
+├─ Network finalization: 0.0262548 XRD, 525096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08726119845 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32585539845"),
+     amount: Decimal("0.33885539845"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.162927699225"),
+     amount: Decimal("0.169427699225"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.162927699225"),
+     amount: Decimal("0.169427699225"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.4406133903575"),
+             0u8 => Decimal("0.4536133903575"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989998.23754643857")),
+         LiquidFungibleResource(Decimal("99999999999989998.18554643857")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("0.881226780715")),
+         LiquidFungibleResource(Decimal("0.907226780715")),
        )
 
 OUTPUTS: 3
@@ -114,7 +114,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32585539845
+   Change: -0.33885539845
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -123,6 +123,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.162927699225
+   Change: 0.169427699225
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/005--transfer--try_deposit_batch_or_refund.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/005--transfer--try_deposit_batch_or_refund.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.32876686588 XRD
-├─ Network execution: 0.2201555 XRD, 4403110 execution cost units
-├─ Network finalization: 0.0212548 XRD, 425096 finalization cost units
+TRANSACTION COST: 0.34176686588 XRD
+├─ Network execution: 0.2281555 XRD, 4563110 execution cost units
+├─ Network finalization: 0.0262548 XRD, 525096 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08735656588 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.32876686588"),
+     amount: Decimal("0.34176686588"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.16438343294"),
+     amount: Decimal("0.17088343294"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.16438343294"),
+     amount: Decimal("0.17088343294"),
    }
 
 STATE UPDATES: 7 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 7 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.5228051068275"),
+             0u8 => Decimal("0.5390551068275"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.90877957269")),
+         LiquidFungibleResource(Decimal("99999999999989997.84377957269")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -103,7 +103,7 @@ STATE UPDATES: 7 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.045610213655")),
+         LiquidFungibleResource(Decimal("1.078110213655")),
        )
 
 OUTPUTS: 3
@@ -114,7 +114,7 @@ OUTPUTS: 3
 BALANCE CHANGES: 4
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.32876686588
+   Change: -0.34176686588
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -1
@@ -123,6 +123,6 @@ BALANCE CHANGES: 4
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.16438343294
+   Change: 0.17088343294
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/006--self-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/006--self-transfer--deposit_batch.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.30067496957 XRD
-├─ Network execution: 0.1986853 XRD, 3973706 execution cost units
-├─ Network finalization: 0.01625435 XRD, 325087 finalization cost units
+TRANSACTION COST: 0.31367496957 XRD
+├─ Network execution: 0.2066853 XRD, 4133706 execution cost units
+├─ Network finalization: 0.02125435 XRD, 425087 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.08573531957 XRD
 └─ Royalties: 0 XRD
@@ -34,15 +34,15 @@ EVENTS: 8
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.30067496957"),
+     amount: Decimal("0.31367496957"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.150337484785"),
+     amount: Decimal("0.156837484785"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.150337484785"),
+     amount: Decimal("0.156837484785"),
    }
 
 STATE UPDATES: 6 entities
@@ -52,7 +52,7 @@ STATE UPDATES: 6 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.59797384922"),
+             0u8 => Decimal("0.61747384922"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -85,7 +85,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989997.60810460312")),
+         LiquidFungibleResource(Decimal("99999999999989997.53010460312")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -97,7 +97,7 @@ STATE UPDATES: 6 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.19594769844")),
+         LiquidFungibleResource(Decimal("1.23494769844")),
        )
 
 OUTPUTS: 3
@@ -108,9 +108,9 @@ OUTPUTS: 3
 BALANCE CHANGES: 2
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.30067496957
+   Change: -0.31367496957
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.150337484785
+   Change: 0.156837484785
 
 NEW ENTITIES: 0

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/007--multi-transfer--deposit_batch.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/receipts/007--multi-transfer--deposit_batch.txt
@@ -1,8 +1,8 @@
 TRANSACTION STATUS: COMMITTED SUCCESS
 
-TRANSACTION COST: 0.62422446304 XRD
-├─ Network execution: 0.3156205 XRD, 6312410 execution cost units
-├─ Network finalization: 0.0675151 XRD, 1350302 finalization cost units
+TRANSACTION COST: 0.63722446304 XRD
+├─ Network execution: 0.3236205 XRD, 6472410 execution cost units
+├─ Network finalization: 0.0725151 XRD, 1450302 finalization cost units
 ├─ Tip: 0 XRD
 ├─ Network Storage: 0.24108886304 XRD
 └─ Royalties: 0 XRD
@@ -56,15 +56,15 @@ EVENTS: 13
    )
 ├─ Emitter: Method { node: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u, module_id: Main }
    Event: PayFeeEvent {
-     amount: Decimal("0.62422446304"),
+     amount: Decimal("0.63722446304"),
    }
 ├─ Emitter: Method { node: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel, module_id: Main }
    Event: DepositEvent {
-     amount: Decimal("0.31211223152"),
+     amount: Decimal("0.31861223152"),
    }
 └─ Emitter: Method { node: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3, module_id: Main }
    Event: BurnFungibleResourceEvent {
-     amount: Decimal("0.31211223152"),
+     amount: Decimal("0.31861223152"),
    }
 
 STATE UPDATES: 9 entities
@@ -74,7 +74,7 @@ STATE UPDATES: 9 entities
        Value: UNLOCKED ConsensusManagerValidatorRewardsFieldPayload::V1(
          ValidatorRewardsSubstate {
            proposer_rewards: {
-             0u8 => Decimal("0.75402996498"),
+             0u8 => Decimal("0.77677996498"),
            },
            rewards_vault: Vault(Own("internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel")),
          },
@@ -107,7 +107,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("99999999999989996.98388014008")),
+         LiquidFungibleResource(Decimal("99999999999989996.89288014008")),
        )
 ├─ internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305 across 1 partitions
   └─ Partition(64): 1 change
@@ -253,7 +253,7 @@ STATE UPDATES: 9 entities
   └─ Partition(64): 1 change
     └─ Set: Field(0)
        Value: UNLOCKED FungibleVaultBalanceFieldPayload::V1(
-         LiquidFungibleResource(Decimal("1.50805992996")),
+         LiquidFungibleResource(Decimal("1.55355992996")),
        )
 
 OUTPUTS: 5
@@ -266,7 +266,7 @@ OUTPUTS: 5
 BALANCE CHANGES: 5
 ├─ Vault: internal_vault_sim1tz9uaalv8g3ahmwep2trlyj2m3zn7rstm9pwessa3k56me2fcduq2u
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: -0.62422446304
+   Change: -0.63722446304
 ├─ Vault: internal_vault_sim1tqsmp4sts684nukw686ze0gkagrdaz558pfq64v2x45qevqapak305
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
    Change: -2
@@ -278,7 +278,7 @@ BALANCE CHANGES: 5
    Change: 1
 └─ Vault: internal_vault_sim1tpsesv77qvw782kknjks9g3x2msg8cc8ldshk28pkf6m6lkhun3sel
    ResAddr: resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3
-   Change: 0.31211223152
+   Change: 0.31861223152
 
 NEW ENTITIES: 1
 └─ Component: account_sim128cqk4tgnu2trlvmpf242a0lsq4062a2c45hhymr3tly0ps3w57yav

--- a/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/scenario_summary.txt
+++ b/radix-transaction-scenarios/generated-examples/cuttlefish/transfer_xrd/scenario_summary.txt
@@ -2,8 +2,8 @@ Name: transfer_xrd
 
 == SUMMARY HASHES ==
 These Cuttlefish hashes are permitted to change only until the scenario is deployed to a permanent network, else it can cause divergence.
-State changes: da65b4aa510a0e69 (allowed to change if not deployed to any network)
-Events       : 20a705dc0dc35d27 (allowed to change if not deployed to any network)
+State changes: a908c2ca4d12f942 (allowed to change if not deployed to any network)
+Events       : 2b0c74547f6e70b7 (allowed to change if not deployed to any network)
 
 == INTERESTING ADDRESSES ==
 - from_account: account_sim16996e320lnez82q6430eunaz9l3n5fnwk6eh9avrmtmj22e7jmhemw

--- a/scrypto-test/src/ledger_simulator/inject_costing_err.rs
+++ b/scrypto-test/src/ledger_simulator/inject_costing_err.rs
@@ -72,8 +72,8 @@ impl<
         executable: &ExecutableTransaction,
         init_input: Self::Init,
         always_visible_global_nodes: &'static IndexSet<NodeId>,
-    ) -> Result<(Self, Vec<CallFrameInit<Self::CallFrameData>>, usize), Self::Receipt> {
-        let (mut system, call_frame_inits, num_of_intent_statuses) = E::init(
+    ) -> Result<(Self, Vec<CallFrameInit<Self::CallFrameData>>), Self::Receipt> {
+        let (mut system, call_frame_inits) = E::init(
             store,
             executable,
             init_input.system_input,
@@ -91,7 +91,6 @@ impl<
                 wrapped: system,
             },
             call_frame_inits,
-            num_of_intent_statuses,
         ))
     }
 
@@ -105,12 +104,11 @@ impl<
 
     fn finalize(
         &mut self,
+        executable: &ExecutableTransaction,
         store_commit_info: StoreCommitInfo,
-        num_of_intent_statuses: usize,
     ) -> Result<(), RuntimeError> {
         self.maybe_err()?;
-        self.wrapped
-            .finalize(store_commit_info, num_of_intent_statuses)
+        self.wrapped.finalize(executable, store_commit_info)
     }
 
     fn create_receipt<S: SubstateDatabase>(


### PR DESCRIPTION
## Summary

Starting from cuttlefish, Radix network will charge every transaction for checking the validity of transaction intent hash and committing its status into substate store.

This effectively increase the cost of every transaction by `0.013` XRD.