### PR TITLE
fix: Fix `PUSH_TO_AUTH_ZONE` instruction compilation

### DIFF
--- a/radix-transactions/examples/resources/auth_zone.rtm
+++ b/radix-transactions/examples/resources/auth_zone.rtm
@@ -14,10 +14,10 @@ DROP_PROOF Proof("proof1d");
 DROP_PROOF Proof("proof1c");
 DROP_AUTH_ZONE_PROOFS;
 
-# Create a proof from account and drop it
+# Create a proof from account, pop it and push it back
 CALL_METHOD Address("${account_address}") "create_proof_of_amount" Address("${resource_address}") Decimal("5.0");
 POP_FROM_AUTH_ZONE Proof("proof3");
-DROP_PROOF Proof("proof3");
+PUSH_TO_AUTH_ZONE Proof("proof3");
 
 # Compose proofs
 CALL_METHOD Address("${account_address}") "create_proof_of_amount" Address("${resource_address}") Decimal("5.0");

--- a/radix-transactions/src/manifest/e2e.rs
+++ b/radix-transactions/src/manifest/e2e.rs
@@ -197,7 +197,7 @@ CALL_METHOD
 POP_FROM_AUTH_ZONE
     Proof("proof3")
 ;
-DROP_PROOF
+PUSH_TO_AUTH_ZONE
     Proof("proof3")
 ;
 CALL_METHOD

--- a/radix-transactions/src/manifest/manifest_instructions.rs
+++ b/radix-transactions/src/manifest/manifest_instructions.rs
@@ -709,7 +709,7 @@ pub struct PushToAuthZone {
 }
 
 impl ManifestInstruction for PushToAuthZone {
-    const IDENT: &'static str = "PUSH_TO_AUTHZONE";
+    const IDENT: &'static str = "PUSH_TO_AUTH_ZONE";
     const ID: u8 = INSTRUCTION_PUSH_TO_AUTH_ZONE_DISCRIMINATOR;
 
     fn decompile(


### PR DESCRIPTION
## Summary
Fixes a sheepish typo in `DropAuthZoneRegularProofs::IDENT`...

## Testing
... and ensures this instruction is covered in `e2e.rs`