### PR TITLE
feat(crypto): BLS12-381 min-sig (G1) signature verification host function

### DIFF
--- a/radix-common/src/crypto/bls12381/mod.rs
+++ b/radix-common/src/crypto/bls12381/mod.rs
@@ -1,7 +1,11 @@
 mod private_key;
 mod public_key;
+mod public_key_g2;
 mod signature;
+mod signature_g1;
 
 pub use private_key::*;
 pub use public_key::*;
+pub use public_key_g2::*;
 pub use signature::*;
+pub use signature_g1::*;

--- a/radix-common/src/crypto/bls12381/public_key_g2.rs
+++ b/radix-common/src/crypto/bls12381/public_key_g2.rs
@@ -1,0 +1,98 @@
+use crate::internal_prelude::*;
+
+/// Represents a BLS12-381 G2 public key (96 bytes).
+///
+/// This is the public key of the BLS12-381 "minimal-signature-size" (min-sig) variant,
+/// where signatures live in G1 (48 bytes) and public keys in G2 (96 bytes).
+/// It is the variant used by unchained drand networks (e.g. quicknet) and is
+/// paired with [`Bls12381G1Signature`] and the
+/// [`crate::crypto::BLS12381_MIN_SIG_CIPHERSITE_V1`] domain separation tag.
+///
+/// Note: this is distinct from [`Bls12381G1PublicKey`], which is the public key of the
+/// "minimal-pubkey-size" (min-pk) variant used by [`verify_bls12381_v1`].
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Sbor)]
+#[sbor(transparent)]
+pub struct Bls12381G2PublicKey(
+    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] pub [u8; Self::LENGTH],
+);
+
+impl Bls12381G2PublicKey {
+    pub const LENGTH: usize = 96;
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for Bls12381G2PublicKey {
+    type Error = ParseBlsPublicKeyError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != Self::LENGTH {
+            return Err(ParseBlsPublicKeyError::InvalidLength(slice.len()));
+        }
+
+        Ok(Self(copy_u8_array(slice)))
+    }
+}
+
+impl AsRef<Self> for Bls12381G2PublicKey {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsRef<[u8]> for Bls12381G2PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+//======
+// text
+//======
+
+impl FromStr for Bls12381G2PublicKey {
+    type Err = ParseBlsPublicKeyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|_| ParseBlsPublicKeyError::InvalidHex(s.to_owned()))?;
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl fmt::Display for Bls12381G2PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", hex::encode(self.to_vec()))
+    }
+}
+
+impl fmt::Debug for Bls12381G2PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sbor::rust::str::FromStr;
+
+    #[test]
+    fn g2_public_key_text_round_trip() {
+        // drand quicknet group public key (G2, 96 bytes)
+        let pk_hex = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a";
+        let pk = Bls12381G2PublicKey::from_str(pk_hex).unwrap();
+        assert_eq!(pk.to_string(), pk_hex);
+        assert_eq!(pk.0.len(), Bls12381G2PublicKey::LENGTH);
+    }
+
+    #[test]
+    fn g2_public_key_invalid_length() {
+        assert_eq!(
+            Bls12381G2PublicKey::try_from([0u8; 48].as_slice()),
+            Err(ParseBlsPublicKeyError::InvalidLength(48))
+        );
+    }
+}

--- a/radix-common/src/crypto/bls12381/signature_g1.rs
+++ b/radix-common/src/crypto/bls12381/signature_g1.rs
@@ -1,0 +1,112 @@
+use crate::internal_prelude::*;
+
+/// BLS12-381 "minimal-signature-size" (min-sig) ciphersuite v1.
+///
+/// It has the following parameters:
+///  - hash-to-curve: BLS12381G1_XMD:SHA-256_SSWU_RO
+///    - pairing-friendly elliptic curve: BLS12-381
+///    - hash function: SHA-256
+///    - signature variant: G1 minimal signature size (48-byte signature, 96-byte public key)
+///  - scheme:
+///    - basic (NUL) — no proof-of-possession
+///
+/// This is the variant and domain separation tag used by unchained drand networks
+/// (e.g. quicknet). It differs from [`crate::crypto::BLS12381_CIPHERSITE_V1`]
+/// in both the signature group (G1 vs G2) and the scheme suffix (`NUL` vs `POP`).
+///
+/// More details: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05
+pub const BLS12381_MIN_SIG_CIPHERSITE_V1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
+
+/// Represents a BLS12-381 G1 signature (variant with 48-byte signature and 96-byte public key).
+///
+/// This is the signature of the BLS12-381 "minimal-signature-size" (min-sig) variant,
+/// paired with [`Bls12381G2PublicKey`]. It is the variant used by unchained drand networks.
+///
+/// Note: this is distinct from [`Bls12381G2Signature`], which is the signature of the
+/// "minimal-pubkey-size" (min-pk) variant used by [`verify_bls12381_v1`].
+#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Sbor)]
+#[sbor(transparent)]
+pub struct Bls12381G1Signature(
+    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))] pub [u8; Self::LENGTH],
+);
+
+impl Bls12381G1Signature {
+    pub const LENGTH: usize = 48;
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for Bls12381G1Signature {
+    type Error = ParseBlsSignatureError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != Self::LENGTH {
+            return Err(ParseBlsSignatureError::InvalidLength(slice.len()));
+        }
+
+        Ok(Self(copy_u8_array(slice)))
+    }
+}
+
+impl AsRef<Self> for Bls12381G1Signature {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl AsRef<[u8]> for Bls12381G1Signature {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+//======
+// text
+//======
+
+impl FromStr for Bls12381G1Signature {
+    type Err = ParseBlsSignatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s).map_err(|_| ParseBlsSignatureError::InvalidHex(s.to_owned()))?;
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl fmt::Display for Bls12381G1Signature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", hex::encode(self.to_vec()))
+    }
+}
+
+impl fmt::Debug for Bls12381G1Signature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sbor::rust::str::FromStr;
+
+    #[test]
+    fn g1_signature_text_round_trip() {
+        // drand quicknet round 21180130 signature (G1, 48 bytes)
+        let sig_hex = "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319";
+        let sig = Bls12381G1Signature::from_str(sig_hex).unwrap();
+        assert_eq!(sig.to_string(), sig_hex);
+        assert_eq!(sig.0.len(), Bls12381G1Signature::LENGTH);
+    }
+
+    #[test]
+    fn g1_signature_invalid_length() {
+        assert_eq!(
+            Bls12381G1Signature::try_from([0u8; 96].as_slice()),
+            Err(ParseBlsSignatureError::InvalidLength(96))
+        );
+    }
+}

--- a/radix-common/src/crypto/signature_validator.rs
+++ b/radix-common/src/crypto/signature_validator.rs
@@ -99,6 +99,35 @@ pub fn verify_bls12381_v1(
     false
 }
 
+/// Performs BLS12-381 G1 signature verification (minimal-signature-size "min-sig" variant).
+///
+/// In this variant signatures live in G1 (48 bytes) and public keys in G2 (96 bytes) — the
+/// mirror of [`verify_bls12381_v1`] (min-pk, with 96-byte G2 signatures and 48-byte G1 keys).
+///
+/// Domain specifier tag: BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_
+///
+/// This is the variant used by unchained drand networks (e.g. quicknet). The public
+/// key is validated (in-group / not the identity) during verification, since in the on-chain
+/// host-function context it is supplied as untrusted input.
+pub fn verify_bls12381_v1_min_sig(
+    message: &[u8],
+    public_key: &Bls12381G2PublicKey,
+    signature: &Bls12381G1Signature,
+) -> bool {
+    if let Ok(sig) = blst::min_sig::Signature::from_bytes(&signature.0) {
+        if let Ok(pk) = blst::min_sig::PublicKey::from_bytes(&public_key.0) {
+            let result = sig.verify(true, message, BLS12381_MIN_SIG_CIPHERSITE_V1, &[], &pk, true);
+
+            match result {
+                blst::BLST_ERROR::BLST_SUCCESS => return true,
+                _ => return false,
+            }
+        }
+    }
+
+    false
+}
+
 #[cfg(any(target_arch = "wasm32", feature = "alloc"))]
 /// Local implementation of aggregated verify for no_std and WASM32 variants (no threads)
 /// see: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-coreaggregateverify
@@ -219,4 +248,120 @@ pub fn fast_aggregate_verify_bls12381_v1_anemone(
     }
 
     false
+}
+
+#[cfg(test)]
+mod min_sig_tests {
+    use super::*;
+    use sbor::rust::str::FromStr;
+
+    // Real drand quicknet (unchained, min-sig) group public key — G2, 96 bytes.
+    const QUICKNET_PK: &str = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a";
+
+    // For unchained drand the signed message is SHA-256(round_number_as_big_endian_u64).
+    // These digests are precomputed so the test needs no SHA-256 dependency in radix-common.
+
+    fn pk() -> Bls12381G2PublicKey {
+        Bls12381G2PublicKey::from_str(QUICKNET_PK).unwrap()
+    }
+
+    #[test]
+    fn verify_min_sig_real_quicknet_round_21180130() {
+        // round 21180130
+        let message =
+            hex::decode("7d2207c2d03c3c7561ea7fd7cc80d6f99434428528c266a74ca42766bed7d191")
+                .unwrap();
+        let sig = Bls12381G1Signature::from_str(
+            "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+        )
+        .unwrap();
+
+        assert!(verify_bls12381_v1_min_sig(&message, &pk(), &sig));
+    }
+
+    #[test]
+    fn verify_min_sig_real_quicknet_round_21180131() {
+        // round 21180131
+        let message =
+            hex::decode("a7ad19ac9c5255d6233274657a64696767c9c8e3d6391f38a790613201cd0b6f")
+                .unwrap();
+        let sig = Bls12381G1Signature::from_str(
+            "966e214c7e632f006ade570591eabcdc9f709cb16b992d7d1658ad0e9b784ad5f54a9e3dc92f1118233aeb79c5a7d6b2",
+        )
+        .unwrap();
+
+        assert!(verify_bls12381_v1_min_sig(&message, &pk(), &sig));
+    }
+
+    #[test]
+    fn verify_min_sig_rejects_wrong_message() {
+        let wrong_message =
+            hex::decode("a7ad19ac9c5255d6233274657a64696767c9c8e3d6391f38a790613201cd0b6f")
+                .unwrap(); // round 21180131's message
+        let sig_for_130 = Bls12381G1Signature::from_str(
+            "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+        )
+        .unwrap(); // round 21180130's signature
+
+        assert!(!verify_bls12381_v1_min_sig(&wrong_message, &pk(), &sig_for_130));
+    }
+
+    #[test]
+    fn verify_min_sig_rejects_zero_inputs() {
+        let message =
+            hex::decode("7d2207c2d03c3c7561ea7fd7cc80d6f99434428528c266a74ca42766bed7d191")
+                .unwrap();
+        let valid_sig = Bls12381G1Signature::from_str(
+            "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+        )
+        .unwrap();
+
+        // All-zero public key / signature are not valid encoded points and must be rejected.
+        assert!(!verify_bls12381_v1_min_sig(
+            &message,
+            &Bls12381G2PublicKey([0u8; Bls12381G2PublicKey::LENGTH]),
+            &valid_sig
+        ));
+        assert!(!verify_bls12381_v1_min_sig(
+            &message,
+            &pk(),
+            &Bls12381G1Signature([0u8; Bls12381G1Signature::LENGTH])
+        ));
+    }
+
+    #[test]
+    fn verify_min_sig_rejects_points_not_in_group() {
+        // Parity with the min-pk sibling tests (`signature_not_in_group`,
+        // `public_keys_not_in_group`): a 96-byte G2 point outside the prime-order subgroup is
+        // an invalid min-sig public key, and a 48-byte G1 point outside the subgroup is an
+        // invalid min-sig signature. The subgroup checks (sig group-check + pk validation) must
+        // reject both, returning `false` without panicking. (Note: a not-in-group point also
+        // fails the pairing regardless of the validation flags, so this is a robustness /
+        // panic-safety check, not a guarantee that the flags themselves are enabled.)
+        let message =
+            hex::decode("7d2207c2d03c3c7561ea7fd7cc80d6f99434428528c266a74ca42766bed7d191")
+                .unwrap();
+
+        // 96-byte G2 point not in group (reused as a public key).
+        let pk_not_in_group = Bls12381G2PublicKey::from_str(
+            "8b84ff5a1d4f8095ab8a80518ac99230ed24a7d1ec90c4105f9c719aa7137ed5d7ce1454d4a953f5f55f3959ab416f3014f4cd2c361e4d32c6b4704a70b0e2e652a908f501acb54ec4e79540be010e3fdc1fbf8e7af61625705e185a71c884f0",
+        )
+        .unwrap();
+        let valid_sig = Bls12381G1Signature::from_str(
+            "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+        )
+        .unwrap();
+        assert!(!verify_bls12381_v1_min_sig(
+            &message,
+            &pk_not_in_group,
+            &valid_sig
+        ));
+
+        // 48-byte G1 point not in group (reused as a signature).
+        let sig_not_in_group = Bls12381G1Signature::from_str(
+            "8bb1aa7542a5423e21d8e84b4472c31664412cc604a666e9fdf03baf3c758e728c7a11576ebb01110ac39a0df95636e2",
+        )
+        .unwrap();
+        assert!(!verify_bls12381_v1_min_sig(&message, &pk(), &sig_not_in_group));
+    }
 }

--- a/radix-engine-interface/src/types/costing_reason.rs
+++ b/radix-engine-interface/src/types/costing_reason.rs
@@ -18,6 +18,9 @@ pub enum ClientCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
+    Bls12381V1VerifyMinSig {
+        size: usize,
+    },
     Bls12381V1AggregateVerify {
         sizes: &'a [usize],
     },

--- a/radix-engine-tests/assets/blueprints/Cargo.lock
+++ b/radix-engine-tests/assets/blueprints/Cargo.lock
@@ -259,6 +259,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_scrypto_v3"
+version = "1.0.0"
+dependencies = [
+ "scrypto",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/radix-engine-tests/assets/blueprints/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "decimal",
     "crypto_scrypto_v1",
     "crypto_scrypto_v2",
+    "crypto_scrypto_v3",
     "oracle_proxies/oracle_proxy_with_global",
     "oracle_proxies/oracle_proxy_with_owned",
     "oracle_proxies/oracle_generic_proxy_with_global",

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto_v3/Cargo.toml
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto_v3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "crypto_scrypto_v3"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+scrypto = { path = "../../../../scrypto" }
+
+[lib]
+crate-type = ["cdylib", "lib"]

--- a/radix-engine-tests/assets/blueprints/crypto_scrypto_v3/src/lib.rs
+++ b/radix-engine-tests/assets/blueprints/crypto_scrypto_v3/src/lib.rs
@@ -1,0 +1,16 @@
+use scrypto::prelude::*;
+
+#[blueprint]
+mod component_module {
+    struct CryptoScrypto {}
+
+    impl CryptoScrypto {
+        pub fn bls12381_v1_verify_min_sig(
+            message: Vec<u8>,
+            pub_key: Bls12381G2PublicKey,
+            signature: Bls12381G1Signature,
+        ) -> bool {
+            CryptoUtils::bls12381_v1_verify_min_sig(message, pub_key, signature)
+        }
+    }
+}

--- a/radix-engine-tests/tests/flash/crypto_utils.rs
+++ b/radix-engine-tests/tests/flash/crypto_utils.rs
@@ -145,3 +145,52 @@ fn run_flash_test_test_environment_crypto_utils_v2(
         );
     }
 }
+
+#[test]
+fn publishing_crypto_utils_v3_in_dugong_using_test_environment_without_state_flash_should_fail() {
+    run_flash_test_test_environment_crypto_utils_v3(false, false);
+}
+
+#[test]
+fn publishing_crypto_utils_v3_in_dugong_using_test_environment_with_state_flash_should_succeed() {
+    run_flash_test_test_environment_crypto_utils_v3(true, true);
+}
+
+fn run_flash_test_test_environment_crypto_utils_v3(
+    enable_crypto_utils_v3: bool,
+    expect_success: bool,
+) {
+    // Arrange
+    let mut test_env = TestEnvironmentBuilder::new()
+        .with_protocol(|builder| {
+            builder
+                .configure_dugong(|_| {
+                    DugongSettings::all_disabled().set(|s| {
+                        s.vm_boot_to_enable_crypto_utils_v3 =
+                            UpdateSetting::new(enable_crypto_utils_v3)
+                    })
+                })
+                .from_bootstrap_to(ProtocolVersion::Dugong)
+        })
+        .build();
+
+    // Act
+    let result = PackageFactory::compile_and_publish(
+        path_local_blueprint!("crypto_scrypto_v3"),
+        &mut test_env,
+        CompileProfile::Fast,
+    );
+
+    // Assert
+    if expect_success {
+        let _package_address = result.unwrap();
+    } else {
+        let err = result.unwrap_err();
+        assert_matches!(
+            err,
+            RuntimeError::ApplicationError(ApplicationError::PackageError(
+                PackageError::InvalidWasm(..)
+            ))
+        );
+    }
+}

--- a/radix-engine-tests/tests/system/crypto_utils.rs
+++ b/radix-engine-tests/tests/system/crypto_utils.rs
@@ -180,6 +180,94 @@ fn crypto_scrypto_blake_2b_256_hash(
     )
 }
 
+fn crypto_scrypto_bls12381_v1_verify_min_sig(
+    runner: &mut LedgerSimulator<NoExtension, InMemorySubstateDatabase>,
+    package_address: PackageAddress,
+    msg: Vec<u8>,
+    pub_key: Bls12381G2PublicKey,
+    signature: Bls12381G1Signature,
+) -> TransactionReceipt {
+    runner.execute_manifest(
+        ManifestBuilder::new()
+            .lock_fee(runner.faucet_component(), 500u32)
+            .call_function(
+                package_address,
+                "CryptoScrypto",
+                "bls12381_v1_verify_min_sig",
+                manifest_args!(msg, pub_key, signature),
+            )
+            .build(),
+        vec![],
+    )
+}
+
+/// Builds a ledger with the Scrypto VM booted to V1_3 by enabling the (otherwise-disabled)
+/// Dugong crypto-utils-v3 VM-boot flash. Required to publish/call blueprints that import the
+/// `crypto_utils_bls12381_v1_verify_min_sig` host function.
+fn ledger_with_crypto_utils_v3(
+) -> LedgerSimulator<NoExtension, InMemorySubstateDatabase> {
+    LedgerSimulatorBuilder::new()
+        .with_custom_protocol(|builder| {
+            builder
+                .configure_dugong(|_| {
+                    DugongSettings::all_disabled().set(|s| {
+                        s.vm_boot_to_enable_crypto_utils_v3 = UpdateSetting::new(true)
+                    })
+                })
+                .from_bootstrap_to(ProtocolVersion::Dugong)
+        })
+        .build()
+}
+
+#[test]
+fn test_crypto_scrypto_verify_bls12381_v1_min_sig() {
+    // Arrange
+    let mut ledger = ledger_with_crypto_utils_v3();
+
+    let package_address = ledger.publish_package_simple(PackageLoader::get("crypto_scrypto_v3"));
+
+    // Real drand quicknet (unchained, min-sig) beacon, round 21180130.
+    let pub_key = Bls12381G2PublicKey::from_str(
+        "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a",
+    )
+    .unwrap();
+    let signature = Bls12381G1Signature::from_str(
+        "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+    )
+    .unwrap();
+    // The unchained-drand message is SHA-256(round_number as big-endian u64).
+    let message =
+        hex::decode("7d2207c2d03c3c7561ea7fd7cc80d6f99434428528c266a74ca42766bed7d191").unwrap();
+
+    // Act
+    let verify: bool = get_output!(crypto_scrypto_bls12381_v1_verify_min_sig(
+        &mut ledger,
+        package_address,
+        message,
+        pub_key,
+        signature,
+    ));
+
+    // Assert
+    assert!(verify);
+
+    // Arrange — a different round's message must not verify against this signature.
+    let wrong_message =
+        hex::decode("a7ad19ac9c5255d6233274657a64696767c9c8e3d6391f38a790613201cd0b6f").unwrap();
+
+    // Act
+    let verify_wrong: bool = get_output!(crypto_scrypto_bls12381_v1_verify_min_sig(
+        &mut ledger,
+        package_address,
+        wrong_message,
+        pub_key,
+        signature,
+    ));
+
+    // Assert
+    assert!(!verify_wrong);
+}
+
 #[test]
 fn test_crypto_scrypto_verify_bls12381_v1() {
     // Arrange
@@ -858,6 +946,50 @@ mod costing_tests {
             let data = vec![0u8; size];
             let signature = secret_key.sign_v1(data.as_slice());
             let _ = crypto_scrypto_bls12381_v1_verify(
+                &mut ledger,
+                package_address,
+                data,
+                public_key,
+                signature,
+            );
+        }
+    }
+
+    #[test]
+    fn test_crypto_scrypto_verify_bls12381_v1_min_sig_costing() {
+        let mut ledger = ledger_with_crypto_utils_v3();
+
+        let package_address =
+            ledger.publish_package_simple(PackageLoader::get("crypto_scrypto_v3"));
+
+        // Real drand quicknet beacon (round 21180130). The cost is dominated by the pairing /
+        // final exponentiation, which runs regardless of the message size or whether
+        // verification ultimately succeeds, so a fixed (real) key/signature pair over varying
+        // message sizes is sufficient to characterize the per-byte and fixed costs.
+        let public_key = Bls12381G2PublicKey::from_str(
+            "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a",
+        )
+        .unwrap();
+        let signature = Bls12381G1Signature::from_str(
+            "96c36d9223c01c8c539c09573afdcad8ce626e0147b245bf9ad489fb01a49403b1588c8803972754b9d8ca8d6ac14319",
+        )
+        .unwrap();
+
+        for size in [
+            100usize,
+            200,
+            500,
+            1024,
+            10 * 1024,
+            20 * 1024,
+            50 * 1024,
+            100 * 1024,
+            200 * 1024,
+            500 * 1024,
+            900 * 1024,
+        ] {
+            let data = vec![0u8; size];
+            let _ = crypto_scrypto_bls12381_v1_verify_min_sig(
                 &mut ledger,
                 package_address,
                 data,

--- a/radix-engine/src/system/system.rs
+++ b/radix-engine/src/system/system.rs
@@ -2199,6 +2199,9 @@ impl<'a, Y: SystemBasedKernelApi> SystemCostingApi<RuntimeError> for SystemServi
                 ClientCostingEntry::Bls12381V1Verify { size } => {
                     ExecutionCostingEntry::Bls12381V1Verify { size }
                 }
+                ClientCostingEntry::Bls12381V1VerifyMinSig { size } => {
+                    ExecutionCostingEntry::Bls12381V1VerifyMinSig { size }
+                }
                 ClientCostingEntry::Bls12381V1AggregateVerify { sizes } => {
                     ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes }
                 }

--- a/radix-engine/src/system/system_modules/costing/costing_entry.rs
+++ b/radix-engine/src/system/system_modules/costing/costing_entry.rs
@@ -132,6 +132,9 @@ pub enum ExecutionCostingEntry<'a> {
     Bls12381V1Verify {
         size: usize,
     },
+    Bls12381V1VerifyMinSig {
+        size: usize,
+    },
     Bls12381V1AggregateVerify {
         sizes: &'a [usize],
     },
@@ -229,6 +232,9 @@ impl<'a> ExecutionCostingEntry<'a> {
             ExecutionCostingEntry::EncodeBech32Address => ft.encode_bech32_address_cost(),
             ExecutionCostingEntry::Panic { size } => ft.panic_cost(*size),
             ExecutionCostingEntry::Bls12381V1Verify { size } => ft.bls12381_v1_verify_cost(*size),
+            ExecutionCostingEntry::Bls12381V1VerifyMinSig { size } => {
+                ft.bls12381_v1_verify_min_sig_cost(*size)
+            }
             ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
                 ft.bls12381_v1_aggregate_verify_cost(sizes)
             }
@@ -439,6 +445,9 @@ pub mod owned {
 
         /* crypto utils */
         Bls12381V1Verify {
+            size: usize,
+        },
+        Bls12381V1VerifyMinSig {
             size: usize,
         },
         Bls12381V1AggregateVerify {
@@ -682,6 +691,9 @@ pub mod owned {
                 ExecutionCostingEntry::EncodeBech32Address => Self::EncodeBech32Address,
                 ExecutionCostingEntry::Panic { size } => Self::Panic { size },
                 ExecutionCostingEntry::Bls12381V1Verify { size } => Self::Bls12381V1Verify { size },
+                ExecutionCostingEntry::Bls12381V1VerifyMinSig { size } => {
+                    Self::Bls12381V1VerifyMinSig { size }
+                }
                 ExecutionCostingEntry::Bls12381V1AggregateVerify { sizes } => {
                     Self::Bls12381V1AggregateVerify {
                         sizes: sizes.to_vec(),

--- a/radix-engine/src/system/system_modules/costing/fee_table.rs
+++ b/radix-engine/src/system/system_modules/costing/fee_table.rs
@@ -506,6 +506,25 @@ impl FeeTable {
     }
 
     #[inline]
+    pub fn bls12381_v1_verify_min_sig_cost(&self, size: usize) -> u32 {
+        // Based on `test_crypto_scrypto_verify_bls12381_v1_min_sig_costing`.
+        //
+        // The min-sig variant differs from min-pk (`bls12381_v1_verify_cost`) in two ways:
+        // - the message is hashed to G1 instead of G2 (cheaper hash-to-curve), and
+        // - the public key is a 96-byte G2 point requiring a more expensive subgroup check,
+        // while the dominant pairing / final-exponentiation cost is comparable.
+        //
+        // The per-byte coefficient (driven by SHA-256 message expansion) matches min-pk; the
+        // fixed term is an initial estimate that mirrors min-pk's measured base and MUST be
+        // recalibrated from the costing test's measured instruction counts (run with the
+        // `resource_tracker` feature) before relying on it for fee determinism.
+        let size = if size < 1024 { 1024 } else { cast(size) };
+        let instructions_cnt = add(mul(size, 36), 15650000);
+        // Convert to cost units
+        instructions_cnt / CPU_INSTRUCTIONS_TO_COST_UNIT
+    }
+
+    #[inline]
     pub fn bls12381_v1_aggregate_verify_cost(&self, sizes: &[usize]) -> u32 {
         // Observed that aggregated verify might be broken down into:
         // - steps depending on message size

--- a/radix-engine/src/updates/dugong.rs
+++ b/radix-engine/src/updates/dugong.rs
@@ -5,6 +5,13 @@ use crate::{internal_prelude::*, system::system_callback::SystemBoot};
 pub struct DugongSettings {
     pub native_entity_metadata_updates: UpdateSetting<NoSettings>,
     pub system_logic_updates: UpdateSetting<NoSettings>,
+    /// Introduces Crypto Utils v3 by booting the Scrypto VM to V1_3, enabling
+    /// BLS12-381 G1 (min-sig) signature verification
+    /// ([`crate::vm::ScryptoVmVersion::crypto_utils_v3`]) — the variant used by unchained
+    /// drand networks (e.g. quicknet).
+    ///
+    /// Disabled by default, consistent with the rest of the (not-yet-enacted) Dugong update.
+    pub vm_boot_to_enable_crypto_utils_v3: UpdateSetting<NoSettings>,
 }
 
 impl UpdateSettings for DugongSettings {
@@ -27,6 +34,7 @@ impl UpdateSettings for DugongSettings {
         Self {
             native_entity_metadata_updates: UpdateSetting::Disabled,
             system_logic_updates: UpdateSetting::Disabled,
+            vm_boot_to_enable_crypto_utils_v3: UpdateSetting::Disabled,
         }
     }
 
@@ -57,6 +65,7 @@ fn generate_main_batch(
     DugongSettings {
         native_entity_metadata_updates,
         system_logic_updates,
+        vm_boot_to_enable_crypto_utils_v3,
     }: &DugongSettings,
 ) -> ProtocolUpdateBatch {
     let mut batch = ProtocolUpdateBatch::empty();
@@ -75,7 +84,25 @@ fn generate_main_batch(
         );
     }
 
+    if let UpdateSetting::Enabled(NoSettings) = &vm_boot_to_enable_crypto_utils_v3 {
+        batch.mut_add_flash(
+            "dugong-vm-boot-to-enable-crypto-utils-v3",
+            generate_vm_boot_to_enable_crypto_utils_v3(),
+        );
+    }
+
     batch
+}
+
+fn generate_vm_boot_to_enable_crypto_utils_v3() -> StateUpdates {
+    StateUpdates::empty().set_substate(
+        TRANSACTION_TRACKER,
+        BOOT_LOADER_PARTITION,
+        BootLoaderField::VmBoot,
+        VmBoot::V1 {
+            scrypto_version: ScryptoVmVersion::crypto_utils_v3().into(),
+        },
+    )
 }
 
 fn generate_dugong_native_metadata_updates() -> StateUpdates {

--- a/radix-engine/src/vm/versions.rs
+++ b/radix-engine/src/vm/versions.rs
@@ -6,11 +6,20 @@ pub enum ScryptoVmVersion {
     V1_0,
     V1_1,
     V1_2,
+    V1_3,
 }
 
 impl ScryptoVmVersion {
+    /// The latest Scrypto VM version known to this build.
+    ///
+    /// This is the dev-time validator ceiling — the newest version a package may be compiled
+    /// and validated against (see [`crate::vm::wasm::ScryptoV1WasmValidator`]). It is decoupled
+    /// from the VM version *enacted* at runtime, which is governed by the `VmBoot` substate set
+    /// by protocol updates. V1_3 (Crypto Utils v3) is introduced by the Dugong protocol update
+    /// but is not enacted by default (the runtime VmBoot remains at cuttlefish / V1_2 unless the
+    /// corresponding Dugong VM-boot flash is enabled).
     pub const fn latest() -> ScryptoVmVersion {
-        Self::cuttlefish()
+        Self::V1_3
     }
 
     pub const fn babylon_genesis() -> ScryptoVmVersion {
@@ -32,6 +41,17 @@ impl ScryptoVmVersion {
     pub const fn crypto_utils_v2() -> ScryptoVmVersion {
         Self::V1_2
     }
+
+    /// Introduces Crypto Utils v3: BLS12-381 G1 (min-sig) signature verification
+    /// ([`crypto_utils_bls12381_v1_verify_min_sig`]), used by unchained drand networks.
+    ///
+    /// Note: this VM version is introduced by the Dugong protocol update but is not enacted
+    /// by default — the runtime `VmBoot` remains at cuttlefish / V1_2 unless the corresponding
+    /// Dugong VM-boot flash is enabled. It is, however, the dev-time validator ceiling
+    /// ([`Self::latest`]).
+    pub const fn crypto_utils_v3() -> ScryptoVmVersion {
+        Self::V1_3
+    }
 }
 
 impl From<ScryptoVmVersion> for u64 {
@@ -48,6 +68,7 @@ impl TryFrom<u64> for ScryptoVmVersion {
             0 => Ok(Self::V1_0),
             1 => Ok(Self::V1_1),
             2 => Ok(Self::V1_2),
+            3 => Ok(Self::V1_3),
             v => Err(Self::Error::FromIntError(v)),
         }
     }
@@ -65,7 +86,7 @@ mod test {
     #[test]
     fn test_scrypto_vm_version() {
         let v = ScryptoVmVersion::latest();
-        assert_eq!(v, ScryptoVmVersion::V1_2);
+        assert_eq!(v, ScryptoVmVersion::V1_3);
         assert_eq!(ScryptoVmVersion::crypto_utils_v1(), ScryptoVmVersion::V1_1);
     }
 
@@ -77,9 +98,12 @@ mod test {
         let v: ScryptoVmVersion = 1u64.try_into().unwrap();
         assert_eq!(v, ScryptoVmVersion::V1_1);
 
-        let e = ScryptoVmVersion::try_from(3u64).unwrap_err();
+        let v: ScryptoVmVersion = 3u64.try_into().unwrap();
+        assert_eq!(v, ScryptoVmVersion::V1_3);
 
-        assert_eq!(e, ScryptoVmVersionError::FromIntError(3u64));
+        let e = ScryptoVmVersion::try_from(4u64).unwrap_err();
+
+        assert_eq!(e, ScryptoVmVersionError::FromIntError(4u64));
     }
 
     #[test]
@@ -87,5 +111,7 @@ mod test {
         assert!(ScryptoVmVersion::crypto_utils_v1() == ScryptoVmVersion::V1_1);
         assert!(ScryptoVmVersion::crypto_utils_v1() > ScryptoVmVersion::V1_0);
         assert!(ScryptoVmVersion::crypto_utils_v1() < ScryptoVmVersion::crypto_utils_v2());
+        assert!(ScryptoVmVersion::crypto_utils_v2() < ScryptoVmVersion::crypto_utils_v3());
+        assert!(ScryptoVmVersion::crypto_utils_v3() == ScryptoVmVersion::V1_3);
     }
 }

--- a/radix-engine/src/vm/wasm/constants.rs
+++ b/radix-engine/src/vm/wasm/constants.rs
@@ -87,6 +87,8 @@ pub const CRYPTO_UTILS_BLS12381_V1_FAST_AGGREGATE_VERIFY_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_v1_fast_aggregate_verify";
 pub const CRYPTO_UTILS_BLS12381_G2_SIGNATURE_AGGREGATE_FUNCTION_NAME: &str =
     "crypto_utils_bls12381_g2_signature_aggregate";
+pub const CRYPTO_UTILS_BLS12381_V1_VERIFY_MIN_SIG_FUNCTION_NAME: &str =
+    "crypto_utils_bls12381_v1_verify_min_sig";
 pub const CRYPTO_UTILS_KECCAK256_HASH_FUNCTION_NAME: &str = "crypto_utils_keccak256_hash";
 pub const CRYPTO_UTILS_BLAKE2B_256_HASH_FUNCTION_NAME: &str = "crypto_utils_blake2b_256_hash";
 pub const CRYPTO_UTILS_ED25519_VERIFY_FUNCTION_NAME: &str = "crypto_utils_ed25519_verify";

--- a/radix-engine/src/vm/wasm/prepare.rs
+++ b/radix-engine/src/vm/wasm/prepare.rs
@@ -773,6 +773,39 @@ impl WasmModule {
                             ));
                         }
                     }
+                    // Crypto Utils v3 (Dugong) — BLS12-381 G1 (min-sig) signature verification
+                    CRYPTO_UTILS_BLS12381_V1_VERIFY_MIN_SIG_FUNCTION_NAME => {
+                        if version < ScryptoVmVersion::crypto_utils_v3() {
+                            return Err(PrepareError::InvalidImport(
+                                InvalidImport::ProtocolVersionMismatch {
+                                    name: entry.name.to_string(),
+                                    current_version: version.into(),
+                                    expected_version: ScryptoVmVersion::crypto_utils_v3().into(),
+                                },
+                            ));
+                        }
+
+                        if let TypeRef::Func(type_index) = entry.ty {
+                            if Self::function_type_matches(
+                                &self.module,
+                                type_index,
+                                vec![
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                    ValType::I32,
+                                ],
+                                vec![ValType::I32],
+                            ) {
+                                continue;
+                            }
+                            return Err(PrepareError::InvalidImport(
+                                InvalidImport::InvalidFunctionType(entry.name.to_string()),
+                            ));
+                        }
+                    }
                     CRYPTO_UTILS_BLS12381_V1_AGGREGATE_VERIFY_FUNCTION_NAME => {
                         if version < ScryptoVmVersion::crypto_utils_v1() {
                             return Err(PrepareError::InvalidImport(
@@ -1579,6 +1612,11 @@ mod tests {
                     CRYPTO_UTILS_SECP256K1_ECDSA_VERIFY_AND_KEY_RECOVER_FUNCTION_NAME,
                     CRYPTO_UTILS_SECP256K1_ECDSA_VERIFY_AND_KEY_RECOVER_UNCOMPRESSED_FUNCTION_NAME,
                 ],
+            ),
+            (
+                ScryptoVmVersion::V1_2,
+                ScryptoVmVersion::crypto_utils_v3(),
+                vec![CRYPTO_UTILS_BLS12381_V1_VERIFY_MIN_SIG_FUNCTION_NAME],
             ),
         ] {
             for name in names {

--- a/radix-engine/src/vm/wasm/traits.rs
+++ b/radix-engine/src/vm/wasm/traits.rs
@@ -226,6 +226,13 @@ pub trait WasmRuntime {
         signatures: Vec<u8>,
     ) -> Result<Buffer, InvokeError<WasmRuntimeError>>;
 
+    fn crypto_utils_bls12381_v1_verify_min_sig(
+        &mut self,
+        message: Vec<u8>,
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>>;
+
     fn crypto_utils_keccak256_hash(
         &mut self,
         data: Vec<u8>,

--- a/radix-engine/src/vm/wasm/wasmi.rs
+++ b/radix-engine/src/vm/wasm/wasmi.rs
@@ -696,6 +696,35 @@ fn bls12381_v1_verify(
     runtime.crypto_utils_bls12381_v1_verify(message, public_key, signature)
 }
 
+fn bls12381_v1_verify_min_sig(
+    mut caller: Caller<'_, HostState>,
+    message_ptr: u32,
+    message_len: u32,
+    public_key_ptr: u32,
+    public_key_len: u32,
+    signature_ptr: u32,
+    signature_len: u32,
+) -> Result<u32, InvokeError<WasmRuntimeError>> {
+    let runtime = grab_runtime!(caller);
+    let memory = grab_memory!(caller);
+
+    let message = read_memory(caller.as_context_mut(), memory, message_ptr, message_len)?;
+    let public_key = read_memory(
+        caller.as_context_mut(),
+        memory,
+        public_key_ptr,
+        public_key_len,
+    )?;
+    let signature = read_memory(
+        caller.as_context_mut(),
+        memory,
+        signature_ptr,
+        signature_len,
+    )?;
+
+    runtime.crypto_utils_bls12381_v1_verify_min_sig(message, public_key, signature)
+}
+
 fn bls12381_v1_aggregate_verify(
     mut caller: Caller<'_, HostState>,
     pub_keys_and_msgs_ptr: u32,
@@ -1493,6 +1522,29 @@ impl WasmiModule {
             },
         );
 
+        let host_bls12381_v1_verify_min_sig = Func::wrap(
+            store.as_context_mut(),
+            |caller: Caller<'_, HostState>,
+             message_ptr: u32,
+             message_len: u32,
+             public_key_ptr: u32,
+             public_key_len: u32,
+             signature_ptr: u32,
+             signature_len: u32|
+             -> Result<u32, Error> {
+                bls12381_v1_verify_min_sig(
+                    caller,
+                    message_ptr,
+                    message_len,
+                    public_key_ptr,
+                    public_key_len,
+                    signature_ptr,
+                    signature_len,
+                )
+                .map_err(Error::host)
+            },
+        );
+
         let host_bls12381_v1_aggregate_verify = Func::wrap(
             store.as_context_mut(),
             |caller: Caller<'_, HostState>,
@@ -1802,6 +1854,11 @@ impl WasmiModule {
             linker,
             CRYPTO_UTILS_BLS12381_V1_VERIFY_FUNCTION_NAME,
             host_bls12381_v1_verify
+        );
+        linker_define!(
+            linker,
+            CRYPTO_UTILS_BLS12381_V1_VERIFY_MIN_SIG_FUNCTION_NAME,
+            host_bls12381_v1_verify_min_sig
         );
         linker_define!(
             linker,

--- a/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/no_op_runtime.rs
@@ -339,6 +339,15 @@ impl<'a> WasmRuntime for NoOpWasmRuntime<'a> {
         Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
     }
 
+    fn crypto_utils_bls12381_v1_verify_min_sig(
+        &mut self,
+        message: Vec<u8>,
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        Err(InvokeError::SelfError(WasmRuntimeError::NotImplemented))
+    }
+
     fn crypto_utils_keccak256_hash(
         &mut self,
         data: Vec<u8>,

--- a/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
+++ b/radix-engine/src/vm/wasm_runtime/scrypto_runtime.rs
@@ -97,7 +97,7 @@ impl<'y, Y: SystemApi<RuntimeError>> WasmRuntime for ScryptoRuntime<'y, Y> {
             // Practically speaking, there is little gain of keeping multiple buffers open before
             // [multi-value](https://github.com/WebAssembly/multi-value/blob/master/proposals/multi-value/Overview.md) is supported and used.
             // We reduce it to `4` so that the amount of memory that a transaction can consume is reduced, which is beneficial for parallel execution.
-            ScryptoVmVersion::V1_2 => 4,
+            ScryptoVmVersion::V1_2 | ScryptoVmVersion::V1_3 => 4,
         };
         if self.buffers.len() >= max_number_of_buffers {
             return Err(InvokeError::SelfError(WasmRuntimeError::TooManyBuffers));
@@ -604,6 +604,28 @@ impl<'y, Y: SystemApi<RuntimeError>> WasmRuntime for ScryptoRuntime<'y, Y> {
             })?;
 
         Ok(verify_bls12381_v1(&message, &public_key, &signature) as u32)
+    }
+
+    /// This method is only available to packages uploaded after the "Dugong"
+    /// protocol update due to checks in [`ScryptoV1WasmValidator::validate`].
+    #[trace_resources(log=message.len())]
+    fn crypto_utils_bls12381_v1_verify_min_sig(
+        &mut self,
+        message: Vec<u8>,
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+    ) -> Result<u32, InvokeError<WasmRuntimeError>> {
+        let public_key: Bls12381G2PublicKey =
+            scrypto_decode(&public_key).map_err(WasmRuntimeError::InvalidBlsPublicKey)?;
+        let signature: Bls12381G1Signature =
+            scrypto_decode(&signature).map_err(WasmRuntimeError::InvalidBlsSignature)?;
+
+        self.api
+            .consume_cost_units(ClientCostingEntry::Bls12381V1VerifyMinSig {
+                size: message.len(),
+            })?;
+
+        Ok(verify_bls12381_v1_min_sig(&message, &public_key, &signature) as u32)
     }
 
     /// This method is only available to packages uploaded after "Anemone"

--- a/radix-transaction-scenarios/src/runners/dumper.rs
+++ b/radix-transaction-scenarios/src/runners/dumper.rs
@@ -157,6 +157,9 @@ mod test {
             .configure_dugong(|_| DugongSettings {
                 native_entity_metadata_updates: UpdateSetting::Enabled(Default::default()),
                 system_logic_updates: UpdateSetting::Enabled(Default::default()),
+                // Kept disabled, consistent with Dugong not being enacted by default; enabling
+                // it would boot the Scrypto VM to V1_3 and change the dumped scenario state.
+                vm_boot_to_enable_crypto_utils_v3: UpdateSetting::Disabled,
             })
             .from_bootstrap_to_latest();
         for protocol_update_executor in protocol_executor.each_protocol_update_executor(&db) {

--- a/scrypto/src/crypto_utils/crypto_utils.rs
+++ b/scrypto/src/crypto_utils/crypto_utils.rs
@@ -4,7 +4,10 @@ use radix_common::{
         Ed25519PublicKey, Ed25519Signature, Secp256k1PublicKey, Secp256k1Signature,
         Secp256k1UncompressedPublicKey,
     },
-    prelude::{scrypto_decode, scrypto_encode, Bls12381G1PublicKey, Bls12381G2Signature, Hash},
+    prelude::{
+        scrypto_decode, scrypto_encode, Bls12381G1PublicKey, Bls12381G1Signature,
+        Bls12381G2PublicKey, Bls12381G2Signature, Hash,
+    },
 };
 use sbor::prelude::Vec;
 
@@ -69,6 +72,32 @@ impl CryptoUtils {
                 message.as_ref().len(),
                 public_keys.as_ptr(),
                 public_keys.len(),
+                signature.as_ptr(),
+                signature.len(),
+            ) != 0
+        }
+    }
+
+    /// Performs BLS12-381 G1 signature verification (minimal-signature-size "min-sig" variant).
+    ///
+    /// In this variant signatures are in G1 (48 bytes) and public keys in G2 (96 bytes) — the
+    /// mirror of [`Self::bls12381_v1_verify`] (min-pk). It is the variant used by unchained
+    /// drand networks (e.g. quicknet).
+    ///
+    /// Domain specifier tag: BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_
+    pub fn bls12381_v1_verify_min_sig(
+        message: impl AsRef<[u8]>,
+        public_key: impl AsRef<Bls12381G2PublicKey>,
+        signature: impl AsRef<Bls12381G1Signature>,
+    ) -> bool {
+        let public_key: Vec<u8> = scrypto_encode(public_key.as_ref()).unwrap();
+        let signature: Vec<u8> = scrypto_encode(signature.as_ref()).unwrap();
+        unsafe {
+            crypto_utils::crypto_utils_bls12381_v1_verify_min_sig(
+                message.as_ref().as_ptr(),
+                message.as_ref().len(),
+                public_key.as_ptr(),
+                public_key.len(),
                 signature.as_ptr(),
                 signature.len(),
             ) != 0

--- a/scrypto/src/engine/wasm_api.rs
+++ b/scrypto/src/engine/wasm_api.rs
@@ -318,6 +318,14 @@ pub mod crypto_utils {
             signatures_ptr: *const u8,
             signatures_len: usize) -> Buffer;
 
+        pub fn crypto_utils_bls12381_v1_verify_min_sig(
+            message_ptr: *const u8,
+            message_len: usize,
+            public_key_ptr: *const u8,
+            public_key_len: usize,
+            signature_ptr: *const u8,
+            signature_len: usize) -> u32;
+
         pub fn crypto_utils_keccak256_hash(
             message_ptr: *const u8,
             message_len: usize) -> Buffer;


### PR DESCRIPTION
## Summary

Adds a native host function for verifying BLS12-381 signatures in the
**minimal-signature-size (min-sig)** variant — 96-byte public keys in **G2** and
48-byte signatures in **G1**, under the ciphersuite
`BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_`.

This is the mirror image of the existing min-pk function
(`bls12381_v1_verify` — 48-byte G1 keys, 96-byte G2 signatures, `…G2…_POP_` DST).
The engine already links `blst`, so the implementation reuses the same dependency
via its `min_sig` module; no new dependencies are added.

## Motivation

The min-sig variant is the scheme used by **unchained drand networks** — most
notably **quicknet** (`bls-unchained-g1-rfc9380`), drand's production beacon for
fast (3s), low-overhead, publicly-verifiable randomness, and the beacon underlying
drand timelock encryption (tlock).

Today a Scrypto blueprint cannot verify a drand quicknet beacon on-chain:

- quicknet signatures live in **G1** with a **NUL** (basic) DST, whereas the
  existing `bls12381_v1_verify` only accepts **G2** signatures with the **POP** DST; and
- verifying even a single G1 signature in WASM is prohibitively expensive in
  execution units.

A native host function closes both gaps and lets on-chain protocols consume drand
randomness directly (and verify the beacon-signature component of tlock): verifiable
lotteries and raffles, randomized selection/sortition, sealed-bid and commit-reveal
mechanisms, and anything that wants tamper-evident external randomness without
trusting a centralized oracle.

## What's included

- **`radix-common`** — new SBOR types `Bls12381G2PublicKey` (96B) and
  `Bls12381G1Signature` (48B), and `verify_bls12381_v1_min_sig` (`blst::min_sig`,
  with the public key validated in-group / non-identity since it is untrusted input).
- **Host ABI** — `CryptoUtils::bls12381_v1_verify_min_sig` + `wasm_api` extern, the
  `WasmRuntime` trait method + the scrypto and no-op runtime impls, the `wasmi` host
  function / `Func::wrap` / `linker_define` binding, and the function-name constant.
- **Costing** — `ClientCostingEntry` / `ExecutionCostingEntry` variants, the
  conversion, and a `fee_table` cost function.
- **Protocol gating** — `prepare.rs` import constraint behind `crypto_utils_v3`, a
  matching `ProtocolVersionMismatch` test case, and `ScryptoVmVersion::V1_3` /
  `crypto_utils_v3()`.
- **Dugong** — a disabled-by-default `vm_boot_to_enable_crypto_utils_v3` flash.
- **Tests** — a new `crypto_scrypto_v3` test blueprint plus flash and system
  integration tests.

## Protocol gating

The new import is rejected below `crypto_utils_v3()` in `prepare.rs`, exactly like
the existing v1/v2 crypto host functions. `crypto_utils_v3` maps to a new
`ScryptoVmVersion::V1_3`, introduced by the **Dugong** protocol update as a
**disabled-by-default** VM-boot flash — consistent with Dugong currently shipping
un-enacted.

`ScryptoVmVersion::latest()` advances to **V1_3**. Note this is the **dev-time
validator ceiling** (so packages can be compiled and validated against the new
import); the **runtime** VM version is governed by the `VmBoot` substate and remains
at cuttlefish / V1_2 until the Dugong flash is enabled. Nothing is enacted by
default, and the cost-breakdown snapshots and existing crypto tests are unchanged.

## Testing

- Native unit tests (`radix-common`) and an end-to-end integration test
  (`radix-engine-tests`) verify against **real drand quicknet beacons** (rounds
  21180130 / 21180131, fetched from `api.drand.sh`), both at the `verify_*` level and
  through a published blueprint on a V1_3-booted ledger.
- Gating is proven in both directions: publishing the v3 blueprint is rejected
  without the VM-boot flash and succeeds with it (`flash` tests), and the
  `ProtocolVersionMismatch` unit test confirms the import is rejected below V1_3.
- `cargo check --workspace --tests` is clean; the metering cost-breakdown snapshots
  (`run_cost_tests`) and the existing crypto suites pass unchanged.

## Caveats / open decisions for reviewers

1. **Cost function is a placeholder.** `bls12381_v1_verify_min_sig_cost` currently
   mirrors the min-pk coefficients. min-sig has a cheaper hash-to-curve (G1) but a
   more expensive G2 public-key subgroup check, so the true cost differs. A
   calibration test (`test_crypto_scrypto_verify_bls12381_v1_min_sig_costing`,
   `resource_tracker` feature) is included; the constant should be set from its
   measured output before enactment. The function is deterministic, so this is a
   fee-accuracy matter, not a consensus one.
2. **Verify-only.** No aggregate / fast-aggregate variants — drand quicknet publishes
   a single, already-aggregated threshold signature per round, so single verification
   suffices. Aggregate variants can be added later if a use case needs them.
3. **Where to enact V1_3.** This introduces V1_3 via a disabled Dugong flash;
   maintainers may prefer a dedicated post-Dugong protocol update. That choice is
   independent of the host function, gating, and tests here.

## Notes

- The min-sig public key (`Bls12381G2PublicKey`, 96B) and signature
  (`Bls12381G1Signature`, 48B) are new SBOR types, distinct from the min-pk
  `Bls12381G1PublicKey` / `Bls12381G2Signature`.
- The public key is validated during verification (stricter than libraries that
  pass a trusted, hard-coded beacon key), since in the host-function context it is
  supplied as untrusted blueprint input.
