### PR TITLE
tweak: use fungible and non-fungible types in template and examples

### DIFF
--- a/examples/everything/src/lib.rs
+++ b/examples/everything/src/lib.rs
@@ -37,7 +37,7 @@ mod everything {
         Faucet as FiFi {
             fn new(
                 address_reservation: GlobalAddressReservation,
-                bucket: Bucket
+                bucket: FungibleBucket
             ) -> Global<FiFi>;
 
             fn lock_fee(&self, amount: Decimal);
@@ -96,7 +96,7 @@ mod everything {
             faucet.lock_fee(amount);
         }
 
-        pub fn public_method(&self) -> ResourceManager {
+        pub fn public_method(&self) -> NonFungibleResourceManager {
             ResourceBuilder::new_ruid_non_fungible::<TestNFData>(OwnerRole::None)
                 .mint_roles(mint_roles! {
                     minter => rule!(allow_all);

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -26,7 +26,7 @@ use scrypto::prelude::*;
 #[blueprint]
 mod hello {
     struct Hello {
-        sample_vault: Vault,
+        sample_vault: FungibleVault,
     }
 
     impl Hello {
@@ -34,7 +34,7 @@ mod hello {
             // stripped
          }
 
-         pub fn free_token(&mut self) -> Bucket {
+         pub fn free_token(&mut self) -> FungibleBucket {
             // stripped
          }
     }
@@ -47,7 +47,7 @@ The way to instantiate a component is through the `instantiate()` method on the 
 
 ```rust
 Self {
-    sample_vault: Vault::with_bucket(my_bucket),
+    sample_vault: FungibleVault::with_bucket(my_bucket),
 }
 .instantiate()
 ```
@@ -59,16 +59,16 @@ In Scrypto, assets like tokens, NFTs, and more are not implemented as blueprints
 To define a new resource, we use the `ResourceBuilder`, specifying the metadata and initial supply. We can use the `ResourceBuilder` to create a simple fungible-supply token called `HelloToken` like this:
 
 ```rust
-let my_bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
+let my_bucket: FungibleBucket = ResourceBuilder::new_fungible(OwnerRole::None)
     .metadata("name", "HelloToken")
     .metadata("symbol", "HT")
     .mint_initial_supply(1000);
 ```
 
-Once created, the 1000 resource-based `HelloToken` tokens are held in transient container `my_bucket`. To permanently store the created resources, we need to put them into a `Vault` like this:
+Once created, the 1000 resource-based `HelloToken` tokens are held in transient container `my_bucket`. To permanently store the created resources, we need to put them into a `FungibleVault` like this:
 
 ```rust
-let vault: Vault = Vault::with_bucket(my_bucket);
+let vault = FungibleVault::with_bucket(my_bucket);
 ```
 
 ## How to Play?

--- a/examples/hello-world/src/lib.rs
+++ b/examples/hello-world/src/lib.rs
@@ -4,7 +4,7 @@ use scrypto::prelude::*;
 mod hello {
     struct Hello {
         // Define what resources and data will be managed by Hello components
-        sample_vault: Vault,
+        sample_vault: FungibleVault,
     }
 
     impl Hello {
@@ -13,7 +13,7 @@ mod hello {
         // This is a function, and can be called directly on the blueprint once deployed
         pub fn instantiate_hello() -> Global<Hello> {
             // Create a new token called "HelloToken," with a fixed supply of 1000, and put that supply into a bucket
-            let my_bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
+            let my_bucket: FungibleBucket = ResourceBuilder::new_fungible(OwnerRole::None)
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata(metadata! {
                     init {
@@ -26,7 +26,7 @@ mod hello {
 
             // Instantiate a Hello component, populating its vault with our supply of 1000 HelloToken
             Self {
-                sample_vault: Vault::with_bucket(my_bucket),
+                sample_vault: FungibleVault::with_bucket(my_bucket),
             }
             .instantiate()
             .prepare_to_globalize(OwnerRole::None)
@@ -34,7 +34,7 @@ mod hello {
         }
 
         // This is a method, because it needs a reference to self.  Methods can only be called on components
-        pub fn free_token(&mut self) -> Bucket {
+        pub fn free_token(&mut self) -> FungibleBucket {
             info!(
                 "My balance is: {} HelloToken. Now giving away a token!",
                 self.sample_vault.amount()

--- a/radix-clis/assets/template/src/lib.rs
+++ b/radix-clis/assets/template/src/lib.rs
@@ -4,7 +4,7 @@ use scrypto::prelude::*;
 mod hello {
     struct Hello {
         // Define what resources and data will be managed by Hello components
-        sample_vault: Vault,
+        sample_vault: FungibleVault,
     }
 
     impl Hello {
@@ -13,7 +13,7 @@ mod hello {
         // This is a function, and can be called directly on the blueprint once deployed
         pub fn instantiate_hello() -> Global<Hello> {
             // Create a new token called "HelloToken," with a fixed supply of 1000, and put that supply into a bucket
-            let my_bucket: Bucket = ResourceBuilder::new_fungible(OwnerRole::None)
+            let my_bucket: FungibleBucket = ResourceBuilder::new_fungible(OwnerRole::None)
                 .divisibility(DIVISIBILITY_MAXIMUM)
                 .metadata(metadata! {
                     init {
@@ -26,7 +26,7 @@ mod hello {
 
             // Instantiate a Hello component, populating its vault with our supply of 1000 HelloToken
             Self {
-                sample_vault: Vault::with_bucket(my_bucket),
+                sample_vault: FungibleVault::with_bucket(my_bucket),
             }
             .instantiate()
             .prepare_to_globalize(OwnerRole::None)
@@ -34,7 +34,7 @@ mod hello {
         }
 
         // This is a method, because it needs a reference to self.  Methods can only be called on components
-        pub fn free_token(&mut self) -> Bucket {
+        pub fn free_token(&mut self) -> FungibleBucket {
             info!(
                 "My balance is: {} HelloToken. Now giving away a token!",
                 self.sample_vault.amount()


### PR DESCRIPTION
## Summary
Update `Vault` and `Bucket` types to `Fungible` and `NonFungible` versions in examples and template.

## Testing
- Existing tests pass.
- Manually tested updated `Hello` blueprint template
