### PR TITLE
Add further transaction validation tests

### DIFF
--- a/radix-common/src/data/manifest/model/manifest_resource_assertion.rs
+++ b/radix-common/src/data/manifest/model/manifest_resource_assertion.rs
@@ -20,13 +20,25 @@ impl ManifestResourceConstraints {
     /// * Panics if the constraint isn't valid for the resource address
     /// * Panics if constraints have already been specified against the resource
     pub fn with(
-        mut self,
+        self,
         resource_address: ResourceAddress,
         constraint: ManifestResourceConstraint,
     ) -> Self {
         if !constraint.is_valid_for(&resource_address) {
             panic!("Constraint isn't valid for the resource address");
         }
+        self.with_unchecked(resource_address, constraint)
+    }
+
+    /// Unlike `with`, this does not validate the constraint.
+    ///
+    /// ## Panics
+    /// * Panics if constraints have already been specified against the resource
+    pub fn with_unchecked(
+        mut self,
+        resource_address: ResourceAddress,
+        constraint: ManifestResourceConstraint,
+    ) -> Self {
         let replaced = self
             .specified_resources
             .insert(resource_address, constraint);

--- a/radix-rust/src/macros.rs
+++ b/radix-rust/src/macros.rs
@@ -46,7 +46,7 @@ macro_rules! assert_matches {
             )
         }
     };
-    ($expression:expr, $pattern:pat $(if $condition:expr)? $(,)? => $code:expr) => {
+    ($expression:expr, $pattern:pat $(if $condition:expr)? => $code:expr $(,)?) => {
         match $expression {
             $pattern $(if $condition)? => $code,
             ref expression => panic!(
@@ -56,7 +56,7 @@ macro_rules! assert_matches {
             )
         }
     };
-    ($expression:expr, $pattern:pat $(if $condition:expr)?, $($arg:tt)+) => {
+    ($expression:expr, $pattern:pat $(if $condition:expr)?, $($arg:tt)+ $(,)?) => {
         match $expression {
             $pattern $(if $condition)? => (),
             ref expression => panic!(
@@ -67,7 +67,7 @@ macro_rules! assert_matches {
             )
         }
     };
-    ($expression:expr, $pattern:pat $(if $condition:expr)? $(,)? => $code:expr, $($arg:tt)+) => {
+    ($expression:expr, $pattern:pat $(if $condition:expr)? => $code:expr, $($arg:tt)+ $(,)?) => {
         match $expression {
             $pattern $(if $condition)? => $code,
             ref expression => panic!(

--- a/radix-rust/src/macros.rs
+++ b/radix-rust/src/macros.rs
@@ -56,7 +56,7 @@ macro_rules! assert_matches {
             )
         }
     };
-    ($expression:expr, $pattern:pat $(if $condition:expr)?, $($arg:tt)+ $(,)?) => {
+    ($expression:expr, $pattern:pat $(if $condition:expr)?, $($arg:tt)+) => {
         match $expression {
             $pattern $(if $condition)? => (),
             ref expression => panic!(
@@ -67,7 +67,7 @@ macro_rules! assert_matches {
             )
         }
     };
-    ($expression:expr, $pattern:pat $(if $condition:expr)? => $code:expr, $($arg:tt)+ $(,)?) => {
+    ($expression:expr, $pattern:pat $(if $condition:expr)? => $code:expr, $($arg:tt)+) => {
         match $expression {
             $pattern $(if $condition)? => $code,
             ref expression => panic!(

--- a/radix-transactions/src/builder/manifest_builder.rs
+++ b/radix-transactions/src/builder/manifest_builder.rs
@@ -343,7 +343,9 @@ impl<M: BuildableManifest> ManifestBuilder<M> {
         self
     }
 
-    #[deprecated = "This should not be used apart from for test code purposefully constructing invalid manifests. Instead use the more-tailored instruction, or add_instruction_advanced."]
+    /// This should not be used apart from for test code purposefully constructing invalid manifests.
+    /// Instead use the more-tailored instruction, or add_instruction_advanced.
+    #[cfg(test)]
     pub fn add_raw_instruction_ignoring_all_side_effects(
         self,
         instruction: impl Into<M::Instruction>,

--- a/radix-transactions/src/errors.rs
+++ b/radix-transactions/src/errors.rs
@@ -3,11 +3,9 @@ use sbor::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HeaderValidationError {
-    UnknownVersion(u8),
     InvalidEpochRange,
     InvalidTimestampRange,
     InvalidNetwork,
-    InvalidCostUnitLimit,
     InvalidTip,
     NoValidEpochRangeAcrossAllIntents,
     NoValidTimestampRangeAcrossAllIntents,

--- a/radix-transactions/src/manifest/generator.rs
+++ b/radix-transactions/src/manifest/generator.rs
@@ -2262,14 +2262,13 @@ pub fn generator_error_diagnostics(
         GeneratorErrorKind::ManifestBuildError(
             ManifestBuildError::PreallocatedAddressesUnsupportedByManifestType,
         ) => {
-            let title =
-                format!("preallocated addresses are not supported in this manifest version");
+            let title = format!("preallocated addresses are not supported in this manifest type");
             (title, "unsupported instruction".to_string())
         }
         GeneratorErrorKind::ManifestBuildError(
             ManifestBuildError::ChildSubintentsUnsupportedByManifestType,
         ) => {
-            let title = format!("child subintents are not supported in this manifest version");
+            let title = format!("child subintents are not supported in this manifest type");
             (title, "unsupported instruction".to_string())
         }
         GeneratorErrorKind::HeaderInstructionMustComeFirst => {

--- a/radix-transactions/src/model/mod.rs
+++ b/radix-transactions/src/model/mod.rs
@@ -238,7 +238,7 @@ Enum<3u8>(
         assert_eq!(
             validated,
             Err(TransactionValidationError::PrepareError(
-                PrepareError::Other(format!("Unknown transaction payload discriminator byte: 4"))
+                PrepareError::UnexpectedTransactionDiscriminator { actual: Some(4) }
             ))
         )
     }

--- a/radix-transactions/src/model/preparation/decoder.rs
+++ b/radix-transactions/src/model/preparation/decoder.rs
@@ -4,10 +4,10 @@ use sbor::*;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ValueType {
     Blob,
-    Message,
     Subintent,
-    ChildIntentConstraint,
-    IntentSignatures,
+    ChildSubintentSpecifier,
+    SubintentSignatureBatches,
+    // Too many signatures is captured at validation time
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -22,7 +22,9 @@ pub enum PrepareError {
         max: usize,
     },
     LengthOverflow,
-    Other(String),
+    UnexpectedTransactionDiscriminator {
+        actual: Option<u8>,
+    },
 }
 
 impl From<DecodeError> for PrepareError {

--- a/radix-transactions/src/model/user_transaction.rs
+++ b/radix-transactions/src/model/user_transaction.rs
@@ -248,9 +248,9 @@ impl PreparedTransaction for PreparedUserTransaction {
     ) -> Result<Self, PrepareError> {
         let offset = decoder.get_offset();
         let slice = decoder.get_input_slice();
-        let discriminator_byte = slice.get(offset + 1).ok_or(PrepareError::Other(
-            "Could not read transaction payload discriminator byte".to_string(),
-        ))?;
+        let discriminator_byte = slice
+            .get(offset + 1)
+            .ok_or(PrepareError::UnexpectedTransactionDiscriminator { actual: None })?;
 
         let prepared = match TransactionDiscriminator::from_repr(*discriminator_byte) {
             Some(TransactionDiscriminator::V1Notarized) => PreparedUserTransaction::V1(
@@ -260,9 +260,9 @@ impl PreparedTransaction for PreparedUserTransaction {
                 PreparedNotarizedTransactionV2::prepare_from_transaction_enum(decoder)?,
             ),
             _ => {
-                return Err(PrepareError::Other(format!(
-                    "Unknown transaction payload discriminator byte: {discriminator_byte}"
-                )))
+                return Err(PrepareError::UnexpectedTransactionDiscriminator {
+                    actual: Some(*discriminator_byte),
+                })
             }
         };
 

--- a/radix-transactions/src/model/v2/child_subintent_hashes_v2.rs
+++ b/radix-transactions/src/model/v2/child_subintent_hashes_v2.rs
@@ -92,7 +92,7 @@ impl TransactionPreparableFromValueBody for PreparedChildSubintentSpecifiersV2 {
         let (hashes, summary) =
             ConcatenatedDigest::prepare_from_sbor_array_value_body::<Vec<RawHash>>(
                 decoder,
-                ValueType::ChildIntentConstraint,
+                ValueType::ChildSubintentSpecifier,
                 max_child_subintents_per_intent,
             )?;
 

--- a/radix-transactions/src/model/v2/intent_signatures_v2.rs
+++ b/radix-transactions/src/model/v2/intent_signatures_v2.rs
@@ -46,7 +46,7 @@ impl TransactionPreparableFromValueBody for PreparedNonRootSubintentSignaturesV2
             Vec<PreparedIntentSignaturesV2>,
         >(
             decoder,
-            ValueType::IntentSignatures,
+            ValueType::SubintentSignatureBatches,
             max_subintents_per_transaction,
         )?;
 

--- a/radix-transactions/src/model/v2/transaction_manifest_v2.rs
+++ b/radix-transactions/src/model/v2/transaction_manifest_v2.rs
@@ -102,6 +102,18 @@ impl TransactionManifestV2 {
         }
     }
 
+    pub fn to_intent_core(self, header: IntentHeaderV2, message: MessageV2) -> IntentCoreV2 {
+        IntentCoreV2 {
+            header,
+            blobs: self.blobs.into(),
+            message,
+            instructions: self.instructions.into(),
+            children: ChildSubintentSpecifiersV2 {
+                children: self.children,
+            },
+        }
+    }
+
     pub fn for_intent(self) -> (InstructionsV2, BlobsV1, ChildSubintentSpecifiersV2) {
         (
             self.instructions.into(),

--- a/radix-transactions/src/model/v2/transaction_manifest_v2.rs
+++ b/radix-transactions/src/model/v2/transaction_manifest_v2.rs
@@ -84,6 +84,15 @@ impl BuildableManifest for TransactionManifestV2 {
 impl BuildableManifestSupportingChildren for TransactionManifestV2 {}
 
 impl TransactionManifestV2 {
+    pub fn empty() -> Self {
+        Self {
+            instructions: Default::default(),
+            blobs: Default::default(),
+            children: Default::default(),
+            object_names: ManifestObjectNames::Unknown,
+        }
+    }
+
     pub fn from_intent_core(intent: &IntentCoreV2) -> Self {
         Self {
             instructions: intent.instructions.to_vec(),

--- a/radix-transactions/src/validation/transaction_validator_v1.rs
+++ b/radix-transactions/src/validation/transaction_validator_v1.rs
@@ -678,7 +678,6 @@ mod tests {
             123,
             vec![55],
             66,
-            #[allow(deprecated)]
             ManifestBuilder::new()
                 .take_from_worktop(XRD, dec!(100), "bucket")
                 .create_proof_from_bucket_of_amount("bucket", dec!(5), "proof1")

--- a/radix-transactions/src/validation/validation_test_helpers.rs
+++ b/radix-transactions/src/validation/validation_test_helpers.rs
@@ -19,25 +19,33 @@ pub(crate) fn unsigned_v1_builder(notary_public_key: PublicKey) -> TransactionV1
 
 // All of these are only added when in #[cfg(test)]
 impl TransactionV2Builder {
-    pub fn default_notary() -> Ed25519PrivateKey {
+    pub fn testing_default_notary() -> Ed25519PrivateKey {
         Ed25519PrivateKey::from_u64(1337).unwrap()
+    }
+
+    pub fn testing_default_intent_header() -> IntentHeaderV2 {
+        IntentHeaderV2 {
+            network_id: NetworkDefinition::simulator().id,
+            start_epoch_inclusive: Epoch::of(0),
+            end_epoch_exclusive: Epoch::of(1),
+            min_proposer_timestamp_inclusive: None,
+            max_proposer_timestamp_exclusive: None,
+            intent_discriminator: 0,
+        }
+    }
+
+    pub fn testing_default_transaction_header() -> TransactionHeaderV2 {
+        TransactionHeaderV2 {
+            notary_public_key: Self::testing_default_notary().public_key().into(),
+            notary_is_signatory: false,
+            tip_basis_points: 0,
+        }
     }
 
     pub fn new_with_test_defaults() -> Self {
         Self::new()
-            .intent_header(IntentHeaderV2 {
-                network_id: NetworkDefinition::simulator().id,
-                start_epoch_inclusive: Epoch::of(0),
-                end_epoch_exclusive: Epoch::of(1),
-                min_proposer_timestamp_inclusive: None,
-                max_proposer_timestamp_exclusive: None,
-                intent_discriminator: 0,
-            })
-            .transaction_header(TransactionHeaderV2 {
-                notary_public_key: Self::default_notary().public_key().into(),
-                notary_is_signatory: false,
-                tip_basis_points: 0,
-            })
+            .intent_header(Self::testing_default_intent_header())
+            .transaction_header(Self::testing_default_transaction_header())
     }
 
     pub fn add_children<T: ResolvableSignedPartialTransaction>(
@@ -141,7 +149,7 @@ impl TransactionV2Builder {
     }
 
     pub fn default_notarize(self) -> Self {
-        self.notarize(&Self::default_notary())
+        self.notarize(&Self::testing_default_notary())
     }
 
     pub fn default_notarize_and_validate(

--- a/radix-transactions/src/validation/validation_test_helpers.rs
+++ b/radix-transactions/src/validation/validation_test_helpers.rs
@@ -102,6 +102,39 @@ impl TransactionV2Builder {
             .expect("Intent Header should already have been set, e.g. via new_with_test_defaults()")
     }
 
+    pub fn network_id(mut self, network_id: u8) -> Self {
+        self.intent_header_mut().network_id = network_id;
+        self
+    }
+
+    pub fn start_epoch_inclusive(mut self, start_epoch_inclusive: Epoch) -> Self {
+        self.intent_header_mut().start_epoch_inclusive = start_epoch_inclusive;
+        self
+    }
+
+    pub fn end_epoch_exclusive(mut self, end_epoch_exclusive: Epoch) -> Self {
+        self.intent_header_mut().end_epoch_exclusive = end_epoch_exclusive;
+        self
+    }
+
+    pub fn min_proposer_timestamp_inclusive(
+        mut self,
+        min_proposer_timestamp_inclusive: Option<Instant>,
+    ) -> Self {
+        self.intent_header_mut().min_proposer_timestamp_inclusive =
+            min_proposer_timestamp_inclusive;
+        self
+    }
+
+    pub fn max_proposer_timestamp_exclusive(
+        mut self,
+        max_proposer_timestamp_exclusive: Option<Instant>,
+    ) -> Self {
+        self.intent_header_mut().max_proposer_timestamp_exclusive =
+            max_proposer_timestamp_exclusive;
+        self
+    }
+
     pub fn intent_discriminator(mut self, intent_discriminator: u64) -> Self {
         self.intent_header_mut().intent_discriminator = intent_discriminator;
         self
@@ -171,6 +204,39 @@ impl PartialTransactionV2Builder {
         self.root_subintent_header
             .as_mut()
             .expect("Intent Header should already have been set, e.g. via new_with_test_defaults()")
+    }
+
+    pub fn network_id(mut self, network_id: u8) -> Self {
+        self.intent_header_mut().network_id = network_id;
+        self
+    }
+
+    pub fn start_epoch_inclusive(mut self, start_epoch_inclusive: Epoch) -> Self {
+        self.intent_header_mut().start_epoch_inclusive = start_epoch_inclusive;
+        self
+    }
+
+    pub fn end_epoch_exclusive(mut self, end_epoch_exclusive: Epoch) -> Self {
+        self.intent_header_mut().end_epoch_exclusive = end_epoch_exclusive;
+        self
+    }
+
+    pub fn min_proposer_timestamp_inclusive(
+        mut self,
+        min_proposer_timestamp_inclusive: Option<Instant>,
+    ) -> Self {
+        self.intent_header_mut().min_proposer_timestamp_inclusive =
+            min_proposer_timestamp_inclusive;
+        self
+    }
+
+    pub fn max_proposer_timestamp_exclusive(
+        mut self,
+        max_proposer_timestamp_exclusive: Option<Instant>,
+    ) -> Self {
+        self.intent_header_mut().max_proposer_timestamp_exclusive =
+            max_proposer_timestamp_exclusive;
+        self
     }
 
     pub fn intent_discriminator(mut self, intent_discriminator: u64) -> Self {

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_1.diag
@@ -1,0 +1,11 @@
+error: an argument's structure does not fit with the radix_common::data::manifest::model::manifest_resource_assertion::ManifestResourceConstraints type. [ERROR] byte offset: 36-38, value path: ManifestResourceConstraints.[0].Value->ManifestResourceConstraint::{8}, cause: { unknown_variant_id: 8 }
+  |
+1 | ASSERT_WORKTOP_RESOURCES_INCLUDE
+2 |     Map<Address, Enum>(
+  |     ^^^ cannot be decoded as a radix_common::data::manifest::model::manifest_resource_assertion::ManifestResourceConstraints
+3 |         Address("resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8") => Enum<8u8>(
+4 |             Decimal("10")
+5 |         )
+6 |     )
+7 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_1.rtm
@@ -1,0 +1,7 @@
+ASSERT_WORKTOP_RESOURCES_INCLUDE
+    Map<Address, Enum>(
+        Address("resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8") => Enum<8u8>(
+            Decimal("10")
+        )
+    )
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_2.diag
@@ -1,0 +1,11 @@
+error: an argument's structure does not fit with the radix_common::data::manifest::model::manifest_resource_assertion::ManifestResourceConstraint type. [ERROR] byte offset: 1-26, value path: [Root], cause: { expected_type: Enum, found: Custom(Decimal) }
+  |
+2 |     Address("resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8")
+3 |     Bucket("my_bucket")
+4 | ;
+5 | ASSERT_BUCKET_CONTENTS
+6 |     Bucket("my_bucket")
+7 |     Decimal("10")
+  |     ^^^^^^^ cannot be decoded as a radix_common::data::manifest::model::manifest_resource_assertion::ManifestResourceConstraint
+8 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_2.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_2.rtm
@@ -1,0 +1,8 @@
+TAKE_ALL_FROM_WORKTOP
+    Address("resource_sim1thqu8jcc3zh8ukuh0rwtllr84dgrd3z8j9zjdelkx3zf4kjasgvnm8")
+    Bucket("my_bucket")
+;
+ASSERT_BUCKET_CONTENTS
+    Bucket("my_bucket")
+    Decimal("10")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_3.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_3.diag
@@ -1,0 +1,7 @@
+error: an argument's structure does not fit with the radix_engine_interface::blueprints::resource::proof_rule::AccessRule type. [ERROR] byte offset: 1-3, value path: [Root], cause: { expected_type: Enum, found: Tuple }
+  |
+1 | VERIFY_PARENT
+2 |     Tuple()
+  |     ^^^^^ cannot be decoded as a radix_engine_interface::blueprints::resource::proof_rule::AccessRule
+3 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_3.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_argument_could_not_be_read_as_expected_type_3.rtm
@@ -1,0 +1,3 @@
+VERIFY_PARENT
+    Tuple()
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_blob_not_found_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_blob_not_found_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mblob with hash 'f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1' not found[0m
-[1m[94m   |[0m
-[1m[94m12 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m13 |[0m     Enum<AccessRule::AllowAll>()
-[1m[94m14 |[0m     Tuple(
-[1m[94m15 |[0m         Map<String, Tuple>()
-[1m[94m16 |[0m     )
-[1m[94m17 |[0m     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
-[1m[94m   |[0m[1m[91m          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mblob not found[0m
-[1m[94m18 |[0m     Map<String, Tuple>()
-[1m[94m19 |[0m     Some(AddressReservation("my_reservation"))
-[1m[94m20 |[0m ;
-[1m[94m21 |[0m CALL_FUNCTION
-[1m[94m22 |[0m     NamedAddress("my_package")
-[1m[94m   |[0m
+error: blob with hash 'f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1' not found
+   |
+12 | PUBLISH_PACKAGE_ADVANCED
+13 |     Enum<AccessRule::AllowAll>()
+14 |     Tuple(
+15 |         Map<String, Tuple>()
+16 |     )
+17 |     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ blob not found
+18 |     Map<String, Tuple>()
+19 |     Some(AddressReservation("my_reservation"))
+20 | ;
+21 | CALL_FUNCTION
+22 |     NamedAddress("my_package")
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_bucket_locked_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_bucket_locked_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mcannot consume bucket 'some_bucket' because it's believed to be currently locked[0m
-[1m[94m   |[0m
-[1m[94m18 |[0m   Bucket("some_bucket")
-[1m[94m19 |[0m   Decimal("1")
-[1m[94m20 |[0m   Proof("proof");
-[1m[94m21 |[0m 
-[1m[94m22 |[0m RETURN_TO_WORKTOP
-[1m[94m23 |[0m     Bucket("some_bucket");
-[1m[94m   |[0m[1m[91m            ^^^^^^^^^^^^^[0m [1m[91mbucket locked[0m
-[1m[94m24 |[0m 
-[1m[94m   |[0m
+error: cannot consume bucket 'some_bucket' because it's believed to be currently locked
+   |
+18 |   Bucket("some_bucket")
+19 |   Decimal("1")
+20 |   Proof("proof");
+21 | 
+22 | RETURN_TO_WORKTOP
+23 |     Bucket("some_bucket");
+   |            ^^^^^^^^^^^^^ bucket locked
+24 | 
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_bucket_not_found_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_bucket_not_found_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mbucket id 'ManifestBucket(1)' not found[0m
-[1m[94m   |[0m
-[1m[94m 7 |[0m TAKE_ALL_FROM_WORKTOP
-[1m[94m 8 |[0m   Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
-[1m[94m 9 |[0m   Bucket("some_xrd");
-[1m[94m10 |[0m 
-[1m[94m11 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
-[1m[94m12 |[0m   Bucket(1u32)
-[1m[94m   |[0m[1m[91m          ^^^^[0m [1m[91mbucket not found[0m
-[1m[94m13 |[0m   Decimal("1")
-[1m[94m14 |[0m   Proof("proof");
-[1m[94m15 |[0m 
-[1m[94m16 |[0m DROP_PROOF
-[1m[94m17 |[0m   Proof("proof");
-[1m[94m   |[0m
+error: bucket id 'ManifestBucket(1)' not found
+   |
+ 7 | TAKE_ALL_FROM_WORKTOP
+ 8 |   Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+ 9 |   Bucket("some_xrd");
+10 | 
+11 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
+12 |   Bucket(1u32)
+   |          ^^^^ bucket not found
+13 |   Decimal("1")
+14 |   Proof("proof");
+15 | 
+16 | DROP_PROOF
+17 |   Proof("proof");
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_bucket_not_found_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_bucket_not_found_2.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1mbucket id 'ManifestBucket(1)' not found[0m
-[1m[94m   |[0m
-[1m[94m 7 |[0m TAKE_ALL_FROM_WORKTOP
-[1m[94m 8 |[0m   Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
-[1m[94m 9 |[0m   Bucket("some_xrd");
-[1m[94m10 |[0m 
-[1m[94m11 |[0m BURN_RESOURCE
-[1m[94m12 |[0m   Bucket(1u32);
-[1m[94m   |[0m[1m[91m          ^^^^[0m [1m[91mbucket not found[0m
-[1m[94m   |[0m
+error: bucket id 'ManifestBucket(1)' not found
+   |
+ 7 | TAKE_ALL_FROM_WORKTOP
+ 8 |   Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+ 9 |   Bucket("some_xrd");
+10 | 
+11 | BURN_RESOURCE
+12 |   Bucket(1u32);
+   |          ^^^^ bucket not found
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_child_subintents_unsupported_by_manifest_type_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_child_subintents_unsupported_by_manifest_type_1.diag
@@ -1,0 +1,8 @@
+error: child subintents are not supported in this manifest type
+  |
+1 | / USE_CHILD
+2 | |     NamedIntent("my_child")
+3 | |     Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+4 | | ;
+  | |_^ unsupported instruction
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_child_subintents_unsupported_by_manifest_type_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_child_subintents_unsupported_by_manifest_type_1.rtm
@@ -1,0 +1,4 @@
+USE_CHILD
+    NamedIntent("my_child")
+    Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_duplicate_subintent_hash_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_duplicate_subintent_hash_1.diag
@@ -1,0 +1,12 @@
+error: child subintents cannot have the same hash
+  |
+1 |   USE_CHILD
+2 |       NamedIntent("my_child")
+3 |       Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+4 |   ;
+5 | / USE_CHILD
+6 | |     NamedIntent("my_second_child")
+7 | |     Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+8 | | ;
+  | |_^ duplicate hash
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_duplicate_subintent_hash_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_duplicate_subintent_hash_1.rtm
@@ -1,0 +1,8 @@
+USE_CHILD
+    NamedIntent("my_child")
+    Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+;
+USE_CHILD
+    NamedIntent("my_second_child")
+    Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_header_instruction_must_come_first_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_header_instruction_must_come_first_1.diag
@@ -1,0 +1,9 @@
+error: a psuedo-instruction such as USE_CHILD must come before all other instructions
+  |
+1 |   DROP_ALL_PROOFS;
+2 | / USE_CHILD
+3 | |     NamedIntent("my_child")
+4 | |     Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+5 | | ;
+  | |_^ must be at the start of the manifest
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_header_instruction_must_come_first_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_header_instruction_must_come_first_1.rtm
@@ -1,0 +1,5 @@
+DROP_ALL_PROOFS;
+USE_CHILD
+    NamedIntent("my_child")
+    Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_instruction_not_supported_in_manifest_version_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_instruction_not_supported_in_manifest_version_1.diag
@@ -1,0 +1,5 @@
+error: unsupported instruction for this manifest version
+  |
+1 | YIELD_TO_PARENT;
+  | ^^^^^^^^^^^^^^^^ unsupported instruction
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_instruction_not_supported_in_manifest_version_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_instruction_not_supported_in_manifest_version_1.rtm
@@ -1,0 +1,1 @@
+YIELD_TO_PARENT;

--- a/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_as_value_kind_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_as_value_kind_1.diag
@@ -1,0 +1,9 @@
+error: an Intent cannot be used as a value kind
+  |
+1 | CALL_METHOD
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "my_method"
+4 |     Array<Intent>()
+  |           ^^^^^^ cannot be used as a value kind
+5 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_as_value_kind_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_as_value_kind_1.rtm
@@ -1,0 +1,5 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "my_method"
+    Array<Intent>()
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_in_value_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_in_value_1.diag
@@ -1,0 +1,9 @@
+error: an Intent(...) cannot currently be used inside a value
+  |
+1 | CALL_METHOD
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "my_method"
+4 |     Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+  |     ^^^^^^ cannot be used inside a value
+5 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_in_value_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_intent_cannot_be_used_in_value_1.rtm
@@ -1,0 +1,5 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "my_method"
+    Intent("subtxid_sim1f0dp5mcrzvgnujw33lgnjy9usluaek6edfkqdjkj5vhuqf8t7apqnaqedd")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_type_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_type_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected NonFungibleLocalId, found String[0m
-[1m[94m   |[0m
-[1m[94m 1 |[0m CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
-[1m[94m 2 |[0m 
-[1m[94m 3 |[0m # Create a proof from bucket, clone it and drop both
-[1m[94m 4 |[0m TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
-[1m[94m 5 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
-[1m[94m 6 |[0m CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<String>("some_string") Proof("proof1b");
-[1m[94m   |[0m[1m[91m                                                                    ^^^^^^[0m [1m[91mexpected NonFungibleLocalId[0m
-[1m[94m 7 |[0m CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
-[1m[94m 8 |[0m CLONE_PROOF Proof("proof1c") Proof("proof1d");
-[1m[94m 9 |[0m DROP_PROOF Proof("proof1d");
-[1m[94m10 |[0m DROP_PROOF Proof("proof1c");
-[1m[94m11 |[0m DROP_AUTH_ZONE_PROOFS;
-[1m[94m   |[0m
+error: expected NonFungibleLocalId, found String
+   |
+ 1 | CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
+ 2 | 
+ 3 | # Create a proof from bucket, clone it and drop both
+ 4 | TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
+ 5 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
+ 6 | CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<String>("some_string") Proof("proof1b");
+   |                                                                    ^^^^^^ expected NonFungibleLocalId
+ 7 | CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
+ 8 | CLONE_PROOF Proof("proof1c") Proof("proof1d");
+ 9 | DROP_PROOF Proof("proof1d");
+10 | DROP_PROOF Proof("proof1c");
+11 | DROP_AUTH_ZONE_PROOFS;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected String, found U32[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m CALL_METHOD
-[1m[94m2 |[0m     Address(100u32)
-[1m[94m  |[0m[1m[91m             ^^^^^^[0m [1m[91mexpected String[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_FUNCTION
-[1m[94m6 |[0m     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m7 |[0m     "Hello"
-[1m[94m  |[0m
+error: expected String, found U32
+  |
+1 | CALL_METHOD
+2 |     Address(100u32)
+  |             ^^^^^^ expected String
+3 |     "lock_fee"
+4 | ;
+5 | CALL_FUNCTION
+6 |     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+7 |     "Hello"
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_2.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected String, found Decimal[0m
-[1m[94m   |[0m
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 8 |[0m     "create_proof_of_amount"
-[1m[94m 9 |[0m     Address("resource_sim1t5lam43hk5fg9h2x7a8zgpfxsd78539kzm4h0xugldymfexuh2wzru")
-[1m[94m10 |[0m     Expression(
-[1m[94m11 |[0m       Decimal("1")
-[1m[94m   |[0m[1m[91m       ^^^^^^^[0m [1m[91mexpected String[0m
-[1m[94m12 |[0m     );
-[1m[94m   |[0m
+error: expected String, found Decimal
+   |
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 8 |     "create_proof_of_amount"
+ 9 |     Address("resource_sim1t5lam43hk5fg9h2x7a8zgpfxsd78539kzm4h0xugldymfexuh2wzru")
+10 |     Expression(
+11 |       Decimal("1")
+   |       ^^^^^^^ expected String
+12 |     );
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_3.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_3.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected Address or NamedAddress, found String[0m
-[1m[94m   |[0m
-[1m[94m 8 |[0m     "create_proof_of_amount"
-[1m[94m 9 |[0m     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
-[1m[94m10 |[0m     Decimal("1");
-[1m[94m11 |[0m 
-[1m[94m12 |[0m MINT_FUNGIBLE
-[1m[94m13 |[0m     "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh"
-[1m[94m   |[0m[1m[91m     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mexpected Address or NamedAddress[0m
-[1m[94m14 |[0m     Decimal("20");
-[1m[94m15 |[0m 
-[1m[94m16 |[0m CALL_METHOD
-[1m[94m17 |[0m     Address("${account_address}")
-[1m[94m18 |[0m     "deposit_batch"
-[1m[94m   |[0m
+error: expected Address or NamedAddress, found String
+   |
+ 8 |     "create_proof_of_amount"
+ 9 |     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+10 |     Decimal("1");
+11 | 
+12 | MINT_FUNGIBLE
+13 |     "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh"
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected Address or NamedAddress
+14 |     Decimal("20");
+15 | 
+16 | CALL_METHOD
+17 |     Address("${account_address}")
+18 |     "deposit_batch"
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_4.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_4.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected NonFungibleLocalId, found U32[0m
-[1m[94m   |[0m
-[1m[94m 1 |[0m CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
-[1m[94m 2 |[0m 
-[1m[94m 3 |[0m # Create a proof from bucket, clone it and drop both
-[1m[94m 4 |[0m TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
-[1m[94m 5 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
-[1m[94m 6 |[0m CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<NonFungibleLocalId>(1u32) Proof("proof1b");
-[1m[94m   |[0m[1m[91m                                                                                        ^^^^[0m [1m[91mexpected NonFungibleLocalId[0m
-[1m[94m 7 |[0m CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
-[1m[94m 8 |[0m CLONE_PROOF Proof("proof1c") Proof("proof1d");
-[1m[94m 9 |[0m DROP_PROOF Proof("proof1d");
-[1m[94m10 |[0m DROP_PROOF Proof("proof1c");
-[1m[94m11 |[0m DROP_AUTH_ZONE_PROOFS;
-[1m[94m   |[0m
+error: expected NonFungibleLocalId, found U32
+   |
+ 1 | CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
+ 2 | 
+ 3 | # Create a proof from bucket, clone it and drop both
+ 4 | TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
+ 5 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
+ 6 | CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<NonFungibleLocalId>(1u32) Proof("proof1b");
+   |                                                                                        ^^^^ expected NonFungibleLocalId
+ 7 | CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
+ 8 | CLONE_PROOF Proof("proof1c") Proof("proof1d");
+ 9 | DROP_PROOF Proof("proof1d");
+10 | DROP_PROOF Proof("proof1c");
+11 | DROP_AUTH_ZONE_PROOFS;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_5.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_ast_value_5.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected String, found Bool[0m
-[1m[94m   |[0m
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m     "some_method"
-[1m[94m 9 |[0m     "text mixed with 🤓 and 🥸 unicodes"
-[1m[94m10 |[0m     "\uD83D\uDC69"
-[1m[94m11 |[0m     Decimal(true)
-[1m[94m   |[0m[1m[91m             ^^^^[0m [1m[91mexpected String[0m
-[1m[94m12 |[0m ;
-[1m[94m   |[0m
+error: expected String, found Bool
+   |
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |     "some_method"
+ 9 |     "text mixed with 🤓 and 🥸 unicodes"
+10 |     "\uD83D\uDC69"
+11 |     Decimal(true)
+   |             ^^^^ expected String
+12 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_blob_hash_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_blob_hash_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid blob hash 'abbcc' - invalid hex value[0m
-[1m[94m   |[0m
-[1m[94m12 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m13 |[0m     Enum<AccessRule::AllowAll>()
-[1m[94m14 |[0m     Tuple(
-[1m[94m15 |[0m         Map<String, Tuple>()
-[1m[94m16 |[0m     )
-[1m[94m17 |[0m     Blob("abbcc")
-[1m[94m   |[0m[1m[91m          ^^^^^^^[0m [1m[91minvalid blob hash[0m
-[1m[94m18 |[0m     Map<String, Tuple>()
-[1m[94m19 |[0m     Some(AddressReservation("my_reservation"))
-[1m[94m20 |[0m ;
-[1m[94m21 |[0m CALL_FUNCTION
-[1m[94m22 |[0m     NamedAddress("my_package")
-[1m[94m   |[0m
+error: invalid blob hash 'abbcc' - invalid hex value
+   |
+12 | PUBLISH_PACKAGE_ADVANCED
+13 |     Enum<AccessRule::AllowAll>()
+14 |     Tuple(
+15 |         Map<String, Tuple>()
+16 |     )
+17 |     Blob("abbcc")
+   |          ^^^^^^^ invalid blob hash
+18 |     Map<String, Tuple>()
+19 |     Some(AddressReservation("my_reservation"))
+20 | ;
+21 | CALL_FUNCTION
+22 |     NamedAddress("my_package")
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_blob_hash_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_blob_hash_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid blob hash 'aabbcc' - invalid hash length 3, expected 32[0m
-[1m[94m   |[0m
-[1m[94m12 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m13 |[0m     Enum<AccessRule::AllowAll>()
-[1m[94m14 |[0m     Tuple(
-[1m[94m15 |[0m         Map<String, Tuple>()
-[1m[94m16 |[0m     )
-[1m[94m17 |[0m     Blob("aabbcc")
-[1m[94m   |[0m[1m[91m          ^^^^^^^^[0m [1m[91minvalid blob hash[0m
-[1m[94m18 |[0m     Map<String, Tuple>()
-[1m[94m19 |[0m     Some(AddressReservation("my_reservation"))
-[1m[94m20 |[0m ;
-[1m[94m21 |[0m CALL_FUNCTION
-[1m[94m22 |[0m     NamedAddress("my_package")
-[1m[94m   |[0m
+error: invalid blob hash 'aabbcc' - invalid hash length 3, expected 32
+   |
+12 | PUBLISH_PACKAGE_ADVANCED
+13 |     Enum<AccessRule::AllowAll>()
+14 |     Tuple(
+15 |         Map<String, Tuple>()
+16 |     )
+17 |     Blob("aabbcc")
+   |          ^^^^^^^^ invalid blob hash
+18 |     Map<String, Tuple>()
+19 |     Some(AddressReservation("my_reservation"))
+20 | ;
+21 | CALL_FUNCTION
+22 |     NamedAddress("my_package")
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_bytes_hex_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_bytes_hex_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid hex value 'invalid_hex'[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m CALL_FUNCTION
-[1m[94m 6 |[0m     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m 7 |[0m     "Hello"
-[1m[94m 8 |[0m     "instantiate_hello"
-[1m[94m 9 |[0m     Bytes("invalid_hex")
-[1m[94m   |[0m[1m[91m           ^^^^^^^^^^^^^[0m [1m[91minvalid hex value[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: invalid hex value 'invalid_hex'
+   |
+ 4 | ;
+ 5 | CALL_FUNCTION
+ 6 |     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+ 7 |     "Hello"
+ 8 |     "instantiate_hello"
+ 9 |     Bytes("invalid_hex")
+   |           ^^^^^^^^^^^^^ invalid hex value
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid decimal '1.000000000000000011111111' - MoreThanEighteenDecimalPlaces[0m
-[1m[94m   |[0m
-[1m[94m 8 |[0m     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
-[1m[94m 9 |[0m     Bucket("some_xrd");
-[1m[94m10 |[0m 
-[1m[94m11 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
-[1m[94m12 |[0m   Bucket("some_xrd")
-[1m[94m13 |[0m   Decimal("1.000000000000000011111111")
-[1m[94m   |[0m[1m[91m           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid decimal[0m
-[1m[94m14 |[0m   Proof("proof1a");
-[1m[94m   |[0m
+error: invalid decimal '1.000000000000000011111111' - MoreThanEighteenDecimalPlaces
+   |
+ 8 |     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+ 9 |     Bucket("some_xrd");
+10 | 
+11 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT
+12 |   Bucket("some_xrd")
+13 |   Decimal("1.000000000000000011111111")
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid decimal
+14 |   Proof("proof1a");
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_2.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid decimal '基数引擎' - InvalidDigit[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m     "some_method"
-[1m[94m 9 |[0m     Decimal("基数引擎")
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^[0m [1m[91minvalid decimal[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: invalid decimal '基数引擎' - InvalidDigit
+   |
+ 4 | ;
+ 5 | 
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |     "some_method"
+ 9 |     Decimal("基数引擎")
+   |             ^^^^^^^^^^ invalid decimal
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_3.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_decimal_3.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid decimal '👩' - InvalidDigit[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m     "some_method"
-[1m[94m 9 |[0m     Decimal("\uD83D\uDC69")
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^^^^^[0m [1m[91minvalid decimal[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: invalid decimal '👩' - InvalidDigit
+   |
+ 4 | ;
+ 5 | 
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |     "some_method"
+ 9 |     Decimal("\uD83D\uDC69")
+   |             ^^^^^^^^^^^^^^ invalid decimal
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_expression_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_expression_1.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1minvalid expression 'FULL_WORKTOP'[0m
-[1m[94m   |[0m
-[1m[94m24 |[0m     Expression("ENTIRE_AUTH_ZONE");
-[1m[94m25 |[0m 
-[1m[94m26 |[0m CALL_METHOD
-[1m[94m27 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m28 |[0m     "deposit_batch"
-[1m[94m29 |[0m     Expression("FULL_WORKTOP");
-[1m[94m   |[0m[1m[91m                ^^^^^^^^^^^^^^[0m [1m[91minvalid expression[0m
-[1m[94m   |[0m
+error: invalid expression 'FULL_WORKTOP'
+   |
+24 |     Expression("ENTIRE_AUTH_ZONE");
+25 | 
+26 | CALL_METHOD
+27 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+28 |     "deposit_batch"
+29 |     Expression("FULL_WORKTOP");
+   |                ^^^^^^^^^^^^^^ invalid expression
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_global_address_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_global_address_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid global address 'invalid_address'[0m
-[1m[94m   |[0m
-[1m[94m 2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m     Decimal("500");
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("invalid_address")
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^^^^^^^^[0m [1m[91minvalid global address[0m
-[1m[94m 8 |[0m     "create_proof_of_amount"
-[1m[94m 9 |[0m     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
-[1m[94m10 |[0m     Decimal("1");
-[1m[94m11 |[0m 
-[1m[94m12 |[0m MINT_FUNGIBLE
-[1m[94m   |[0m
+error: invalid global address 'invalid_address'
+   |
+ 2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 3 |     "lock_fee"
+ 4 |     Decimal("500");
+ 5 | 
+ 6 | CALL_METHOD
+ 7 |     Address("invalid_address")
+   |             ^^^^^^^^^^^^^^^^^ invalid global address
+ 8 |     "create_proof_of_amount"
+ 9 |     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+10 |     Decimal("1");
+11 | 
+12 | MINT_FUNGIBLE
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_internal_address_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_internal_address_1.diag
@@ -1,14 +1,14 @@
-[1m[91merror[0m: [1minvalid internal address 'component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh'[0m
-[1m[94m   |[0m
-[1m[94m 2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m     Decimal("5000")
-[1m[94m 5 |[0m ;
-[1m[94m 6 |[0m FREEZE_VAULT
-[1m[94m 7 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid internal address[0m
-[1m[94m 8 |[0m     Tuple(
-[1m[94m 9 |[0m         2u32
-[1m[94m10 |[0m     )
-[1m[94m11 |[0m ;
-[1m[94m   |[0m
+error: invalid internal address 'component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh'
+   |
+ 2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 3 |     "lock_fee"
+ 4 |     Decimal("5000")
+ 5 | ;
+ 6 | FREEZE_VAULT
+ 7 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid internal address
+ 8 |     Tuple(
+ 9 |         2u32
+10 |     )
+11 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_non_fungible_global_id_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_non_fungible_global_id_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid non-fungible global id[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m CALL_FUNCTION
-[1m[94m 6 |[0m     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m 7 |[0m     "Hello"
-[1m[94m 8 |[0m     "instantiate_hello"
-[1m[94m 9 |[0m     NonFungibleGlobalId("resource_sim1n2n538l5hpaagvl0phkff3qkdd6pxh0kskh8umuknr8c3whsl62dxp:some_id")
-[1m[94m   |[0m[1m[91m                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid non-fungible global id[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: invalid non-fungible global id
+   |
+ 4 | ;
+ 5 | CALL_FUNCTION
+ 6 |     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+ 7 |     "Hello"
+ 8 |     "instantiate_hello"
+ 9 |     NonFungibleGlobalId("resource_sim1n2n538l5hpaagvl0phkff3qkdd6pxh0kskh8umuknr8c3whsl62dxp:some_id")
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid non-fungible global id
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_non_fungible_local_id_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_non_fungible_local_id_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid non-fungible local id 'some_id'[0m
-[1m[94m   |[0m
-[1m[94m 1 |[0m CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
-[1m[94m 2 |[0m 
-[1m[94m 3 |[0m # Create a proof from bucket, clone it and drop both
-[1m[94m 4 |[0m TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
-[1m[94m 5 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
-[1m[94m 6 |[0m CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<NonFungibleLocalId>(NonFungibleLocalId("some_id")) Proof("proof1b");
-[1m[94m   |[0m[1m[91m                                                                                                           ^^^^^^^^^[0m [1m[91minvalid non-fungible local id[0m
-[1m[94m 7 |[0m CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
-[1m[94m 8 |[0m CLONE_PROOF Proof("proof1c") Proof("proof1d");
-[1m[94m 9 |[0m DROP_PROOF Proof("proof1d");
-[1m[94m10 |[0m DROP_PROOF Proof("proof1c");
-[1m[94m11 |[0m DROP_AUTH_ZONE_PROOFS;
-[1m[94m   |[0m
+error: invalid non-fungible local id 'some_id'
+   |
+ 1 | CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "withdraw" Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Decimal("5.0");
+ 2 | 
+ 3 | # Create a proof from bucket, clone it and drop both
+ 4 | TAKE_ALL_FROM_WORKTOP Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3") Bucket("some_xrd");
+ 5 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd") Decimal("1") Proof("proof1a");
+ 6 | CREATE_PROOF_FROM_BUCKET_OF_NON_FUNGIBLES Bucket("some_xrd") Array<NonFungibleLocalId>(NonFungibleLocalId("some_id")) Proof("proof1b");
+   |                                                                                                           ^^^^^^^^^ invalid non-fungible local id
+ 7 | CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1c");
+ 8 | CLONE_PROOF Proof("proof1c") Proof("proof1d");
+ 9 | DROP_PROOF Proof("proof1d");
+10 | DROP_PROOF Proof("proof1c");
+11 | DROP_AUTH_ZONE_PROOFS;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_package_address_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_package_address_1.diag
@@ -1,13 +1,13 @@
-[1m[91merror[0m: [1minvalid package address 'package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk'[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m CALL_METHOD
-[1m[94m2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_FUNCTION
-[1m[94m6 |[0m     Address("package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m  |[0m[1m[91m             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid package address[0m
-[1m[94m7 |[0m     "Hello"
-[1m[94m8 |[0m     "instantiate_hello"
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: invalid package address 'package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk'
+  |
+1 | CALL_METHOD
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "lock_fee"
+4 | ;
+5 | CALL_FUNCTION
+6 |     Address("package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid package address
+7 |     "Hello"
+8 |     "instantiate_hello"
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_package_address_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_package_address_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid package address 'package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk'[0m
-[1m[94m   |[0m
-[1m[94m 2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m     Decimal("500")
-[1m[94m 5 |[0m ;
-[1m[94m 6 |[0m ALLOCATE_GLOBAL_ADDRESS
-[1m[94m 7 |[0m     Address("package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid package address[0m
-[1m[94m 8 |[0m     "Package"
-[1m[94m 9 |[0m     AddressReservation("my_reservation")
-[1m[94m10 |[0m     NamedAddress("my_package")
-[1m[94m11 |[0m ;
-[1m[94m12 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m   |[0m
+error: invalid package address 'package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk'
+   |
+ 2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 3 |     "lock_fee"
+ 4 |     Decimal("500")
+ 5 | ;
+ 6 | ALLOCATE_GLOBAL_ADDRESS
+ 7 |     Address("package_1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid package address
+ 8 |     "Package"
+ 9 |     AddressReservation("my_reservation")
+10 |     NamedAddress("my_package")
+11 | ;
+12 | PUBLISH_PACKAGE_ADVANCED
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_precise_decimal_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_precise_decimal_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid precise decimal '1.' - EmptyFractionalPart[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m CALL_FUNCTION
-[1m[94m 6 |[0m     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m 7 |[0m     "Hello"
-[1m[94m 8 |[0m     "instantiate_hello"
-[1m[94m 9 |[0m     PreciseDecimal("1.")
-[1m[94m   |[0m[1m[91m                    ^^^^[0m [1m[91minvalid precise decimal[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: invalid precise decimal '1.' - EmptyFractionalPart
+   |
+ 4 | ;
+ 5 | CALL_FUNCTION
+ 6 |     Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+ 7 |     "Hello"
+ 8 |     "instantiate_hello"
+ 9 |     PreciseDecimal("1.")
+   |                    ^^^^ invalid precise decimal
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_resource_address_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_resource_address_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid resource address 'resource_address'[0m
-[1m[94m   |[0m
-[1m[94m13 |[0m   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m14 |[0m   "buy_gumball"
-[1m[94m15 |[0m   Bucket("xrd_bucket");
-[1m[94m16 |[0m 
-[1m[94m17 |[0m ASSERT_WORKTOP_CONTAINS_ANY
-[1m[94m18 |[0m   Address("resource_address");
-[1m[94m   |[0m[1m[91m           ^^^^^^^^^^^^^^^^^^[0m [1m[91minvalid resource address[0m
-[1m[94m19 |[0m 
-[1m[94m20 |[0m ASSERT_WORKTOP_CONTAINS
-[1m[94m21 |[0m   Address("resource_sim1t5q5qqum600pwwu27zl7m4rpr8g0400e72n368g09tgnptqe6kuwst")
-[1m[94m22 |[0m   Decimal("3.0");
-[1m[94m23 |[0m 
-[1m[94m   |[0m
+error: invalid resource address 'resource_address'
+   |
+13 |   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+14 |   "buy_gumball"
+15 |   Bucket("xrd_bucket");
+16 | 
+17 | ASSERT_WORKTOP_CONTAINS_ANY
+18 |   Address("resource_address");
+   |           ^^^^^^^^^^^^^^^^^^ invalid resource address
+19 | 
+20 | ASSERT_WORKTOP_CONTAINS
+21 |   Address("resource_sim1t5q5qqum600pwwu27zl7m4rpr8g0400e72n368g09tgnptqe6kuwst")
+22 |   Decimal("3.0");
+23 | 
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_sub_transaction_id_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_sub_transaction_id_1.diag
@@ -1,0 +1,8 @@
+error: invalid sub transaction id 'subtxid_sim1___oops_this_is_invalid'
+  |
+1 | USE_CHILD
+2 |     NamedIntent("my_child")
+3 |     Intent("subtxid_sim1___oops_this_is_invalid")
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid sub transaction id
+4 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_invalid_sub_transaction_id_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_invalid_sub_transaction_id_1.rtm
@@ -1,0 +1,4 @@
+USE_CHILD
+    NamedIntent("my_child")
+    Intent("subtxid_sim1___oops_this_is_invalid")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mname already defined 'my_reservation'[0m
-[1m[94m   |[0m
-[1m[94m10 |[0m     NamedAddress("my_package")
-[1m[94m11 |[0m ;
-[1m[94m12 |[0m ALLOCATE_GLOBAL_ADDRESS
-[1m[94m13 |[0m     Address("package_sim1pkgxxxxxxxxxpackgexxxxxxxxx000726633226xxxxxxxxxlk8hc9")
-[1m[94m14 |[0m     "Package"
-[1m[94m15 |[0m     AddressReservation("my_reservation")
-[1m[94m   |[0m[1m[91m                        ^^^^^^^^^^^^^^^^[0m [1m[91mname already defined[0m
-[1m[94m16 |[0m     NamedAddress("my_second_package")
-[1m[94m17 |[0m ;
-[1m[94m18 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m19 |[0m     Enum<AccessRule::AllowAll>()
-[1m[94m20 |[0m     Tuple(
-[1m[94m   |[0m
+error: name already defined 'my_reservation'
+   |
+10 |     NamedAddress("my_package")
+11 | ;
+12 | ALLOCATE_GLOBAL_ADDRESS
+13 |     Address("package_sim1pkgxxxxxxxxxpackgexxxxxxxxx000726633226xxxxxxxxxlk8hc9")
+14 |     "Package"
+15 |     AddressReservation("my_reservation")
+   |                        ^^^^^^^^^^^^^^^^ name already defined
+16 |     NamedAddress("my_second_package")
+17 | ;
+18 | PUBLISH_PACKAGE_ADVANCED
+19 |     Enum<AccessRule::AllowAll>()
+20 |     Tuple(
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mname already defined 'my_package'[0m
-[1m[94m   |[0m
-[1m[94m11 |[0m ;
-[1m[94m12 |[0m ALLOCATE_GLOBAL_ADDRESS
-[1m[94m13 |[0m     Address("package_sim1pkgxxxxxxxxxpackgexxxxxxxxx000726633226xxxxxxxxxlk8hc9")
-[1m[94m14 |[0m     "Package"
-[1m[94m15 |[0m     AddressReservation("my_second_reservation")
-[1m[94m16 |[0m     NamedAddress("my_package")
-[1m[94m   |[0m[1m[91m                  ^^^^^^^^^^^^[0m [1m[91mname already defined[0m
-[1m[94m17 |[0m ;
-[1m[94m18 |[0m PUBLISH_PACKAGE_ADVANCED
-[1m[94m19 |[0m     Enum<AccessRule::AllowAll>()
-[1m[94m20 |[0m     Tuple(
-[1m[94m21 |[0m         Map<String, Tuple>()
-[1m[94m   |[0m
+error: name already defined 'my_package'
+   |
+11 | ;
+12 | ALLOCATE_GLOBAL_ADDRESS
+13 |     Address("package_sim1pkgxxxxxxxxxpackgexxxxxxxxx000726633226xxxxxxxxxlk8hc9")
+14 |     "Package"
+15 |     AddressReservation("my_second_reservation")
+16 |     NamedAddress("my_package")
+   |                  ^^^^^^^^^^^^ name already defined
+17 | ;
+18 | PUBLISH_PACKAGE_ADVANCED
+19 |     Enum<AccessRule::AllowAll>()
+20 |     Tuple(
+21 |         Map<String, Tuple>()
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_3.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_3.diag
@@ -1,14 +1,14 @@
-[1m[91merror[0m: [1mname already defined 'proof1a'[0m
-[1m[94m   |[0m
-[1m[94m 7 |[0m   Bucket("some_xrd")
-[1m[94m 8 |[0m   Array<NonFungibleLocalId>(
-[1m[94m 9 |[0m     NonFungibleLocalId("#123#")
-[1m[94m10 |[0m   )
-[1m[94m11 |[0m   Proof("proof1b");
-[1m[94m12 |[0m CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1a");
-[1m[94m   |[0m[1m[91m                                                          ^^^^^^^^^[0m [1m[91mname already defined[0m
-[1m[94m13 |[0m CLONE_PROOF Proof("proof1c") Proof("proof1d");
-[1m[94m14 |[0m DROP_PROOF Proof("proof1d");
-[1m[94m15 |[0m DROP_PROOF Proof("proof1c");
-[1m[94m16 |[0m DROP_AUTH_ZONE_PROOFS;
-[1m[94m   |[0m
+error: name already defined 'proof1a'
+   |
+ 7 |   Bucket("some_xrd")
+ 8 |   Array<NonFungibleLocalId>(
+ 9 |     NonFungibleLocalId("#123#")
+10 |   )
+11 |   Proof("proof1b");
+12 | CREATE_PROOF_FROM_BUCKET_OF_ALL Bucket("some_xrd") Proof("proof1a");
+   |                                                          ^^^^^^^^^ name already defined
+13 | CLONE_PROOF Proof("proof1c") Proof("proof1d");
+14 | DROP_PROOF Proof("proof1d");
+15 | DROP_PROOF Proof("proof1c");
+16 | DROP_AUTH_ZONE_PROOFS;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_4.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_name_already_defined_4.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mname already defined 'xrd'[0m
-[1m[94m   |[0m
-[1m[94m10 |[0m   Bucket("xrd");
-[1m[94m11 |[0m 
-[1m[94m12 |[0m TAKE_FROM_WORKTOP
-[1m[94m13 |[0m   Address("resource_sim1t45r6lyr36ypj64sumrmkk9pjesfyl9na849jz00qrwnx28c8sletw")
-[1m[94m14 |[0m   Decimal("1.0")
-[1m[94m15 |[0m   Bucket("xrd");
-[1m[94m   |[0m[1m[91m          ^^^^^[0m [1m[91mname already defined[0m
-[1m[94m16 |[0m 
-[1m[94m17 |[0m CALL_METHOD
-[1m[94m18 |[0m   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m19 |[0m   "buy_gumball"
-[1m[94m20 |[0m   Bucket("xrd");
-[1m[94m   |[0m
+error: name already defined 'xrd'
+   |
+10 |   Bucket("xrd");
+11 | 
+12 | TAKE_FROM_WORKTOP
+13 |   Address("resource_sim1t45r6lyr36ypj64sumrmkk9pjesfyl9na849jz00qrwnx28c8sletw")
+14 |   Decimal("1.0")
+15 |   Bucket("xrd");
+   |          ^^^^^ name already defined
+16 | 
+17 | CALL_METHOD
+18 |   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+19 |   "buy_gumball"
+20 |   Bucket("xrd");
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_as_value_kind_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_as_value_kind_1.diag
@@ -1,0 +1,9 @@
+error: a NamedIntent cannot be used as a value kind
+  |
+1 | CALL_METHOD
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "my_method"
+4 |     Array<NamedIntent>()
+  |           ^^^^^^^^^^^ cannot be used as a value kind
+5 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_as_value_kind_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_as_value_kind_1.rtm
@@ -1,0 +1,5 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "my_method"
+    Array<NamedIntent>()
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_in_value_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_in_value_1.diag
@@ -1,0 +1,9 @@
+error: a NamedIntent(...) cannot currently be used inside a value
+  |
+1 | CALL_METHOD
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "my_method"
+4 |     NamedIntent("my_intent")
+  |     ^^^^^^^^^^^ cannot be used inside a value
+5 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_in_value_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_named_intent_cannot_be_used_in_value_1.rtm
@@ -1,0 +1,5 @@
+CALL_METHOD
+    Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+    "my_method"
+    NamedIntent("my_intent")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type_1.diag
@@ -1,0 +1,10 @@
+error: preallocated addresses are not supported in this manifest type
+  |
+1 | / USE_PREALLOCATED_ADDRESS
+2 | |     Address("package_sim1pkgxxxxxxxxxresrcexxxxxxxxx000538436477xxxxxxxxxaj0zg9")
+3 | |     "FungibleResourceManager"
+4 | |     AddressReservation("reservation1")
+5 | |     Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+6 | | ;
+  | |_^ unsupported instruction
+  |

--- a/radix-transactions/tests/assets/manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type_1.rtm
+++ b/radix-transactions/tests/assets/manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type_1.rtm
@@ -1,0 +1,6 @@
+USE_PREALLOCATED_ADDRESS
+    Address("package_sim1pkgxxxxxxxxxresrcexxxxxxxxx000538436477xxxxxxxxxaj0zg9")
+    "FungibleResourceManager"
+    AddressReservation("reservation1")
+    Address("resource_sim1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxakj8n3")
+;

--- a/radix-transactions/tests/assets/manifest_generator_error_proof_not_found_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_proof_not_found_1.diag
@@ -1,12 +1,12 @@
-[1m[91merror[0m: [1mproof id 'ManifestProof(1)' not found[0m
-[1m[94m   |[0m
-[1m[94m18 |[0m   Bucket("some_bucket")
-[1m[94m19 |[0m   Decimal("1")
-[1m[94m20 |[0m   Proof("proof");
-[1m[94m21 |[0m 
-[1m[94m22 |[0m CLONE_PROOF
-[1m[94m23 |[0m   Proof(1u32)
-[1m[94m   |[0m[1m[91m         ^^^^[0m [1m[91mproof not found[0m
-[1m[94m24 |[0m   Proof("cloned_proof")
-[1m[94m25 |[0m ;
-[1m[94m   |[0m
+error: proof id 'ManifestProof(1)' not found
+   |
+18 |   Bucket("some_bucket")
+19 |   Decimal("1")
+20 |   Proof("proof");
+21 | 
+22 | CLONE_PROOF
+23 |   Proof(1u32)
+   |         ^^^^ proof not found
+24 |   Proof("cloned_proof")
+25 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_proof_not_found_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_proof_not_found_2.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mproof id 'ManifestProof(1)' not found[0m
-[1m[94m   |[0m
-[1m[94m18 |[0m   Bucket("some_bucket")
-[1m[94m19 |[0m   Decimal("1")
-[1m[94m20 |[0m   Proof("proof");
-[1m[94m21 |[0m 
-[1m[94m22 |[0m DROP_PROOF
-[1m[94m23 |[0m   Proof(1u32)
-[1m[94m   |[0m[1m[91m         ^^^^[0m [1m[91mproof not found[0m
-[1m[94m24 |[0m ;
-[1m[94m   |[0m
+error: proof id 'ManifestProof(1)' not found
+   |
+18 |   Bucket("some_bucket")
+19 |   Decimal("1")
+20 |   Proof("proof");
+21 | 
+22 | DROP_PROOF
+23 |   Proof(1u32)
+   |         ^^^^ proof not found
+24 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_undefined_address_reservation_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_undefined_address_reservation_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mundefined address reservation 'invalid_reservation'[0m
-[1m[94m   |[0m
-[1m[94m14 |[0m     Tuple(
-[1m[94m15 |[0m         Map<String, Tuple>()
-[1m[94m16 |[0m     )
-[1m[94m17 |[0m     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
-[1m[94m18 |[0m     Map<String, Tuple>()
-[1m[94m19 |[0m     Some(AddressReservation("invalid_reservation"))
-[1m[94m   |[0m[1m[91m                             ^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mundefined address reservation[0m
-[1m[94m20 |[0m ;
-[1m[94m21 |[0m CALL_FUNCTION
-[1m[94m22 |[0m     NamedAddress("my_package")
-[1m[94m23 |[0m     "BlueprintName"
-[1m[94m24 |[0m     "no_such_function"
-[1m[94m   |[0m
+error: undefined address reservation 'invalid_reservation'
+   |
+14 |     Tuple(
+15 |         Map<String, Tuple>()
+16 |     )
+17 |     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
+18 |     Map<String, Tuple>()
+19 |     Some(AddressReservation("invalid_reservation"))
+   |                             ^^^^^^^^^^^^^^^^^^^^^ undefined address reservation
+20 | ;
+21 | CALL_FUNCTION
+22 |     NamedAddress("my_package")
+23 |     "BlueprintName"
+24 |     "no_such_function"
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_undefined_bucket_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_undefined_bucket_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mundefined bucket 'another_xrd_bucket'[0m
-[1m[94m   |[0m
-[1m[94m10 |[0m   Bucket("xrd_bucket");
-[1m[94m11 |[0m 
-[1m[94m12 |[0m CALL_METHOD
-[1m[94m13 |[0m   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m14 |[0m   "buy_gumball"
-[1m[94m15 |[0m   Bucket("another_xrd_bucket");
-[1m[94m   |[0m[1m[91m          ^^^^^^^^^^^^^^^^^^^^[0m [1m[91mundefined bucket[0m
-[1m[94m16 |[0m 
-[1m[94m17 |[0m ASSERT_WORKTOP_CONTAINS_ANY
-[1m[94m18 |[0m   Address("resource_sim1t5q5qqum600pwwu27zl7m4rpr8g0400e72n368g09tgnptqe6kuwst");
-[1m[94m19 |[0m 
-[1m[94m20 |[0m ASSERT_WORKTOP_CONTAINS
-[1m[94m   |[0m
+error: undefined bucket 'another_xrd_bucket'
+   |
+10 |   Bucket("xrd_bucket");
+11 | 
+12 | CALL_METHOD
+13 |   Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+14 |   "buy_gumball"
+15 |   Bucket("another_xrd_bucket");
+   |          ^^^^^^^^^^^^^^^^^^^^ undefined bucket
+16 | 
+17 | ASSERT_WORKTOP_CONTAINS_ANY
+18 |   Address("resource_sim1t5q5qqum600pwwu27zl7m4rpr8g0400e72n368g09tgnptqe6kuwst");
+19 | 
+20 | ASSERT_WORKTOP_CONTAINS
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_undefined_named_address_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_undefined_named_address_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mundefined named address 'package_address'[0m
-[1m[94m   |[0m
-[1m[94m17 |[0m     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
-[1m[94m18 |[0m     Map<String, Tuple>()
-[1m[94m19 |[0m     Some(AddressReservation("my_reservation"))
-[1m[94m20 |[0m ;
-[1m[94m21 |[0m CALL_FUNCTION
-[1m[94m22 |[0m     NamedAddress("package_address")
-[1m[94m   |[0m[1m[91m                  ^^^^^^^^^^^^^^^^^[0m [1m[91mundefined named address[0m
-[1m[94m23 |[0m     "BlueprintName"
-[1m[94m24 |[0m     "no_such_function"
-[1m[94m25 |[0m     Decimal("1.0")
-[1m[94m26 |[0m     NamedAddress("my_package")
-[1m[94m27 |[0m ;
-[1m[94m   |[0m
+error: undefined named address 'package_address'
+   |
+17 |     Blob("f531e5e82dc195a7a9f6709f5ee048d9541d51c52904b7a76295a13ddfa377b1")
+18 |     Map<String, Tuple>()
+19 |     Some(AddressReservation("my_reservation"))
+20 | ;
+21 | CALL_FUNCTION
+22 |     NamedAddress("package_address")
+   |                  ^^^^^^^^^^^^^^^^^ undefined named address
+23 |     "BlueprintName"
+24 |     "no_such_function"
+25 |     Decimal("1.0")
+26 |     NamedAddress("my_package")
+27 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_undefined_proof_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_undefined_proof_1.diag
@@ -1,14 +1,14 @@
-[1m[91merror[0m: [1mundefined proof 'proof_2'[0m
-[1m[94m   |[0m
-[1m[94m11 |[0m CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd")
-[1m[94m12 |[0m   Decimal("1")
-[1m[94m13 |[0m   Proof("proof_1");
-[1m[94m14 |[0m 
-[1m[94m15 |[0m CLONE_PROOF
-[1m[94m16 |[0m   Proof("proof_2")
-[1m[94m   |[0m[1m[91m         ^^^^^^^^^[0m [1m[91mundefined proof[0m
-[1m[94m17 |[0m   Proof("cloned_proof");
-[1m[94m18 |[0m 
-[1m[94m19 |[0m DROP_PROOF Proof("proof_1");
-[1m[94m20 |[0m DROP_PROOF Proof("cloned_proof");
-[1m[94m   |[0m
+error: undefined proof 'proof_2'
+   |
+11 | CREATE_PROOF_FROM_BUCKET_OF_AMOUNT Bucket("some_xrd")
+12 |   Decimal("1")
+13 |   Proof("proof_1");
+14 | 
+15 | CLONE_PROOF
+16 |   Proof("proof_2")
+   |         ^^^^^^^^^ undefined proof
+17 |   Proof("cloned_proof");
+18 | 
+19 | DROP_PROOF Proof("proof_1");
+20 | DROP_PROOF Proof("cloned_proof");
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_unexpected_value_1.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_unexpected_value_1.diag
@@ -1,13 +1,13 @@
-[1m[91merror[0m: [1mexpected String, found U32[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m CALL_METHOD
-[1m[94m 6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 7 |[0m     "some_method"
-[1m[94m 8 |[0m     Array<String>(
-[1m[94m 9 |[0m       "one",
-[1m[94m10 |[0m       2u32,
-[1m[94m   |[0m[1m[91m       ^^^^[0m [1m[91mexpected String[0m
-[1m[94m11 |[0m       "three"
-[1m[94m12 |[0m     )
-[1m[94m13 |[0m ;
-[1m[94m   |[0m
+error: expected String, found U32
+   |
+ 5 | CALL_METHOD
+ 6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 7 |     "some_method"
+ 8 |     Array<String>(
+ 9 |       "one",
+10 |       2u32,
+   |       ^^^^ expected String
+11 |       "three"
+12 |     )
+13 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_generator_error_unexpected_value_2.diag
+++ b/radix-transactions/tests/assets/manifest_generator_error_unexpected_value_2.diag
@@ -1,13 +1,13 @@
-[1m[91merror[0m: [1mexpected String, found Bytes[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m CALL_METHOD
-[1m[94m 6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 7 |[0m     "some_method"
-[1m[94m 8 |[0m     Array<String>(
-[1m[94m 9 |[0m       "one",
-[1m[94m10 |[0m       Bytes(1u32),
-[1m[94m   |[0m[1m[91m       ^^^^^[0m [1m[91mexpected String[0m
-[1m[94m11 |[0m       "three"
-[1m[94m12 |[0m     )
-[1m[94m13 |[0m ;
-[1m[94m   |[0m
+error: expected String, found Bytes
+   |
+ 5 | CALL_METHOD
+ 6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 7 |     "some_method"
+ 8 |     Array<String>(
+ 9 |       "one",
+10 |       Bytes(1u32),
+   |       ^^^^^ expected String
+11 |       "three"
+12 |     )
+13 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1minvalid integer value '-300i8' - number too small to fit in target type[0m
-[1m[94m   |[0m
-[1m[94m 2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 3 |[0m     "lock_fee";
-[1m[94m 4 |[0m CALL_METHOD
-[1m[94m 5 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 6 |[0m     "some_method"
-[1m[94m 7 |[0m     -300i8;
-[1m[94m   |[0m[1m[91m     ^^^^^^[0m [1m[91minvalid integer value[0m
-[1m[94m 8 |[0m CALL_METHOD
-[1m[94m 9 |[0m     Address("account_sim1c956qr3kxlgypxwst89j9yf24tjc7zxd4up38x37zr6q4jxdx9rhma")
-[1m[94m10 |[0m     "try_deposit_batch_or_abort"
-[1m[94m11 |[0m     Expression("ENTIRE_WORKTOP")
-[1m[94m12 |[0m     None;
-[1m[94m   |[0m
+error: invalid integer value '-300i8' - number too small to fit in target type
+   |
+ 2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 3 |     "lock_fee";
+ 4 | CALL_METHOD
+ 5 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 6 |     "some_method"
+ 7 |     -300i8;
+   |     ^^^^^^ invalid integer value
+ 8 | CALL_METHOD
+ 9 |     Address("account_sim1c956qr3kxlgypxwst89j9yf24tjc7zxd4up38x37zr6q4jxdx9rhma")
+10 |     "try_deposit_batch_or_abort"
+11 |     Expression("ENTIRE_WORKTOP")
+12 |     None;
+   |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_2.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_2.diag
@@ -1,7 +1,7 @@
-[1m[91merror[0m: [1minvalid integer value '300i8' - number too large to fit in target type[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "lock_fee";
-[1m[94m2 |[0m CALL_METHOD Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq") "some_method" 300i8;
-[1m[94m  |[0m[1m[91m                                                                                                           ^^^^^[0m [1m[91minvalid integer value[0m
-[1m[94m3 |[0m CALL_METHOD Address("account_sim1c956qr3kxlgypxwst89j9yf24tjc7zxd4up38x37zr6q4jxdx9rhma") "try_deposit_batch_or_abort" Expression("ENTIRE_WORKTOP") None;
-[1m[94m  |[0m
+error: invalid integer value '300i8' - number too large to fit in target type
+  |
+1 | CALL_METHOD Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh") "lock_fee";
+2 | CALL_METHOD Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq") "some_method" 300i8;
+  |                                                                                                           ^^^^^ invalid integer value
+3 | CALL_METHOD Address("account_sim1c956qr3kxlgypxwst89j9yf24tjc7zxd4up38x37zr6q4jxdx9rhma") "try_deposit_batch_or_abort" Expression("ENTIRE_WORKTOP") None;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_3.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_3.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid integer value '-300u8' - invalid digit found in string[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     -300u8
-[1m[94m  |[0m[1m[91m     ^^^^^^[0m [1m[91minvalid integer value[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: invalid integer value '-300u8' - invalid digit found in string
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     -300u8
+  |     ^^^^^^ invalid integer value
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_literal_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_literal_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid integer literal '- '[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     - 107u32
-[1m[94m  |[0m[1m[91m     ^^[0m [1m[91minvalid integer literal[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: invalid integer literal '- '
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     - 107u32
+  |     ^^ invalid integer literal
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_type_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_type_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid integer type 'i9'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Decimal(300i9)
-[1m[94m  |[0m[1m[91m                ^^[0m [1m[91minvalid integer type[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: invalid integer type 'i9'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     Decimal(300i9)
+  |                ^^ invalid integer type
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_type_2.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_integer_type_2.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid integer type '_'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     3_0u32
-[1m[94m  |[0m[1m[91m      ^[0m [1m[91minvalid integer type[0m
-[1m[94m9 |[0m 
-[1m[94m  |[0m
+error: invalid integer type '_'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     3_0u32
+  |      ^ invalid integer type
+9 | 
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_invalid_unicode_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_invalid_unicode_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1minvalid unicode code point 1238580[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     "\uDCAC\u1234"
-[1m[94m  |[0m[1m[91m       ^^^^^^^^^^^[0m [1m[91minvalid unicode code point[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: invalid unicode code point 1238580
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     "\uDCAC\u1234"
+  |       ^^^^^^^^^^^ invalid unicode code point
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_missing_unicode_surrogate_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_missing_unicode_surrogate_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mmissing unicode 'DCAC' surrogate pair[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     "\uDCACsome_text"
-[1m[94m  |[0m[1m[91m       ^^^^^[0m [1m[91mmissing unicode surrogate pair[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: missing unicode 'DCAC' surrogate pair
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     "\uDCACsome_text"
+  |       ^^^^^ missing unicode surrogate pair
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_1.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1munexpected character '%', expected digit, letter, quotation mark or one of punctuation characters '(', ')', '<', '>', ',', ';', '='[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Decimal(%27)
-[1m[94m  |[0m[1m[91m             ^[0m [1m[91munexpected character[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: unexpected character '%', expected digit, letter, quotation mark or one of punctuation characters '(', ')', '<', '>', ',', ';', '='
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     Decimal(%27)
+  |             ^ unexpected character
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_2.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_2.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected character 'x', expected '"', '\', '/', 'b', 'f', 'n', 'r', 't' or 'u'[0m
-[1m[94m  |[0m
-[1m[94m2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "\xaaaa"
-[1m[94m  |[0m[1m[91m       ^[0m [1m[91munexpected character[0m
-[1m[94m  |[0m
+error: unexpected character 'x', expected '"', '\', '/', 'b', 'f', 'n', 'r', 't' or 'u'
+  |
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "\xaaaa"
+  |       ^ unexpected character
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_3.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_3.diag
@@ -1,5 +1,5 @@
-[1m[91merror[0m: [1munexpected character '7', expected '>'[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m x=7
-[1m[94m  |[0m[1m[91m   ^[0m [1m[91munexpected character[0m
-[1m[94m  |[0m
+error: unexpected character '7', expected '>'
+  |
+1 | x=7
+  |   ^ unexpected character
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_4.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_4.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1munexpected character 'K', expected hex digit[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     "\uFAKE"
-[1m[94m  |[0m[1m[91m          ^[0m [1m[91munexpected character[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: unexpected character 'K', expected hex digit
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     "\uFAKE"
+  |          ^ unexpected character
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_5.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_char_5.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1munexpected character '基', expected digit, letter, quotation mark or one of punctuation characters '(', ')', '<', '>', ',', ';', '='[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m     "some_method"
-[1m[94m 9 |[0m     基数引擎
-[1m[94m   |[0m[1m[91m     ^^[0m [1m[91munexpected character[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: unexpected character '基', expected digit, letter, quotation mark or one of punctuation characters '(', ')', '<', '>', ',', ';', '='
+   |
+ 4 | ;
+ 5 | 
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |     "some_method"
+ 9 |     基数引擎
+   |     ^^ unexpected character
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_eof_1.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_eof_1.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected end of file[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     "\uDCA
-[1m[94m  |[0m[1m[91m           ^[0m [1m[91munexpected end of file[0m
-[1m[94m  |[0m
+error: unexpected end of file
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     "\uDCA
+  |           ^ unexpected end of file
+  |

--- a/radix-transactions/tests/assets/manifest_lexer_error_unexpected_eof_2.diag
+++ b/radix-transactions/tests/assets/manifest_lexer_error_unexpected_eof_2.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected end of file[0m
-[1m[94m  |[0m
-[1m[94m2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "xxx
-[1m[94m  |[0m[1m[91m         ^[0m [1m[91munexpected end of file[0m
-[1m[94m  |[0m
+error: unexpected end of file
+  |
+2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "xxx
+  |         ^ unexpected end of file
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_argument_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_argument_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected a manifest SBOR value or ';' to end an argument list, found 'SET_COMPONENT_ROYALTY'[0m
-[1m[94m   |[0m
-[1m[94m10 |[0m SET_COMPONENT_ROYALTY
-[1m[94m11 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m12 |[0m     "method_with_xrd_package_royalty"
-[1m[94m13 |[0m     Enum<0u8>()
-[1m[94m14 |[0m 
-[1m[94m15 |[0m SET_COMPONENT_ROYALTY
-[1m[94m   |[0m[1m[91m ^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mexpected a manifest SBOR value or ';' to end an argument list[0m
-[1m[94m16 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m17 |[0m     "method_with_usd_package_royalty"
-[1m[94m18 |[0m     Enum<0u8>()
-[1m[94m19 |[0m ;
-[1m[94m20 |[0m SET_COMPONENT_ROYALTY
-[1m[94m   |[0m
+error: expected a manifest SBOR value or ';' to end an argument list, found 'SET_COMPONENT_ROYALTY'
+   |
+10 | SET_COMPONENT_ROYALTY
+11 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+12 |     "method_with_xrd_package_royalty"
+13 |     Enum<0u8>()
+14 | 
+15 | SET_COMPONENT_ROYALTY
+   | ^^^^^^^^^^^^^^^^^^^^^ expected a manifest SBOR value or ';' to end an argument list
+16 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+17 |     "method_with_usd_package_royalty"
+18 |     Enum<0u8>()
+19 | ;
+20 | SET_COMPONENT_ROYALTY
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_argument_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_argument_2.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected a manifest SBOR value or ';' to end an argument list, found ')'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m SET_COMPONENT_ROYALTY
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "method_with_no_package_royalty"
-[1m[94m8 |[0m     Enum<0u8>())
-[1m[94m  |[0m[1m[91m                ^[0m [1m[91mexpected a manifest SBOR value or ';' to end an argument list[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: expected a manifest SBOR value or ';' to end an argument list, found ')'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | SET_COMPONENT_ROYALTY
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "method_with_no_package_royalty"
+8 |     Enum<0u8>())
+  |                ^ expected a manifest SBOR value or ';' to end an argument list
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected 2 number of types, found 3[0m
-[1m[94m   |[0m
-[1m[94m19 |[0m         None,
-[1m[94m20 |[0m         None,
-[1m[94m21 |[0m         None
-[1m[94m22 |[0m     )
-[1m[94m23 |[0m     Tuple(
-[1m[94m24 |[0m         Map<String, Tuple, Tuple>(
-[1m[94m   |[0m[1m[91m             ^^^^^^^^^^^^^^^^^^^^[0m [1m[91mexpected 2 number of types[0m
-[1m[94m25 |[0m         "name" => Tuple(
-[1m[94m26 |[0m                 Some(Enum<Metadata::String>("MyResource")),
-[1m[94m27 |[0m                 true
-[1m[94m28 |[0m             )
-[1m[94m29 |[0m         ),
-[1m[94m   |[0m
+error: expected 2 number of types, found 3
+   |
+19 |         None,
+20 |         None,
+21 |         None
+22 |     )
+23 |     Tuple(
+24 |         Map<String, Tuple, Tuple>(
+   |             ^^^^^^^^^^^^^^^^^^^^ expected 2 number of types
+25 |         "name" => Tuple(
+26 |                 Some(Enum<Metadata::String>("MyResource")),
+27 |                 true
+28 |             )
+29 |         ),
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected 1 number of types, found 2[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CREATE_NON_FUNGIBLE_RESOURCE
-[1m[94m 7 |[0m     Enum<OwnerRole::None>()
-[1m[94m 8 |[0m     Enum<NonFungibleIdType::Integer>()
-[1m[94m 9 |[0m     true
-[1m[94m10 |[0m     Enum<0u8>(Enum<0u8>(Tuple(Array<String, Tuple>(), Array<Tuple>(), Array<Enum>())), Enum<0u8>(66u8), Array<String>())
-[1m[94m   |[0m[1m[91m                                     ^^^^^^^^^^^^^[0m [1m[91mexpected 1 number of types[0m
-[1m[94m11 |[0m     Tuple(
-[1m[94m12 |[0m         Some(
-[1m[94m13 |[0m             Tuple(
-[1m[94m14 |[0m                 Some(Enum<AccessRule::AllowAll>()),
-[1m[94m15 |[0m                 Some(Enum<AccessRule::DenyAll>())
-[1m[94m   |[0m
+error: expected 1 number of types, found 2
+   |
+ 5 | 
+ 6 | CREATE_NON_FUNGIBLE_RESOURCE
+ 7 |     Enum<OwnerRole::None>()
+ 8 |     Enum<NonFungibleIdType::Integer>()
+ 9 |     true
+10 |     Enum<0u8>(Enum<0u8>(Tuple(Array<String, Tuple>(), Array<Tuple>(), Array<Enum>())), Enum<0u8>(66u8), Array<String>())
+   |                                     ^^^^^^^^^^^^^ expected 1 number of types
+11 |     Tuple(
+12 |         Some(
+13 |             Tuple(
+14 |                 Some(Enum<AccessRule::AllowAll>()),
+15 |                 Some(Enum<AccessRule::DenyAll>())
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_3.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_3.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected 1 number of types, found 0[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m 
-[1m[94m 6 |[0m CALL_METHOD
-[1m[94m 7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m     "some_method"
-[1m[94m 9 |[0m     # Invalid array specification
-[1m[94m10 |[0m     Array<>
-[1m[94m   |[0m[1m[91m          ^^[0m [1m[91mexpected 1 number of types[0m
-[1m[94m11 |[0m ;
-[1m[94m   |[0m
+error: expected 1 number of types, found 0
+   |
+ 5 | 
+ 6 | CALL_METHOD
+ 7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |     "some_method"
+ 9 |     # Invalid array specification
+10 |     Array<>
+   |          ^^ expected 1 number of types
+11 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_4.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_types_4.diag
@@ -1,14 +1,14 @@
-[1m[91merror[0m: [1mexpected 2 number of types, found 0[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m   
-[1m[94m 6 |[0m   CALL_METHOD
-[1m[94m 7 |[0m       Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 8 |[0m       "some_method"
-[1m[94m 9 |[0m       # Invalid array specification
-[1m[94m10 |[0m       Map<
-[1m[94m   |[0m  [1m[91m________^[0m
-[1m[94m11 |[0m [1m[91m|[0m 
-[1m[94m12 |[0m [1m[91m|[0m     >
-[1m[94m   |[0m [1m[91m|[0m[1m[91m_____^[0m [1m[91mexpected 2 number of types[0m
-[1m[94m13 |[0m   ;
-[1m[94m   |[0m
+error: expected 2 number of types, found 0
+   |
+ 5 |   
+ 6 |   CALL_METHOD
+ 7 |       Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 8 |       "some_method"
+ 9 |       # Invalid array specification
+10 |       Map<
+   |  ________^
+11 | | 
+12 | |     >
+   | |_____^ expected 2 number of types
+13 |   ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_values_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_values_1.diag
@@ -1,14 +1,14 @@
-[1m[91merror[0m: [1mexpected 1 number of values, found 2[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m   CALL_METHOD
-[1m[94m2 |[0m       Address(
-[1m[94m3 |[0m         "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh",
-[1m[94m  |[0m  [1m[91m_______^[0m
-[1m[94m4 |[0m [1m[91m|[0m       "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m  |[0m [1m[91m|[0m[1m[91m____________________________________________________________________________^[0m [1m[91mexpected 1 number of values[0m
-[1m[94m5 |[0m       "lock_fee"
-[1m[94m6 |[0m   ;
-[1m[94m7 |[0m   SET_COMPONENT_ROYALTY
-[1m[94m8 |[0m       Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m9 |[0m       "method_with_no_package_royalty"
-[1m[94m  |[0m
+error: expected 1 number of values, found 2
+  |
+1 |   CALL_METHOD
+2 |       Address(
+3 |         "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh",
+  |  _______^
+4 | |       "component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+  | |____________________________________________________________________________^ expected 1 number of values
+5 |       "lock_fee"
+6 |   ;
+7 |   SET_COMPONENT_ROYALTY
+8 |       Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+9 |       "method_with_no_package_royalty"
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_values_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_invalid_number_of_values_2.diag
@@ -1,12 +1,12 @@
-[1m[91merror[0m: [1mexpected 1 number of values, found 3[0m
-[1m[94m   |[0m
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m CALL_METHOD
-[1m[94m 6 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 7 |[0m     "some_method"
-[1m[94m 8 |[0m     Some("radix", "is", "fun")
-[1m[94m   |[0m[1m[91m          ^^^^^^^^^^^^^^^^^^^^[0m [1m[91mexpected 1 number of values[0m
-[1m[94m 9 |[0m     Enum<0u8>()
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: expected 1 number of values, found 3
+   |
+ 3 |     "lock_fee"
+ 4 | ;
+ 5 | CALL_METHOD
+ 6 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 7 |     "some_method"
+ 8 |     Some("radix", "is", "fun")
+   |          ^^^^^^^^^^^^^^^^^^^^ expected 1 number of values
+ 9 |     Enum<0u8>()
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_max_depth_exceeded_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_max_depth_exceeded_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mmanifest actual depth 21 exceeded max 20[0m
-[1m[94m   |[0m
-[1m[94m20 |[0m                                 Tuple(
-[1m[94m21 |[0m                                   Tuple(
-[1m[94m22 |[0m                                     Tuple(
-[1m[94m23 |[0m                                       Tuple(
-[1m[94m24 |[0m                                         Tuple(
-[1m[94m25 |[0m                                           Tuple(
-[1m[94m   |[0m[1m[91m                                           ^^^^^[0m [1m[91mmax depth exceeded[0m
-[1m[94m26 |[0m                                             Tuple(
-[1m[94m27 |[0m                                               Tuple(
-[1m[94m28 |[0m                                                 Tuple(
-[1m[94m29 |[0m                                                   Tuple(
-[1m[94m30 |[0m                                                     Tuple(
-[1m[94m   |[0m
+error: manifest actual depth 21 exceeded max 20
+   |
+20 |                                 Tuple(
+21 |                                   Tuple(
+22 |                                     Tuple(
+23 |                                       Tuple(
+24 |                                         Tuple(
+25 |                                           Tuple(
+   |                                           ^^^^^ max depth exceeded
+26 |                                             Tuple(
+27 |                                               Tuple(
+28 |                                                 Tuple(
+29 |                                                   Tuple(
+30 |                                                     Tuple(
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_max_depth_exceeded_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_max_depth_exceeded_2.diag
@@ -1,9 +1,9 @@
-[1m[91merror[0m: [1mmanifest actual depth 21 exceeded max 20[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m CALL_FUNCTION
-[1m[94m2 |[0m   Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
-[1m[94m3 |[0m   "blueprint"
-[1m[94m4 |[0m   "func"
-[1m[94m5 |[0m   Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(0u8)))))))))))))))))))))))))))));
-[1m[94m  |[0m[1m[91m                                                                                                                           ^^^^^[0m [1m[91mmax depth exceeded[0m
-[1m[94m  |[0m
+error: manifest actual depth 21 exceeded max 20
+  |
+1 | CALL_FUNCTION
+2 |   Address("package_sim1p4r4955skdjq9swg8s5jguvcjvyj7tsxct87a9z6sw76cdfd2jg3zk")
+3 |   "blueprint"
+4 |   "func"
+5 |   Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(Tuple(0u8)))))))))))))))))))))))))))));
+  |                                                                                                                           ^^^^^ max depth exceeded
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_1.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected end of file[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Enum<0u8>(
-[1m[94m  |[0m[1m[91m               ^[0m [1m[91munexpected end of file[0m
-[1m[94m  |[0m
+error: unexpected end of file
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+7 |     "some_method"
+8 |     Enum<0u8>(
+  |               ^ unexpected end of file
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_2.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected end of file[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Decimal("700"
-[1m[94m  |[0m[1m[91m                  ^[0m [1m[91munexpected end of file[0m
-[1m[94m  |[0m
+error: unexpected end of file
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     Decimal("700"
+  |                  ^ unexpected end of file
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_3.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_eof_3.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1munexpected end of file[0m
-[1m[94m  |[0m
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m 
-[1m[94m6 |[0m CALL_METHOD
-[1m[94m7 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m8 |[0m     "some_method"
-[1m[94m9 |[0m     Address("基数引擎")
-[1m[94m  |[0m[1m[91m                        ^[0m [1m[91munexpected end of file[0m
-[1m[94m  |[0m
+error: unexpected end of file
+  |
+4 | ;
+5 | 
+6 | CALL_METHOD
+7 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+8 |     "some_method"
+9 |     Address("基数引擎")
+  |                        ^ unexpected end of file
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_1.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1mexpected an instruction, found ';'[0m
-[1m[94m  |[0m
-[1m[94m1 |[0m ;
-[1m[94m  |[0m[1m[91m ^[0m [1m[91mexpected an instruction[0m
-[1m[94m2 |[0m CALL_METHOD
-[1m[94m3 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m4 |[0m     "lock_fee"
-[1m[94m5 |[0m ;
-[1m[94m6 |[0m SET_COMPONENT_ROYALTY
-[1m[94m  |[0m
+error: expected an instruction, found ';'
+  |
+1 | ;
+  | ^ expected an instruction
+2 | CALL_METHOD
+3 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+4 |     "lock_fee"
+5 | ;
+6 | SET_COMPONENT_ROYALTY
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1mexpected an instruction, found ';'[0m
-[1m[94m   |[0m
-[1m[94m10 |[0m SET_COMPONENT_ROYALTY
-[1m[94m11 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m12 |[0m     "method_with_xrd_package_royalty"
-[1m[94m13 |[0m     Enum<0u8>()
-[1m[94m14 |[0m ;
-[1m[94m15 |[0m ;
-[1m[94m   |[0m[1m[91m ^[0m [1m[91mexpected an instruction[0m
-[1m[94m16 |[0m SET_COMPONENT_ROYALTY
-[1m[94m17 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m18 |[0m     "method_with_usd_package_royalty"
-[1m[94m19 |[0m     Enum<0u8>()
-[1m[94m20 |[0m ;
-[1m[94m   |[0m
+error: expected an instruction, found ';'
+   |
+10 | SET_COMPONENT_ROYALTY
+11 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+12 |     "method_with_xrd_package_royalty"
+13 |     Enum<0u8>()
+14 | ;
+15 | ;
+   | ^ expected an instruction
+16 | SET_COMPONENT_ROYALTY
+17 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+18 |     "method_with_usd_package_royalty"
+19 |     Enum<0u8>()
+20 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_3.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_3.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected an instruction, found '1u32'[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m SET_COMPONENT_ROYALTY
-[1m[94m 6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 7 |[0m     "method_with_no_package_royalty"
-[1m[94m 8 |[0m     Enum<0u8>();
-[1m[94m 9 |[0m     1u32
-[1m[94m   |[0m[1m[91m     ^^^^[0m [1m[91mexpected an instruction[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: expected an instruction, found '1u32'
+   |
+ 4 | ;
+ 5 | SET_COMPONENT_ROYALTY
+ 6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 7 |     "method_with_no_package_royalty"
+ 8 |     Enum<0u8>();
+ 9 |     1u32
+   |     ^^^^ expected an instruction
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_4.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_4.diag
@@ -1,10 +1,10 @@
-[1m[91merror[0m: [1mexpected an instruction, found "CALL_METHOD"[0m
-[1m[94m   |[0m
-[1m[94m 5 |[0m SET_COMPONENT_ROYALTY
-[1m[94m 6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 7 |[0m     "method_with_no_package_royalty"
-[1m[94m 8 |[0m     Enum<0u8>()
-[1m[94m 9 |[0m ;
-[1m[94m10 |[0m "CALL_METHOD"
-[1m[94m   |[0m[1m[91m ^^^^^^^^^^^^^[0m [1m[91mexpected an instruction[0m
-[1m[94m   |[0m
+error: expected an instruction, found "CALL_METHOD"
+   |
+ 5 | SET_COMPONENT_ROYALTY
+ 6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 7 |     "method_with_no_package_royalty"
+ 8 |     Enum<0u8>()
+ 9 | ;
+10 | "CALL_METHOD"
+   | ^^^^^^^^^^^^^ expected an instruction
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_5.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_5.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected an instruction, found 'true'[0m
-[1m[94m   |[0m
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m SET_COMPONENT_ROYALTY
-[1m[94m 6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m 7 |[0m     "method_with_no_package_royalty"
-[1m[94m 8 |[0m     Enum<0u8>();
-[1m[94m 9 |[0m     true
-[1m[94m   |[0m[1m[91m     ^^^^[0m [1m[91mexpected an instruction[0m
-[1m[94m10 |[0m ;
-[1m[94m   |[0m
+error: expected an instruction, found 'true'
+   |
+ 4 | ;
+ 5 | SET_COMPONENT_ROYALTY
+ 6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+ 7 |     "method_with_no_package_royalty"
+ 8 |     Enum<0u8>();
+ 9 |     true
+   |     ^^^^ expected an instruction
+10 | ;
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_6.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_6.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected a u8 enum discriminator or valid discriminator alias, found '1u128'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m SET_COMPONENT_ROYALTY
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "method_with_no_package_royalty"
-[1m[94m8 |[0m     Enum<1u128>()
-[1m[94m  |[0m[1m[91m          ^^^^^[0m [1m[91mexpected a u8 enum discriminator or valid discriminator alias[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: expected a u8 enum discriminator or valid discriminator alias, found '1u128'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | SET_COMPONENT_ROYALTY
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "method_with_no_package_royalty"
+8 |     Enum<1u128>()
+  |          ^^^^^ expected a u8 enum discriminator or valid discriminator alias
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_7.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_7.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected a manifest SBOR value kind, found '1u8'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Array<1u8>()
-[1m[94m  |[0m[1m[91m           ^^^[0m [1m[91mexpected a manifest SBOR value kind[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: expected a manifest SBOR value kind, found '1u8'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     Array<1u8>()
+  |           ^^^ expected a manifest SBOR value kind
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_8.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unexpected_token_8.diag
@@ -1,11 +1,11 @@
-[1m[91merror[0m: [1mexpected exactly '>', found ')'[0m
-[1m[94m  |[0m
-[1m[94m3 |[0m     "lock_fee"
-[1m[94m4 |[0m ;
-[1m[94m5 |[0m CALL_METHOD
-[1m[94m6 |[0m     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
-[1m[94m7 |[0m     "some_method"
-[1m[94m8 |[0m     Enum<0u8)
-[1m[94m  |[0m[1m[91m             ^[0m [1m[91mexpected exactly '>'[0m
-[1m[94m9 |[0m ;
-[1m[94m  |[0m
+error: expected exactly '>', found ')'
+  |
+3 |     "lock_fee"
+4 | ;
+5 | CALL_METHOD
+6 |     Address("component_sim1cpyavrltfeu9ppx24pcpvh93xf44sfjygtv6dgf6uq3cdwafl7f9rq")
+7 |     "some_method"
+8 |     Enum<0u8)
+  |             ^ expected exactly '>'
+9 | ;
+  |

--- a/radix-transactions/tests/assets/manifest_parser_error_unknown_enum_discriminator_1.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unknown_enum_discriminator_1.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1munknown enum discriminator found 'OwnerRol::Updatable'[0m
-[1m[94m   |[0m
-[1m[94m 1 |[0m CALL_METHOD
-[1m[94m 2 |[0m     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m CREATE_ACCOUNT_ADVANCED
-[1m[94m 6 |[0m     Enum<OwnerRol::Updatable>(
-[1m[94m   |[0m[1m[91m          ^^^^^^^^^^^^^^^^^^^[0m [1m[91munknown enum discriminator[0m
-[1m[94m 7 |[0m         Enum<AccessRule::AllowAll>()
-[1m[94m 8 |[0m     )
-[1m[94m 9 |[0m ;
-[1m[94m10 |[0m TAKE_ALL_FROM_WORKTOP
-[1m[94m11 |[0m     Address("${resource_address}")
-[1m[94m   |[0m
+error: unknown enum discriminator found 'OwnerRol::Updatable'
+   |
+ 1 | CALL_METHOD
+ 2 |     Address("component_sim1cptxxxxxxxxxfaucetxxxxxxxxx000527798379xxxxxxxxxhkrefh")
+ 3 |     "lock_fee"
+ 4 | ;
+ 5 | CREATE_ACCOUNT_ADVANCED
+ 6 |     Enum<OwnerRol::Updatable>(
+   |          ^^^^^^^^^^^^^^^^^^^ unknown enum discriminator
+ 7 |         Enum<AccessRule::AllowAll>()
+ 8 |     )
+ 9 | ;
+10 | TAKE_ALL_FROM_WORKTOP
+11 |     Address("${resource_address}")
+   |

--- a/radix-transactions/tests/assets/manifest_parser_error_unknown_enum_discriminator_2.diag
+++ b/radix-transactions/tests/assets/manifest_parser_error_unknown_enum_discriminator_2.diag
@@ -1,15 +1,15 @@
-[1m[91merror[0m: [1munknown enum discriminator found 'Metadata::StingArray'[0m
-[1m[94m   |[0m
-[1m[94m 3 |[0m     "lock_fee"
-[1m[94m 4 |[0m ;
-[1m[94m 5 |[0m SET_METADATA
-[1m[94m 6 |[0m     Address("resource_sim1n2pqvufl0fmexzpkl6rzk50n2seaz49jgfaqensv7ujxdlf6szr08f")
-[1m[94m 7 |[0m     "field_name"
-[1m[94m 8 |[0m     Enum<Metadata::StingArray>(
-[1m[94m   |[0m[1m[91m          ^^^^^^^^^^^^^^^^^^^^[0m [1m[91munknown enum discriminator[0m
-[1m[94m 9 |[0m         Array<String>(
-[1m[94m10 |[0m             "some_string",
-[1m[94m11 |[0m             "another_string",
-[1m[94m12 |[0m             "yet_another_string"
-[1m[94m13 |[0m         )
-[1m[94m   |[0m
+error: unknown enum discriminator found 'Metadata::StingArray'
+   |
+ 3 |     "lock_fee"
+ 4 | ;
+ 5 | SET_METADATA
+ 6 |     Address("resource_sim1n2pqvufl0fmexzpkl6rzk50n2seaz49jgfaqensv7ujxdlf6szr08f")
+ 7 |     "field_name"
+ 8 |     Enum<Metadata::StingArray>(
+   |          ^^^^^^^^^^^^^^^^^^^^ unknown enum discriminator
+ 9 |         Array<String>(
+10 |             "some_string",
+11 |             "another_string",
+12 |             "yet_another_string"
+13 |         )
+   |

--- a/radix-transactions/tests/test_manifest_compiler_error_diagnostics.rs
+++ b/radix-transactions/tests/test_manifest_compiler_error_diagnostics.rs
@@ -28,7 +28,7 @@ macro_rules! check_manifest {
             panic!("diagnostic reports differ");
         }
     }};
-    ($manifest_kind:expr, $manifest:expr, $(,)?) => {{
+    ($manifest_kind:expr, $manifest:expr $(,)?) => {{
         check_manifest!(
             $manifest_kind,
             $manifest,
@@ -311,6 +311,113 @@ fn test_manifest_generator_error_proof_not_found() {
     // IdValidationError(BucketNotFound)
     check_manifest!("manifest_generator_error_proof_not_found_1");
     check_manifest!("manifest_generator_error_proof_not_found_2");
+}
+
+#[test]
+fn test_manifest_generator_error_invalid_sub_transaction_id() {
+    // InvalidSubTransactionId(String)
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_invalid_sub_transaction_id_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_instruction_not_supported_in_manifest_version() {
+    // InstructionNotSupportedInManifestVersion
+    check_manifest!(
+        ManifestKind::V1,
+        "manifest_generator_error_instruction_not_supported_in_manifest_version_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_duplicate_subintent_hash() {
+    // ManifestBuildError(ManifestBuildError::DuplicateChildSubintentHash)
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_duplicate_subintent_hash_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_child_subintents_unsupported_by_manifest_type() {
+    // ManifestBuildError(ManifestBuildError::ChildSubintentsUnsupportedByManifestType)
+    check_manifest!(
+        ManifestKind::V1,
+        "manifest_generator_error_child_subintents_unsupported_by_manifest_type_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type() {
+    // ManifestBuildError(ManifestBuildError::PreallocatedAddressesUnsupportedByManifestType)
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_preallocated_addresses_unsupported_by_manifest_type_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_header_instruction_must_come_first() {
+    // HeaderInstructionMustComeFirst
+    check_manifest!(
+        ManifestKind::SubintentV2,
+        "manifest_generator_error_header_instruction_must_come_first_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_intent_cannot_be_used_in_value() {
+    // IntentCannotBeUsedInValue
+    check_manifest!(
+        ManifestKind::SubintentV2,
+        "manifest_generator_error_intent_cannot_be_used_in_value_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_intent_cannot_be_used_as_value_kind() {
+    // IntentCannotBeUsedAsValueKind
+    check_manifest!(
+        ManifestKind::SubintentV2,
+        "manifest_generator_error_intent_cannot_be_used_as_value_kind_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_named_intent_cannot_be_used_in_value() {
+    // NamedIntentCannotBeUsedInValue
+    check_manifest!(
+        ManifestKind::SubintentV2,
+        "manifest_generator_error_named_intent_cannot_be_used_in_value_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_named_intent_cannot_be_used_as_value_kind() {
+    // NamedIntentCannotBeUsedAsValueKind
+    check_manifest!(
+        ManifestKind::SubintentV2,
+        "manifest_generator_error_named_intent_cannot_be_used_as_value_kind_1"
+    );
+}
+
+#[test]
+fn test_manifest_generator_error_argument_could_not_be_read_as_expected_type() {
+    // ArgumentCouldNotBeReadAsExpectedType { type_name: String, error_message: String, },
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_argument_could_not_be_read_as_expected_type_1"
+    );
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_argument_could_not_be_read_as_expected_type_2"
+    );
+    check_manifest!(
+        ManifestKind::V2,
+        "manifest_generator_error_argument_could_not_be_read_as_expected_type_3"
+    );
 }
 
 #[test]

--- a/radix-transactions/tests/test_manifest_compiler_error_diagnostics.rs
+++ b/radix-transactions/tests/test_manifest_compiler_error_diagnostics.rs
@@ -1,15 +1,19 @@
 use radix_common::network::NetworkDefinition;
-use radix_transactions::manifest::blob_provider::*;
-use radix_transactions::manifest::compiler::*;
+use radix_transactions::manifest::*;
 
 macro_rules! check_manifest {
-    ($manifest:expr, $blob_provider:expr, $style:expr) => {{
+    ($manifest_kind:expr, $manifest:expr, $blob_provider:expr $(,)?) => {{
         let manifest = include_str!(concat!("assets/", $manifest, ".rtm"));
         let diagnostic = include_str!(concat!("assets/", $manifest, ".diag"));
 
-        let err = compile(manifest, &NetworkDefinition::simulator(), $blob_provider).unwrap_err();
-
-        let x = compile_error_diagnostics(manifest, err, $style);
+        let x = compile_any_manifest_with_pretty_error(
+            manifest,
+            $manifest_kind,
+            &NetworkDefinition::simulator(),
+            $blob_provider,
+            CompileErrorDiagnosticsStyle::PlainText,
+        )
+        .unwrap_err();
 
         if x != diagnostic {
             let path = format!("tests/assets/{}.diag.res", $manifest);
@@ -24,13 +28,20 @@ macro_rules! check_manifest {
             panic!("diagnostic reports differ");
         }
     }};
-    ($manifest:expr) => {{
-        // Some instructions require valid blob in order to let
-        // manifest compile, eg. PUBLISH_PACKAGE_ADVANCED
+    ($manifest_kind:expr, $manifest:expr, $(,)?) => {{
         check_manifest!(
+            $manifest_kind,
             $manifest,
-            MockBlobProvider::default(),
-            CompileErrorDiagnosticsStyle::TextTerminalColors
+            // The MockBlobProvider pretends any blob is valid
+            MockBlobProvider::default()
+        )
+    }};
+    ($manifest:expr $(,)?) => {{
+        check_manifest!(
+            ManifestKind::V1,
+            $manifest,
+            // The MockBlobProvider pretends any blob is valid
+            MockBlobProvider::default()
         )
     }};
 }
@@ -212,9 +223,9 @@ fn test_manifest_generator_error_invalid_blob_hash() {
 fn test_manifest_generator_error_blob_not_found() {
     // BlobNotFound
     check_manifest!(
+        ManifestKind::V1,
         "manifest_generator_error_blob_not_found_1",
-        BlobProvider::default(),
-        CompileErrorDiagnosticsStyle::TextTerminalColors
+        BlobProvider::default()
     );
 }
 
@@ -305,8 +316,8 @@ fn test_manifest_generator_error_proof_not_found() {
 #[test]
 fn test_manifest_compiler_error_plain_text() {
     check_manifest!(
+        ManifestKind::V1,
         "manifest_compiler_error_plain_text_1",
         BlobProvider::default(),
-        CompileErrorDiagnosticsStyle::PlainText
     );
 }

--- a/sbor/src/payload_validation/payload_validator.rs
+++ b/sbor/src/payload_validation/payload_validator.rs
@@ -780,7 +780,7 @@ mod tests {
         ];
         check_location_path::<Vec<u8>>(
             payload,
-            "", // container state not established due to failing to read size
+            "[Root]", // container state not established due to failing to read size
             "DecodeError(InvalidSize)",
         );
     }

--- a/sbor/src/traversal/path_formatting.rs
+++ b/sbor/src/traversal/path_formatting.rs
@@ -233,7 +233,11 @@ pub trait PathAnnotate {
 
         if let Some(leaf) = self.annotated_leaf() {
             leaf.write(f, is_start_of_path)?;
-        };
+        } else {
+            if is_start_of_path {
+                write!(f, "[Root]")?;
+            }
+        }
 
         Ok(())
     }

--- a/sbor/src/value.rs
+++ b/sbor/src/value.rs
@@ -72,6 +72,19 @@ impl<X: CustomValueKind, Y: CustomValue<X>> Value<X, Y> {
     pub fn unit() -> Self {
         Value::Tuple { fields: vec![] }
     }
+
+    pub fn tuple(fields: impl IntoIterator<Item = Self>) -> Self {
+        Value::Tuple {
+            fields: fields.into_iter().collect(),
+        }
+    }
+
+    pub fn enum_variant(discriminator: u8, fields: impl IntoIterator<Item = Self>) -> Self {
+        Value::Enum {
+            discriminator,
+            fields: fields.into_iter().collect(),
+        }
+    }
 }
 
 /// Represents a custom SBOR value.


### PR DESCRIPTION
## Summary
Covering:
* Each `HeaderValidationError`
* Each `InvalidMessageError`
* Each untested `SignatureValidationError`
* Each `ManifestValidationError`
* Each `PrepareError`
* Also a test to cover the display of all new compiler errors

Also had a few minor fixes:
* Removed a couple of unused `HeaderValidationError`s
* Fixed trailing comma handling in the `assert_matches!` macro
* Fixed all the other compiler errors to use plain text encoding, so they can be viewed more easily in diffs/editors