### PR TITLE
CI fix + update Rust version comments

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -27,7 +27,9 @@ runs:
         components: rustfmt
 
     - name: Install nextest
-      uses: RDXWorks-actions/install-action@nextest
+      uses: RDXWorks-actions/install-action@main
+      with:
+        tool: nextest@0.9.85
 
     - name: Set LIBCLANG_PATH # See https://github.com/rust-lang/rust-bindgen/issues/1797
       if: runner.os == 'Windows'

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: RDXWorks-actions/toolchain@master
       with:
         # IMPORTANT:
-        # To update the Rust version, you must update it in five total places (including the toolchain below):
+        # To update the Rust version, you must update it in below places (including the toolchain below) in this repo:
         # => [README.md - part 1] Update "Install Rust - we recommend to use Rust X.XX.X"
         # => [README.md - part 2] Update "rustup default X.XX.X"
         # => [action.yml - part 1] Update "toolchain: X.XX.X" below
@@ -18,6 +18,9 @@ runs:
         # => [Dockerfile] Update "FROM rust:X.XX.X-slim-bookworm AS base-image" in the deterministic builder
         # => [radix-clis/assets/template/rust-toolchain.toml_template] Update the rust version
         # => [https://docs.radixdlt.com/docs/getting-rust-scrypto] Update the recommended rust version on docs
+        # Additionally, Rust version should be updated in below repos on respective branches:
+        # - babylon-node - .github/actions/setup-env/action.yml
+        # - fuzzer - .github/actions/setup-env/action.yml
         toolchain: 1.81.0
         default: true
         target: wasm32-unknown-unknown

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: RDXWorks-actions/toolchain@master
       with:
         # IMPORTANT:
-        # To update the Rust version, you must update it in below places (including the toolchain below) in this repo:
+        # To update the Rust version, you must update it in the below places (including the toolchain below) in this repo:
         # => [README.md - part 1] Update "Install Rust - we recommend to use Rust X.XX.X"
         # => [README.md - part 2] Update "rustup default X.XX.X"
         # => [action.yml - part 1] Update "toolchain: X.XX.X" below

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   SCRYPTO_CARGO_LOCKED: 1
+  # Produce a warning and exit with code 0 if no tests to run
+  # (nextest returns error by default since version 0.9.85)
+  NEXTEST_NO_TESTS: warn
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
- Warn (instead of return error) when no tests to run for `nextest`
(nextest changed default behaviour since version `0.9.85`)
- Update Rust version comments
