### PR TITLE
Easier way to construct typed manifest globals

### DIFF
--- a/radix-engine-interface/src/blueprints/component.rs
+++ b/radix-engine-interface/src/blueprints/component.rs
@@ -61,6 +61,15 @@ where
     }
 }
 
+impl<M> From<ComponentAddress> for GenericGlobal<ManifestComponentAddress, M>
+where
+    M: TypeInfoMarker,
+{
+    fn from(value: ComponentAddress) -> Self {
+        Self(value.into_manifest_address(), PhantomData)
+    }
+}
+
 impl<A, M> Describe<ScryptoCustomTypeKind> for GenericGlobal<A, M>
 where
     M: TypeInfoMarker,

--- a/radix-engine-tests/tests/blueprints/account_locker.rs
+++ b/radix-engine-tests/tests/blueprints/account_locker.rs
@@ -196,7 +196,7 @@ fn store_can_only_be_called_by_storer_role() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: account.into_manifest_address().into(),
+                            claimant: account.into(),
                             try_direct_send: false,
                         },
                     )
@@ -349,7 +349,7 @@ fn recover_can_only_be_called_by_recoverer_role() {
                     account_locker,
                     ACCOUNT_LOCKER_RECOVER_IDENT,
                     AccountLockerRecoverManifestInput {
-                        claimant: account.into_manifest_address().into(),
+                        claimant: account.into(),
                         resource_address: XRD.into(),
                         amount: dec!(0),
                     },
@@ -424,7 +424,7 @@ fn recover_non_fungibles_can_only_be_called_by_recoverer_role() {
                     account_locker,
                     ACCOUNT_LOCKER_RECOVER_NON_FUNGIBLES_IDENT,
                     AccountLockerRecoverNonFungiblesManifestInput {
-                        claimant: account.into_manifest_address().into(),
+                        claimant: account.into(),
                         resource_address: ACCOUNT_OWNER_BADGE.into(),
                         ids: indexset! {},
                     },
@@ -527,7 +527,7 @@ fn send_or_store_stores_the_resources_if_the_account_rejects_the_deposit_and_the
                     account_locker,
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
-                        claimant: user_account.into_manifest_address().into(),
+                        claimant: user_account.into(),
                         bucket,
                         try_direct_send: true,
                     },
@@ -630,7 +630,7 @@ fn send_or_store_sends_the_resources_if_the_locker_is_an_authorized_depositor() 
                     account_locker,
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
-                        claimant: user_account.into_manifest_address().into(),
+                        claimant: user_account.into(),
                         bucket,
                         try_direct_send: true,
                     },
@@ -699,7 +699,7 @@ fn claim_is_public_and_callable_by_all() {
                     account_locker,
                     ACCOUNT_LOCKER_CLAIM_IDENT,
                     AccountLockerClaimManifestInput {
-                        claimant: account.into_manifest_address().into(),
+                        claimant: account.into(),
                         resource_address: XRD.into(),
                         amount: dec!(0),
                     },
@@ -774,7 +774,7 @@ fn claim_non_fungibles_is_public_and_callable_by_all() {
                     account_locker,
                     ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                     AccountLockerClaimNonFungiblesManifestInput {
-                        claimant: account.into_manifest_address().into(),
+                        claimant: account.into(),
                         resource_address: ACCOUNT_OWNER_BADGE.into(),
                         ids: indexset! {},
                     },
@@ -858,7 +858,7 @@ fn an_account_can_claim_its_resources_from_the_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -878,7 +878,7 @@ fn an_account_can_claim_its_resources_from_the_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -957,7 +957,7 @@ fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -977,7 +977,7 @@ fn an_account_cant_claim_another_accounts_resources_from_the_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1056,7 +1056,7 @@ fn account_locker_admin_can_recover_resources_from_an_account_locker() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -1077,7 +1077,7 @@ fn account_locker_admin_can_recover_resources_from_an_account_locker() {
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1155,7 +1155,7 @@ fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disab
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -1176,7 +1176,7 @@ fn account_locker_admin_cant_recover_resources_from_an_account_locker_when_disab
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: XRD.into(),
                     amount: dec!(10_000),
                 },
@@ -1257,7 +1257,7 @@ fn get_amount_method_reports_the_correct_amount_in_the_vault() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -1277,7 +1277,7 @@ fn get_amount_method_reports_the_correct_amount_in_the_vault() {
                 account_locker,
                 ACCOUNT_LOCKER_GET_AMOUNT_IDENT,
                 AccountLockerGetAmountManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: XRD.into(),
                 },
             )
@@ -1351,7 +1351,7 @@ fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
                         ACCOUNT_LOCKER_STORE_IDENT,
                         AccountLockerStoreManifestInput {
                             bucket,
-                            claimant: user_account1.into_manifest_address().into(),
+                            claimant: user_account1.into(),
                             try_direct_send: false,
                         },
                     )
@@ -1371,7 +1371,7 @@ fn get_non_fungible_local_ids_method_reports_the_correct_ids_in_the_vault() {
                 account_locker,
                 ACCOUNT_LOCKER_GET_NON_FUNGIBLE_LOCAL_IDS_IDENT,
                 AccountLockerGetNonFungibleLocalIdsManifestInput {
-                    claimant: user_account1.into_manifest_address().into(),
+                    claimant: user_account1.into(),
                     resource_address: non_fungible_resource.into(),
                     limit: 100,
                 },
@@ -2620,7 +2620,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into_manifest_address().into(),
+                                claimant: claimant.into(),
                                 try_direct_send: false,
                             },
                         )
@@ -2650,7 +2650,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into_manifest_address().into(),
+                                claimant: claimant.into(),
                                 try_direct_send: false,
                             },
                         )
@@ -2680,7 +2680,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into_manifest_address().into(),
+                                claimant: claimant.into(),
                                 try_direct_send: true,
                             },
                         )
@@ -2710,7 +2710,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                             ACCOUNT_LOCKER_STORE_IDENT,
                             AccountLockerStoreManifestInput {
                                 bucket,
-                                claimant: claimant.into_manifest_address().into(),
+                                claimant: claimant.into(),
                                 try_direct_send: true,
                             },
                         )
@@ -2751,7 +2751,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                                 bucket,
                                 claimants: claimants
                                     .into_iter()
-                                    .map(|(k, v)| (k.into_manifest_address().into(), v))
+                                    .map(|(k, v)| (k.into(), v))
                                     .collect(),
                                 try_direct_send: false,
                             },
@@ -2793,7 +2793,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                                 bucket,
                                 claimants: claimants
                                     .into_iter()
-                                    .map(|(k, v)| (k.into_manifest_address().into(), v))
+                                    .map(|(k, v)| (k.into(), v))
                                     .collect(),
                                 try_direct_send: true,
                             },
@@ -2820,7 +2820,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_RECOVER_IDENT,
                         AccountLockerRecoverManifestInput {
-                            claimant: claimant.into_manifest_address().into(),
+                            claimant: claimant.into(),
                             resource_address: resource_to_recover.into(),
                             amount,
                         },
@@ -2847,7 +2847,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_RECOVER_NON_FUNGIBLES_IDENT,
                         AccountLockerRecoverNonFungiblesManifestInput {
-                            claimant: claimant.into_manifest_address().into(),
+                            claimant: claimant.into(),
                             resource_address: resource_to_recover.into(),
                             ids,
                         },
@@ -2869,7 +2869,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_CLAIM_IDENT,
                         AccountLockerClaimManifestInput {
-                            claimant: claimant.into_manifest_address().into(),
+                            claimant: claimant.into(),
                             resource_address: resource_to_claim.into(),
                             amount,
                         },
@@ -2894,7 +2894,7 @@ fn state_of_the_account_locker_can_be_reconciled_from_events_alone() {
                         account_locker,
                         ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                         AccountLockerClaimNonFungiblesManifestInput {
-                            claimant: claimant.into_manifest_address().into(),
+                            claimant: claimant.into(),
                             resource_address: resource_to_claim.into(),
                             ids,
                         },
@@ -3128,7 +3128,7 @@ fn send_does_not_accept_an_address_that_is_not_an_account() {
                     ACCOUNT_LOCKER_STORE_IDENT,
                     AccountLockerStoreManifestInput {
                         bucket,
-                        claimant: FAUCET.into_manifest_address().into(),
+                        claimant: FAUCET.into(),
                         try_direct_send: false,
                     },
                 )
@@ -3212,7 +3212,7 @@ fn airdrop_does_not_accept_an_address_that_is_not_an_account() {
                     AccountLockerAirdropManifestInput {
                         bucket,
                         claimants: indexmap! {
-                            FAUCET.into_manifest_address().into() => ResourceSpecifier::Fungible(dec!(1))
+                            FAUCET.into() => ResourceSpecifier::Fungible(dec!(1))
                         },
                         try_direct_send: false,
                     },
@@ -3292,7 +3292,7 @@ fn claim_does_not_accept_an_address_that_is_not_an_account() {
                 account_locker,
                 ACCOUNT_LOCKER_CLAIM_IDENT,
                 AccountLockerClaimManifestInput {
-                    claimant: FAUCET.into_manifest_address().into(),
+                    claimant: FAUCET.into(),
                     resource_address: XRD.into(),
                     amount: dec!(1),
                 },
@@ -3371,7 +3371,7 @@ fn recover_does_not_accept_an_address_that_is_not_an_account() {
                 account_locker,
                 ACCOUNT_LOCKER_RECOVER_IDENT,
                 AccountLockerRecoverManifestInput {
-                    claimant: FAUCET.into_manifest_address().into(),
+                    claimant: FAUCET.into(),
                     resource_address: XRD.into(),
                     amount: dec!(1),
                 },
@@ -3480,12 +3480,7 @@ fn exceeding_one_of_the_limits_when_airdropping_returns_the_expected_error() {
                     AccountLockerAirdropManifestInput {
                         claimants: keys_and_accounts
                             .iter()
-                            .map(|entry| {
-                                (
-                                    entry.1.into_manifest_address().into(),
-                                    ResourceSpecifier::Fungible(dec!(1)),
-                                )
-                            })
+                            .map(|entry| (entry.1.into(), ResourceSpecifier::Fungible(dec!(1))))
                             .collect(),
                         bucket,
                         try_direct_send: true,

--- a/radix-transaction-scenarios/src/scenarios/account_locker.rs
+++ b/radix-transaction-scenarios/src/scenarios/account_locker.rs
@@ -263,7 +263,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -294,7 +293,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_rejecting_fungible_resource
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -325,7 +323,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: false,
                                     },
@@ -362,7 +359,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::Fungible(dec!(100)),
                                             )
                                         })
@@ -401,7 +398,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::Fungible(dec!(100)),
                                             )
                                         })
@@ -437,7 +434,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -471,7 +467,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_rejecting_fungible_resource
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: true,
                                     },
@@ -505,7 +500,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         claimant: state
                                             .account_accepting_all_resources
                                             .unwrap()
-                                            .into_manifest_address()
                                             .into(),
                                         try_direct_send: false,
                                     },
@@ -549,7 +543,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::Fungible(dec!(1)),
                                             )
                                         })
@@ -595,7 +589,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|account| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::Fungible(dec!(1)),
                                             )
                                         })
@@ -641,7 +635,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|(account, id)| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::NonFungible(indexset![
                                                     NonFungibleLocalId::integer(id)
                                                 ]),
@@ -689,7 +683,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                         .into_iter()
                                         .map(|(account, id)| {
                                             (
-                                                account.unwrap().into_manifest_address().into(),
+                                                account.unwrap().into(),
                                                 ResourceSpecifier::NonFungible(indexset![
                                                     NonFungibleLocalId::integer(id)
                                                 ]),
@@ -725,7 +719,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                             claimant: state
                                                 .account_rejecting_all_deposits
                                                 .unwrap()
-                                                .into_manifest_address()
                                                 .into(),
                                             try_direct_send: true,
                                         },
@@ -773,7 +766,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
-                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.fungible_resource.unwrap().into(),
@@ -798,7 +790,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
-                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
@@ -820,11 +811,7 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                 state.account_locker.unwrap(),
                                 ACCOUNT_LOCKER_CLAIM_NON_FUNGIBLES_IDENT,
                                 AccountLockerClaimNonFungiblesManifestInput {
-                                    claimant: state
-                                        .account_accepting_all_resources
-                                        .unwrap()
-                                        .into_manifest_address()
-                                        .into(),
+                                    claimant: state.account_accepting_all_resources.unwrap().into(),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
                                     ids: indexset![NonFungibleLocalId::integer(3)],
                                 },
@@ -851,7 +838,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
-                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.fungible_resource.unwrap().into(),
@@ -884,7 +870,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_fungible_resource
                                         .unwrap()
-                                        .into_manifest_address()
                                         .into(),
                                     amount: dec!(1),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
@@ -917,7 +902,6 @@ impl ScenarioCreator for AccountLockerScenarioCreator {
                                     claimant: state
                                         .account_rejecting_non_fungible_resource
                                         .unwrap()
-                                        .into_manifest_address()
                                         .into(),
                                     resource_address: state.non_fungible_resource.unwrap().into(),
                                     ids: indexset![NonFungibleLocalId::integer(15)],

--- a/sbor/src/schema/schema_comparison/schema_comparison_settings.rs
+++ b/sbor/src/schema/schema_comparison/schema_comparison_settings.rs
@@ -143,7 +143,7 @@ impl SchemaComparisonCompletenessSettings {
         self
     }
 
-    pub fn with_dont_allow_root_unreachable_types_in_base_schema(mut self) -> Self {
+    pub const fn with_dont_allow_root_unreachable_types_in_base_schema(mut self) -> Self {
         self.allow_root_unreachable_types_in_base_schema = false;
         self
     }
@@ -153,7 +153,7 @@ impl SchemaComparisonCompletenessSettings {
         self
     }
 
-    pub fn with_dont_allow_root_unreachable_types_in_compared_schema(mut self) -> Self {
+    pub const fn with_dont_allow_root_unreachable_types_in_compared_schema(mut self) -> Self {
         self.allow_root_unreachable_types_in_compared_schema = false;
         self
     }
@@ -163,7 +163,7 @@ impl SchemaComparisonCompletenessSettings {
         self
     }
 
-    pub fn with_dont_allow_compared_to_have_more_root_types(mut self) -> Self {
+    pub const fn with_dont_allow_compared_to_have_more_root_types(mut self) -> Self {
         self.allow_compared_to_have_more_root_types = false;
         self
     }


### PR DESCRIPTION
Implemented `From<ComponentAddress>` for `GenericGlobal<ManifestComponentAddress, M>`