### PR TITLE
Add tests for the typed invocations type

### DIFF
--- a/radix-common/src/data/manifest/model/manifest_address_kinds.rs
+++ b/radix-common/src/data/manifest/model/manifest_address_kinds.rs
@@ -64,6 +64,12 @@ macro_rules! labelled_resolvable_address {
     };
 }
 
+pub trait IntoManifestAddress {
+    type ManifestAddress;
+
+    fn into_manifest_address(self) -> Self::ManifestAddress;
+}
+
 // Alias for backwards-compatibility
 pub type DynamicGlobalAddress = ManifestGlobalAddress;
 
@@ -71,6 +77,14 @@ pub type DynamicGlobalAddress = ManifestGlobalAddress;
 pub enum ManifestGlobalAddress {
     Static(GlobalAddress),
     Named(ManifestNamedAddress),
+}
+
+impl IntoManifestAddress for GlobalAddress {
+    type ManifestAddress = ManifestGlobalAddress;
+
+    fn into_manifest_address(self) -> Self::ManifestAddress {
+        Self::ManifestAddress::Static(self)
+    }
 }
 
 scrypto_describe_for_manifest_type!(
@@ -253,6 +267,14 @@ pub enum ManifestPackageAddress {
     Named(ManifestNamedAddress),
 }
 
+impl IntoManifestAddress for PackageAddress {
+    type ManifestAddress = ManifestPackageAddress;
+
+    fn into_manifest_address(self) -> Self::ManifestAddress {
+        Self::ManifestAddress::Static(self)
+    }
+}
+
 scrypto_describe_for_manifest_type!(
     ManifestPackageAddress,
     PACKAGE_ADDRESS_TYPE,
@@ -410,6 +432,14 @@ pub enum ManifestComponentAddress {
     Named(ManifestNamedAddress),
 }
 
+impl IntoManifestAddress for ComponentAddress {
+    type ManifestAddress = ManifestComponentAddress;
+
+    fn into_manifest_address(self) -> Self::ManifestAddress {
+        Self::ManifestAddress::Static(self)
+    }
+}
+
 scrypto_describe_for_manifest_type!(
     ManifestComponentAddress,
     COMPONENT_ADDRESS_TYPE,
@@ -515,6 +545,14 @@ pub type DynamicResourceAddress = ManifestResourceAddress;
 pub enum ManifestResourceAddress {
     Static(ResourceAddress),
     Named(ManifestNamedAddress),
+}
+
+impl IntoManifestAddress for ResourceAddress {
+    type ManifestAddress = ManifestResourceAddress;
+
+    fn into_manifest_address(self) -> Self::ManifestAddress {
+        Self::ManifestAddress::Static(self)
+    }
 }
 
 scrypto_describe_for_manifest_type!(

--- a/radix-common/src/data/manifest/model/manifest_blob.rs
+++ b/radix-common/src/data/manifest/model/manifest_blob.rs
@@ -1,14 +1,7 @@
 #[cfg(feature = "fuzzing")]
 use arbitrary::Arbitrary;
-use radix_rust::copy_u8_array;
-use sbor::rust::convert::TryFrom;
-#[cfg(not(feature = "alloc"))]
-use sbor::rust::fmt;
-use sbor::rust::vec::Vec;
-use sbor::*;
 
-use crate::data::manifest::*;
-use crate::*;
+use crate::internal_prelude::*;
 
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -57,10 +50,17 @@ impl ManifestBlobRef {
 
 manifest_type!(ManifestBlobRef, ManifestCustomValueKind::Blob, 32);
 
+impl sbor::Describe<ScryptoCustomTypeKind> for ManifestBlobRef {
+    const TYPE_ID: sbor::RustTypeId = <Vec<u8> as Describe<ScryptoCustomTypeKind>>::TYPE_ID;
+
+    fn type_data() -> sbor::TypeData<ScryptoCustomTypeKind, sbor::RustTypeId> {
+        Vec::<u8>::type_data()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal_prelude::*;
 
     #[test]
     fn manifest_blob_parse_fail() {

--- a/radix-common/src/lib.rs
+++ b/radix-common/src/lib.rs
@@ -87,7 +87,7 @@ pub mod prelude {
 
 pub(crate) mod internal_prelude {
     pub use super::prelude::*;
-    pub use crate::*;
+    pub use crate::manifest_type;
     pub use sbor::representations::*;
     pub use sbor::traversal::*;
 }

--- a/radix-common/src/lib.rs
+++ b/radix-common/src/lib.rs
@@ -87,6 +87,7 @@ pub mod prelude {
 
 pub(crate) mod internal_prelude {
     pub use super::prelude::*;
+    pub use crate::*;
     pub use sbor::representations::*;
     pub use sbor::traversal::*;
 }

--- a/radix-engine-interface/src/blueprints/access_controller/invocations.rs
+++ b/radix-engine-interface/src/blueprints/access_controller/invocations.rs
@@ -25,7 +25,7 @@ pub struct AccessControllerCreateInput {
     pub address_reservation: Option<GlobalAddressReservation>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccessControllerCreateManifestInput {
     pub controlled_asset: ManifestBucket,
     pub rule_set: RuleSet,
@@ -358,7 +358,7 @@ pub struct AccessControllerContributeRecoveryFeeInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccessControllerContributeRecoveryFeeManifestInput {
     pub bucket: ManifestBucket,
 }

--- a/radix-engine-interface/src/blueprints/account/invocations.rs
+++ b/radix-engine-interface/src/blueprints/account/invocations.rs
@@ -47,7 +47,7 @@ pub struct AccountCreateAdvancedInput {
 }
 
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountCreateAdvancedManifestInput {
     pub owner_role: OwnerRole,
     pub address_reservation: Option<ManifestAddressReservation>,
@@ -123,7 +123,7 @@ pub struct AccountDepositInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountDepositManifestInput {
     pub bucket: ManifestBucket,
 }
@@ -141,7 +141,7 @@ pub struct AccountDepositBatchInput {
     pub buckets: Vec<Bucket>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountDepositBatchManifestInput {
     pub buckets: ManifestBucketBatch,
 }
@@ -160,7 +160,7 @@ pub struct AccountWithdrawInput {
     pub amount: Decimal,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountWithdrawManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub amount: Decimal,
@@ -180,7 +180,7 @@ pub struct AccountWithdrawNonFungiblesInput {
     pub ids: IndexSet<NonFungibleLocalId>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountWithdrawNonFungiblesManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub ids: IndexSet<NonFungibleLocalId>,
@@ -201,7 +201,7 @@ pub struct AccountLockFeeAndWithdrawInput {
     pub amount: Decimal,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountLockFeeAndWithdrawManifestInput {
     pub amount_to_lock: Decimal,
     pub resource_address: ManifestResourceAddress,
@@ -224,7 +224,7 @@ pub struct AccountLockFeeAndWithdrawNonFungiblesInput {
     pub ids: IndexSet<NonFungibleLocalId>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountLockFeeAndWithdrawNonFungiblesManifestInput {
     pub amount_to_lock: Decimal,
     pub resource_address: ManifestResourceAddress,
@@ -245,7 +245,7 @@ pub struct AccountCreateProofOfAmountInput {
     pub amount: Decimal,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountCreateProofOfAmountManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub amount: Decimal,
@@ -265,7 +265,7 @@ pub struct AccountCreateProofOfNonFungiblesInput {
     pub ids: IndexSet<NonFungibleLocalId>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountCreateProofOfNonFungiblesManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub ids: IndexSet<NonFungibleLocalId>,
@@ -300,7 +300,7 @@ pub struct AccountSetResourcePreferenceInput {
     pub resource_preference: ResourcePreference,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountSetResourcePreferenceManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub resource_preference: ResourcePreference,
@@ -319,7 +319,7 @@ pub struct AccountRemoveResourcePreferenceInput {
     pub resource_address: ResourceAddress,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountRemoveResourcePreferenceManifestInput {
     pub resource_address: ManifestResourceAddress,
 }
@@ -338,7 +338,7 @@ pub struct AccountTryDepositOrRefundInput {
     pub authorized_depositor_badge: Option<ResourceOrNonFungible>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountTryDepositOrRefundManifestInput {
     pub bucket: ManifestBucket,
     pub authorized_depositor_badge: Option<ManifestResourceOrNonFungible>,
@@ -358,7 +358,7 @@ pub struct AccountTryDepositBatchOrRefundInput {
     pub authorized_depositor_badge: Option<ResourceOrNonFungible>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountTryDepositBatchOrRefundManifestInput {
     pub buckets: ManifestBucketBatch,
     pub authorized_depositor_badge: Option<ManifestResourceOrNonFungible>,
@@ -378,7 +378,7 @@ pub struct AccountTryDepositOrAbortInput {
     pub authorized_depositor_badge: Option<ResourceOrNonFungible>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountTryDepositOrAbortManifestInput {
     pub bucket: ManifestBucket,
     pub authorized_depositor_badge: Option<ManifestResourceOrNonFungible>,
@@ -398,7 +398,7 @@ pub struct AccountTryDepositBatchOrAbortInput {
     pub authorized_depositor_badge: Option<ResourceOrNonFungible>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountTryDepositBatchOrAbortManifestInput {
     pub buckets: ManifestBucketBatch,
     pub authorized_depositor_badge: Option<ManifestResourceOrNonFungible>,
@@ -418,7 +418,7 @@ pub struct AccountBurnInput {
     pub amount: Decimal,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountBurnManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub amount: Decimal,
@@ -438,7 +438,7 @@ pub struct AccountBurnNonFungiblesInput {
     pub ids: IndexSet<NonFungibleLocalId>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountBurnNonFungiblesManifestInput {
     pub resource_address: ManifestResourceAddress,
     pub ids: IndexSet<NonFungibleLocalId>,
@@ -457,7 +457,7 @@ pub struct AccountAddAuthorizedDepositorInput {
     pub badge: ResourceOrNonFungible,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountAddAuthorizedDepositorManifestInput {
     pub badge: ManifestResourceOrNonFungible,
 }
@@ -475,7 +475,7 @@ pub struct AccountRemoveAuthorizedDepositorInput {
     pub badge: ResourceOrNonFungible,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct AccountRemoveAuthorizedDepositorManifestInput {
     pub badge: ManifestResourceOrNonFungible,
 }
@@ -493,8 +493,8 @@ pub struct AccountBalanceInput {
     pub resource_address: ResourceAddress,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
-pub struct AccountBalanceDynamicInput {
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
+pub struct AccountBalanceManifestInput {
     pub resource_address: ManifestResourceAddress,
 }
 
@@ -512,7 +512,11 @@ pub struct AccountNonFungibleLocalIdsInput {
     pub limit: u32,
 }
 
-pub type AccountNonFungibleLocalIdsManifestInput = AccountNonFungibleLocalIdsInput;
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
+pub struct AccountNonFungibleLocalIdsManifestInput {
+    pub resource_address: ManifestResourceAddress,
+    pub limit: u32,
+}
 
 pub type AccountNonFungibleLocalIdsOutput = IndexSet<NonFungibleLocalId>;
 
@@ -528,6 +532,10 @@ pub struct AccountHasNonFungibleInput {
     pub local_id: NonFungibleLocalId,
 }
 
-pub type AccountHasNonFungibleManifestInput = AccountHasNonFungibleInput;
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
+pub struct AccountHasNonFungibleManifestInput {
+    pub resource_address: ManifestResourceAddress,
+    pub local_id: NonFungibleLocalId,
+}
 
 pub type AccountHasNonFungibleOutput = bool;

--- a/radix-engine-interface/src/blueprints/component.rs
+++ b/radix-engine-interface/src/blueprints/component.rs
@@ -1,5 +1,5 @@
+use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
-
 use radix_common::prelude::*;
 
 pub trait TypeInfoMarker {
@@ -9,84 +9,73 @@ pub trait TypeInfoMarker {
     const GLOBAL_TYPE_NAME: &'static str;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Global<T>(pub ComponentAddress, PhantomData<T>)
-where
-    T: TypeInfoMarker;
+// This type is added for backwards compatibility so that this change is not apparent at all to
+// Scrypto Developers
+pub type Global<T> = GenericGlobal<ComponentAddress, T>;
 
-impl<T: TypeInfoMarker> core::hash::Hash for Global<T> {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.as_node_id().hash(state)
-    }
-}
-
-pub struct Owned<T>(pub InternalAddress, PhantomData<T>)
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    ScryptoEncode,
+    ScryptoDecode,
+    ScryptoCategorize,
+    ManifestEncode,
+    ManifestDecode,
+    ManifestCategorize,
+)]
+#[sbor(transparent, child_types = "A")]
+pub struct GenericGlobal<A, M>(pub A, #[sbor(skip)] PhantomData<M>)
 where
-    T: TypeInfoMarker;
+    M: TypeInfoMarker;
 
-impl<T> Global<T>
+impl<A, M> GenericGlobal<A, M>
 where
-    T: TypeInfoMarker,
+    M: TypeInfoMarker,
 {
-    pub fn new(address: ComponentAddress) -> Self {
+    pub fn new(address: A) -> Self {
         Self(address, PhantomData)
     }
 }
 
-impl<T> Owned<T>
+impl<A, M> Hash for GenericGlobal<A, M>
 where
-    T: TypeInfoMarker,
+    A: Hash,
+    M: TypeInfoMarker,
 {
-    pub fn new(address: InternalAddress) -> Self {
-        Self(address, PhantomData)
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 
-impl<O: TypeInfoMarker> Categorize<ScryptoCustomValueKind> for Global<O> {
-    #[inline]
-    fn value_kind() -> ValueKind<ScryptoCustomValueKind> {
-        ValueKind::Custom(ScryptoCustomValueKind::Reference)
-    }
-}
-
-impl<O: TypeInfoMarker, E: Encoder<ScryptoCustomValueKind>> Encode<ScryptoCustomValueKind, E>
-    for Global<O>
+impl<A, M> From<A> for GenericGlobal<A, M>
+where
+    M: TypeInfoMarker,
 {
-    #[inline]
-    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        encoder.write_value_kind(Self::value_kind())
-    }
-
-    #[inline]
-    fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.0.encode_body(encoder)
+    fn from(value: A) -> Self {
+        Self(value, PhantomData)
     }
 }
 
-impl<O: TypeInfoMarker, D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D>
-    for Global<O>
+impl<A, M> Describe<ScryptoCustomTypeKind> for GenericGlobal<A, M>
+where
+    M: TypeInfoMarker,
 {
-    fn decode_body_with_value_kind(
-        decoder: &mut D,
-        value_kind: ValueKind<ScryptoCustomValueKind>,
-    ) -> Result<Self, DecodeError> {
-        ComponentAddress::decode_body_with_value_kind(decoder, value_kind)
-            .map(|address| Self(address, Default::default()))
-    }
-}
-
-impl<T: TypeInfoMarker> Describe<ScryptoCustomTypeKind> for Global<T> {
     const TYPE_ID: RustTypeId =
-        RustTypeId::Novel(const_sha1::sha1(T::GLOBAL_TYPE_NAME.as_bytes()).as_bytes());
+        RustTypeId::Novel(const_sha1::sha1(M::GLOBAL_TYPE_NAME.as_bytes()).as_bytes());
 
     fn type_data() -> TypeData<ScryptoCustomTypeKind, RustTypeId> {
         TypeData {
             kind: TypeKind::Custom(ScryptoCustomTypeKind::Reference),
-            metadata: TypeMetadata::no_child_names(T::GLOBAL_TYPE_NAME),
+            metadata: TypeMetadata::no_child_names(M::GLOBAL_TYPE_NAME),
             validation: TypeValidation::Custom(ScryptoCustomTypeValidation::Reference(
                 ReferenceValidation::IsGlobalTyped(
-                    T::PACKAGE_ADDRESS,
-                    T::BLUEPRINT_NAME.to_string(),
+                    M::PACKAGE_ADDRESS,
+                    M::BLUEPRINT_NAME.to_string(),
                 ),
             )),
         }
@@ -95,49 +84,71 @@ impl<T: TypeInfoMarker> Describe<ScryptoCustomTypeKind> for Global<T> {
     fn add_all_dependencies(_aggregator: &mut TypeAggregator<ScryptoCustomTypeKind>) {}
 }
 
-impl<O: TypeInfoMarker> Categorize<ScryptoCustomValueKind> for Owned<O> {
-    #[inline]
-    fn value_kind() -> ValueKind<ScryptoCustomValueKind> {
-        ValueKind::Custom(ScryptoCustomValueKind::Own)
-    }
-}
+// This type is added for backwards compatibility so that this change is not apparent at all to
+// Scrypto Developers
+pub type Owned<T> = GenericOwned<InternalAddress, T>;
 
-impl<O: TypeInfoMarker, E: Encoder<ScryptoCustomValueKind>> Encode<ScryptoCustomValueKind, E>
-    for Owned<O>
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    ScryptoEncode,
+    ScryptoDecode,
+    ScryptoCategorize,
+    ManifestEncode,
+    ManifestDecode,
+    ManifestCategorize,
+)]
+#[sbor(transparent, child_types = "A")]
+pub struct GenericOwned<A, M>(pub A, #[sbor(skip)] PhantomData<M>)
+where
+    M: TypeInfoMarker;
+
+impl<A, M> GenericOwned<A, M>
+where
+    M: TypeInfoMarker,
 {
-    #[inline]
-    fn encode_value_kind(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        encoder.write_value_kind(Self::value_kind())
-    }
-
-    #[inline]
-    fn encode_body(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        self.0.encode_body(encoder)
+    pub fn new(address: A) -> Self {
+        Self(address, PhantomData)
     }
 }
 
-impl<O: TypeInfoMarker, D: Decoder<ScryptoCustomValueKind>> Decode<ScryptoCustomValueKind, D>
-    for Owned<O>
+impl<A, M> Hash for GenericOwned<A, M>
+where
+    A: Hash,
+    M: TypeInfoMarker,
 {
-    fn decode_body_with_value_kind(
-        decoder: &mut D,
-        value_kind: ValueKind<ScryptoCustomValueKind>,
-    ) -> Result<Self, DecodeError> {
-        InternalAddress::decode_body_with_value_kind(decoder, value_kind)
-            .map(|address| Self(address, Default::default()))
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 
-impl<T: TypeInfoMarker> Describe<ScryptoCustomTypeKind> for Owned<T> {
+impl<A, M> From<A> for GenericOwned<A, M>
+where
+    M: TypeInfoMarker,
+{
+    fn from(value: A) -> Self {
+        Self(value, PhantomData)
+    }
+}
+
+impl<A, M> Describe<ScryptoCustomTypeKind> for GenericOwned<A, M>
+where
+    M: TypeInfoMarker,
+{
     const TYPE_ID: RustTypeId =
-        RustTypeId::Novel(const_sha1::sha1(T::OWNED_TYPE_NAME.as_bytes()).as_bytes());
+        RustTypeId::Novel(const_sha1::sha1(M::OWNED_TYPE_NAME.as_bytes()).as_bytes());
 
     fn type_data() -> TypeData<ScryptoCustomTypeKind, RustTypeId> {
         TypeData {
             kind: TypeKind::Custom(ScryptoCustomTypeKind::Own),
-            metadata: TypeMetadata::no_child_names(T::OWNED_TYPE_NAME),
+            metadata: TypeMetadata::no_child_names(M::OWNED_TYPE_NAME),
             validation: TypeValidation::Custom(ScryptoCustomTypeValidation::Own(
-                OwnValidation::IsTypedObject(T::PACKAGE_ADDRESS, T::BLUEPRINT_NAME.to_string()),
+                OwnValidation::IsTypedObject(M::PACKAGE_ADDRESS, M::BLUEPRINT_NAME.to_string()),
             )),
         }
     }

--- a/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
+++ b/radix-engine-interface/src/blueprints/consensus_manager/invocations.rs
@@ -30,7 +30,7 @@ pub struct ConsensusManagerCreateInput {
     pub initial_current_leader: Option<ValidatorIndex>,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ConsensusManagerCreateManifestInput {
     pub validator_owner_token_address: ManifestAddressReservation,
     pub component_address: ManifestAddressReservation,
@@ -381,7 +381,7 @@ pub struct ConsensusManagerCreateValidatorInput {
     pub xrd_payment: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ConsensusManagerCreateValidatorManifestInput {
     pub key: Secp256k1PublicKey,
     pub fee_factor: Decimal,
@@ -415,7 +415,7 @@ pub struct ValidatorStakeAsOwnerInput {
     pub stake: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorStakeAsOwnerManifestInput {
     pub stake: ManifestBucket,
 }
@@ -428,7 +428,7 @@ pub struct ValidatorStakeInput {
     pub stake: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorStakeManifestInput {
     pub stake: ManifestBucket,
 }
@@ -441,7 +441,7 @@ pub struct ValidatorUnstakeInput {
     pub stake_unit_bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorUnstakeManifestInput {
     pub stake_unit_bucket: ManifestBucket,
 }
@@ -454,7 +454,7 @@ pub struct ValidatorClaimXrdInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorClaimXrdManifestInput {
     pub bucket: ManifestBucket,
 }
@@ -573,7 +573,7 @@ pub struct ValidatorApplyEmissionInput {
     pub proposals_missed: u64,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorApplyEmissionManifestInput {
     /// A bucket with the emitted XRDs for this validator.
     /// The validator should subtract the configured fee from this amount.
@@ -598,7 +598,7 @@ pub struct ValidatorApplyRewardInput {
     pub epoch: Epoch,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorApplyRewardManifestInput {
     /// A bucket with the rewarded XRDs (from transaction fees) for this validator.
     pub xrd_bucket: ManifestBucket,
@@ -615,7 +615,7 @@ pub struct ValidatorLockOwnerStakeUnitsInput {
     pub stake_unit_bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ValidatorLockOwnerStakeUnitsManifestInput {
     pub stake_unit_bucket: ManifestBucket,
 }

--- a/radix-engine-interface/src/blueprints/locker/invocations.rs
+++ b/radix-engine-interface/src/blueprints/locker/invocations.rs
@@ -61,7 +61,7 @@ define_invocation! {
     },
     output: type (),
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         bucket: ManifestBucket,
         try_direct_send: bool
     }
@@ -77,7 +77,7 @@ define_invocation! {
     },
     output: type Option<Bucket>,
     manifest_input: struct {
-        claimants: IndexMap<ManifestComponentAddress, ResourceSpecifier>,
+        claimants: IndexMap<GenericGlobal<ManifestComponentAddress, AccountMarker>, ResourceSpecifier>,
         bucket: ManifestBucket,
         try_direct_send: bool
     }
@@ -97,7 +97,7 @@ define_invocation! {
     },
     output: type Bucket,
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: ManifestResourceAddress,
         amount: Decimal
     }
@@ -113,7 +113,7 @@ define_invocation! {
     },
     output: type Bucket,
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: ManifestResourceAddress,
         ids: IndexSet<NonFungibleLocalId>
     }
@@ -133,7 +133,7 @@ define_invocation! {
     },
     output: type Bucket,
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: ManifestResourceAddress,
         amount: Decimal
     }
@@ -149,7 +149,7 @@ define_invocation! {
     },
     output: type Bucket,
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: ManifestResourceAddress,
         ids: IndexSet<NonFungibleLocalId>
     }
@@ -168,7 +168,7 @@ define_invocation! {
     },
     output: type Decimal,
     manifest_input: struct {
-        claimant: DynamicComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: DynamicResourceAddress,
     }
 }
@@ -183,7 +183,7 @@ define_invocation! {
     },
     output: type IndexSet<NonFungibleLocalId>,
     manifest_input: struct {
-        claimant: ManifestComponentAddress,
+        claimant: GenericGlobal<ManifestComponentAddress, AccountMarker>,
         resource_address: ManifestResourceAddress,
         limit: u32
     }

--- a/radix-engine-interface/src/blueprints/macros.rs
+++ b/radix-engine-interface/src/blueprints/macros.rs
@@ -14,20 +14,20 @@ macro_rules! define_invocation {
 
             $crate::blueprints::macros::resolve_struct_definition! {
                 [< $blueprint_name:camel $function_name:camel Input >],
-                radix_common::ScryptoSbor,
+                [radix_common::ScryptoSbor],
                 $($input_ident: $input_type),*
             }
 
             $crate::blueprints::macros::resolve_struct_definition! {
                 [< $blueprint_name:camel $function_name:camel Output >],
-                radix_common::ScryptoSbor,
+                [radix_common::ScryptoSbor],
                 $($output_ident: $output_type),*
             }
 
             $(
                 $crate::blueprints::macros::resolve_struct_definition! {
                     [< $blueprint_name:camel $function_name:camel ManifestInput >],
-                    radix_common::ManifestSbor,
+                    [radix_common::ManifestSbor, $crate::internal_prelude::ScryptoDescribe],
                     $($manifest_input_ident: $manifest_input_type),*
                 }
             )?
@@ -45,7 +45,7 @@ macro_rules! define_invocation {
 
             $crate::blueprints::macros::resolve_struct_definition! {
                 [< $blueprint_name:camel $function_name:camel Input >],
-                radix_common::ScryptoSbor,
+                [radix_common::ScryptoSbor],
                 $($input_ident: $input_type),*
             }
 
@@ -57,7 +57,7 @@ macro_rules! define_invocation {
             $(
                 $crate::blueprints::macros::resolve_struct_definition! {
                     [< $blueprint_name:camel $function_name:camel ManifestInput >],
-                    radix_common::ManifestSbor,
+                    [radix_common::ManifestSbor, $crate::internal_prelude::ScryptoDescribe],
                     $($manifest_input_ident: $manifest_input_type),*
                 }
             )?
@@ -80,14 +80,14 @@ macro_rules! define_invocation {
 
             $crate::blueprints::macros::resolve_struct_definition! {
                 [< $blueprint_name:camel $function_name:camel Output >],
-                radix_common::ScryptoSbor,
+                [radix_common::ScryptoSbor],
                 $($output_ident: $output_type),*
             }
 
             $(
                 $crate::blueprints::macros::resolve_struct_definition! {
                     [< $blueprint_name:camel $function_name:camel ManifestInput >],
-                    radix_common::ManifestSbor,
+                    [radix_common::ManifestSbor, $crate::internal_prelude::ScryptoDescribe],
                     $($manifest_input_ident: $manifest_input_type),*
                 }
             )?
@@ -116,7 +116,7 @@ macro_rules! define_invocation {
             $(
                 $crate::blueprints::macros::resolve_struct_definition! {
                     [< $blueprint_name:camel $function_name:camel ManifestInput >],
-                    radix_common::ManifestSbor,
+                    [radix_common::ManifestSbor, $crate::internal_prelude::ScryptoDescribe],
                     $($manifest_input_ident: $manifest_input_type),*
                 }
             )?
@@ -125,12 +125,14 @@ macro_rules! define_invocation {
 }
 
 macro_rules! resolve_struct_definition {
-    ($name: ident, $derive: ty$(,)?) => {
-        #[derive(sbor::rust::fmt::Debug, Eq, PartialEq, $derive)]
+    ($name: ident, [$($derive: ty),* $(,)?] $(,)?) => {
+        #[derive( $($derive),* )]
+        #[derive(sbor::rust::fmt::Debug, Eq, PartialEq)]
         pub struct $name;
     };
-    ($name: ident, $derive: ty, $($ident: ident: $type: ty),* $(,)?) => {
-        #[derive(sbor::rust::fmt::Debug, Eq, PartialEq, $derive)]
+    ($name: ident, [$($derive: ty),* $(,)?], $($ident: ident: $type: ty),* $(,)?) => {
+        #[derive( $($derive),* )]
+        #[derive(sbor::rust::fmt::Debug, Eq, PartialEq)]
         pub struct $name {
             $(
                 pub $ident: $type,

--- a/radix-engine-interface/src/blueprints/package/invocations.rs
+++ b/radix-engine-interface/src/blueprints/package/invocations.rs
@@ -25,7 +25,7 @@ pub struct PackagePublishWasmInput {
     pub metadata: MetadataInit,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct PackagePublishWasmManifestInput {
     pub definition: PackageDefinition,
     pub code: ManifestBlobRef,
@@ -45,7 +45,7 @@ pub struct PackagePublishWasmAdvancedInput {
     pub package_address: Option<GlobalAddressReservation>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct PackagePublishWasmAdvancedManifestInput {
     pub owner_role: OwnerRole,
     pub definition: PackageDefinition,
@@ -66,7 +66,7 @@ pub struct PackagePublishNativeInput {
     pub package_address: Option<GlobalAddressReservation>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct PackagePublishNativeManifestInput {
     pub definition: PackageDefinition,
     pub native_package_code_id: u64,

--- a/radix-engine-interface/src/blueprints/resource/fungible/fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/fungible/fungible_resource_manager.rs
@@ -107,7 +107,7 @@ pub struct FungibleResourceManagerCreateWithInitialSupplyInput {
 }
 
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct FungibleResourceManagerCreateWithInitialSupplyManifestInput {
     pub owner_role: OwnerRole,
     pub track_total_supply: bool,

--- a/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/non_fungible/non_fungible_resource_manager.rs
@@ -80,7 +80,7 @@ pub struct NonFungibleResourceManagerCreateInput {
 }
 
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerCreateManifestInput {
     pub owner_role: OwnerRole,
     pub id_type: NonFungibleIdType,
@@ -123,7 +123,7 @@ pub struct NonFungibleResourceManagerCreateWithInitialSupplyInput {
 
 /// For manifest
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerCreateWithInitialSupplyManifestInput {
     pub owner_role: OwnerRole,
     pub id_type: NonFungibleIdType,
@@ -167,7 +167,7 @@ pub struct NonFungibleResourceManagerCreateRuidWithInitialSupplyInput {
 
 /// For manifest
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerCreateRuidWithInitialSupplyManifestInput {
     pub owner_role: OwnerRole,
     pub track_total_supply: bool,
@@ -204,7 +204,7 @@ pub struct NonFungibleResourceManagerUpdateDataInput {
 
 /// For manifest
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerUpdateDataManifestInput {
     pub id: NonFungibleLocalId,
     pub field_name: String,
@@ -253,7 +253,7 @@ pub struct NonFungibleResourceManagerMintInput {
 
 /// For manifest
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerMintManifestInput {
     pub entries: IndexMap<NonFungibleLocalId, (ManifestValue,)>,
 }
@@ -275,7 +275,7 @@ pub struct NonFungibleResourceManagerMintRuidInput {
 
 /// For manifest
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerMintRuidManifestInput {
     pub entries: Vec<(ManifestValue,)>,
 }
@@ -295,7 +295,7 @@ pub struct NonFungibleResourceManagerMintSingleRuidInput {
     pub entry: ScryptoValue,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Clone, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct NonFungibleResourceManagerMintSingleRuidManifestInput {
     pub entry: ManifestValue,
 }

--- a/radix-engine-interface/src/blueprints/resource/proof_rule.rs
+++ b/radix-engine-interface/src/blueprints/resource/proof_rule.rs
@@ -25,7 +25,7 @@ pub enum ResourceOrNonFungible {
     Resource(ResourceAddress),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ManifestSbor)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, ManifestSbor, ScryptoDescribe)]
 pub enum ManifestResourceOrNonFungible {
     NonFungible(NonFungibleGlobalId),
     Resource(ManifestResourceAddress),

--- a/radix-engine-interface/src/blueprints/resource/resource_manager.rs
+++ b/radix-engine-interface/src/blueprints/resource/resource_manager.rs
@@ -35,7 +35,7 @@ pub struct ResourceManagerBurnInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ResourceManagerBurnManifestInput {
     pub bucket: ManifestBucket,
 }
@@ -49,7 +49,7 @@ pub struct ResourceManagerPackageBurnInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ResourceManagerPackageBurnManifestInput {
     pub bucket: ManifestBucket,
 }
@@ -81,7 +81,7 @@ pub struct ResourceManagerDropEmptyBucketInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct ResourceManagerDropEmptyBucketManifestInput {
     pub bucket: ManifestBucket,
 }

--- a/radix-engine-interface/src/blueprints/resource/vault.rs
+++ b/radix-engine-interface/src/blueprints/resource/vault.rs
@@ -16,7 +16,7 @@ pub struct VaultPutInput {
     pub bucket: Bucket,
 }
 
-#[derive(Debug, Eq, PartialEq, ManifestSbor)]
+#[derive(Debug, Eq, PartialEq, ManifestSbor, ScryptoDescribe)]
 pub struct VaultPutManifestInput {
     pub bucket: ManifestBucket,
 }

--- a/radix-engine-interface/src/blueprints/transaction_tracker/invocations.rs
+++ b/radix-engine-interface/src/blueprints/transaction_tracker/invocations.rs
@@ -9,7 +9,7 @@ pub struct TransactionTrackerCreateInput {
     pub address_reservation: GlobalAddressReservation,
 }
 
-#[derive(Debug, Clone, ManifestSbor)]
+#[derive(Debug, Clone, ManifestSbor, ScryptoDescribe)]
 pub struct TransactionTrackerCreateManifestInput {
     pub address_reservation: ManifestAddressReservation,
 }

--- a/radix-engine-tests/tests/blueprints/account_locker.rs
+++ b/radix-engine-tests/tests/blueprints/account_locker.rs
@@ -196,7 +196,7 @@ fn store_can_only_be_called_by_storer_role() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: account.into(),
+                            claimant: account.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -349,7 +349,7 @@ fn recover_can_only_be_called_by_recoverer_role() {
                     account_locker,
                     ACCOUNT_LOCKER_RECOVER_IDENT,
                     AccountLockerRecoverManifestInput {
-                        claimant: account.into(),
+                        claimant: account.into_manifest_address().into(),
                         resource_address: XRD.into(),
                         amount: dec!(0),
                     },
@@ -424,7 +424,7 @@ fn recover_non_fungibles_can_only_be_called_by_recoverer_role() {
                     account_locker,
                     ACCOUNT_LOCKER_RECOVER_NON_FUNGIBLES_IDENT,
                     AccountLockerRecoverNonFungiblesManifestInput {
-                        claimant: account.into(),
+                        claimant: account.into_manifest_address().into(),
                         resource_address: ACCOUNT_OWNER_BADGE.into(),
                         ids: indexset! {},
                     },
@@ -527,7 +527,7 @@ fn send_or_store_stores_the_resources_if_the_account_rejects_the_deposit_and_the
                     account_locker,
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
-                        claimant: user_account.into(),
+                        claimant: user_account.into_manifest_address().into(),
                         bucket,
                         try_direct_send: true,
                     },
@@ -630,7 +630,7 @@ fn send_or_store_sends_the_resources_if_the_locker_is_an_authorized_depositor() 
                     account_locker,
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
-                        claimant: user_account.into(),
+                        claimant: user_account.into_manifest_address().into(),
                         bucket,
                         try_direct_send: true,
                     },
@@ -699,7 +699,7 @@ fn claim_is_public_and_callable_by_all() {
                     account_locker,
                     ACCOUNT_LOCKER_CLAIM_IDENT,
                     AccountLockerClaimManifestInput {
-                        claimant: account.into(),
+                        claimant: account.into_manifest_address().into(),
                         resource_address: XRD.into(),
                         amount: dec!(0),
                     },
@@ -774,7 +774,7 @@ fn claim_non_fungibles_is_public_and_callable_by_all() {
                     account_locker,
                     ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                     AccountLockerClaimNonFungiblesManifestInput {
-                        claimant: account.into(),
+                        claimant: account.into_manifest_address().into(),
                         resource_address: ACCOUNT_OWNER_BADGE.into(),
                         ids: indexset! {},
                     },
@@ -858,7 +858,7 @@ fn an_account_can_claim_its_resources_from_the_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -878,7 +878,7 @@ fn an_account_can_claim_its_resources_from_the_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -957,7 +957,7 @@ fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -977,7 +977,7 @@ fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1056,7 +1056,7 @@ fn account_locker_admin_can_recover_resources_from_an_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -1077,7 +1077,7 @@ fn account_locker_admin_can_recover_resources_from_an_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1155,7 +1155,7 @@ fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disab
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -1176,7 +1176,7 @@ fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disab
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1257,7 +1257,7 @@ fn get_amount_method_reports_the_correct_amount_in_the_vault() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -1277,7 +1277,7 @@ fn get_amount_method_reports_the_correct_amount_in_the_vault() {
                 account_locker,
                 ACCOUNT_LOCKER_GET_AMOUNT_IDENT,
                 AccountLockerGetAmountManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: XRD.into(),
                 },
             )
@@ -1351,7 +1351,7 @@ fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into(),
+                            claimant: user_account1.into_manifest_address().into(),
                             try_direct_send: false,
                         },
                     )
@@ -1371,7 +1371,7 @@ fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
                 account_locker,
                 ACCOUNT_LOCKER_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT,
                 AccountLockerGetNonFungibleLocalIdsManifestInput {
-                    claimant: user_account1.into(),
+                    claimant: user_account1.into_manifest_address().into(),
                     resource_address: non_fungible_resource.into(),
                     limit: 100,
                 },
@@ -2620,7 +2620,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into(),
+                                claimant: claimant.into_manifest_address().into(),
                                 try_direct_send: false,
                             },
                         )
@@ -2650,7 +2650,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into(),
+                                claimant: claimant.into_manifest_address().into(),
                                 try_direct_send: false,
                             },
                         )
@@ -2680,7 +2680,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into(),
+                                claimant: claimant.into_manifest_address().into(),
                                 try_direct_send: true,
                             },
                         )
@@ -2710,7 +2710,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into(),
+                                claimant: claimant.into_manifest_address().into(),
                                 try_direct_send: true,
                             },
                         )
@@ -2751,7 +2751,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                                 bucket,
                                 claimants: claimants
                                     .into_iter()
-                                    .map(|(k, v)| (k.into(), v))
+                                    .map(|(k, v)| (k.into_manifest_address().into(), v))
                                     .collect(),
                                 try_direct_send: false,
                             },
@@ -2793,7 +2793,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                                 bucket,
                                 claimants: claimants
                                     .into_iter()
-                                    .map(|(k, v)| (k.into(), v))
+                                    .map(|(k, v)| (k.into_manifest_address().into(), v))
                                     .collect(),
                                 try_direct_send: true,
                             },
@@ -2820,7 +2820,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_RECOVER_IDENT,
                         AccountLockerRecoverManifestInput {
-                            claimant: claimant.into(),
+                            claimant: claimant.into_manifest_address().into(),
                             resource_address: resource_to_recover.into(),
                             amount,
                         },
@@ -2847,7 +2847,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_RECOVER_NON_FUNGIBLES_IDENT,
                         AccountLockerRecoverNonFungiblesManifestInput {
-                            claimant: claimant.into(),
+                            claimant: claimant.into_manifest_address().into(),
                             resource_address: resource_to_recover.into(),
                             ids,
                         },
@@ -2869,7 +2869,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_CLAIM_IDENT,
                         AccountLockerClaimManifestInput {
-                            claimant: claimant.into(),
+                            claimant: claimant.into_manifest_address().into(),
                             resource_address: resource_to_claim.into(),
                             amount,
                         },
@@ -2894,7 +2894,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                         AccountLockerClaimNonFungiblesManifestInput {
-                            claimant: claimant.into(),
+                            claimant: claimant.into_manifest_address().into(),
                             resource_address: resource_to_claim.into(),
                             ids,
                         },
@@ -3128,7 +3128,7 @@ fn send_does_not_accept_an_address_that_is_not_an_account() {
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
                         bucket,
-                        claimant: FAUCET.into(),
+                        claimant: FAUCET.into_manifest_address().into(),
                         try_direct_send: false,
                     },
                 )
@@ -3212,7 +3212,7 @@ fn airdrop_does_not_accept_an_address_that_is_not_an_account() {
                     AccountLockerAirdropManifestInput {
                         bucket,
                         claimants: indexmap! {
-                            FAUCET.into() => ResourceSpecifier::Fungible(dec!(1))
+                            FAUCET.into_manifest_address().into() => ResourceSpecifier::Fungible(dec!(1))
                         },
                         try_direct_send: false,
                     },
@@ -3292,7 +3292,7 @@ fn claim_does_not_accept_an_address_that_is_not_an_account() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: FAUCET.into(),
+                    claimant: FAUCET.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(1),
                 },
@@ -3371,7 +3371,7 @@ fn recover_does_not_accept_an_address_that_is_not_an_account() {
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: FAUCET.into(),
+                    claimant: FAUCET.into_manifest_address().into(),
                     resource_address: XRD.into(),
                     amount: dec!(1),
                 },
@@ -3480,7 +3480,12 @@ fn exceeding_one_of_the_limits_when_airdropping_returns_the_expected_error() {
                     AccountLockerAirdropManifestInput {
                         claimants: keys_and_accounts
                             .iter()
-                            .map(|entry| (entry.1.into(), ResourceSpecifier::Fungible(dec!(1))))
+                            .map(|entry| {
+                                (
+                                    entry.1.into_manifest_address().into(),
+                                    ResourceSpecifier::Fungible(dec!(1)),
+                                )
+                            })
                             .collect(),
                         bucket,
                         try_direct_send: true,

--- a/radix-engine-tests/tests/misc/mod.rs
+++ b/radix-engine-tests/tests/misc/mod.rs
@@ -1,0 +1,1 @@
+mod typed_manifest_invocation;

--- a/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
+++ b/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
@@ -1,0 +1,189 @@
+use crate::prelude::*;
+use radix_blueprint_schema_init::RefTypes;
+use radix_engine::system::system_db_reader::SystemDatabaseReader;
+use radix_transactions::manifest::static_resource_movements::*;
+
+/// This is a test to ensure that the [`TypedManifestNativeInvocation`] type has all the functions
+/// that blueprints have. To be clear, we don't check that it has all of the blueprints but that for
+/// the blueprints that it has that all the functions (a generic term we use for functions and
+/// methods) are present in the type. This is because we use this type heavily in places like the
+/// radix engine toolkit where we make the assumption that the type has all of the functions for
+/// the blueprints it supports.
+#[test]
+fn test_that_all_functions_are_in_the_typed_invocation_type() {
+    /* Arrange */
+    // We will be using a latest ledger to obtain the set of functions that we currently have. This
+    // is to ensure that this test is resistant to protocol updates and adding new functions to the
+    // various blueprints we have.
+    let ledger = LedgerSimulatorBuilder::new().without_kernel_trace().build();
+    let db = ledger.substate_db();
+    let ledger_function_table = FunctionTable::construct_from_substate_database(db);
+
+    /* Act */
+    // Constructing the function table of the typed manifest invocations type from the SBOR schema.
+    let typed_manifest_invocations_function_table =
+        FunctionTable::construct_from_typed_invocation_function_table();
+
+    /* Assert */
+    // We're taking the blueprint names in the typed invocations enum as the canonical set of
+    // blueprints since we don't want to check that we support all blueprints, just all functions.
+    for (blueprint_name, typed_native_invocation_blueprint_function_table) in
+        typed_manifest_invocations_function_table.0.into_iter()
+    {
+        let Some(canonical_blueprint_function_table) =
+            ledger_function_table.0.get(&blueprint_name).cloned()
+        else {
+            panic!(
+                "Blueprint \"{blueprint_name:?}\" is in the typed manifest enum but not on ledger"
+            );
+        };
+
+        for function_type in [
+            FunctionType::Function,
+            FunctionType::Method,
+            FunctionType::DirectMethod,
+        ] {
+            let typed_invocations_blueprint_function_type_functions =
+                typed_native_invocation_blueprint_function_table
+                    .0
+                    .get(&function_type);
+            let canonical_blueprint_function_type_functions =
+                canonical_blueprint_function_table.0.get(&function_type);
+
+            match (
+                typed_invocations_blueprint_function_type_functions,
+                canonical_blueprint_function_type_functions,
+            ) {
+                (
+                    Some(typed_invocations_blueprint_function_type_functions),
+                    Some(canonical_blueprint_function_type_functions),
+                ) => {
+                    let functions_in_typed_invocation_but_not_in_ledger =
+                        typed_invocations_blueprint_function_type_functions
+                            .difference(canonical_blueprint_function_type_functions)
+                            .collect::<HashSet<_>>();
+                    let functions_in_ledger_but_not_in_typed_invocation =
+                        canonical_blueprint_function_type_functions
+                            .difference(typed_invocations_blueprint_function_type_functions)
+                            .collect::<HashSet<_>>();
+
+                    if !functions_in_typed_invocation_but_not_in_ledger.is_empty() {
+                        panic!("For blueprint \"{blueprint_name:?}\" and function type \"{function_type:?}\" the following set of functions are defined in the typed invocation enum but are not present on ledger: {functions_in_typed_invocation_but_not_in_ledger:?}")
+                    }
+                    if !functions_in_ledger_but_not_in_typed_invocation.is_empty() {
+                        panic!("For blueprint \"{blueprint_name:?}\" and function type \"{function_type:?}\" the following set of functions are defined in ledger but are not present in the typed invocations enum: {functions_in_ledger_but_not_in_typed_invocation:?}")
+                    }
+                }
+                (Some(_), None) => {
+                    panic!("Typed manifest invocation has {function_type:?} functions defined for {blueprint_name:?} but ledger doesnt")
+                }
+                (None, Some(_)) => {
+                    panic!("Ledger has {function_type:?} functions defined for {blueprint_name:?} but typed invocation doesnt")
+                }
+                (None, None) => continue,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct FunctionTable(HashMap<BlueprintName, BlueprintFunctionTable>);
+
+impl FunctionTable {
+    /// Constructs the function table of the [`TypedManifestNativeInvocation`] type based on its
+    /// SBOR schema.
+    fn construct_from_typed_invocation_function_table() -> Self {
+        let function_table = typed_native_invocation_function_table();
+        Self(
+            function_table
+                .into_iter()
+                .map(|(blueprint_name, functions)| {
+                    (
+                        BlueprintName(blueprint_name.to_owned()),
+                        BlueprintFunctionTable(
+                            functions
+                                .into_iter()
+                                .filter_map(|(function_type, functions)| {
+                                    if !functions.is_empty() {
+                                        let function_type = match function_type {
+                                            "Function" => FunctionType::Function,
+                                            "Method" => FunctionType::Method,
+                                            "DirectMethod" => FunctionType::DirectMethod,
+                                            _ => unreachable!(),
+                                        };
+                                        Some((
+                                            function_type,
+                                            functions
+                                                .into_iter()
+                                                .map(ToOwned::to_owned)
+                                                .map(FunctionIdent)
+                                                .collect(),
+                                        ))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect(),
+                        ),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn construct_from_substate_database<S: SubstateDatabase + ListableSubstateDatabase>(
+        database: &S,
+    ) -> Self {
+        let mut this = Self::default();
+        let reader = SystemDatabaseReader::new(database);
+
+        let packages = database
+            .list_partition_keys()
+            .map(|value| SpreadPrefixKeyMapper::from_db_node_key(&value.node_key))
+            .filter_map(|node_id| PackageAddress::try_from(node_id.0.as_slice()).ok())
+            .collect::<HashSet<_>>();
+
+        for package_address in packages.into_iter() {
+            for (BlueprintVersionKey { blueprint, .. }, blueprint_definition) in
+                reader.get_package_definition(package_address).into_iter()
+            {
+                for (function_ident, FunctionSchema { receiver, .. }) in
+                    blueprint_definition.interface.functions.into_iter()
+                {
+                    let function_type = match receiver {
+                        Some(receiver) if receiver.ref_types.contains(RefTypes::DIRECT_ACCESS) => {
+                            FunctionType::DirectMethod
+                        }
+                        Some(_) => FunctionType::Method,
+                        None => FunctionType::Function,
+                    };
+                    this.0
+                        .entry(BlueprintName(blueprint.clone()))
+                        .or_default()
+                        .0
+                        .entry(function_type)
+                        .or_default()
+                        .insert(FunctionIdent(function_ident));
+                }
+            }
+        }
+
+        this
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct BlueprintFunctionTable(HashMap<FunctionType, HashSet<FunctionIdent>>);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct FunctionIdent(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct BlueprintName(String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum FunctionType {
+    Function,
+    Method,
+    DirectMethod,
+}

--- a/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
+++ b/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use radix_blueprint_schema_init::RefTypes;
+use radix_blueprint_schema_init::{ReceiverInfo, RefTypes};
 use radix_engine::system::system_db_reader::SystemDatabaseReader;
+use radix_rust::rust::ops::*;
 use radix_transactions::manifest::static_resource_movements::*;
 
 /// This is a test to ensure that the [`TypedManifestNativeInvocation`] type has all the functions
@@ -20,170 +21,314 @@ fn test_that_all_functions_are_in_the_typed_invocation_type() {
     let ledger_function_table = FunctionTable::construct_from_substate_database(db);
 
     /* Act */
-    // Constructing the function table of the typed manifest invocations type from the SBOR schema.
+    // Constructing the function table of typed manifest invocation from the Scrypto function table.
     let typed_manifest_invocations_function_table =
         FunctionTable::construct_from_typed_invocation_function_table();
 
     /* Assert */
-    // We're taking the blueprint names in the typed invocations enum as the canonical set of
-    // blueprints since we don't want to check that we support all blueprints, just all functions.
-    for (blueprint_name, typed_native_invocation_blueprint_function_table) in
-        typed_manifest_invocations_function_table.0.into_iter()
+
+    // From this point onward I will refer to all of the information obtained from the ledger db as
+    // being "canonical" and I will refer to the typed manifest invocation as being "constructed".
+    // This should make the variable names and everything else much shorter.
+    //
+    // Note: since we do not wish to test that all blueprints are there we will take the typed
+    // manifest invocation's set of blueprints as being canonical.
+    let canonical_function_table = ledger_function_table;
+    let constructed_function_table = typed_manifest_invocations_function_table;
+
+    for (blueprint_name, constructed_blueprint_function_table) in
+        constructed_function_table.into_iter()
     {
         let Some(canonical_blueprint_function_table) =
-            ledger_function_table.0.get(&blueprint_name).cloned()
+            canonical_function_table.get(&blueprint_name).cloned()
         else {
-            panic!(
-                "Blueprint \"{blueprint_name:?}\" is in the typed manifest enum but not on ledger"
-            );
+            panic!("Blueprint \"{blueprint_name:?}\" not found in canonical function table.");
         };
 
-        for function_type in [
-            FunctionType::Function,
-            FunctionType::Method,
-            FunctionType::DirectMethod,
-        ] {
-            let typed_invocations_blueprint_function_type_functions =
-                typed_native_invocation_blueprint_function_table
-                    .0
-                    .get(&function_type);
-            let canonical_blueprint_function_type_functions =
-                canonical_blueprint_function_table.0.get(&function_type);
+        // We use the all constant on the function type since we want to visit all of the function
+        // types and not just the ones seen in the canonical function table. This is to ensure that
+        // the constructed type doesn't have any additional ones.
+        for function_type in FunctionType::ALL {
+            let constructed_function_type_functions =
+                constructed_blueprint_function_table.get(&function_type);
+            let canonical_function_type_functions =
+                canonical_blueprint_function_table.get(&function_type);
+
+            let constructed_function_type_functions_idents =
+                constructed_blueprint_function_table.function_idents_set(&function_type);
+            let canonical_function_type_functions_idents =
+                canonical_blueprint_function_table.function_idents_set(&function_type);
 
             match (
-                typed_invocations_blueprint_function_type_functions,
-                canonical_blueprint_function_type_functions,
+                constructed_function_type_functions,
+                canonical_function_type_functions,
             ) {
                 (
-                    Some(typed_invocations_blueprint_function_type_functions),
-                    Some(canonical_blueprint_function_type_functions),
+                    Some(constructed_function_type_functions),
+                    Some(canonical_function_type_functions),
                 ) => {
-                    let functions_in_typed_invocation_but_not_in_ledger =
-                        typed_invocations_blueprint_function_type_functions
-                            .difference(canonical_blueprint_function_type_functions)
+                    // Checking that the functions in both the constructed and the canonical tables
+                    // are present. We check that both sets are subsets of each other. If they're
+                    // not then we panic.
+                    let functions_in_constructed_but_not_in_canonical =
+                        constructed_function_type_functions_idents
+                            .difference(&canonical_function_type_functions_idents)
                             .collect::<HashSet<_>>();
-                    let functions_in_ledger_but_not_in_typed_invocation =
-                        canonical_blueprint_function_type_functions
-                            .difference(typed_invocations_blueprint_function_type_functions)
+                    let functions_in_canonical_but_not_in_constructed =
+                        canonical_function_type_functions_idents
+                            .difference(&constructed_function_type_functions_idents)
                             .collect::<HashSet<_>>();
 
-                    if !functions_in_typed_invocation_but_not_in_ledger.is_empty() {
-                        panic!("For blueprint \"{blueprint_name:?}\" and function type \"{function_type:?}\" the following set of functions are defined in the typed invocation enum but are not present on ledger: {functions_in_typed_invocation_but_not_in_ledger:?}")
+                    if !functions_in_constructed_but_not_in_canonical.is_empty() {
+                        panic!("Some functions for {blueprint_name:?}::{function_type} are in typed manifest invocation but not on-ledger: {:?}", functions_in_constructed_but_not_in_canonical)
                     }
-                    if !functions_in_ledger_but_not_in_typed_invocation.is_empty() {
-                        panic!("For blueprint \"{blueprint_name:?}\" and function type \"{function_type:?}\" the following set of functions are defined in ledger but are not present in the typed invocations enum: {functions_in_ledger_but_not_in_typed_invocation:?}")
+                    if !functions_in_canonical_but_not_in_constructed.is_empty() {
+                        panic!("Some functions for {blueprint_name:?}::{function_type} are on ledger but not typed manifest invocation: {:?}", functions_in_canonical_but_not_in_constructed)
+                    }
+
+                    // At this point we know that both types have the same set of functions. We can
+                    // now iterate over the function list and compare their schemas to ensure that
+                    // they're equal.
+                    let function_idents = constructed_function_type_functions_idents;
+                    for function_ident in function_idents.iter() {
+                        let _constructed_function_schema = constructed_function_type_functions
+                            .get(function_ident)
+                            .unwrap();
+                        let _canonical_function_schema = canonical_function_type_functions
+                            .get(function_ident)
+                            .unwrap();
+
+                        // TODO: We can currently compare the schemas together since some of them
+                        // use typed addresses (references in particular) and others do not.
+                        // compare_single_type_schemas(
+                        //     &SchemaComparisonSettings::require_equality()
+                        //         .with_metadata(|metadata| {
+                        //             metadata.with_type_name_changes(NameChangeRule::AllowAllChanges)
+                        //         })
+                        //         .with_completeness(|completeness| {
+                        //             completeness
+                        //                 .with_allow_root_unreachable_types_in_base_schema()
+                        //                 .with_allow_root_unreachable_types_in_compared_schema()
+                        //         }),
+                        //     constructed_function_schema,
+                        //     canonical_function_schema,
+                        // )
+                        // .assert_valid("Typed Manifest Invocation", "Blueprint Definition");
                     }
                 }
-                (Some(_), None) => {
-                    panic!("Typed manifest invocation has {function_type:?} functions defined for {blueprint_name:?} but ledger doesnt")
+                (Some(v), None) if !v.is_empty() => {
+                    panic!("{blueprint_name:?}::{function_type} is defined in typed manifest invocation but not on ledger")
                 }
-                (None, Some(_)) => {
-                    panic!("Ledger has {function_type:?} functions defined for {blueprint_name:?} but typed invocation doesnt")
+                (None, Some(v)) if !v.is_empty() => {
+                    panic!("{blueprint_name:?}::{function_type} is defined on ledger but not in typed manifest invocation")
                 }
-                (None, None) => continue,
+                (Some(_), None) | (None, Some(_)) | (None, None) => continue,
             }
         }
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct FunctionTable(HashMap<BlueprintName, BlueprintFunctionTable>);
+mod test_types {
+    use super::*;
+    use radix_rust::rust::collections::hash_map::Entry;
 
-impl FunctionTable {
-    /// Constructs the function table of the [`TypedManifestNativeInvocation`] type based on its
-    /// SBOR schema.
-    fn construct_from_typed_invocation_function_table() -> Self {
-        let function_table = typed_native_invocation_function_table();
-        Self(
-            function_table
-                .into_iter()
-                .map(|(blueprint_name, functions)| {
-                    (
-                        BlueprintName(blueprint_name.to_owned()),
-                        BlueprintFunctionTable(
-                            functions
-                                .into_iter()
-                                .filter_map(|(function_type, functions)| {
-                                    if !functions.is_empty() {
-                                        let function_type = match function_type {
-                                            "Function" => FunctionType::Function,
-                                            "Method" => FunctionType::Method,
-                                            "DirectMethod" => FunctionType::DirectMethod,
-                                            _ => unreachable!(),
-                                        };
-                                        Some((
-                                            function_type,
-                                            functions
-                                                .into_iter()
-                                                .map(ToOwned::to_owned)
-                                                .map(FunctionIdent)
-                                                .collect(),
-                                        ))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect(),
-                        ),
-                    )
-                })
-                .collect(),
-        )
+    #[derive(Clone, Debug, Default)]
+    pub struct FunctionTable(HashMap<BlueprintName, BlueprintFunctionTable>);
+
+    impl IntoIterator for FunctionTable {
+        type Item = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::Item;
+        type IntoIter = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::IntoIter;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
     }
 
-    fn construct_from_substate_database<S: SubstateDatabase + ListableSubstateDatabase>(
-        database: &S,
-    ) -> Self {
-        let mut this = Self::default();
-        let reader = SystemDatabaseReader::new(database);
+    impl FunctionTable {
+        pub fn get(&self, key: &BlueprintName) -> Option<&BlueprintFunctionTable> {
+            self.0.get(key)
+        }
 
-        let packages = database
-            .list_partition_keys()
-            .map(|value| SpreadPrefixKeyMapper::from_db_node_key(&value.node_key))
-            .filter_map(|node_id| PackageAddress::try_from(node_id.0.as_slice()).ok())
-            .collect::<HashSet<_>>();
+        pub fn entry(
+            &mut self,
+            key: BlueprintName,
+        ) -> Entry<'_, BlueprintName, BlueprintFunctionTable> {
+            self.0.entry(key)
+        }
 
-        for package_address in packages.into_iter() {
-            for (BlueprintVersionKey { blueprint, .. }, blueprint_definition) in
-                reader.get_package_definition(package_address).into_iter()
-            {
-                for (function_ident, FunctionSchema { receiver, .. }) in
-                    blueprint_definition.interface.functions.into_iter()
+        /// Constructs the function table of the [`TypedManifestNativeInvocation`] typed based on the
+        /// function table defined by the macro.
+        pub fn construct_from_typed_invocation_function_table() -> Self {
+            let mut this = Self::default();
+
+            let function_table = typed_native_invocation_function_table();
+            for (blueprint_name, functions_map) in function_table.into_iter() {
+                let blueprint_name = BlueprintName(blueprint_name.to_owned());
+
+                for (function_type, functions_map) in functions_map.into_iter() {
+                    let function_type = FunctionType::from_str(function_type).unwrap();
+
+                    for (function_ident, input_schema) in functions_map.into_iter() {
+                        let function_ident = FunctionIdent(function_ident.to_owned());
+
+                        this.entry(blueprint_name.clone())
+                            .or_default()
+                            .entry(function_type)
+                            .or_default()
+                            .insert(function_ident, input_schema);
+                    }
+                }
+            }
+
+            this
+        }
+
+        pub fn construct_from_substate_database<S: SubstateDatabase + ListableSubstateDatabase>(
+            database: &S,
+        ) -> Self {
+            let mut this = Self::default();
+            let reader = SystemDatabaseReader::new(database);
+
+            // Getting all of the packages on ledger.
+            let packages = database
+                .list_partition_keys()
+                .map(|value| SpreadPrefixKeyMapper::from_db_node_key(&value.node_key))
+                .filter_map(|node_id| PackageAddress::try_from(node_id.0.as_slice()).ok())
+                .collect::<HashSet<_>>();
+
+            // Constructing the function table from all of the packages on-ledger
+            for package_address in packages.into_iter() {
+                for (BlueprintVersionKey { blueprint, .. }, blueprint_definition) in
+                    reader.get_package_definition(package_address).into_iter()
                 {
-                    let function_type = match receiver {
-                        Some(receiver) if receiver.ref_types.contains(RefTypes::DIRECT_ACCESS) => {
-                            FunctionType::DirectMethod
-                        }
-                        Some(_) => FunctionType::Method,
-                        None => FunctionType::Function,
-                    };
-                    this.0
-                        .entry(BlueprintName(blueprint.clone()))
-                        .or_default()
-                        .0
-                        .entry(function_type)
-                        .or_default()
-                        .insert(FunctionIdent(function_ident));
+                    let blueprint_name = BlueprintName(blueprint);
+
+                    for (
+                        function_ident,
+                        FunctionSchema {
+                            receiver, input, ..
+                        },
+                    ) in blueprint_definition.interface.functions.into_iter()
+                    {
+                        let function_type = FunctionType::from(receiver);
+                        let function_ident = FunctionIdent(function_ident);
+
+                        let BlueprintPayloadDef::Static(ScopedTypeId(schema_hash, type_id)) = input
+                        else {
+                            unreachable!()
+                        };
+                        let schema = reader
+                            .get_schema(package_address.as_node_id(), &schema_hash)
+                            .unwrap()
+                            .deref()
+                            .clone();
+
+                        let single_type_schema = SingleTypeSchema { schema, type_id };
+
+                        this.entry(blueprint_name.clone())
+                            .or_default()
+                            .entry(function_type)
+                            .or_default()
+                            .insert(function_ident, single_type_schema);
+                    }
                 }
             }
+
+            this
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct BlueprintFunctionTable(
+        HashMap<FunctionType, HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>>,
+    );
+
+    impl BlueprintFunctionTable {
+        pub fn get(
+            &self,
+            key: &FunctionType,
+        ) -> Option<&HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>> {
+            self.0.get(key)
         }
 
-        this
+        pub fn entry(
+            &mut self,
+            key: FunctionType,
+        ) -> Entry<'_, FunctionType, HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>>
+        {
+            self.0.entry(key)
+        }
+
+        pub fn function_idents_set(&self, function_type: &FunctionType) -> HashSet<&FunctionIdent> {
+            self.0
+                .get(function_type)
+                .into_iter()
+                .flat_map(|value| value.keys())
+                .collect()
+        }
+    }
+
+    impl IntoIterator for BlueprintFunctionTable {
+        type Item = <HashMap<
+            FunctionType,
+            HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
+        > as IntoIterator>::Item;
+        type IntoIter = <HashMap<
+            FunctionType,
+            HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
+        > as IntoIterator>::IntoIter;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct FunctionIdent(String);
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct BlueprintName(String);
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub enum FunctionType {
+        Function,
+        Method,
+        DirectMethod,
+    }
+
+    impl FunctionType {
+        pub const ALL: [Self; 3] = [Self::Function, Self::Method, Self::DirectMethod];
+    }
+
+    impl Display for FunctionType {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Debug::fmt(&self, f)
+        }
+    }
+
+    impl FromStr for FunctionType {
+        type Err = ();
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "Function" => Ok(Self::Function),
+                "Method" => Ok(Self::Method),
+                "DirectMethod" => Ok(Self::DirectMethod),
+                _ => Err(()),
+            }
+        }
+    }
+
+    impl From<Option<ReceiverInfo>> for FunctionType {
+        fn from(value: Option<ReceiverInfo>) -> Self {
+            match value {
+                Some(value) if value.ref_types.contains(RefTypes::DIRECT_ACCESS) => {
+                    FunctionType::DirectMethod
+                }
+                Some(_) => FunctionType::Method,
+                None => FunctionType::Function,
+            }
+        }
     }
 }
-
-#[derive(Clone, Debug, Default)]
-struct BlueprintFunctionTable(HashMap<FunctionType, HashSet<FunctionIdent>>);
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct FunctionIdent(String);
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct BlueprintName(String);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum FunctionType {
-    Function,
-    Method,
-    DirectMethod,
-}
+use test_types::*;

--- a/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
+++ b/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
@@ -91,29 +91,27 @@ fn test_that_all_functions_are_in_the_typed_invocation_type() {
                     // they're equal.
                     let function_idents = constructed_function_type_functions_idents;
                     for function_ident in function_idents.iter() {
-                        let _constructed_function_schema = constructed_function_type_functions
+                        let constructed_function_schema = constructed_function_type_functions
                             .get(function_ident)
                             .unwrap();
-                        let _canonical_function_schema = canonical_function_type_functions
+                        let canonical_function_schema = canonical_function_type_functions
                             .get(function_ident)
                             .unwrap();
 
-                        // TODO: We can currently compare the schemas together since some of them
-                        // use typed addresses (references in particular) and others do not.
-                        // compare_single_type_schemas(
-                        //     &SchemaComparisonSettings::require_equality()
-                        //         .with_metadata(|metadata| {
-                        //             metadata.with_type_name_changes(NameChangeRule::AllowAllChanges)
-                        //         })
-                        //         .with_completeness(|completeness| {
-                        //             completeness
-                        //                 .with_allow_root_unreachable_types_in_base_schema()
-                        //                 .with_allow_root_unreachable_types_in_compared_schema()
-                        //         }),
-                        //     constructed_function_schema,
-                        //     canonical_function_schema,
-                        // )
-                        // .assert_valid("Typed Manifest Invocation", "Blueprint Definition");
+                        compare_single_type_schemas(
+                            &SchemaComparisonSettings::require_equality()
+                                .with_metadata(|metadata| {
+                                    metadata.with_type_name_changes(NameChangeRule::AllowAllChanges)
+                                })
+                                .with_completeness(|completeness| {
+                                    completeness
+                                        .with_allow_root_unreachable_types_in_base_schema()
+                                        .with_allow_root_unreachable_types_in_compared_schema()
+                                }),
+                            constructed_function_schema,
+                            canonical_function_schema,
+                        )
+                        .assert_valid("Typed Manifest Invocation", "Blueprint Definition");
                     }
                 }
                 (Some(v), None) if !v.is_empty() => {

--- a/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
+++ b/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
@@ -89,13 +89,12 @@ fn test_that_all_functions_are_in_the_typed_invocation_type() {
                     // At this point we know that both types have the same set of functions. We can
                     // now iterate over the function list and compare their schemas to ensure that
                     // they're equal.
-                    let function_idents = constructed_function_type_functions_idents;
-                    for function_ident in function_idents.iter() {
+                    for function_ident in constructed_function_type_functions_idents.iter() {
                         let constructed_function_schema = constructed_function_type_functions
-                            .get(function_ident)
+                            .get(*function_ident)
                             .unwrap();
                         let canonical_function_schema = canonical_function_type_functions
-                            .get(function_ident)
+                            .get(*function_ident)
                             .unwrap();
 
                         compare_single_type_schemas(
@@ -126,207 +125,190 @@ fn test_that_all_functions_are_in_the_typed_invocation_type() {
     }
 }
 
-mod test_types {
-    use super::*;
-    use radix_rust::rust::collections::hash_map::Entry;
+#[derive(Clone, Debug, Default)]
+pub struct FunctionTable(HashMap<BlueprintName, BlueprintFunctionTable>);
 
-    #[derive(Clone, Debug, Default)]
-    pub struct FunctionTable(HashMap<BlueprintName, BlueprintFunctionTable>);
+impl IntoIterator for FunctionTable {
+    type Item = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::Item;
+    type IntoIter = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::IntoIter;
 
-    impl IntoIterator for FunctionTable {
-        type Item = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::Item;
-        type IntoIter = <HashMap<BlueprintName, BlueprintFunctionTable> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
-        fn into_iter(self) -> Self::IntoIter {
-            self.0.into_iter()
-        }
+impl FunctionTable {
+    pub fn get(&self, key: &BlueprintName) -> Option<&BlueprintFunctionTable> {
+        self.0.get(key)
     }
 
-    impl FunctionTable {
-        pub fn get(&self, key: &BlueprintName) -> Option<&BlueprintFunctionTable> {
-            self.0.get(key)
-        }
+    /// Constructs the function table of the [`TypedManifestNativeInvocation`] typed based on the
+    /// function table defined by the macro.
+    pub fn construct_from_typed_invocation_function_table() -> Self {
+        let mut this = Self::default();
 
-        pub fn entry(
-            &mut self,
-            key: BlueprintName,
-        ) -> Entry<'_, BlueprintName, BlueprintFunctionTable> {
-            self.0.entry(key)
-        }
+        let function_table = typed_native_invocation_function_table();
+        for (blueprint_name, functions_map) in function_table.into_iter() {
+            let blueprint_name = BlueprintName(blueprint_name.to_owned());
 
-        /// Constructs the function table of the [`TypedManifestNativeInvocation`] typed based on the
-        /// function table defined by the macro.
-        pub fn construct_from_typed_invocation_function_table() -> Self {
-            let mut this = Self::default();
+            for (function_type, functions_map) in functions_map.into_iter() {
+                let function_type = FunctionType::from_str(function_type).unwrap();
 
-            let function_table = typed_native_invocation_function_table();
-            for (blueprint_name, functions_map) in function_table.into_iter() {
-                let blueprint_name = BlueprintName(blueprint_name.to_owned());
+                for (function_ident, input_schema) in functions_map.into_iter() {
+                    let function_ident = FunctionIdent(function_ident.to_owned());
 
-                for (function_type, functions_map) in functions_map.into_iter() {
-                    let function_type = FunctionType::from_str(function_type).unwrap();
-
-                    for (function_ident, input_schema) in functions_map.into_iter() {
-                        let function_ident = FunctionIdent(function_ident.to_owned());
-
-                        this.entry(blueprint_name.clone())
-                            .or_default()
-                            .entry(function_type)
-                            .or_default()
-                            .insert(function_ident, input_schema);
-                    }
+                    this.0
+                        .entry(blueprint_name.clone())
+                        .or_default()
+                        .0
+                        .entry(function_type)
+                        .or_default()
+                        .insert(function_ident, input_schema);
                 }
             }
-
-            this
         }
 
-        pub fn construct_from_substate_database<S: SubstateDatabase + ListableSubstateDatabase>(
-            database: &S,
-        ) -> Self {
-            let mut this = Self::default();
-            let reader = SystemDatabaseReader::new(database);
+        this
+    }
 
-            // Getting all of the packages on ledger.
-            let packages = database
-                .list_partition_keys()
-                .map(|value| SpreadPrefixKeyMapper::from_db_node_key(&value.node_key))
-                .filter_map(|node_id| PackageAddress::try_from(node_id.0.as_slice()).ok())
-                .collect::<HashSet<_>>();
+    pub fn construct_from_substate_database<S: SubstateDatabase + ListableSubstateDatabase>(
+        database: &S,
+    ) -> Self {
+        let mut this = Self::default();
+        let reader = SystemDatabaseReader::new(database);
 
-            // Constructing the function table from all of the packages on-ledger
-            for package_address in packages.into_iter() {
-                for (BlueprintVersionKey { blueprint, .. }, blueprint_definition) in
-                    reader.get_package_definition(package_address).into_iter()
+        // Getting all of the packages on ledger.
+        let packages = database
+            .list_partition_keys()
+            .map(|value| SpreadPrefixKeyMapper::from_db_node_key(&value.node_key))
+            .filter_map(|node_id| PackageAddress::try_from(node_id.0.as_slice()).ok())
+            .collect::<HashSet<_>>();
+
+        // Constructing the function table from all of the packages on-ledger
+        for package_address in packages.into_iter() {
+            for (BlueprintVersionKey { blueprint, .. }, blueprint_definition) in
+                reader.get_package_definition(package_address).into_iter()
+            {
+                let blueprint_name = BlueprintName(blueprint);
+
+                for (
+                    function_ident,
+                    FunctionSchema {
+                        receiver, input, ..
+                    },
+                ) in blueprint_definition.interface.functions.into_iter()
                 {
-                    let blueprint_name = BlueprintName(blueprint);
+                    let function_type = FunctionType::from(receiver);
+                    let function_ident = FunctionIdent(function_ident);
 
-                    for (
-                        function_ident,
-                        FunctionSchema {
-                            receiver, input, ..
-                        },
-                    ) in blueprint_definition.interface.functions.into_iter()
-                    {
-                        let function_type = FunctionType::from(receiver);
-                        let function_ident = FunctionIdent(function_ident);
+                    let BlueprintPayloadDef::Static(ScopedTypeId(schema_hash, type_id)) = input
+                    else {
+                        unreachable!()
+                    };
+                    let schema = reader
+                        .get_schema(package_address.as_node_id(), &schema_hash)
+                        .unwrap()
+                        .deref()
+                        .clone();
 
-                        let BlueprintPayloadDef::Static(ScopedTypeId(schema_hash, type_id)) = input
-                        else {
-                            unreachable!()
-                        };
-                        let schema = reader
-                            .get_schema(package_address.as_node_id(), &schema_hash)
-                            .unwrap()
-                            .deref()
-                            .clone();
+                    let single_type_schema = SingleTypeSchema { schema, type_id };
 
-                        let single_type_schema = SingleTypeSchema { schema, type_id };
-
-                        this.entry(blueprint_name.clone())
-                            .or_default()
-                            .entry(function_type)
-                            .or_default()
-                            .insert(function_ident, single_type_schema);
-                    }
+                    this.0
+                        .entry(blueprint_name.clone())
+                        .or_default()
+                        .0
+                        .entry(function_type)
+                        .or_default()
+                        .insert(function_ident, single_type_schema);
                 }
             }
-
-            this
-        }
-    }
-
-    #[derive(Clone, Debug, Default)]
-    pub struct BlueprintFunctionTable(
-        HashMap<FunctionType, HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>>,
-    );
-
-    impl BlueprintFunctionTable {
-        pub fn get(
-            &self,
-            key: &FunctionType,
-        ) -> Option<&HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>> {
-            self.0.get(key)
         }
 
-        pub fn entry(
-            &mut self,
-            key: FunctionType,
-        ) -> Entry<'_, FunctionType, HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>>
-        {
-            self.0.entry(key)
-        }
+        this
+    }
+}
 
-        pub fn function_idents_set(&self, function_type: &FunctionType) -> HashSet<&FunctionIdent> {
-            self.0
-                .get(function_type)
-                .into_iter()
-                .flat_map(|value| value.keys())
-                .collect()
-        }
+#[derive(Clone, Debug, Default)]
+pub struct BlueprintFunctionTable(
+    HashMap<FunctionType, HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>>,
+);
+
+impl BlueprintFunctionTable {
+    pub fn get(
+        &self,
+        key: &FunctionType,
+    ) -> Option<&HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>> {
+        self.0.get(key)
     }
 
-    impl IntoIterator for BlueprintFunctionTable {
-        type Item = <HashMap<
-            FunctionType,
-            HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
-        > as IntoIterator>::Item;
-        type IntoIter = <HashMap<
-            FunctionType,
-            HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
-        > as IntoIterator>::IntoIter;
-
-        fn into_iter(self) -> Self::IntoIter {
-            self.0.into_iter()
-        }
+    pub fn function_idents_set(&self, function_type: &FunctionType) -> HashSet<&FunctionIdent> {
+        self.0
+            .get(function_type)
+            .into_iter()
+            .flat_map(|value| value.keys())
+            .collect()
     }
+}
 
-    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct FunctionIdent(String);
+impl IntoIterator for BlueprintFunctionTable {
+    type Item = <HashMap<
+        FunctionType,
+        HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
+    > as IntoIterator>::Item;
+    type IntoIter = <HashMap<
+        FunctionType,
+        HashMap<FunctionIdent, SingleTypeSchema<ScryptoCustomSchema>>,
+    > as IntoIterator>::IntoIter;
 
-    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct BlueprintName(String);
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub enum FunctionType {
-        Function,
-        Method,
-        DirectMethod,
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
+}
 
-    impl FunctionType {
-        pub const ALL: [Self; 3] = [Self::Function, Self::Method, Self::DirectMethod];
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FunctionIdent(String);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlueprintName(String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FunctionType {
+    Function,
+    Method,
+    DirectMethod,
+}
+
+impl FunctionType {
+    pub const ALL: [Self; 3] = [Self::Function, Self::Method, Self::DirectMethod];
+}
+
+impl Display for FunctionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self, f)
     }
+}
 
-    impl Display for FunctionType {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            Debug::fmt(&self, f)
-        }
-    }
+impl FromStr for FunctionType {
+    type Err = ();
 
-    impl FromStr for FunctionType {
-        type Err = ();
-
-        fn from_str(s: &str) -> Result<Self, Self::Err> {
-            match s {
-                "Function" => Ok(Self::Function),
-                "Method" => Ok(Self::Method),
-                "DirectMethod" => Ok(Self::DirectMethod),
-                _ => Err(()),
-            }
-        }
-    }
-
-    impl From<Option<ReceiverInfo>> for FunctionType {
-        fn from(value: Option<ReceiverInfo>) -> Self {
-            match value {
-                Some(value) if value.ref_types.contains(RefTypes::DIRECT_ACCESS) => {
-                    FunctionType::DirectMethod
-                }
-                Some(_) => FunctionType::Method,
-                None => FunctionType::Function,
-            }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Function" => Ok(Self::Function),
+            "Method" => Ok(Self::Method),
+            "DirectMethod" => Ok(Self::DirectMethod),
+            _ => Err(()),
         }
     }
 }
-use test_types::*;
+
+impl From<Option<ReceiverInfo>> for FunctionType {
+    fn from(value: Option<ReceiverInfo>) -> Self {
+        match value {
+            Some(value) if value.ref_types.contains(RefTypes::DIRECT_ACCESS) => {
+                FunctionType::DirectMethod
+            }
+            Some(_) => FunctionType::Method,
+            None => FunctionType::Function,
+        }
+    }
+}

--- a/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
+++ b/radix-engine-tests/tests/misc/typed_manifest_invocation.rs
@@ -108,10 +108,10 @@ fn test_that_all_functions_are_in_the_typed_invocation_type() {
                                         .with_allow_root_unreachable_types_in_base_schema()
                                         .with_allow_root_unreachable_types_in_compared_schema()
                                 }),
-                            constructed_function_schema,
                             canonical_function_schema,
+                            constructed_function_schema,
                         )
-                        .assert_valid("Typed Manifest Invocation", "Blueprint Definition");
+                        .assert_valid("Blueprint Definition", "Typed Manifest Invocation");
                     }
                 }
                 (Some(v), None) if !v.is_empty() => {

--- a/radix-engine-tests/tests/misc_folder.rs
+++ b/radix-engine-tests/tests/misc_folder.rs
@@ -1,0 +1,13 @@
+// Integration tests reads all files in /tests/*.rs directory as separate
+// crates, but it doesn't read `/tests/x/mod.rs` like we use elsewhere in this
+// codebase. But we still want to have separate compilation units for better
+// parallelism.
+//
+// Our workaround is to:
+// * Have this X_folder.rs file which gets loaded by the test loader
+// * Use a mod definition to point to `X/mod.rs` where tests are defined
+mod misc;
+
+pub mod prelude {
+    pub use radix_engine_tests::prelude::*;
+}

--- a/radix-rust/src/rust.rs
+++ b/radix-rust/src/rust.rs
@@ -294,13 +294,13 @@ pub mod collections {
         #[macro_export]
         macro_rules! hashmap {
             ( ) => ({
-                $crate::rust::collections::hash_map::HashMap::default()
+                $crate::rust::collections::hash_map::new()
             });
             ( $($key:expr => $value:expr),* ) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,
                 // but we throw away that string literal during constant evaluation.
                 const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
-                let mut temp = $crate::rust::collections::hash_map::HashMap::with_capacity(CAP);
+                let mut temp = $crate::rust::collections::hash_map::with_capacity(CAP);
                 $(
                     temp.insert($key, $value);
                 )*
@@ -347,13 +347,13 @@ pub mod collections {
         #[macro_export]
         macro_rules! hashset {
             ( ) => ({
-                $crate::rust::collections::hash_set::HashSet::new()
+                $crate::rust::collections::hash_set::new()
             });
             ( $($key:expr),* ) => ({
                 // Note: `stringify!($key)` is just here to consume the repetition,
                 // but we throw away that string literal during constant evaluation.
                 const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
-                let mut temp = $crate::rust::collections::hash_set::HashSet::with_capacity(CAP);
+                let mut temp = $crate::rust::collections::hash_set::with_capacity(CAP);
                 $(
                     temp.insert($key);
                 )*

--- a/radix-transaction-scenarios/src/scenarios/account_locker.rs
+++ b/radix-transaction-scenarios/src/scenarios/account_locker.rs
@@ -263,6 +263,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -293,6 +294,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_rejecting_fungible_resource
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -323,6 +325,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: false,
                                     },
@@ -359,7 +362,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::Fungible(dec!(100)),
                                             )
                                         })
@@ -398,7 +401,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::Fungible(dec!(100)),
                                             )
                                         })
@@ -434,6 +437,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -467,6 +471,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_rejecting_fungible_resource
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -500,6 +505,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
+                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: false,
                                     },
@@ -543,7 +549,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::Fungible(dec!(1)),
                                             )
                                         })
@@ -589,7 +595,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::Fungible(dec!(1)),
                                             )
                                         })
@@ -635,7 +641,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|(account, id)| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::NonFungible(indexset![
                                                     NonFungibleLocalId::integer(id)
                                                 ]),
@@ -683,7 +689,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|(account, id)| {
                                             (
-                                                account.unwrap().into(),
+                                                account.unwrap().into_manifest_address().into(),
                                                 ResourceSpecifier::NonFungible(indexset![
                                                     NonFungibleLocalId::integer(id)
                                                 ]),
@@ -719,6 +725,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                             claimant: state
                                                 .account_rejecting_all_deposits
                                                 .unwrap()
+                                                .into_manifest_address()
                                                 .into(),
                                             try_direct_send: true,
                                         },
@@ -766,6 +773,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
+                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.fungible_resource.unwrap().into(),
@@ -790,6 +798,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
+                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
@@ -811,7 +820,11 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                 state.account_locker.unwrap(),
                                 ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                                 AccountLockerClaimNonFungiblesManifestInput {
-                                    claimant: state.account_accepting_all_resources.unwrap().into(),
+                                    claimant: state
+                                        .account_accepting_all_resources
+                                        .unwrap()
+                                        .into_manifest_address()
+                                        .into(),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
                                     ids: indexset![NonFungibleLocalId::integer(3)],
                                 },
@@ -838,6 +851,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
+                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.fungible_resource.unwrap().into(),
@@ -870,6 +884,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
+                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
@@ -902,6 +917,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_non_fungible_resource
                                         .unwrap()
+                                        .into_manifest_address()
                                         .into(),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
                                     ids: indexset![NonFungibleLocalId::integer(15)],

--- a/radix-transactions/src/manifest/static_resource_movements/effect.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/effect.rs
@@ -114,6 +114,9 @@ no_output_static_invocation_resources_output_impl![
     AccountTryDepositBatchOrAbortManifestInput,
     AccountAddAuthorizedDepositorManifestInput,
     AccountRemoveAuthorizedDepositorManifestInput,
+    AccountBalanceManifestInput,
+    AccountNonFungibleLocalIdsManifestInput,
+    AccountHasNonFungibleManifestInput,
     // ConsensusManager
     ConsensusManagerCreateManifestInput,
     ConsensusManagerGetCurrentEpochManifestInput,
@@ -212,6 +215,7 @@ no_output_static_invocation_resources_output_impl![
     RoleAssignmentLockOwnerManifestInput,
     RoleAssignmentSetManifestInput,
     RoleAssignmentGetManifestInput,
+    RoleAssignmentGetOwnerRoleManifestInput,
     // ComponentRoyalty
     ComponentRoyaltyCreateManifestInput,
     ComponentRoyaltySetManifestInput,
@@ -505,7 +509,6 @@ impl StaticInvocationResourcesOutput for ValidatorClaimXrdManifestInput {
             .add_resource(XRD, TrackedResource::zero_or_more([details.source]))
     }
 }
-
 // endregion:Validator
 
 // region:Identity

--- a/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
@@ -14,6 +14,7 @@ use radix_engine_interface::object_modules::royalty::*;
 use super::*;
 use radix_common::prelude::*;
 use radix_engine_interface::prelude::*;
+use radix_rust::rust::collections::{HashMap, HashSet};
 
 /// This macro defines a TypedManifestNativeInvocation type for our native blueprints. To make this
 /// easier to define this macro doesn't care about what package they live in when being INVOKED.

--- a/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
@@ -43,7 +43,7 @@ macro_rules! define_manifest_typed_invocation {
     ) => {
         paste::paste! {
             /* The TypedManifestNativeInvocation enum */
-            #[derive(Debug, ManifestSbor)]
+            #[derive(Debug, ManifestSbor, ScryptoDescribe)]
             pub enum TypedManifestNativeInvocation {
                 $(
                     [< $blueprint_ident BlueprintInvocation >]([< $blueprint_ident BlueprintInvocation >])
@@ -152,7 +152,7 @@ macro_rules! define_manifest_typed_invocation {
 
             /* The Method and Function types for each blueprint */
             $(
-                #[derive(Debug, ManifestSbor)]
+                #[derive(Debug, ManifestSbor, ScryptoDescribe)]
                 pub enum [< $blueprint_ident BlueprintInvocation >] {
                     Method([< $blueprint_ident BlueprintMethod >]),
                     DirectMethod([< $blueprint_ident BlueprintDirectMethod >]),
@@ -160,7 +160,7 @@ macro_rules! define_manifest_typed_invocation {
                 }
 
                 /* The Method Invocations */
-                #[derive(Debug, ManifestSbor)]
+                #[derive(Debug, ManifestSbor, ScryptoDescribe)]
                 pub enum [< $blueprint_ident BlueprintMethod >] {
                     $(
                         $method_ident($method_input)
@@ -197,7 +197,7 @@ macro_rules! define_manifest_typed_invocation {
                     }
                 }
 
-                #[derive(Debug, ManifestSbor)]
+                #[derive(Debug, ManifestSbor, ScryptoDescribe)]
                 pub enum [< $blueprint_ident BlueprintDirectMethod >] {
                     $(
                         $direct_method_ident($direct_method_input)
@@ -235,7 +235,7 @@ macro_rules! define_manifest_typed_invocation {
                 }
 
                 /* The Function Invocation */
-                #[derive(Debug, ManifestSbor)]
+                #[derive(Debug, ManifestSbor, ScryptoDescribe)]
                 pub enum [< $blueprint_ident BlueprintFunction >] {
                     $(
                         $function_ident($function_input)
@@ -313,6 +313,19 @@ macro_rules! define_manifest_typed_invocation {
                 }
             }
             pub use uniform_match_on_manifest_typed_invocation;
+
+            /// This is a function that's there for testing purposes only.
+            pub fn typed_native_invocation_function_table() -> HashMap<&'static str, HashMap<&'static str, HashSet<&'static str>>> {
+                hashmap! {
+                    $(
+                        stringify!($blueprint_ident) => hashmap! {
+                            "Function" => hashset![$($function_name),*],
+                            "Method" => hashset![$($method_name),*],
+                            "DirectMethod" => hashset![$($direct_method_name),*],
+                        },
+                    )*
+                }
+            }
         }
     };
 }
@@ -514,6 +527,18 @@ define_manifest_typed_invocation! {
             RemoveAuthorizedDepositor => (
                 AccountRemoveAuthorizedDepositorManifestInput,
                 ACCOUNT_REMOVE_AUTHORIZED_DEPOSITOR_IDENT,
+            ),
+            Balance => (
+                AccountBalanceManifestInput,
+                ACCOUNT_BALANCE_IDENT,
+            ),
+            NonFungibleLocalIds => (
+                AccountNonFungibleLocalIdsManifestInput,
+                ACCOUNT_NON_FUNGIBLE_LOCAL_IDS_IDENT,
+            ),
+            HasNonFungible => (
+                AccountHasNonFungibleManifestInput,
+                ACCOUNT_HAS_NON_FUNGIBLE_IDENT,
             ),
         },
         direct_methods: {}
@@ -1167,6 +1192,10 @@ define_manifest_typed_invocation! {
             Get => (
                 RoleAssignmentGetManifestInput,
                 ROLE_ASSIGNMENT_GET_IDENT,
+            ),
+            GetOwnerRole => (
+                RoleAssignmentGetOwnerRoleManifestInput,
+                ROLE_ASSIGNMENT_GET_OWNER_ROLE_IDENT,
             ),
         },
         direct_methods: {}

--- a/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
@@ -316,13 +316,19 @@ macro_rules! define_manifest_typed_invocation {
             pub use uniform_match_on_manifest_typed_invocation;
 
             /// This is a function that's there for testing purposes only.
-            pub fn typed_native_invocation_function_table() -> HashMap<&'static str, HashMap<&'static str, HashSet<&'static str>>> {
+            pub fn typed_native_invocation_function_table() -> HashMap<&'static str, HashMap<&'static str, HashMap<&'static str, SingleTypeSchema<ScryptoCustomSchema>>>> {
                 hashmap! {
                     $(
                         stringify!($blueprint_ident) => hashmap! {
-                            "Function" => hashset![$($function_name),*],
-                            "Method" => hashset![$($method_name),*],
-                            "DirectMethod" => hashset![$($direct_method_name),*],
+                            "Function" => hashmap![$(
+                                $function_name => generate_single_type_schema::<$function_input, ScryptoCustomSchema>()
+                            ),*],
+                            "Method" => hashmap![$(
+                                $method_name => generate_single_type_schema::<$method_input, ScryptoCustomSchema>()
+                            ),*],
+                            "DirectMethod" => hashmap![$(
+                                $direct_method_name => generate_single_type_schema::<$direct_method_input, ScryptoCustomSchema>()
+                            ),*],
                         },
                     )*
                 }

--- a/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
+++ b/radix-transactions/src/manifest/static_resource_movements/typed_invocation.rs
@@ -14,7 +14,7 @@ use radix_engine_interface::object_modules::royalty::*;
 use super::*;
 use radix_common::prelude::*;
 use radix_engine_interface::prelude::*;
-use radix_rust::rust::collections::{HashMap, HashSet};
+use radix_rust::rust::collections::HashMap;
 
 /// This macro defines a TypedManifestNativeInvocation type for our native blueprints. To make this
 /// easier to define this macro doesn't care about what package they live in when being INVOKED.

--- a/sbor/src/schema/schema_comparison/schema_comparison_settings.rs
+++ b/sbor/src/schema/schema_comparison/schema_comparison_settings.rs
@@ -137,6 +137,36 @@ impl SchemaComparisonCompletenessSettings {
             allow_compared_to_have_more_root_types: false,
         }
     }
+
+    pub const fn with_allow_root_unreachable_types_in_base_schema(mut self) -> Self {
+        self.allow_root_unreachable_types_in_base_schema = true;
+        self
+    }
+
+    pub fn with_dont_allow_root_unreachable_types_in_base_schema(mut self) -> Self {
+        self.allow_root_unreachable_types_in_base_schema = false;
+        self
+    }
+
+    pub const fn with_allow_root_unreachable_types_in_compared_schema(mut self) -> Self {
+        self.allow_root_unreachable_types_in_compared_schema = true;
+        self
+    }
+
+    pub fn with_dont_allow_root_unreachable_types_in_compared_schema(mut self) -> Self {
+        self.allow_root_unreachable_types_in_compared_schema = false;
+        self
+    }
+
+    pub const fn with_allow_compared_to_have_more_root_types(mut self) -> Self {
+        self.allow_compared_to_have_more_root_types = true;
+        self
+    }
+
+    pub fn with_dont_allow_compared_to_have_more_root_types(mut self) -> Self {
+        self.allow_compared_to_have_more_root_types = false;
+        self
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
@@ -191,6 +221,19 @@ impl SchemaComparisonMetadataSettings {
             field_name_changes: NameChangeRule::AllowAllChanges,
             variant_name_changes: NameChangeRule::AllowAllChanges,
         }
+    }
+
+    pub const fn with_type_name_changes(mut self, type_name_changes: NameChangeRule) -> Self {
+        self.type_name_changes = type_name_changes;
+        self
+    }
+    pub const fn with_field_name_changes(mut self, field_name_changes: NameChangeRule) -> Self {
+        self.field_name_changes = field_name_changes;
+        self
+    }
+    pub const fn with_variant_name_changes(mut self, variant_name_changes: NameChangeRule) -> Self {
+        self.variant_name_changes = variant_name_changes;
+        self
     }
 
     pub(crate) fn checks_required(&self) -> bool {


### PR DESCRIPTION
## Summary

This PR adds tests to ensure that the `TypedManifestNativeInvocation` type has all of the functions and methods that are defined on blueprints that we support. This is because clients such as the toolkit are heavily relying on this and it must cover all functions

## Tests

* Added a test that does NOT check that all blueprints are supported but that all functions, methods, and direct methods of the blueprints we've supported are supported.