### PR TITLE
Feature/support non fungibles in execution trace

### DIFF
--- a/radix-engine-tests/assets/blueprints/execution_trace/src/execution_trace.rs
+++ b/radix-engine-tests/assets/blueprints/execution_trace/src/execution_trace.rs
@@ -1,5 +1,8 @@
 use scrypto::prelude::*;
 
+#[derive(ScryptoSbor, NonFungibleData)]
+pub struct DummyData {}
+
 #[blueprint]
 mod execution_trace_test {
     struct ExecutionTraceBp {
@@ -7,7 +10,7 @@ mod execution_trace_test {
     }
 
     impl ExecutionTraceBp {
-        pub fn transfer_resource_between_two_components(
+        pub fn transfer_fungible_resource_between_two_components(
             amount: u8,
             use_take_advanced: bool,
         ) -> (
@@ -45,12 +48,57 @@ mod execution_trace_test {
             (resource_address, source_component, target_component)
         }
 
+        pub fn transfer_non_fungible_resource_between_two_components(
+            amount: u8,
+        ) -> (
+            ResourceAddress,
+            Global<ExecutionTraceBp>,
+            Global<ExecutionTraceBp>,
+        ) {
+            let mut entries = vec![];
+            for i in 1..amount as u64 + 1 {
+                entries.push((i.into(), DummyData {}));
+            }
+            let bucket = ResourceBuilder::new_integer_non_fungible::<DummyData>(OwnerRole::None)
+                .mint_initial_supply(entries);
+            let resource_address = bucket.resource_address();
+
+            let source_component = ExecutionTraceBp {
+                vault: Vault::with_bucket(bucket.into()),
+            }
+            .instantiate()
+            .prepare_to_globalize(OwnerRole::None)
+            .globalize();
+
+            let target_component = ExecutionTraceBp {
+                vault: Vault::new(resource_address),
+            }
+            .instantiate()
+            .prepare_to_globalize(OwnerRole::None)
+            .globalize();
+
+            let transfer_bucket: Bucket = source_component.take_non_fungibles(amount);
+            target_component.put(transfer_bucket);
+
+            (resource_address, source_component, target_component)
+        }
+
         pub fn take(&mut self, amount: u8) -> Bucket {
             self.vault.take(amount)
         }
 
         pub fn take_advanced(&mut self, amount: u8) -> Bucket {
             self.vault.take_advanced(amount, WithdrawStrategy::Exact)
+        }
+
+        pub fn take_non_fungibles(&mut self, amount: u8) -> Bucket {
+            let amount = amount as u64;
+            let mut ids = indexset![];
+            for i in 1..amount + 1 {
+                ids.insert(NonFungibleLocalId::integer(i));
+            }
+
+            self.vault.as_non_fungible().take_non_fungibles(&ids).into()
         }
 
         pub fn put(&mut self, b: Bucket) {
@@ -70,3 +118,4 @@ mod execution_trace_test {
         }
     }
 }
+

--- a/radix-engine-tests/assets/blueprints/execution_trace/src/execution_trace.rs
+++ b/radix-engine-tests/assets/blueprints/execution_trace/src/execution_trace.rs
@@ -118,4 +118,3 @@ mod execution_trace_test {
         }
     }
 }
-

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -91,8 +91,10 @@ impl From<&BucketSnapshot> for ResourceSpecifier {
 
 #[derive(Debug, Clone)]
 pub enum VaultOp {
-    Put(ResourceAddress, Decimal), // TODO: add non-fungible support
+    Put(ResourceAddress, Decimal),
     Take(ResourceAddress, Decimal),
+    // We intentionally disregard IDs and only use the amount for non-fungibles.
+    // This maintains backward compatibility for users of the `ResourceChange` struct.
     TakeNonFungibles(ResourceAddress, Decimal),
     TakeAdvanced(ResourceAddress, Decimal),
     LockFee(Decimal, bool),

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -95,7 +95,6 @@ pub enum VaultOp {
     Take(ResourceAddress, Decimal),
     TakeNonFungibles(ResourceAddress, Decimal),
     TakeAdvanced(ResourceAddress, Decimal),
-    Recall(ResourceAddress, Decimal),
     LockFee(Decimal, bool),
 }
 
@@ -728,7 +727,6 @@ impl ExecutionTraceModule {
                     match ident.as_str() {
                         VAULT_TAKE_IDENT
                         | VAULT_TAKE_ADVANCED_IDENT
-                        | VAULT_RECALL_IDENT
                         | NON_FUNGIBLE_VAULT_TAKE_NON_FUNGIBLES_IDENT => {
                             for (_, resource) in &resource_summary.buckets {
                                 let op = if ident == VAULT_TAKE_IDENT {
@@ -743,8 +741,6 @@ impl ExecutionTraceModule {
                                         resource.resource_address(),
                                         resource.amount(),
                                     )
-                                } else if ident == VAULT_RECALL_IDENT {
-                                    VaultOp::Recall(resource.resource_address(), resource.amount())
                                 } else {
                                     panic!("Unhandled vault method")
                                 };
@@ -760,7 +756,8 @@ impl ExecutionTraceModule {
                         | VAULT_GET_AMOUNT_IDENT
                         | VAULT_FREEZE_IDENT
                         | VAULT_UNFREEZE_IDENT
-                        | VAULT_BURN_IDENT => { /* no-op */ }
+                        | VAULT_BURN_IDENT
+                        | VAULT_RECALL_IDENT => { /* no-op */ }
                         FUNGIBLE_VAULT_LOCK_FEE_IDENT
                         | FUNGIBLE_VAULT_LOCK_FUNGIBLE_AMOUNT_IDENT
                         | FUNGIBLE_VAULT_UNLOCK_FUNGIBLE_AMOUNT_IDENT
@@ -913,8 +910,7 @@ pub fn calculate_resource_changes(
                 }
                 VaultOp::Take(resource_address, amount)
                 | VaultOp::TakeAdvanced(resource_address, amount)
-                | VaultOp::TakeNonFungibles(resource_address, amount)
-                | VaultOp::Recall(resource_address, amount) => {
+                | VaultOp::TakeNonFungibles(resource_address, amount) => {
                     let entry = &mut vault_changes
                         .entry(instruction_index)
                         .or_default()

--- a/radix-engine/src/system/system_modules/execution_trace/module.rs
+++ b/radix-engine/src/system/system_modules/execution_trace/module.rs
@@ -52,6 +52,13 @@ impl ExecutionTraceModule {
     }
 }
 
+// This structure tracks changes in resource balances per actor and vault.
+// Its purpose is to record balance changes for each instruction within a transaction
+// (as observed in `TransactionExecutionTrace`).
+// These changes can be further examined using the node's Core API.
+// NOTE!
+// This feature is not a comprehensive abstraction and may be removed in the future once it
+// is deprecated in the node's Core API.
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoSbor)]
 pub struct ResourceChange {
     pub node_id: NodeId,
@@ -89,6 +96,9 @@ impl From<&BucketSnapshot> for ResourceSpecifier {
     }
 }
 
+// Supported operations on Vaults.
+// The Recall operation is intentionally not supported, as it is impossible to identify the account
+// from which resources are recalled. This is because Recall functions with an internal vault.
 #[derive(Debug, Clone)]
 pub enum VaultOp {
     Put(ResourceAddress, Decimal),


### PR DESCRIPTION
## Summary

- Add support for non-fungible resources in `ExecutionTrace` resource changes 
- Removed support for Recall operations in `ExecutionTrace` resource changes
With `recall` it is not possible to determine the account the resources are recalled from, because `recall` operates with internal vault.

## Testing
Relevant tests added


