### PR TITLE
tweak: Change dependency version fixing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ crossbeam = { version = "0.8.2" }
 dirs = { version = "4.0.0" } # Used in radix-clis
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["fast", "zeroize"] }
 ethnum = {version = "1.3.2", default-features = false }
+extend = { version = "1.2.0" }
 fixedstr = { version = "0.2.9" }
 flate2 = { version = "1.0.27" } # Used in radix-clis for GzDecoder
 flume = { version = "0.11.0" } # Used in radix-clis for multi-threaded channels
@@ -126,15 +127,14 @@ strum = { version = "0.24", default-features = false, features = ["derive"] }
 syn = { version = "1.0.93", features = ["full", "extra-traits"] }
 tar = { version = "0.4.40" } # Used in radix-clis
 temp-env = { version = "0.2.0" } # Used in radix-clis
+tempfile = { version = "3.8.0" }
 trybuild = { version = "1.0.85" }
 wabt = { version = "0.10.0" }
 walkdir = { version = "2.3.3", default-features = false }
 wasmi = { version = "=0.39.1" } # Used for WASM Execution in the Engine. Requires explicit upgrades for testing non-determinism.
 wasm-opt = { version = "0.114.1" }
 wasmparser = { version = "0.107.0", default-features = false }
-extend = { version = "1.2.0" }
 zeroize = { version = "1.3.0" }
-tempfile = { version = "3.8.0" }
 
 # Both the release and test profiles use `panic = "unwind"` to allow certain parts of the Radix
 # Engine to be able to catch panics. As an example, the native-vm has a `catch_unwind` to catch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,14 +89,16 @@ ethnum = {version = "1.3.2", default-features = false }
 fixedstr = { version = "0.2.9" }
 flate2 = { version = "1.0.27" } # Used in radix-clis for GzDecoder
 flume = { version = "0.11.0" } # Used in radix-clis for multi-threaded channels
+fslock = { version = "0.2.1" }
 hashbrown = { version = "0.13.2" }
 hex = { version = "0.4.3", default-features = false }
 indexmap = { version = "2.2.5", default-features = false }
+inferno = { version = "0.11.19" }
 itertools = { version = "0.10.3" }
 lazy_static = { version = "1.4.0" }
 linreg = { version = "0.2.0" }
 lru = { version = "0.8.1", default-features = false }
-minicov = { version = "=0.3.5" }
+minicov = { version = "=0.3.5" } # Used for scrypto coverage. Has to be fixed for compatibility with the rust version we use.
 moka = { version = "0.9.9", features = ["sync"], default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-integer = { version = "0.1.45", default-features = false }
@@ -111,7 +113,7 @@ radix-wasm-instrument = { version = "1.0.0", default-features = false,  features
 rand = { version = "0.8.5" }
 rand_chacha = { version = "0.3.1" }
 rayon =  { version = "1.5.3" }
-regex = { version = "=1.9.3", default-features = false, features = [] }
+regex = { version = "1.9.3", default-features = false, features = [] }
 rocksdb = { version = "0.21.0" }
 rug = { version = "1.18" }
 secp256k1 = { version = "0.28.0", default-features = false, features = ["recovery"] }
@@ -127,14 +129,12 @@ temp-env = { version = "0.2.0" } # Used in radix-clis
 trybuild = { version = "1.0.85" }
 wabt = { version = "0.10.0" }
 walkdir = { version = "2.3.3", default-features = false }
-wasmi = { version = "=0.39.1" }
+wasmi = { version = "=0.39.1" } # Used for WASM Execution in the Engine. Requires explicit upgrades for testing non-determinism.
 wasm-opt = { version = "0.114.1" }
 wasmparser = { version = "0.107.0", default-features = false }
 extend = { version = "1.2.0" }
 zeroize = { version = "1.3.0" }
-inferno = { version = "0.11.19" }
 tempfile = { version = "3.8.0" }
-fslock = { version = "0.2.1" }
 
 # Both the release and test profiles use `panic = "unwind"` to allow certain parts of the Radix
 # Engine to be able to catch panics. As an example, the native-vm has a `catch_unwind` to catch


### PR DESCRIPTION
## Summary

Following discussions with the wallet team integrating into sargon, who had some issues with the regex version being fixed, I'm just pulling together a PR to unfix this version, in the hopes that it makes it easier to integrate as a library.

The node still uses a fixed version courtesy of the lock file of course.

## Testing

Existing tests pass 

## Changelog

N/A
